### PR TITLE
implemented masking in  MVMextractModes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,7 @@ install(PROGRAMS
 			scripts/milk-check
 			scripts/milk-cubeslice2shm
 			scripts/milk-exec
+      scripts/milk-fpslist-addentry
 			scripts/milk-streamCTRL
 			scripts/milk-procCTRL
 			scripts/milk-fpsCTRL

--- a/plugins/milk-extra-src/linARfilterPred/build_linPF.c
+++ b/plugins/milk-extra-src/linARfilterPred/build_linPF.c
@@ -686,16 +686,16 @@ static errno_t compute_function()
         //int sampledim = imgin.md->size[1];
 
         // eigenvectors array
+        delete_image_ID("eigenvec", DELETE_IMAGE_ERRMODE_IGNORE);
         IMGID imgevec = mkIMGID_from_name("eigenvec");
 
         // eigenvalues array
+        delete_image_ID("eigenval", DELETE_IMAGE_ERRMODE_IGNORE);
         IMGID imgeval = mkIMGID_from_name("eigenval");
 
         // eigenvalues array
+        delete_image_ID("matU", DELETE_IMAGE_ERRMODE_IGNORE);
         IMGID imgU = mkIMGID_from_name("matU");
-
-        printf("========== %5d ===========\n", __LINE__);
-        fflush(stdout);
 
 
         int GPUdev = 0;

--- a/plugins/milk-extra-src/linalgebra/MVMextractModes.c
+++ b/plugins/milk-extra-src/linalgebra/MVMextractModes.c
@@ -1280,6 +1280,11 @@ static errno_t compute_function()
     free(modevalarray);
     free(modevalarrayref);
 
+    if(use_mask)
+    {
+        free(masked_pix);
+    }
+
     DEBUG_TRACE_FEXIT();
     return RETURN_SUCCESS;
 }

--- a/plugins/milk-extra-src/linalgebra/MVMextractModes.c
+++ b/plugins/milk-extra-src/linalgebra/MVMextractModes.c
@@ -49,8 +49,8 @@ long fpi_nmax;
 static char *insname;
 long fpi_insname;
 
-static char *masksname;
-long fpi_masksname;
+static char *inmasksname;
+long fpi_inmasksname;
 
 static char *immodes;
 long fpi_immodes;
