### PR TITLE
Refactor all sem_*(image[imageIndex].semptr[semIndex]) calls ...

### DIFF
--- a/plugins/milk-extra-src/cudacomp/Coeff2Map_Loop.c
+++ b/plugins/milk-extra-src/cudacomp/Coeff2Map_Loop.c
@@ -380,20 +380,20 @@ errno_t CUDACOMP_Coeff2Map_Loop(const char *IDmodes_name,
                 exit(EXIT_FAILURE);
             }
             ts.tv_sec += 1;
-            semr = sem_timedwait(data.image[IDcoeff].semptr[3], &ts);
+            semr = ImageStreamIO_semtimedwait(data.image+IDcoeff, 3, &ts);
 
             if(iter == 0)
             {
                 //  printf("driving semaphore to zero ... ");
                 // fflush(stdout);
-                sem_getvalue(data.image[IDcoeff].semptr[2], &semval);
+                semval = ImageStreamIO_semvalue(data.image+IDcoeff, 2);
                 for(scnt = 0; scnt < semval; scnt++)
                 {
                     printf("WARNING %s %d  : sem_trywait on semptr2\n",
                            __FILE__,
                            __LINE__);
                     fflush(stdout);
-                    sem_trywait(data.image[IDcoeff].semptr[2]);
+                    ImageStreamIO_semtrywait(data.image+IDcoeff, 2);
                 }
                 // printf("done\n");
                 // fflush(stdout);
@@ -489,15 +489,15 @@ errno_t CUDACOMP_Coeff2Map_Loop(const char *IDmodes_name,
                                   d_outmap,
                                   sizeof(float) * mdim,
                                   cudaMemcpyDeviceToHost);
-            sem_getvalue(data.image[IDoutmap].semptr[0], &semval);
+            semval = ImageStreamIO_semvalue(data.image+IDoutmap, 0);
             if(semval < SEMAPHORE_MAXVAL)
             {
-                sem_post(data.image[IDoutmap].semptr[0]);
+                ImageStreamIO_sempost(data.image+IDoutmap, 0);
             }
-            sem_getvalue(data.image[IDoutmap].semptr[1], &semval);
+            semval = ImageStreamIO_semvalue(data.image+IDoutmap, 1);
             if(semval < SEMAPHORE_MAXVAL)
             {
-                sem_post(data.image[IDoutmap].semptr[1]);
+                ImageStreamIO_sempost(data.image+IDoutmap, 1);
             }
             data.image[IDoutmap].md[0].cnt0++;
             data.image[IDoutmap].md[0].write = 0;

--- a/plugins/milk-extra-src/cudacomp/cudacomp.c
+++ b/plugins/milk-extra-src/cudacomp/cudacomp.c
@@ -291,15 +291,15 @@ int CUDACOMP_createModesLoop(const char *DMmodeval_stream, const char *DMmodes, 
                 exit(EXIT_FAILURE);
             }
             ts.tv_sec += 1;
-            semr = sem_timedwait(data.image[ID_DMact].semptr[0], &ts);
+            semr = ImageStreamIO_semtimedwait(data.image+ID_DMact, 0, &ts);
 
             if(iter == 0)
             {
                 printf("driving semaphore to zero ... ");
                 fflush(stdout);
-                sem_getvalue(data.image[ID_DMact].semptr[0], &semval);
+                semval = ImageStreamIO_semvalue(data.image+ID_DMact, 0);
                 for(scnt=0; scnt<semval; scnt++)
-                    sem_trywait(data.image[ID_DMact].semptr[0]);
+                    ImageStreamIO_semtrywait(data.image+ID_DMact, 0);
                 printf("done\n");
                 fflush(stdout);
             }
@@ -335,12 +335,12 @@ int CUDACOMP_createModesLoop(const char *DMmodeval_stream, const char *DMmodes, 
             // copy result
             data.image[ID_modeval].md[0].write = 1;
             cudaStat = cudaMemcpy(data.image[ID_modeval].array.F, d_modeval, sizeof(float)*NBmodes, cudaMemcpyDeviceToHost);
-            sem_getvalue(data.image[ID_modeval].semptr[0], &semval);
+            semval = ImageStreamIO_semvalue(data.image+ID_modeval, 0);
             if(semval<SEMAPHORE_MAXVAL)
-                sem_post(data.image[ID_modeval].semptr[0]);
-            sem_getvalue(data.image[ID_modeval].semptr[1], &semval);
+                ImageStreamIO_sempost(data.image+ID_modeval, 0);
+            semval = ImageStreamIO_semvalue(data.image+ID_modeval, 1);
             if(semval<SEMAPHORE_MAXVAL)
-                sem_post(data.image[ID_modeval].semptr[1]);
+                ImageStreamIO_sempost(data.image+ID_modeval, 1);
             data.image[ID_modeval].md[0].cnt0++;
             data.image[ID_modeval].md[0].write = 0;
         }

--- a/plugins/milk-extra-src/cudacomp/cudacomp_MVMextractModesLoop.c
+++ b/plugins/milk-extra-src/cudacomp/cudacomp_MVMextractModesLoop.c
@@ -821,7 +821,7 @@ errno_t __attribute__((hot)) CUDACOMP_MVMextractModesLoop_RUN()
         }
 
         // drive semaphore to zero
