### PR TITLE
Move project directive to top of CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
+project(milk LANGUAGES C)
+
 
 # Examples :
 # cmake .. -DUSE_CUDA=ON -DINSTALLMAKEDEFAULT=ON
@@ -40,8 +42,6 @@ pkg_check_modules(OPENBLAS openblas)
 
 enable_language(C)
 
-
-project(milk LANGUAGES C)
 
 # Version number
 set ( VERSION_MAJOR 1 )


### PR DESCRIPTION
CMake errors about internal variables not being set led me to https://stackoverflow.com/a/42018800. Moving `project()` to the top made everything configure (and build) nicely in `cmake3 version 3.17.3`. Not sure if there are any other side effects to be aware of.