### PR TITLE
fixed milk-tutorial path

### DIFF
--- a/src/milk_module_example/scripts/milk-tutorial
+++ b/src/milk_module_example/scripts/milk-tutorial
@@ -89,7 +89,7 @@ function ProbeUserRunExample {
 
 
 
-ExampleDir="${HOME}/src/milk/src/milk_module_example/examples/"
+ExampleDir="${MILK_ROOT}/src/milk_module_example/examples/"
 
 loopOK=1
 while [ ${loopOK} = 1 ]; do


### PR DESCRIPTION
tutorial points to correct path now, using $MILK_ROOT