### PR TITLE
Make GSL support for random number generation optionnal

### DIFF
--- a/src/CommandLineInterface/CLIcore.c
+++ b/src/CommandLineInterface/CLIcore.c
@@ -350,6 +350,7 @@ static errno_t runCLI_initialize()
         PRINT_ERROR("seteuid error");
     }
 
+#ifdef USE_GSL
     // Initialize random-number generator
     //
     const gsl_rng_type *rndgenType;
@@ -358,6 +359,7 @@ static errno_t runCLI_initialize()
     rndgenType  = gsl_rng_rand; // not as good but ~10x faster fast
     data.rndgen = gsl_rng_alloc(rndgenType);
     gsl_rng_set(data.rndgen, time(NULL));
+#endif
 
     // warm up
     //for(i=0; i<10; i++)
@@ -1057,8 +1059,11 @@ static void runCLI_free()
 
 #endif
     //  free(data.cmd);
+
+#ifdef USE_GSL
     DEBUG_TRACEPOINT("free data.rndgen");
     gsl_rng_free(data.rndgen);
+#endif
 }
 
 int user_function()

--- a/src/CommandLineInterface/CLIcore.h
+++ b/src/CommandLineInterface/CLIcore.h
@@ -33,7 +33,14 @@ typedef int errno_t;
 
 #include <errno.h>
 #include <fftw3.h>
+#ifdef USE_GSL
 #include <gsl/gsl_rng.h> // for random numbers
+#else
+typedef struct
+{
+    int dummy;
+} gsl_rng;
+#endif
 #include <sched.h>
 #include <semaphore.h>
 #include <signal.h>

--- a/src/CommandLineInterface/CLIcore.h
+++ b/src/CommandLineInterface/CLIcore.h
@@ -32,7 +32,9 @@ typedef int errno_t;
 #endif
 
 #include <errno.h>
+#ifdef USE_FFTW3
 #include <fftw3.h>
+#endif
 #ifdef USE_GSL
 #include <gsl/gsl_rng.h> // for random numbers
 #else

--- a/src/CommandLineInterface/CMakeLists.txt
+++ b/src/CommandLineInterface/CMakeLists.txt
@@ -9,11 +9,11 @@ option(python_module "Compile Python Wrappers" OFF)
 project(CLIcore C)
 
 find_package(PkgConfig REQUIRED)
-find_package(GSL QUIET REQUIRED)
 pkg_check_modules(FFTW REQUIRED fftw3)
 pkg_check_modules(FFTWF REQUIRED fftw3f)
 pkg_check_modules(NCURSES REQUIRED ncurses)
 find_package(OpenMP)
+find_package(GSL)
 
 pkg_check_modules(HWLOC hwloc)
 
@@ -121,6 +121,10 @@ if(${CFITSIO_FOUND})
   link_directories(${CFITSIO_LIBRARY_DIRS})
   target_compile_definitions(CLIcore PUBLIC USE_CFITSIO=1)
   target_include_directories(CLIcore PUBLIC ${CFITSIO_INCLUDE_DIRS})
+endif()
+
+if(${GSL_FOUND})
+  target_compile_definitions(CLIcore PUBLIC USE_GSL=1)
 endif()
 
 target_include_directories(CLIcore

--- a/src/CommandLineInterface/CMakeLists.txt
+++ b/src/CommandLineInterface/CMakeLists.txt
@@ -9,9 +9,9 @@ option(python_module "Compile Python Wrappers" OFF)
 project(CLIcore C)
 
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(FFTW REQUIRED fftw3)
-pkg_check_modules(FFTWF REQUIRED fftw3f)
 pkg_check_modules(NCURSES REQUIRED ncurses)
+pkg_check_modules(FFTW fftw3)
+pkg_check_modules(FFTWF fftw3f)
 find_package(OpenMP)
 find_package(GSL)
 
@@ -125,15 +125,19 @@ endif()
 
 if(${GSL_FOUND})
   target_compile_definitions(CLIcore PUBLIC USE_GSL=1)
+  target_include_directories(CLIcore PUBLIC ${GSL_INCLUDE_DIRS})
 endif()
 
-target_include_directories(CLIcore
-                PUBLIC ${GSL_INCLUDE_DIRS}
-                      ${FFTW_INCLUDE_DIRS}
-                      ${FFTWF_INCLUDE_DIRS})
+if(${FFTW_FOUND})
+  target_compile_definitions(CLIcore PUBLIC USE_FFTW3=1)
+  target_include_directories(CLIcore PUBLIC
+                             ${FFTW_INCLUDE_DIRS}
+                             ${FFTWF_INCLUDE_DIRS})
+  target_compile_options(CLIcore PUBLIC 
+                         ${FFTW_CFLAGS_OTHER} 
+                         ${FFTWF_CFLAGS_OTHER})
+endif()
 
-target_compile_options(CLIcore
-                        PUBLIC ${FFTW_CFLAGS_OTHER} ${FFTWF_CFLAGS_OTHER})
 if (OPENMP_C_FOUND)
   message("Found OpenMP")
   target_link_libraries(CLIcore PUBLIC OpenMP::OpenMP_C)
@@ -143,9 +147,9 @@ endif()
 target_link_libraries(CLIcore
                       PUBLIC m
                               readline
-                              ${CFITSIO_LIBRARIES}
                               dl
                               rt
+                              ${CFITSIO_LIBRARIES}
                               ${GSL_LIBRARIES}
                               ${FFTW_LIBRARIES}
                               ${FFTWF_LIBRARIES}


### PR DESCRIPTION
Since a while, I wanted to make optional the dependency of GSL for CLIcore because I don't use it.