-        while(sem_trywait(data.image[ID_modeval].semptr[insem]) == 0)
+        while(ImageStreamIO_semtrywait(data.image+ID_modeval, insem) == 0)
         {
             printf("WARNING %s %d  : sem_trywait on ID_modeval\n",
                    __FILE__,
@@ -1413,7 +1413,7 @@ errno_t __attribute__((hot)) CUDACOMP_MVMextractModesLoop_RUN()
         {
             // WAIT FOR NEW MODEVAL
             int rval;
-            rval = sem_wait(data.image[ID_modeval].semptr[insem]);
+            rval = ImageStreamIO_semwait(data.image+ID_modeval, insem);
             if(rval == -1)  // interrupt
             {
                 loopOK = 0;
@@ -1436,15 +1436,15 @@ errno_t __attribute__((hot)) CUDACOMP_MVMextractModesLoop_RUN()
             }
             data.image[IDtrace].md[0].cnt1 = TRACEindex;
 
-            sem_getvalue(data.image[IDtrace].semptr[0], &semval);
+            semval = ImageStreamIO_semvalue(data.image+IDtrace, 0);
             if(semval < SEMAPHORE_MAXVAL)
             {
-                sem_post(data.image[IDtrace].semptr[0]);
+                ImageStreamIO_sempost(data.image+IDtrace, 0);
             }
-            sem_getvalue(data.image[IDtrace].semptr[1], &semval);
+            semval = ImageStreamIO_semvalue(data.image+IDtrace, 1);
             if(semval < SEMAPHORE_MAXVAL)
             {
-                sem_post(data.image[IDtrace].semptr[1]);
+                ImageStreamIO_sempost(data.image+IDtrace, 1);
             }
             data.image[IDtrace].md[0].cnt0++;
             data.image[IDtrace].md[0].write = 0;

--- a/plugins/milk-extra-src/image_basic/streamfeed.c
+++ b/plugins/milk-extra-src/image_basic/streamfeed.c
@@ -176,10 +176,10 @@ long IMAGE_BASIC_streamfeed(const char *__restrict IDname,
     }
     if(data.image[IDs].md[0].sem > 0)
     {
-        sem_getvalue(data.image[IDs].semptr[0], &semval);
+        semval = ImageStreamIO_semvalue(data.image+IDs, 0);
         if(semval < SEMAPHORE_MAXVAL)
         {
-            sem_post(data.image[IDs].semptr[0]);
+            ImageStreamIO_sempost(data.image+IDs, 0);
         }
     }
     data.image[IDs].md[0].write = 0;

--- a/plugins/milk-extra-src/img_reduce/img_reduce.c
+++ b/plugins/milk-extra-src/img_reduce/img_reduce.c
@@ -678,7 +678,7 @@ imageID IMG_REDUCE_cleanbadpix_fast(const char *IDname,
             fflush(stdout);
             if(data.image[ID].md[0].sem > 0)
             {
-                sem_wait(data.image[ID].semptr[0]);
+                ImageStreamIO_semwait(data.image+ID, 0);
             }
             else
             {
@@ -731,7 +731,7 @@ imageID IMG_REDUCE_cleanbadpix_fast(const char *IDname,
         {
             if(data.image[IDout].md[0].sem > 0)
             {
-                sem_post(data.image[IDout].semptr[0]);
+                ImageStreamIO_sempost(data.image+IDout, 0);
             }
         }
         data.image[IDout].md[0].write = 0;

--- a/plugins/milk-extra-src/info/imagemon.c
+++ b/plugins/milk-extra-src/info/imagemon.c
@@ -324,7 +324,7 @@ errno_t printstatus(imageID ID)
         TUI_printfw("[%3ld sems ", image->md->sem);
         for(int s = 0; s < image->md->sem; s++)
         {
-            sem_getvalue(image->semptr[s], &semval);
+            semval = ImageStreamIO_semvalue(image, s);
             TUI_printfw(" %6d ", semval);
         }
         TUI_printfw("]\n");

--- a/plugins/milk-extra-src/info/streamtiming_stats.c
+++ b/plugins/milk-extra-src/info/streamtiming_stats.c
@@ -71,19 +71,19 @@ errno_t info_image_streamtiming_stats(
     // warmup
     for(long cnt = 0; cnt < SEMAPHORE_MAXVAL; cnt++)
     {
-        sem_trywait(image->semptr[sem]);
+        ImageStreamIO_semtrywait(image, sem);
     }
 
     clock_gettime(CLOCK_MILK, &tstart);
     t0 = tstart;
     t_timeout = t0;
     t_timeout.tv_sec += 2;
-    sem_timedwait(image->semptr[sem], &t_timeout);
+    ImageStreamIO_semtimedwait(image, sem, &t_timeout);
 
     while(loopOK == 1)
     {
         //for (long framecnt = 0; framecnt < NBsamplesmax; framecnt++)
-        if(sem_timedwait(image->semptr[sem], &t_timeout))
+        if(ImageStreamIO_semtimedwait(image, sem, &t_timeout))
         {
             return RETURN_FAILURE;
         }

--- a/plugins/milk-extra-src/linARfilterPred/linARfilterPred.c
+++ b/plugins/milk-extra-src/linARfilterPred/linARfilterPred.c
@@ -1291,7 +1291,7 @@ imageID LINARFILTERPRED_Build_LinPredictor(const char *IDin_name,
         clock_gettime(CLOCK_MILK, &t0);
         if(LOOPmode == 1)
         {
-            sem_wait(data.image[IDin].semptr[semtrig]);
+            ImageStreamIO_semwait(data.image+IDin, semtrig);
         }
 
         /// *STEP: Copy IDin to IDincp*
@@ -1754,7 +1754,7 @@ imageID LINARFILTERPRED_Apply_LinPredictor_RT(const char *IDfilt_name,
         abort();
     }
 
-    while(sem_trywait(data.image[IDin].semptr[semtrig]) == 0)
+    while(ImageStreamIO_semtrywait(data.image+IDin, semtrig) == 0)
     {
     }
     while(1)
@@ -1783,7 +1783,7 @@ imageID LINARFILTERPRED_Apply_LinPredictor_RT(const char *IDfilt_name,
                         inarray[kk * NBpix_in + ii];
                 }
 
-        sem_wait(data.image[IDin].semptr[semtrig]);
+        ImageStreamIO_semwait(data.image+IDin, semtrig);
 
         // write new input in inarray vector
         for(uint32_t ii = 0; ii < NBpix_in; ii++)
@@ -2279,7 +2279,7 @@ imageID LINARFILTERPRED_PF_RealTimeApply(const char *IDmodevalIN_name,
         //	printf("iter %5ld / %5ld", iter, NBiter);
         //	fflush(stdout);
 
-        sem_wait(data.image[IDmodevalIN].semptr[semtrig]);
+        ImageStreamIO_semwait(data.image+IDmodevalIN, semtrig);
         //	printf("\n");
         //	fflush(stdout);
 

--- a/plugins/milk-extra-src/linopt_imtools/linopt_imtools.c
+++ b/plugins/milk-extra-src/linopt_imtools/linopt_imtools.c
@@ -357,7 +357,7 @@ imageID linopt_imtools_image_construct_stream(
         }
         else
         {
-            sem_wait(data.image[IDcoeff].semptr[0]);
+            ImageStreamIO_semwait(data.image+IDcoeff, 0);
         }
 
         for(ii = 0; ii < sizexy; ii++)
@@ -372,10 +372,10 @@ imageID linopt_imtools_image_construct_stream(
                 data.image[IDout].array.F[ii] += data.image[IDcoeff].array.F[kk] *
                                                  data.image[IDmodes].array.F[kk * sizexy + ii];
             }
-        sem_getvalue(data.image[IDout].semptr[0], &semval);
+        semval = ImageStreamIO_semvalue(data.image+IDout, 0);
         if(semval < SEMAPHORE_MAXVAL)
         {
-            sem_post(data.image[IDout].semptr[0]);
+            ImageStreamIO_sempost(data.image+IDout, 0);
         }
 
         data.image[IDout].md[0].cnt0++;

--- a/src/COREMOD_memory/delete_image.c
+++ b/src/COREMOD_memory/delete_image.c
@@ -136,17 +136,11 @@ errno_t delete_image(IMGID img, int errmode)
 
         if(data.image[ID].md[0].shared == 1)
         {
-            for(s = 0; s < data.image[ID].md[0].sem; s++)
-            {
-                sem_close(data.image[ID].semptr[s]);
-            }
-
-            free(data.image[ID].semptr);
+            free(data.image[ID].semptr); // ?
             data.image[ID].semptr = NULL;
 
             if(data.image[ID].semlog != NULL)
             {
-                sem_close(data.image[ID].semlog);
                 data.image[ID].semlog = NULL;
             }
 

--- a/src/COREMOD_memory/saveall.c
+++ b/src/COREMOD_memory/saveall.c
@@ -219,14 +219,14 @@ errno_t COREMOD_MEMORY_SaveAll_sequ(const char *dirname,
     fflush(stdout);
 
     // drive semaphore to zero
-    while(sem_trywait(data.image[IDtrig].semptr[semtrig]) == 0)
+    while(ImageStreamIO_semtrywait(data.image+IDtrig, semtrig) == 0)
     {
     }
 
     frame = 0;
     while(frame < NBframes)
     {
-        sem_wait(data.image[IDtrig].semptr[semtrig]);
+        ImageStreamIO_semwait(data.image+IDtrig, semtrig);
         for(i = 0; i < imcnt; i++)
         {
             ID   = IDarray[i];

--- a/src/COREMOD_memory/stream_TCP.c
+++ b/src/COREMOD_memory/stream_TCP.c
@@ -160,7 +160,7 @@ errno_t COREMOD_MEMORY_testfunction_semaphore(const char *IDname,
         printf("\n");
         usleep(500);
 
-        sem_getvalue(img_p->semptr[semtrig], &semval);
+        semval = ImageStreamIO_semvalue(img_p, semtrig);
         snprintf(pinfomsg,
                  200,
                  "%ld TEST 0 semtrig %d  ID %ld  %d",
@@ -173,18 +173,18 @@ errno_t COREMOD_MEMORY_testfunction_semaphore(const char *IDname,
 
         if(testmode == 0)
         {
-            rv = sem_wait(img_p->semptr[semtrig]);
+            rv = ImageStreamIO_semwait(img_p, semtrig);
         }
 
         if(testmode == 1)
         {
-            rv = sem_trywait(img_p->semptr[semtrig]);
+            rv = ImageStreamIO_semtrywait(img_p, semtrig);
         }
 
         if(testmode == 2)
         {
-            sem_post(img_p->semptr[semtrig]);
-            rv = sem_wait(img_p->semptr[semtrig]);
+            ImageStreamIO_sempost(img_p, semtrig);
+            rv = ImageStreamIO_semwait(img_p, semtrig);
         }
 
         if(rv == -1)
@@ -220,7 +220,7 @@ errno_t COREMOD_MEMORY_testfunction_semaphore(const char *IDname,
             printf("    OK\n");
         }
 
-        sem_getvalue(img_p->semptr[semtrig], &semval);
+        semval = ImageStreamIO_semvalue(img_p, semtrig);
         snprintf(pinfomsg,
                  200,
                  "%ld TEST 1 semtrig %d  ID %ld  %d",
@@ -471,26 +471,26 @@ imageID COREMOD_MEMORY_image_NETWORKtransmit(
             }
             ts.tv_sec += 2;
 
-            semr = sem_timedwait(img_p->semptr[semtrig], &ts);
+            semr = ImageStreamIO_semtimedwait(img_p, semtrig, &ts);
 
             if(iter == 0)
             {
                 processinfo_WriteMessage(processinfo, "Driving sem to 0");
                 printf("Driving semaphore to zero ... ");
                 fflush(stdout);
-                sem_getvalue(img_p->semptr[semtrig], &semval);
+                semval = ImageStreamIO_semvalue(img_p, semtrig);
                 int semvalcnt = semval;
                 for(scnt = 0; scnt < semvalcnt; scnt++)
                 {
-                    sem_getvalue(img_p->semptr[semtrig], &semval);
+                    semval = ImageStreamIO_semvalue(img_p, semtrig);
                     printf("sem = %d\n", semval);
                     fflush(stdout);
-                    sem_trywait(img_p->semptr[semtrig]);
+                    ImageStreamIO_semtrywait(img_p, semtrig);
                 }
                 printf("done\n");
                 fflush(stdout);
 
-                sem_getvalue(img_p->semptr[semtrig], &semval);
+                semval = ImageStreamIO_semvalue(img_p, semtrig);
                 printf("-> sem = %d\n", semval);
                 fflush(stdout);
 
@@ -1085,10 +1085,10 @@ imageID COREMOD_MEMORY_image_NETWORKreceive(int                         port,
             img_p->md[0].cnt0++;
             for(semnb = 0; semnb < img_p->md[0].sem; semnb++)
             {
-                sem_getvalue(img_p->semptr[semnb], &semval);
+                semval = ImageStreamIO_semvalue(img_p, semnb);
                 if(semval < SEMAPHORE_MAXVAL)
                 {
-                    sem_post(img_p->semptr[semnb]);
+                    ImageStreamIO_sempost(img_p, semnb);
                 }
             }
 

--- a/src/COREMOD_memory/stream_UDP.c
+++ b/src/COREMOD_memory/stream_UDP.c
@@ -963,7 +963,7 @@ imageID COREMOD_MEMORY_image_NETUDPreceive(
             data.image[ID].md[0].cnt0++;
             for(semnb = 0; semnb < data.image[ID].md[0].sem; semnb++)
             {
-                semval ImageStreamIO_semvalue(data.image+ID, semnb);
+                semval = ImageStreamIO_semvalue(data.image+ID, semnb);
                 if(semval < SEMAPHORE_MAXVAL)
                 {
                     ImageStreamIO_sempost(data.image+ID, semnb);

--- a/src/COREMOD_memory/stream_UDP.c
+++ b/src/COREMOD_memory/stream_UDP.c
@@ -337,7 +337,7 @@ imageID COREMOD_MEMORY_image_NETUDPtransmit(const char *IDname,
                 printf("done\n");
                 fflush(stdout);
 
-                ImageStreamIO_semvalue(data.image+ID, semtrig);
+                semval = ImageStreamIO_semvalue(data.image+ID, semtrig);
                 printf("-> sem = %d\n", semval);
                 fflush(stdout);
 

--- a/src/COREMOD_memory/stream_UDP.c
+++ b/src/COREMOD_memory/stream_UDP.c
@@ -318,26 +318,26 @@ imageID COREMOD_MEMORY_image_NETUDPtransmit(const char *IDname,
             }
             ts.tv_sec += 2;
 
-            semr = sem_timedwait(data.image[ID].semptr[semtrig], &ts);
+            semr = ImageStreamIO_semtimedwait(data.image+ID, semtrig, &ts);
 
             if(iter == 0)
             {
                 processinfo_WriteMessage(processinfo, "Driving sem to 0");
                 printf("Driving semaphore to zero ... ");
                 fflush(stdout);
-                sem_getvalue(data.image[ID].semptr[semtrig], &semval);
+                semval = ImageStreamIO_semvalue(data.image+ID, semtrig);
                 int semvalcnt = semval;
                 for(scnt = 0; scnt < semvalcnt; scnt++)
                 {
-                    sem_getvalue(data.image[ID].semptr[semtrig], &semval);
+                    semval = ImageStreamIO_semvalue(data.image+ID, semtrig);
                     printf("sem = %d\n", semval);
                     fflush(stdout);
-                    sem_trywait(data.image[ID].semptr[semtrig]);
+                    ImageStreamIO_semtrywait(data.image+ID, semtrig);
                 }
                 printf("done\n");
                 fflush(stdout);
 
-                sem_getvalue(data.image[ID].semptr[semtrig], &semval);
+                ImageStreamIO_semvalue(data.image+ID, semtrig);
                 printf("-> sem = %d\n", semval);
                 fflush(stdout);
 
@@ -963,10 +963,10 @@ imageID COREMOD_MEMORY_image_NETUDPreceive(
             data.image[ID].md[0].cnt0++;
             for(semnb = 0; semnb < data.image[ID].md[0].sem; semnb++)
             {
-                sem_getvalue(data.image[ID].semptr[semnb], &semval);
+                semval ImageStreamIO_semvalue(data.image+ID, semnb);
                 if(semval < SEMAPHORE_MAXVAL)
                 {
-                    sem_post(data.image[ID].semptr[semnb]);
+                    ImageStreamIO_sempost(data.image+ID, semnb);
                 }
             }
 

--- a/src/COREMOD_memory/stream_diff.c
+++ b/src/COREMOD_memory/stream_diff.c
@@ -130,7 +130,7 @@ imageID COREMOD_MEMORY_streamDiff(const char *IDstream0_name,
         }
         else
         {
-            sem_wait(data.image[ID0].semptr[semtrig]);
+            ImageStreamIO_semwait(data.image+ID0, semtrig);
         }
 
         data.image[IDout].md[0].write = 1;

--- a/src/COREMOD_memory/stream_halfimdiff.c
+++ b/src/COREMOD_memory/stream_halfimdiff.c
@@ -166,7 +166,7 @@ imageID COREMOD_MEMORY_stream_halfimDiff(const char *IDstream_name,
         }
         else
         {
-            sem_wait(data.image[ID0].semptr[semtrig]);
+            ImageStreamIO_semwait(data.image+ID0, semtrig);
         }
 
         data.image[IDout].md[0].write = 1;

--- a/src/COREMOD_memory/stream_paste.c
+++ b/src/COREMOD_memory/stream_paste.c
@@ -137,7 +137,7 @@ imageID COREMOD_MEMORY_streamPaste(const char *IDstream0_name,
             }
             else
             {
-                sem_wait(data.image[ID0].semptr[semtrig0]);
+                ImageStreamIO_semwait(data.image+ID0, semtrig0);
             }
             Xoffset = 0;
             IDin    = 0;
@@ -156,7 +156,7 @@ imageID COREMOD_MEMORY_streamPaste(const char *IDstream0_name,
             }
             else
             {
-                sem_wait(data.image[ID1].semptr[semtrig1]);
+                ImageStreamIO_semwait(data.image+ID1, semtrig1);
             }
             Xoffset = xsize;
             IDin    = 1;

--- a/src/COREMOD_memory/stream_pixmapdecode.c
+++ b/src/COREMOD_memory/stream_pixmapdecode.c
@@ -361,10 +361,10 @@ imageID COREMOD_MEMORY_PixMapDecode_U(const char *inputstream_name,
 
             if(processinfo->loopcnt == 0)
             {
-                sem_getvalue(data.image[IDin].semptr[in_semwaitindex], &semval);
+                semval = ImageStreamIO_semvalue(data.image+IDin, in_semwaitindex);
                 for(scnt = 0; scnt < semval; scnt++)
                 {
-                    sem_trywait(data.image[IDin].semptr[in_semwaitindex]);
+                    ImageStreamIO_semtrywait(data.image+IDin, in_semwaitindex);
                 }
             }
         }
@@ -429,16 +429,16 @@ imageID COREMOD_MEMORY_PixMapDecode_U(const char *inputstream_name,
 
                 data.image[IDout].md[0].cnt1 = slice;
 
-                sem_getvalue(data.image[IDout].semptr[2], &semval);
+                semval = ImageStreamIO_semvalue(data.image+IDout, 2);
                 if(semval < SEMAPHORE_MAXVAL)
                 {
-                    sem_post(data.image[IDout].semptr[2]);
+                    ImageStreamIO_sempost(data.image+IDout, 2);
                 }
 
-                sem_getvalue(data.image[IDout].semptr[3], &semval);
+                semval = ImageStreamIO_semvalue(data.image+IDout, 3);
                 if(semval < SEMAPHORE_MAXVAL)
                 {
-                    sem_post(data.image[IDout].semptr[3]);
+                    ImageStreamIO_sempost(data.image+IDout, 3);
                 }
 
                 data.image[IDout].md[0].write = 0;

--- a/src/COREMOD_memory/stream_sem.c
+++ b/src/COREMOD_memory/stream_sem.c
@@ -190,7 +190,7 @@ imageID COREMOD_MEMORY_image_seminfo(const char *IDname)
     {
         int semval;
 
-        sem_getvalue(data.image[ID].semptr[s], &semval);
+        semval = ImageStreamIO_semvalue(data.image_ID, s);
 
         printf("  %2d   %6d   %8d  %8d\n",
                s,
@@ -294,10 +294,10 @@ void *waitforsemID(void *ID)
     pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
     tid = pthread_self();
 
-    //    sem_getvalue(data.image[(long) ID].semptr, &semval);
+    //    semval = ImageStreamIO_semgetvalue(data.image+(long) ID, ?sem_index);
     //    printf("tid %u waiting for sem ID %ld   sem = %d   (%s)\n", (unsigned int) tid, (long) ID, semval, data.image[(long) ID].name);
     //    fflush(stdout);
-    sem_wait(data.image[(imageID) ID].semptr[0]);
+    ImageStreamIO_semwait(data.image+(imageID) ID, 0);
     //    printf("tid %u sem ID %ld done\n", (unsigned int) tid, (long) ID);
     //    fflush(stdout);
 
@@ -364,7 +364,7 @@ errno_t COREMOD_MEMORY_image_set_semflush_IDarray(imageID *IDarray, long NB_ID)
     {
         for(s = 0; s < data.image[IDarray[i]].md[0].sem; s++)
         {
-            sem_getvalue(data.image[IDarray[i]].semptr[s], &semval);
+            semval = ImageStreamIO_semvalue(data.image+IDarray[i], s);
             printf("sem %d/%d of %s [%ld] = %d\n",
                    s,
                    data.image[IDarray[i]].md[0].sem,
@@ -374,7 +374,7 @@ errno_t COREMOD_MEMORY_image_set_semflush_IDarray(imageID *IDarray, long NB_ID)
             fflush(stdout);
             for(cnt = 0; cnt < semval; cnt++)
             {
-                sem_trywait(data.image[IDarray[i]].semptr[s]);
+                ImageStreamIO_semtrywait(data.image+IDarray[i], s);
             }
         }
     }

--- a/src/COREMOD_memory/stream_sem.c
+++ b/src/COREMOD_memory/stream_sem.c
@@ -190,7 +190,7 @@ imageID COREMOD_MEMORY_image_seminfo(const char *IDname)
     {
         int semval;
 
-        semval = ImageStreamIO_semvalue(data.image_ID, s);
+        semval = ImageStreamIO_semvalue(data.image+ID, s);
 
         printf("  %2d   %6d   %8d  %8d\n",
                s,

--- a/src/COREMOD_memory/stream_sem.c
+++ b/src/COREMOD_memory/stream_sem.c
@@ -294,7 +294,7 @@ void *waitforsemID(void *ID)
     pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
     tid = pthread_self();
 
-    //    semval = ImageStreamIO_semgetvalue(data.image+(long) ID, ?sem_index);
+    //    semval = ImageStreamIO_semvalue(data.image+(long) ID, ?sem_index);
     //    printf("tid %u waiting for sem ID %ld   sem = %d   (%s)\n", (unsigned int) tid, (long) ID, semval, data.image[(long) ID].name);
     //    fflush(stdout);
     ImageStreamIO_semwait(data.image+(imageID) ID, 0);

--- a/src/COREMOD_memory/stream_updateloop.c
+++ b/src/COREMOD_memory/stream_updateloop.c
@@ -517,7 +517,7 @@ COREMOD_MEMORY_image_streamupdateloop(const char                 *IDinname,
         }
         else
         {
-            sem_wait(data.image[IDsync].semptr[sync_semwaitindex]);
+            ImageStreamIO_semwait(data.image+IDsync, sync_semwaitindex);
         }
 
         if(loopCTRLexit == 1)
@@ -632,7 +632,7 @@ imageID COREMOD_MEMORY_image_streamupdateloop_semtrig(
 
     while(1)
     {
-        sem_wait(data.image[IDsync].semptr[sync_semwaitindex]);
+        ImageStreamIO_semwait(data.image+IDsync, sync_semwaitindex);
 
         kk++;
         if(kk == period)  // UPDATE

--- a/src/CommandLineInterface/processtools_trigger.c
+++ b/src/CommandLineInterface/processtools_trigger.c
@@ -261,8 +261,8 @@ errno_t processinfo_waitoninputstream(PROCESSINFO *processinfo)
             // this should only run once, returning semr = -1 with errno = EAGAIN
             // otherwise, we're potentially missing frames
             DEBUG_TRACEPOINT("sem_trywait %ld", processinfo->triggerstreamID);
-            semr = sem_trywait(data.image[processinfo->triggerstreamID]
-                               .semptr[processinfo->triggersem]);
+            semr = ImageStreamIO_semtrywait(data.image+processinfo->triggerstreamID
+                               ,processinfo->triggersem);
             if(semr == 0)
             {
                 processinfo->triggermissedframe++;
@@ -285,8 +285,8 @@ errno_t processinfo_waitoninputstream(PROCESSINFO *processinfo)
                 ts.tv_sec++;
             }
 
-            semr = sem_timedwait(data.image[processinfo->triggerstreamID]
-                                 .semptr[processinfo->triggersem],
+            semr = ImageStreamIO_semtimedwait(data.image+processinfo->triggerstreamID
+                                 ,processinfo->triggersem,
                                  &ts);
             if(semr == -1)
             {

--- a/src/CommandLineInterface/streamCTRL/streamCTRL_TUI.c
+++ b/src/CommandLineInterface/streamCTRL/streamCTRL_TUI.c
@@ -2528,8 +2528,7 @@ errno_t streamCTRL_CTRLscreen()
                         for(s = 0; s < max_s; s++)
                         {
                             int semval;
-                            sem_getvalue(streamCTRLimages[ID].semptr[s],
-                                         &semval);
+                            semval = ImageStreamIO_semvalue(streamCTRLimages+ID,s);
                             snprintf(string, stringlen, " %7d", semval);
                             TUI_printfw(string);
                         }


### PR DESCRIPTION
~~***Whoops, found a few more typos; hold off for now***~~ fixed

to instead use ImageStreamIO(image+imageIndex, semIndex...) interface calls.
 
 There is no reason for milk to be know about, or do anything with, image->semptr pointers and other shmim internals, or to do any of the shmim internal management.
 
There are still some statements that initialize those pointers, see below, but they should be harmless.

This passes 31 of 32 tests, failing number 24 (milksemloopspeed), but that script, when run by itself, seems to pass, so I don't know if that is an actual issue.

There is a statement that deletes the space as part of deleting a shmim, so we should look at that and see if that can be replaced by an ImageStreamIO_destroyIm or ImageStream_closeIm or similar call to the ImageStreamIO. 
```
find . -name '*.[ch]' | grep -v src/ImageStreamIO/|xargs grep semptr'[^1-5]'
./src/COREMOD_memory/delete_image.c:            free(data.image[ID].semptr); // ?
./src/COREMOD_memory/delete_image.c:            data.image[ID].semptr = NULL;
./src/CommandLineInterface/CLIcore/CLIcore_help.c:    printf("   semptr                      offset = %4zu bit  = %4zu byte\n",
./src/CommandLineInterface/CLIcore/CLIcore_help.c:           8 * offsetof(IMAGE, semptr),
./src/CommandLineInterface/CLIcore/CLIcore_help.c:           offsetof(IMAGE, semptr));
./src/CommandLineInterface/CLIcore/CLIcore_memory.c:            data.image[i].semptr    = NULL;
./src/CommandLineInterface/streamCTRL/streamCTRL_TUI.c:        streamCTRLimages[imID].semptr  = NULL;
./plugins/milk-extra-src/cudacomp/GPU_loop_MultMat_execute.c:        // for safety, set semaphores to zerosem_getvalue(data.image[IDarray[i]].semptr[s], &semval);
```