### PR TITLE
Update fetch_cacao_dev.sh to remove missing patch

### DIFF
--- a/fetch_cacao_dev.sh
+++ b/fetch_cacao_dev.sh
@@ -13,13 +13,4 @@ else
     echo ""
 fi
 
-PATCHFN=patch_cacao_lapacke_optional.txt
-( [ -r  "./$PATCHFN" ] \
-  && cd plugins/cacao-src/computeCalib/ \
-  && PATCHPATH="../../../$PATCHFN" \
-  && [ -r  "$PATCHPATH" ] \
-  && patch -s --reject-file=- -f -p 2 < "$PATCHPATH" \
-  && echo "Successfully patched CACAO computeCalib/CMakeList.txt" \
-  || echo "Failed to patch CACAO computeCalib/CMakeList.txt" \
-  || true
-)
+


### PR DESCRIPTION
this is no longer needed, and the path file is removed.