### PR TITLE
move data from CLImain.c to CommandLineInterface/CLIcore.c

### DIFF
--- a/src/CLImain.c
+++ b/src/CLImain.c
@@ -16,9 +16,6 @@
 #define STYLE_NO_BOLD "\033[22m"
 
 
-DATA __attribute__((used)) data;
-
-
 #define STRINGMAXLEN_VERSIONSTRING 80
 #define STRINGMAXLEN_APPNAME 40
 

--- a/src/CommandLineInterface/CLIcore.c
+++ b/src/CommandLineInterface/CLIcore.c
@@ -106,6 +106,8 @@
 *       Globals exported to all modules
 */
 
+DATA __attribute__((used)) data;
+
 pid_t CLIPID;
 
 
@@ -1389,13 +1391,3 @@ static int command_line_process_options(
     return RETURN_SUCCESS;
 
 }
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
I would like to move
DATA __attribute__((used)) data;

from cream/src/CLImain.c to cream/src/CommandLineInterface/CLIcore.c

It's still a bad practice to have this global variable but this facilitates the use with python wrappers...