### PR TITLE
Introduce PROCESSINFO_TRIGGERMODE_SEMAPHORE_PROP_TIMEOUTS and make it…

### DIFF
--- a/src/COREMOD_memory/scripts/milk-streamFITSlog
+++ b/src/COREMOD_memory/scripts/milk-streamFITSlog
@@ -309,7 +309,7 @@ milk << EOF
 readshmim ${STREAMNAME}
 streamFITSlog ..procinfo 1
 streamFITSlog ..loopcntMax -1
-streamFITSlog ..triggermode 3
+streamFITSlog ..triggermode 5
 streamFITSlog ..triggersname ${STREAMNAME}
 streamFITSlog ..triggertimeout ${cubetimeout}
 streamFITSlog ..RTprio ${realtimeprio}

--- a/src/CommandLineInterface/CLIcore/CLIcore_utils.h
+++ b/src/CommandLineInterface/CLIcore/CLIcore_utils.h
@@ -407,9 +407,12 @@ typedef struct
             processloopOK = processinfo_loopstep(processinfo);                 \
             DEBUG_TRACEPOINT("waitoninputstream");                             \
             processinfo_waitoninputstream(processinfo);                        \
-            if (processinfo->triggerstatus != PROCESSINFO_TRIGGERSTATUS_RECEIVED)   \
+            if (processinfo->triggerstatus == PROCESSINFO_TRIGGERSTATUS_TIMEDOUT && \
+                processinfo->triggermode == PROCESSINFO_TRIGGERMODE_SEMAPHORE)      \
             {                                                                  \
                 /* Don't execute loop at all upon semaphore timeout */         \
+                /* Except if the trigger is SEMAPHORE_PROP_TIMEOUTS */         \
+                /* in which case we avoid this block and keep going */         \
                 continue;                                                      \
             }                                                                  \
             DEBUG_TRACEPOINT("exec_start");                                    \
@@ -938,24 +941,12 @@ static inline imageID resolveIMGID(
     {
         if((ERRMODE == ERRMODE_FAIL) || (ERRMODE == ERRMODE_ABORT))
         {
-            printf("ERROR: %c[%d;%dm Cannot resolve image %s %c[%d;m\n",
-                   (char) 27,
-                   1,
-                   31,
-                   img->name,
-                   (char) 27,
-                   0);
+            PRINT_ERROR("Cannot resolve image %s\n", img->name);
             abort();
         }
         else if(ERRMODE == ERRMODE_WARN)
         {
-            printf("WARNING: %c[%d;%dm Cannot resolve image %s %c[%d;m\n",
-                   (char) 27,
-                   1,
-                   35,
-                   img->name,
-                   (char) 27,
-                   0);
+            PRINT_WARNING("Cannot resolve image %s\n", img->name);
         }
     }
 

--- a/src/CommandLineInterface/processtools_trigger.c
+++ b/src/CommandLineInterface/processtools_trigger.c
@@ -238,7 +238,8 @@ errno_t processinfo_waitoninputstream(PROCESSINFO *processinfo)
         return RETURN_SUCCESS;
     }
 
-    if(processinfo->triggermode == PROCESSINFO_TRIGGERMODE_SEMAPHORE)
+    if(processinfo->triggermode == PROCESSINFO_TRIGGERMODE_SEMAPHORE ||
+            processinfo->triggermode == PROCESSINFO_TRIGGERMODE_SEMAPHORE_PROP_TIMEOUTS)
     {
         int semr;
         int tmpstatus = PROCESSINFO_TRIGGERSTATUS_RECEIVED;

--- a/src/CommandLineInterface/processtools_trigger.h
+++ b/src/CommandLineInterface/processtools_trigger.h
@@ -26,10 +26,14 @@
 // trigger after a time delay
 #define PROCESSINFO_TRIGGERMODE_DELAY 4
 
+// trigger when semaphore is posted AND propagate the timeout (i.e. enter the execution anyway)
+#define PROCESSINFO_TRIGGERMODE_SEMAPHORE_PROP_TIMEOUTS 5
+
 // trigger is currently waiting for input
 #define PROCESSINFO_TRIGGERSTATUS_WAITING 1
-
+// trigger has been received and we're executing the loop
 #define PROCESSINFO_TRIGGERSTATUS_RECEIVED 2
+// trigger has not been received but we've skipped out of the wait into the execution of the loop
 #define PROCESSINFO_TRIGGERSTATUS_TIMEDOUT 3
 
 #include "CLIcore.h"


### PR DESCRIPTION
… default for milk-streamFITSlog.

Adding triggermode 5, which is also a semaphore mode.

In triggermode `PROCESSINFO_TRIGGERMODE_SEMAPHORE` (==3), the TIMEOUT is caught and the overall computation is shunted into a `continue;`
In `PROCESSINFO_TRIGGERMODE_SEMAPHORE_PROP_TIMEOUTS` (==5), the timeout is willfully propagated, the execution of the loop iteration begins, and the timeout status can be checked in processinfo if need be. This actually emulates the old semaphore behavior when timeouts would propagate (by default every second) and click the AO chain unit after unit.

This fixes the following issues in logshim:
- FITS cube is finalized and dumped upon stream timeout
- FITS cube is finalized and dumped if saveON is set to False after the last frame

@oguyon foresee any pitfall?