### PR TITLE
Don't execute function loop code if semaphore trigger has timed out.

### DIFF
--- a/src/CommandLineInterface/CLIcore/CLIcore_utils.h
+++ b/src/CommandLineInterface/CLIcore/CLIcore_utils.h
@@ -407,6 +407,11 @@ typedef struct
             processloopOK = processinfo_loopstep(processinfo);                 \
             DEBUG_TRACEPOINT("waitoninputstream");                             \
             processinfo_waitoninputstream(processinfo);                        \
+            if (processinfo->triggerstatus != PROCESSINFO_TRIGGERSTATUS_RECEIVED)   \
+            {                                                                  \
+                /* Don't execute loop at all upon semaphore timeout */         \
+                continue;                                                      \
+            }                                                                  \
             DEBUG_TRACEPOINT("exec_start");                                    \
             processinfo_exec_start(processinfo);                               \
         }                                                                      \
@@ -911,7 +916,7 @@ static inline imageID resolveIMGID(
 {
     // IF:
     // Not resolved before OR create counter mismatch OR not used
-    if( (img->ID == -1)
+    if((img->ID == -1)
             || (img->createcnt != data.image[img->ID].createcnt)
             || (data.image[img->ID].used != 1))
     {

--- a/src/CommandLineInterface/processtools_trigger.c
+++ b/src/CommandLineInterface/processtools_trigger.c
@@ -261,8 +261,8 @@ errno_t processinfo_waitoninputstream(PROCESSINFO *processinfo)
             // this should only run once, returning semr = -1 with errno = EAGAIN
             // otherwise, we're potentially missing frames
             DEBUG_TRACEPOINT("sem_trywait %ld", processinfo->triggerstreamID);
-            semr = ImageStreamIO_semtrywait(data.image+processinfo->triggerstreamID
-                               ,processinfo->triggersem);
+            semr = ImageStreamIO_semtrywait(data.image + processinfo->triggerstreamID
+                                            , processinfo->triggersem);
             if(semr == 0)
             {
                 processinfo->triggermissedframe++;
@@ -285,9 +285,9 @@ errno_t processinfo_waitoninputstream(PROCESSINFO *processinfo)
                 ts.tv_sec++;
             }
 
-            semr = ImageStreamIO_semtimedwait(data.image+processinfo->triggerstreamID
-                                 ,processinfo->triggersem,
-                                 &ts);
+            semr = ImageStreamIO_semtimedwait(data.image + processinfo->triggerstreamID
+                                              , processinfo->triggersem,
+                                              &ts);
             if(semr == -1)
             {
                 if(errno == ETIMEDOUT)
@@ -297,14 +297,9 @@ errno_t processinfo_waitoninputstream(PROCESSINFO *processinfo)
                     tmpstatus = PROCESSINFO_TRIGGERSTATUS_TIMEDOUT;
                 }
             }
-
-            // measure time spent waiting for input
-            // get current time
-            struct timespec ts1;
-            if(clock_gettime(CLOCK_MILK, &ts1) == -1)
+            else
             {
-                perror("clock_gettime");
-                exit(EXIT_FAILURE);
+                tmpstatus = PROCESSINFO_TRIGGERSTATUS_RECEIVED;
             }
         }
 


### PR DESCRIPTION
Minor, but core modification to the processinfo trigger system.

The only effect achieved is that when the `triggermode` is `SEMAPHORE`, and we hit the 1 second timeout without an upstream trigger, we bypass inner code of the function loop.

In effect, this avoids all the downstream SHMs all clicking at 1Hz. And it lets us leave our `mvalC2dm-X` MVM RUN process ON at all times without it triggering the DMcomb downstream (and thus, for SCExAO, preventing the DM going to idle mode).

Objections anyone?

`semtimedwait` as a default and posting to refresh all downstream SHMs was useful once upon a time when we were dealing with semaphore hell, but I think we're good now.
I also tossed a `clock_gettime` that wasn't used by anything.