@@ -109,12 +109,12 @@ static CLICMDARGDEF farg[] =
     },
     {
         CLIARG_STREAM,
-        ".masksname",
-        "mask stream name",
+        ".inmasksname",
+        "nput mask stream name",
         "inV",
         CLIARG_VISIBLE_DEFAULT,
-        (void **) &masksname,
-        &fpi_masksname
+        (void **) &inmasksname,
+        &fpi_inmasksname
     },
     {
         CLIARG_STREAM,
@@ -326,7 +326,7 @@ static errno_t compute_function()
     uint32_t * mask_idx = NULL; //Array holding the indices of the 1 pixels
     float * masked_pix = NULL; //Array to hold the pixel values
 
-    IMGID imgmask = mkIMGID_from_name(masksname);
+    IMGID imgmask = mkIMGID_from_name(inmasksname);
     if(resolveIMGID(&imgmask, ERRMODE_WARN) != -1)
     {
         printf("Mask stream size : %u %u\n", imgmask.md->size[0], imgmask.md->size[1]);

--- a/plugins/milk-extra-src/linalgebra/MVMextractModes.c
+++ b/plugins/milk-extra-src/linalgebra/MVMextractModes.c
@@ -49,6 +49,9 @@ long fpi_nmax;
 static char *insname;
 long fpi_insname;
 
+static char *masksname;
+long fpi_masksname;
+
 static char *immodes;
 long fpi_immodes;
 
@@ -103,6 +106,15 @@ static CLICMDARGDEF farg[] =
         CLIARG_VISIBLE_DEFAULT,
         (void **) &insname,
         &fpi_insname
+    },
+    {
+        CLIARG_STREAM,
+        ".masksname",
+        "mask stream name",
+        "inV",
+        CLIARG_VISIBLE_DEFAULT,
+        (void **) &masksname,
+        &fpi_masksname
     },
     {
         CLIARG_STREAM,
@@ -307,6 +319,58 @@ static errno_t compute_function()
     resolveIMGID(&imgin, ERRMODE_ABORT);
     printf("Input stream size : %u %u\n", imgin.md->size[0], imgin.md->size[1]);
     long m = imgin.md->size[0] * imgin.md->size[1];
+
+    // CONNECT TO MASK STREAM
+    int use_mask = 0; //flag indicating that the mask is being used
+    uint32_t mask_npix = 0; //The number of 1 pixels in the mask
+    uint32_t * mask_idx = NULL; //Array holding the indices of the 1 pixels
+    float * masked_pix = NULL; //Array to hold the pixel values
+
+    IMGID imgmask = mkIMGID_from_name(masksname);
+    if(resolveIMGID(&imgmask, ERRMODE_WARN) != -1)
+    {
+        printf("Mask stream size : %u %u\n", imgmask.md->size[0], imgmask.md->size[1]);
+        if(imgmask.md->size[0] == imgin.md->size[0] && imgmask.md->size[1] == imgin.md->size[1])
+        {
+            use_mask = 1;
+        }
+    }
+
+    //use_mask = 0; //for testing
+
+    //setup the mask 
+    if(use_mask)
+    {
+        for(long n=0; n < imgmask.md->size[0]*imgmask.md->size[1]; ++n)
+        {
+            if(imgmask.im->array.F[n] == 1)
+            {
+                ++mask_npix;
+            }
+        }
+
+        mask_idx = (uint32_t *) malloc( mask_npix * sizeof(long));
+        masked_pix = (float *) malloc( mask_npix * sizeof(float));
+        long nn = 0;
+        for(long n=0; n < imgmask.md->size[0]*imgmask.md->size[1]; ++n)
+        {
+            if(imgmask.im->array.F[n] == 1)
+            {
+                mask_idx[nn] = n;
+                ++nn;
+            }
+        }
+
+        printf("Mask has : %u pixels (%f%%)\n", mask_npix, (100.0*mask_npix)/(imgmask.md->size[0]*imgmask.md->size[1]));
+    }
+    else
+    {
+        //Just use full image
+        mask_npix = imgin.md->size[0]*imgin.md->size[1];
+        printf("No mask using : %u pixels (%f%%)\n", mask_npix, (100.0*mask_npix)/(imgin.md->size[0]*imgin.md->size[1]));
+    }
+
+
 
     // NORMALIZATION
     // CONNECT TO TOTAL FLUX STREAM
@@ -602,8 +666,34 @@ static errno_t compute_function()
             printf(" done\n");
             fflush(stdout);
 
+            long matsz;
+            float * modesmat;
+
+            if(use_mask)
+            {
+                //reformat the matrix using the mask
+                matsz = mask_npix * NBmodes;
+                modesmat = (float *) malloc(sizeof(float)*mask_npix * data.image[IDmodes].md->size[2]);
+
+                uint32_t nrows = data.image[IDmodes].md->size[2];
+                uint32_t ncols = data.image[IDmodes].md->size[0]*data.image[IDmodes].md->size[1];
+                
+                for(uint32_t rr = 0; rr < nrows; ++rr)
+                {
+                    for(uint32_t cc = 0; cc < mask_npix; ++cc)
+                    {
+                        modesmat[rr*mask_npix + cc] = data.image[IDmodes].array.F[rr*ncols + mask_idx[cc]];
+                    }
+                } 
+            }
+            else
+            {
+                matsz = m * NBmodes;
+                modesmat = data.image[IDmodes].array.F;
+            }
+
             // load modes to GPU
-            cudaStat = cudaMalloc((void **)&d_modes, sizeof(float) * m * NBmodes);
+            cudaStat = cudaMalloc((void **)&d_modes, sizeof(float) * matsz);
             if(cudaStat != cudaSuccess)
             {
                 printf("cudaMalloc d_modes returned error code %d, line %d\n",
@@ -613,10 +703,16 @@ static errno_t compute_function()
             }
 
             cudaStat = cudaMemcpy(d_modes,
-                                  data.image[IDmodes].array.F,
-                                  sizeof(float) * m * NBmodes,
+                                  modesmat,
+                                  sizeof(float) * matsz,
                                   cudaMemcpyHostToDevice);
             // cudaStat = cudaMemcpy(d_modes, imgmodes.im->array.F, sizeof(float) * m * NBmodes, cudaMemcpyHostToDevice);
+
+            if(use_mask)
+            {
+                free(modesmat);
+            }
+
             if(cudaStat != cudaSuccess)
             {
                 printf("cudaMemcpy returned error code %d, line %d\n",
@@ -624,6 +720,7 @@ static errno_t compute_function()
                        __LINE__);
                 exit(EXIT_FAILURE);
             }
+
 
             // create d_in
             cudaStat = cudaMalloc((void **)&d_in, sizeof(float) * m);
@@ -849,7 +946,7 @@ static errno_t compute_function()
         }
     }
 
-    printf(" m       = %ld\n", m);
+    printf(" m       = %u\n", mask_npix);
     printf(" n       = %ld\n", n);
     printf(" NBmodes = %ld\n", NBmodes);
 
@@ -1001,16 +1098,38 @@ static errno_t compute_function()
             // load in_stream to GPU
             if(initref == 0)
             {
+                if(use_mask == 1)
+                {
+                    for(uint32_t cc = 0; cc < mask_npix; ++cc)
+                    {
+                        masked_pix[cc] = data.image[IDinref].array.F[mask_idx[cc]];
+                    }
+                }
+                else
+                {
+                    masked_pix = data.image[IDinref].array.F;
+                }
                 cudaStat = cudaMemcpy(d_in,
-                                      data.image[IDinref].array.F,
-                                      sizeof(float) * m,
+                                      masked_pix,
+                                      sizeof(float) * mask_npix,
                                       cudaMemcpyHostToDevice);
             }
             else
             {
+                if(use_mask == 1)
+                {
+                    for(uint32_t cc = 0; cc < mask_npix; ++cc)
+                    {
+                        masked_pix[cc] = imgin.im->array.F[mask_idx[cc]];
+                    }
+                }
+                else
+                {
+                    masked_pix = imgin.im->array.F;
+                }
                 cudaStat = cudaMemcpy(d_in,
-                                      imgin.im->array.F,
-                                      sizeof(float) * m,
+                                      masked_pix,
+                                      sizeof(float) * mask_npix,
                                       cudaMemcpyHostToDevice);
             }
 
@@ -1039,11 +1158,11 @@ static errno_t compute_function()
             // compute
             cublas_status = cublasSgemv(cublasH,
                                         CUBLAS_OP_T,
-                                        m,
+                                        mask_npix,
                                         NBmodes,
                                         &alpha,
                                         d_modes,
-                                        m,
+                                        mask_npix,
                                         d_in,
                                         1,
                                         &beta,

--- a/plugins/milk-extra-src/linalgebra/SingularValueDecomp.c
+++ b/plugins/milk-extra-src/linalgebra/SingularValueDecomp.c
@@ -254,6 +254,14 @@ errno_t compute_SVD(
 {
     DEBUG_TRACE_FSTART();
 
+    // check if images already exist
+    //
+    resolveIMGID(&imgin, ERRMODE_ABORT);
+    resolveIMGID(&imgU, ERRMODE_NULL);
+    resolveIMGID(&imgS, ERRMODE_NULL);
+    resolveIMGID(&imgV, ERRMODE_NULL);
+
+
 
     // input dimensions
     // input matrix is inMdim x inNdim, column-major
@@ -498,13 +506,6 @@ errno_t compute_SVD(
 
 
 
-
-
-
-
-
-
-
     if( !(compSVDmode & COMPSVD_SKIP_BIGMAT) )
     {
         // create mU (if inMshape_tall)
@@ -537,7 +538,6 @@ errno_t compute_SVD(
         }
 
 
-
         // normalize cols of imgmMsvec
         // Report number of modes kept
         //
@@ -563,15 +563,12 @@ errno_t compute_SVD(
 
 
 
-
-
         // Compute pseudo-inverse
         //
         if( (compSVDmode & COMPSVD_COMP_PSINV) )
         {
             // assumes tall matrix
             //
-
             IMGID imgmNsvec1 = mkIMGID_from_name("matNtemp");
             if( imgmNsvec1.ID == -1)
             {
@@ -582,7 +579,6 @@ errno_t compute_SVD(
 
                 createimagefromIMGID(&imgmNsvec1);
             }
-
 
             // multiply by inverse of singular values
             //
@@ -617,8 +613,6 @@ errno_t compute_SVD(
             }
 
 
-
-
             // Check inverse
             //
             if( (compSVDmode & COMPSVD_COMP_CHECKPSINV) )
@@ -635,14 +629,13 @@ errno_t compute_SVD(
 
     }
 
-
-
     // Compute un-normalized modes U
     // Singular Values included in modes U
     //
     if ( imgU.ID != -1 )
     {
         // un-normalized modes
+        delete_image_ID("SVDunmodes", DELETE_IMAGE_ERRMODE_IGNORE);
         IMGID imgunmodes = mkIMGID_from_name("SVDunmodes");
         imgunmodes.naxis = imgU.md->naxis;
         imgunmodes.datatype = imgU.md->datatype;
@@ -667,6 +660,7 @@ errno_t compute_SVD(
             }
         }
 
+        delete_image_ID("SVDinrec", DELETE_IMAGE_ERRMODE_IGNORE);
         IMGID iminrec = mkIMGID_from_name("SVDinrec");
         computeSGEMM(imgunmodes, imgV, &iminrec, 0, 1, GPUdev);
     }
@@ -678,6 +672,7 @@ errno_t compute_SVD(
     if ( imgV.ID != -1 )
     {
         // un-normalized modes
+        delete_image_ID("SVDvnmodes", DELETE_IMAGE_ERRMODE_IGNORE);
         IMGID imgvnmodes = mkIMGID_from_name("SVDvnmodes");
         imgvnmodes.naxis = imgV.md->naxis;
         imgvnmodes.datatype = imgV.md->datatype;
@@ -706,7 +701,6 @@ errno_t compute_SVD(
         //IMGID iminrec = mkIMGID_from_name("SVDinrec");
         //computeSGEMM(imgvnmodes, imgV, &iminrec, 0, 1, GPUdev);
     }
-
 
     DEBUG_TRACE_FEXIT();
     return RETURN_SUCCESS;

--- a/scripts/milk-fpslist-addentry
+++ b/scripts/milk-fpslist-addentry
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+
+
+if [ "${FPSLISTADD_MODE}" = "info" ]; then
+
+	if [ "${FPSKWval}" = "ON" ]; then
+	  printf "\e[1;102;30m ON  \e[0m  "
+	else
+	  printf " OFF   "
+	fi
+
+	printf "\e[1;34m[${FPSKWname}]\e[0m ( ${fpsfcall} -> ${fpsfname} ) ${fpsdescr}\n"
+#	echo "    ${fpsdescr}"
+#	echo "    Name   : ${fpsfname}"
+#	echo "    Call   : ${fpsfcall}"
+
+else
+
+
+if [ -z ${FPSLISTADDSCRIPT+x} ]; then
+	printf "Adding \e[1;34m${FPSKWname}\e[0m:
+script should be sourced by a deployment script setting variable FPSLISTADDSCRIPT,
+and also have the following variables defined:\n"
+    printf "    FPSKWname   : FPS Keyword name\n"
+    printf "    FPSKWval    : FPS keyword value, "ON" for adding the entry\n"
+    printf "    fpsfcall    : Function call\n"
+    printf "    fpsarg0     : Arguments\n"
+    printf "    fpsdescr    : Short description\n"
+    printf "Run this script with FPSLISTADD_MODE set to \"info\" to print above variable values\n"
+else
+
+
+	if [ "${FPSKWval}" = "ON" ]; then
+
+		echolog "ON  ${FPSKWname}"
+
+		if grep -q "${fpsfname}" fpslist.txt
+		then
+			echolog "Process ${fpsfname} already registered - skipping"
+		else
+			echolog "Adding process ${fpsfname}"
+
+            fpsentry_addmodules
+
+			echo "${fpsname}           ${fpsfcall}     ${fpsarg0}" >> fpslist.txt
+
+			addfpscmdheader
+
+			fpsentry_addcmds
+
+		fi
+	else
+		echolog "OFF ${FPSKWname}"
+	fi
+
+
+fi # end of if [ -z ${FPSLISTADDSCRIPT+x} ]
+
+
+fi


### PR DESCRIPTION
This exposes `masksname` in MVMExtractModes, and then only if using GPU, sends only pixels in mask to GPU.  Reformats the matrix on the fly. 

Note ready to merge yet.

Have so far only tested on the SCExAO vispyr2 simulator, and only for WFS modes.  Still need to test on DM modes.

