### PR TITLE
Use pointer to IMGID in function calls

### DIFF
--- a/src/COREMOD_arith/image_arith__im__im.c
+++ b/src/COREMOD_arith/image_arith__im__im.c
@@ -15,6 +15,7 @@
 
 #include "imfunctions.h"
 #include "mathfuncs.h"
+#include "image_arith__im__im.h"
 
 int arith_image_acos_byID(long ID, long IDout)
 {
@@ -118,106 +119,208 @@ int arith_image_positive_byID(long ID, long IDout)
     return (0);
 }
 
+int arith_image_acos_IMGID(IMGID *imgin, IMGID *imgout)
+{
+    return arith_image_function_1_1_IMGID(imgin, imgout, &Pacos);
+}
+
 int arith_image_acos(const char *ID_name, const char *ID_out)
 {
-    arith_image_function_1_1(ID_name, ID_out, &Pacos);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_acos_IMGID(&imgin, &imgout);
+}
+
+int arith_image_asin_IMGID(IMGID *imgin, IMGID *imgout)
+{
+    return arith_image_function_1_1_IMGID(imgin, imgout, &Pasin);
 }
 
 int arith_image_asin(const char *ID_name, const char *ID_out)
 {
-    arith_image_function_1_1(ID_name, ID_out, &Pasin);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_asin_IMGID(&imgin, &imgout);
+}
+
+int arith_image_atan_IMGID(IMGID *imgin, IMGID *imgout)
+{
+    return arith_image_function_1_1_IMGID(imgin, imgout, &Patan);
 }
 
 int arith_image_atan(const char *ID_name, const char *ID_out)
 {
-    arith_image_function_1_1(ID_name, ID_out, &Patan);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_atan_IMGID(&imgin, &imgout);
+}
+
+int arith_image_ceil_IMGID(IMGID *imgin, IMGID *imgout)
+{
+    return arith_image_function_1_1_IMGID(imgin, imgout, &Pceil);
 }
 
 int arith_image_ceil(const char *ID_name, const char *ID_out)
 {
-    arith_image_function_1_1(ID_name, ID_out, &Pceil);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_ceil_IMGID(&imgin, &imgout);
+}
+
+int arith_image_cos_IMGID(IMGID *imgin, IMGID *imgout)
+{
+    return arith_image_function_1_1_IMGID(imgin, imgout, &Pcos);
 }
 
 int arith_image_cos(const char *ID_name, const char *ID_out)
 {
-    arith_image_function_1_1(ID_name, ID_out, &Pcos);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_cos_IMGID(&imgin, &imgout);
+}
+
+int arith_image_cosh_IMGID(IMGID *imgin, IMGID *imgout)
+{
+    return arith_image_function_1_1_IMGID(imgin, imgout, &Pcosh);
 }
 
 int arith_image_cosh(const char *ID_name, const char *ID_out)
 {
-    arith_image_function_1_1(ID_name, ID_out, &Pcosh);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_cosh_IMGID(&imgin, &imgout);
+}
+
+int arith_image_exp_IMGID(IMGID *imgin, IMGID *imgout)
+{
+    return arith_image_function_1_1_IMGID(imgin, imgout, &Pexp);
 }
 
 int arith_image_exp(const char *ID_name, const char *ID_out)
 {
-    arith_image_function_1_1(ID_name, ID_out, &Pexp);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_exp_IMGID(&imgin, &imgout);
+}
+
+int arith_image_fabs_IMGID(IMGID *imgin, IMGID *imgout)
+{
+    return arith_image_function_1_1_IMGID(imgin, imgout, &Pfabs);
 }
 
 int arith_image_fabs(const char *ID_name, const char *ID_out)
 {
-    arith_image_function_1_1(ID_name, ID_out, &Pfabs);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_fabs_IMGID(&imgin, &imgout);
+}
+
+int arith_image_floor_IMGID(IMGID *imgin, IMGID *imgout)
+{
+    return arith_image_function_1_1_IMGID(imgin, imgout, &Pfloor);
 }
 
 int arith_image_floor(const char *ID_name, const char *ID_out)
 {
-    arith_image_function_1_1(ID_name, ID_out, &Pfloor);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_floor_IMGID(&imgin, &imgout);
+}
+
+int arith_image_ln_IMGID(IMGID *imgin, IMGID *imgout)
+{
+    return arith_image_function_1_1_IMGID(imgin, imgout, &Pln);
 }
 
 int arith_image_ln(const char *ID_name, const char *ID_out)
 {
-    arith_image_function_1_1(ID_name, ID_out, &Pln);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_ln_IMGID(&imgin, &imgout);
+}
+
+int arith_image_log_IMGID(IMGID *imgin, IMGID *imgout)
+{
+    return arith_image_function_1_1_IMGID(imgin, imgout, &Plog);
 }
 
 int arith_image_log(const char *ID_name, const char *ID_out)
 {
-    arith_image_function_1_1(ID_name, ID_out, &Plog);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_log_IMGID(&imgin, &imgout);
+}
+
+int arith_image_sqrt_IMGID(IMGID *imgin, IMGID *imgout)
+{
+    return arith_image_function_1_1_IMGID(imgin, imgout, &Psqrt);
 }
 
 int arith_image_sqrt(const char *ID_name, const char *ID_out)
 {
-    arith_image_function_1_1(ID_name, ID_out, &Psqrt);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_sqrt_IMGID(&imgin, &imgout);
+}
+
+int arith_image_sin_IMGID(IMGID *imgin, IMGID *imgout)
+{
+    return arith_image_function_1_1_IMGID(imgin, imgout, &Psin);
 }
 
 int arith_image_sin(const char *ID_name, const char *ID_out)
 {
-    arith_image_function_1_1(ID_name, ID_out, &Psin);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_sin_IMGID(&imgin, &imgout);
+}
+
+int arith_image_sinh_IMGID(IMGID *imgin, IMGID *imgout)
+{
+    return arith_image_function_1_1_IMGID(imgin, imgout, &Psinh);
 }
 
 int arith_image_sinh(const char *ID_name, const char *ID_out)
 {
-    arith_image_function_1_1(ID_name, ID_out, &Psinh);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_sinh_IMGID(&imgin, &imgout);
+}
+
+int arith_image_tan_IMGID(IMGID *imgin, IMGID *imgout)
+{
+    return arith_image_function_1_1_IMGID(imgin, imgout, &Ptan);
 }
 
 int arith_image_tan(const char *ID_name, const char *ID_out)
 {
-    arith_image_function_1_1(ID_name, ID_out, &Ptan);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_tan_IMGID(&imgin, &imgout);
+}
+
+int arith_image_tanh_IMGID(IMGID *imgin, IMGID *imgout)
+{
+    return arith_image_function_1_1_IMGID(imgin, imgout, &Ptanh);
 }
 
 int arith_image_tanh(const char *ID_name, const char *ID_out)
 {
-    arith_image_function_1_1(ID_name, ID_out, &Ptanh);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_tanh_IMGID(&imgin, &imgout);
+}
+
+int arith_image_positive_IMGID(IMGID *imgin, IMGID *imgout)
+{
+    return arith_image_function_1_1_IMGID(imgin, imgout, &Ppositive);
 }
 
 int arith_image_positive(const char *ID_name, const char *ID_out)
 {
-    arith_image_function_1_1(ID_name, ID_out, &Ppositive);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_positive_IMGID(&imgin, &imgout);
 }
 
 int arith_image_acos_inplace_byID(long ID)

--- a/src/COREMOD_arith/image_arith__im__im.h
+++ b/src/COREMOD_arith/image_arith__im__im.h
@@ -27,22 +27,55 @@ int arith_image_tan_byID(long ID, long IDout);
 int arith_image_tanh_byID(long ID, long IDout);
 
 int arith_image_acos(const char *ID_name, const char *ID_out);
+int arith_image_acos_IMGID(IMGID *imgin, IMGID *imgout);
+
 int arith_image_asin(const char *ID_name, const char *ID_out);
+int arith_image_asin_IMGID(IMGID *imgin, IMGID *imgout);
+
 int arith_image_atan(const char *ID_name, const char *ID_out);
+int arith_image_atan_IMGID(IMGID *imgin, IMGID *imgout);
+
 int arith_image_ceil(const char *ID_name, const char *ID_out);
+int arith_image_ceil_IMGID(IMGID *imgin, IMGID *imgout);
+
 int arith_image_cos(const char *ID_name, const char *ID_out);
+int arith_image_cos_IMGID(IMGID *imgin, IMGID *imgout);
+
 int arith_image_cosh(const char *ID_name, const char *ID_out);
+int arith_image_cosh_IMGID(IMGID *imgin, IMGID *imgout);
+
 int arith_image_exp(const char *ID_name, const char *ID_out);
+int arith_image_exp_IMGID(IMGID *imgin, IMGID *imgout);
+
 int arith_image_fabs(const char *ID_name, const char *ID_out);
+int arith_image_fabs_IMGID(IMGID *imgin, IMGID *imgout);
+
 int arith_image_floor(const char *ID_name, const char *ID_out);
+int arith_image_floor_IMGID(IMGID *imgin, IMGID *imgout);
+
 int arith_image_ln(const char *ID_name, const char *ID_out);
+int arith_image_ln_IMGID(IMGID *imgin, IMGID *imgout);
+
 int arith_image_log(const char *ID_name, const char *ID_out);
+int arith_image_log_IMGID(IMGID *imgin, IMGID *imgout);
+
 int arith_image_sqrt(const char *ID_name, const char *ID_out);
+int arith_image_sqrt_IMGID(IMGID *imgin, IMGID *imgout);
+
 int arith_image_sin(const char *ID_name, const char *ID_out);
+int arith_image_sin_IMGID(IMGID *imgin, IMGID *imgout);
+
 int arith_image_sinh(const char *ID_name, const char *ID_out);
+int arith_image_sinh_IMGID(IMGID *imgin, IMGID *imgout);
+
 int arith_image_tan(const char *ID_name, const char *ID_out);
+int arith_image_tan_IMGID(IMGID *imgin, IMGID *imgout);
+
 int arith_image_tanh(const char *ID_name, const char *ID_out);
+int arith_image_tanh_IMGID(IMGID *imgin, IMGID *imgout);
+
 int arith_image_positive(const char *ID_name, const char *ID_out);
+int arith_image_positive_IMGID(IMGID *imgin, IMGID *imgout);
 
 int arith_image_acos_inplace_byID(long ID);
 int arith_image_asin_inplace_byID(long ID);

--- a/src/COREMOD_arith/image_arith__im_f__im.c
+++ b/src/COREMOD_arith/image_arith__im_f__im.c
@@ -15,78 +15,151 @@
 
 #include "imfunctions.h"
 #include "mathfuncs.h"
+#include "image_arith__im_f__im.h"
 
+
+int arith_image_cstfmod_IMGID(IMGID *imgin, double f1, IMGID *imgout)
+{
+    return arith_image_function_1f_1_IMGID(imgin, f1, imgout, &Pfmod);
+}
 
 int arith_image_cstfmod(const char *ID_name, double f1, const char *ID_out)
 {
-    arith_image_function_1f_1(ID_name, f1, ID_out, &Pfmod);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_cstfmod_IMGID(&imgin, f1, &imgout);
+}
+
+int arith_image_cstadd_IMGID(IMGID *imgin, double f1, IMGID *imgout)
+{
+    return arith_image_function_1f_1_IMGID(imgin, f1, imgout, &Padd);
 }
 
 int arith_image_cstadd(const char *ID_name, double f1, const char *ID_out)
 {
-    arith_image_function_1f_1(ID_name, f1, ID_out, &Padd);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_cstadd_IMGID(&imgin, f1, &imgout);
+}
+
+int arith_image_cstsub_IMGID(IMGID *imgin, double f1, IMGID *imgout)
+{
+    return arith_image_function_1f_1_IMGID(imgin, f1, imgout, &Psub);
 }
 
 int arith_image_cstsub(const char *ID_name, double f1, const char *ID_out)
 {
-    arith_image_function_1f_1(ID_name, f1, ID_out, &Psub);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_cstsub_IMGID(&imgin, f1, &imgout);
+}
+
+int arith_image_cstsubm_IMGID(IMGID *imgin, double f1, IMGID *imgout)
+{
+    return arith_image_function_1f_1_IMGID(imgin, f1, imgout, &Psubm);
 }
 
 int arith_image_cstsubm(const char *ID_name, double f1, const char *ID_out)
 {
-    arith_image_function_1f_1(ID_name, f1, ID_out, &Psubm);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_cstsubm_IMGID(&imgin, f1, &imgout);
+}
+
+int arith_image_cstmult_IMGID(IMGID *imgin, double f1, IMGID *imgout)
+{
+    return arith_image_function_1f_1_IMGID(imgin, f1, imgout, &Pmult);
 }
 
 int arith_image_cstmult(const char *ID_name, double f1, const char *ID_out)
 {
-    arith_image_function_1f_1(ID_name, f1, ID_out, &Pmult);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_cstmult_IMGID(&imgin, f1, &imgout);
+}
+
+int arith_image_cstdiv_IMGID(IMGID *imgin, double f1, IMGID *imgout)
+{
+    return arith_image_function_1f_1_IMGID(imgin, f1, imgout, &Pdiv);
 }
 
 int arith_image_cstdiv(const char *ID_name, double f1, const char *ID_out)
 {
-    arith_image_function_1f_1(ID_name, f1, ID_out, &Pdiv);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_cstdiv_IMGID(&imgin, f1, &imgout);
+}
+
+int arith_image_cstdiv1_IMGID(IMGID *imgin, double f1, IMGID *imgout)
+{
+    return arith_image_function_1f_1_IMGID(imgin, f1, imgout, &Pdiv1);
 }
 
 int arith_image_cstdiv1(const char *ID_name, double f1, const char *ID_out)
 {
-    arith_image_function_1f_1(ID_name, f1, ID_out, &Pdiv1);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_cstdiv1_IMGID(&imgin, f1, &imgout);
+}
+
+int arith_image_cstpow_IMGID(IMGID *imgin, double f1, IMGID *imgout)
+{
+    return arith_image_function_1f_1_IMGID(imgin, f1, imgout, &Ppow);
 }
 
 int arith_image_cstpow(const char *ID_name, double f1, const char *ID_out)
 {
-    arith_image_function_1f_1(ID_name, f1, ID_out, &Ppow);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_cstpow_IMGID(&imgin, f1, &imgout);
+}
+
+int arith_image_cstmaxv_IMGID(IMGID *imgin, double f1, IMGID *imgout)
+{
+    return arith_image_function_1f_1_IMGID(imgin, f1, imgout, &Pmaxv);
 }
 
 int arith_image_cstmaxv(const char *ID_name, double f1, const char *ID_out)
 {
-    arith_image_function_1f_1(ID_name, f1, ID_out, &Pmaxv);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_cstmaxv_IMGID(&imgin, f1, &imgout);
+}
+
+int arith_image_cstminv_IMGID(IMGID *imgin, double f1, IMGID *imgout)
+{
+    return arith_image_function_1f_1_IMGID(imgin, f1, imgout, &Pminv);
 }
 
 int arith_image_cstminv(const char *ID_name, double f1, const char *ID_out)
 {
-    arith_image_function_1f_1(ID_name, f1, ID_out, &Pminv);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_cstminv_IMGID(&imgin, f1, &imgout);
+}
+
+int arith_image_csttestlt_IMGID(IMGID *imgin, double f1, IMGID *imgout)
+{
+    return arith_image_function_1f_1_IMGID(imgin, f1, imgout, &Ptestlt);
 }
 
 int arith_image_csttestlt(const char *ID_name, double f1, const char *ID_out)
 {
-    arith_image_function_1f_1(ID_name, f1, ID_out, &Ptestlt);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_csttestlt_IMGID(&imgin, f1, &imgout);
+}
+
+int arith_image_csttestmt_IMGID(IMGID *imgin, double f1, IMGID *imgout)
+{
+    return arith_image_function_1f_1_IMGID(imgin, f1, imgout, &Ptestmt);
 }
 
 int arith_image_csttestmt(const char *ID_name, double f1, const char *ID_out)
 {
-    arith_image_function_1f_1(ID_name, f1, ID_out, &Ptestmt);
-    return (0);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_csttestmt_IMGID(&imgin, f1, &imgout);
 }
 
 int arith_image_cstfmod_inplace(const char *ID_name, double f1)

--- a/src/COREMOD_arith/image_arith__im_f__im.h
+++ b/src/COREMOD_arith/image_arith__im_f__im.h
@@ -4,28 +4,40 @@
  */
 
 int arith_image_cstfmod(const char *ID_name, double f1, const char *ID_out);
+int arith_image_cstfmod_IMGID(IMGID *imgin, double f1, IMGID *imgout);
 
 int arith_image_cstadd(const char *ID_name, double f1, const char *ID_out);
+int arith_image_cstadd_IMGID(IMGID *imgin, double f1, IMGID *imgout);
 
 int arith_image_cstsub(const char *ID_name, double f1, const char *ID_out);
+int arith_image_cstsub_IMGID(IMGID *imgin, double f1, IMGID *imgout);
 
 int arith_image_cstsubm(const char *ID_name, double f1, const char *ID_out);
+int arith_image_cstsubm_IMGID(IMGID *imgin, double f1, IMGID *imgout);
 
 int arith_image_cstmult(const char *ID_name, double f1, const char *ID_out);
+int arith_image_cstmult_IMGID(IMGID *imgin, double f1, IMGID *imgout);
 
 int arith_image_cstdiv(const char *ID_name, double f1, const char *ID_out);
+int arith_image_cstdiv_IMGID(IMGID *imgin, double f1, IMGID *imgout);
 
 int arith_image_cstdiv1(const char *ID_name, double f1, const char *ID_out);
+int arith_image_cstdiv1_IMGID(IMGID *imgin, double f1, IMGID *imgout);
 
 int arith_image_cstpow(const char *ID_name, double f1, const char *ID_out);
+int arith_image_cstpow_IMGID(IMGID *imgin, double f1, IMGID *imgout);
 
 int arith_image_cstmaxv(const char *ID_name, double f1, const char *ID_out);
+int arith_image_cstmaxv_IMGID(IMGID *imgin, double f1, IMGID *imgout);
 
 int arith_image_cstminv(const char *ID_name, double f1, const char *ID_out);
+int arith_image_cstminv_IMGID(IMGID *imgin, double f1, IMGID *imgout);
 
 int arith_image_csttestlt(const char *ID_name, double f1, const char *ID_out);
+int arith_image_csttestlt_IMGID(IMGID *imgin, double f1, IMGID *imgout);
 
 int arith_image_csttestmt(const char *ID_name, double f1, const char *ID_out);
+int arith_image_csttestmt_IMGID(IMGID *imgin, double f1, IMGID *imgout);
 
 int arith_image_cstfmod_inplace(const char *ID_name, double f1);
 

--- a/src/COREMOD_arith/image_arith__im_f_f__im.c
+++ b/src/COREMOD_arith/image_arith__im_f_f__im.c
@@ -15,12 +15,8 @@
 
 #include "imfunctions.h"
 #include "mathfuncs.h"
+#include "image_arith__im_f_f__im.h"
 
-
-int arith_image_trunc(const char *ID_name,
-                      double      f1,
-                      double      f2,
-                      const char *ID_out);
 
 // ==========================================
 // Command line interface wrapper function(s)
@@ -86,7 +82,11 @@ static errno_t help_function()
 
 static errno_t compute_function()
 {
-    arith_image_trunc(inimname, *valmin, *valmax, outimname);
+    IMGID imgin  = mkIMGID_from_name(inimname);
+    IMGID imgout = mkIMGID_from_name(outimname);
+
+    arith_image_trunc_IMGID(&imgin, *valmin, *valmax, &imgout);
+
     return RETURN_SUCCESS;
 }
 
@@ -102,12 +102,25 @@ errno_t image_arith__im_f_f__im_addCLIcmd()
     return RETURN_SUCCESS;
 }
 
+int arith_image_trunc_IMGID(IMGID *imgin,
+                            double f1,
+                            double f2,
+                            IMGID *imgout)
+{
+    arith_image_function_1ff_1_IMGID(imgin, f1, f2, imgout, &Ptrunc);
+    return (0);
+}
+
 int arith_image_trunc(const char *ID_name,
                       double      f1,
                       double      f2,
                       const char *ID_out)
 {
-    arith_image_function_1ff_1(ID_name, f1, f2, ID_out, &Ptrunc);
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+
+    arith_image_trunc_IMGID(&imgin, f1, f2, &imgout);
+
     return (0);
 }
 

--- a/src/COREMOD_arith/image_arith__im_f_f__im.h
+++ b/src/COREMOD_arith/image_arith__im_f_f__im.h
@@ -13,4 +13,9 @@ int arith_image_trunc(const char *ID_name,
                       double      f2,
                       const char *ID_out);
 
+int arith_image_trunc_IMGID(IMGID  *imgin,
+                            double  f1,
+                            double  f2,
+                            IMGID  *imgout);
+
 int arith_image_trunc_inplace(const char *ID_name, double f1, double f2);

--- a/src/COREMOD_arith/image_arith__im_im__im.c
+++ b/src/COREMOD_arith/image_arith__im_im__im.c
@@ -15,85 +15,156 @@
 
 #include "imfunctions.h"
 #include "mathfuncs.h"
+#include "image_arith__im_im__im.h"
+
+int arith_image_fmod_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout)
+{
+    return arith_image_function_2_1_IMGID(imgin1, imgin2, imgout, &Pfmod);
+}
 
 int arith_image_fmod(const char *ID1_name,
                      const char *ID2_name,
                      const char *ID_out)
 {
-    arith_image_function_2_1(ID1_name, ID2_name, ID_out, &Pfmod);
-    return (0);
+    IMGID imgin1 = mkIMGID_from_name(ID1_name);
+    IMGID imgin2 = mkIMGID_from_name(ID2_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_fmod_IMGID(&imgin1, &imgin2, &imgout);
+}
+
+int arith_image_pow_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout)
+{
+    return arith_image_function_2_1_IMGID(imgin1, imgin2, imgout, &Ppow);
 }
 
 int arith_image_pow(const char *ID1_name,
                     const char *ID2_name,
                     const char *ID_out)
 {
-    arith_image_function_2_1(ID1_name, ID2_name, ID_out, &Ppow);
-    return (0);
+    IMGID imgin1 = mkIMGID_from_name(ID1_name);
+    IMGID imgin2 = mkIMGID_from_name(ID2_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_pow_IMGID(&imgin1, &imgin2, &imgout);
+}
+
+int arith_image_add_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout)
+{
+    return arith_image_function_2_1_IMGID(imgin1, imgin2, imgout, &Padd);
 }
 
 int arith_image_add(const char *ID1_name,
                     const char *ID2_name,
                     const char *ID_out)
 {
-    arith_image_function_2_1(ID1_name, ID2_name, ID_out, &Padd);
-    return (0);
+    IMGID imgin1 = mkIMGID_from_name(ID1_name);
+    IMGID imgin2 = mkIMGID_from_name(ID2_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_add_IMGID(&imgin1, &imgin2, &imgout);
+}
+
+int arith_image_sub_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout)
+{
+    return arith_image_function_2_1_IMGID(imgin1, imgin2, imgout, &Psub);
 }
 
 int arith_image_sub(const char *ID1_name,
                     const char *ID2_name,
                     const char *ID_out)
 {
-    arith_image_function_2_1(ID1_name, ID2_name, ID_out, &Psub);
-    return (0);
+    IMGID imgin1 = mkIMGID_from_name(ID1_name);
+    IMGID imgin2 = mkIMGID_from_name(ID2_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_sub_IMGID(&imgin1, &imgin2, &imgout);
+}
+
+int arith_image_mult_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout)
+{
+    return arith_image_function_2_1_IMGID(imgin1, imgin2, imgout, &Pmult);
 }
 
 int arith_image_mult(const char *ID1_name,
                      const char *ID2_name,
                      const char *ID_out)
 {
-    arith_image_function_2_1(ID1_name, ID2_name, ID_out, &Pmult);
-    return (0);
+    IMGID imgin1 = mkIMGID_from_name(ID1_name);
+    IMGID imgin2 = mkIMGID_from_name(ID2_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_mult_IMGID(&imgin1, &imgin2, &imgout);
+}
+
+int arith_image_div_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout)
+{
+    return arith_image_function_2_1_IMGID(imgin1, imgin2, imgout, &Pdiv);
 }
 
 int arith_image_div(const char *ID1_name,
                     const char *ID2_name,
                     const char *ID_out)
 {
-    arith_image_function_2_1(ID1_name, ID2_name, ID_out, &Pdiv);
-    return (0);
+    IMGID imgin1 = mkIMGID_from_name(ID1_name);
+    IMGID imgin2 = mkIMGID_from_name(ID2_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_div_IMGID(&imgin1, &imgin2, &imgout);
+}
+
+int arith_image_minv_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout)
+{
+    return arith_image_function_2_1_IMGID(imgin1, imgin2, imgout, &Pminv);
 }
 
 int arith_image_minv(const char *ID1_name,
                      const char *ID2_name,
                      const char *ID_out)
 {
-    arith_image_function_2_1(ID1_name, ID2_name, ID_out, &Pminv);
-    return (0);
+    IMGID imgin1 = mkIMGID_from_name(ID1_name);
+    IMGID imgin2 = mkIMGID_from_name(ID2_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_minv_IMGID(&imgin1, &imgin2, &imgout);
+}
+
+int arith_image_maxv_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout)
+{
+    return arith_image_function_2_1_IMGID(imgin1, imgin2, imgout, &Pmaxv);
 }
 
 int arith_image_maxv(const char *ID1_name,
                      const char *ID2_name,
                      const char *ID_out)
 {
-    arith_image_function_2_1(ID1_name, ID2_name, ID_out, &Pmaxv);
-    return (0);
+    IMGID imgin1 = mkIMGID_from_name(ID1_name);
+    IMGID imgin2 = mkIMGID_from_name(ID2_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_maxv_IMGID(&imgin1, &imgin2, &imgout);
+}
+
+int arith_image_testlt_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout)
+{
+    return arith_image_function_2_1_IMGID(imgin1, imgin2, imgout, &Ptestlt);
 }
 
 int arith_image_testlt(const char *ID1_name,
                        const char *ID2_name,
                        const char *ID_out)
 {
-    arith_image_function_2_1(ID1_name, ID2_name, ID_out, &Ptestlt);
-    return (0);
+    IMGID imgin1 = mkIMGID_from_name(ID1_name);
+    IMGID imgin2 = mkIMGID_from_name(ID2_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_testlt_IMGID(&imgin1, &imgin2, &imgout);
+}
+
+int arith_image_testmt_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout)
+{
+    return arith_image_function_2_1_IMGID(imgin1, imgin2, imgout, &Ptestmt);
 }
 
 int arith_image_testmt(const char *ID1_name,
                        const char *ID2_name,
                        const char *ID_out)
 {
-    arith_image_function_2_1(ID1_name, ID2_name, ID_out, &Ptestmt);
-    return (0);
+    IMGID imgin1 = mkIMGID_from_name(ID1_name);
+    IMGID imgin2 = mkIMGID_from_name(ID2_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+    return arith_image_testmt_IMGID(&imgin1, &imgin2, &imgout);
 }
 
 int arith_image_fmod_inplace(const char *ID1_name, const char *ID2_name)

--- a/src/COREMOD_arith/image_arith__im_im__im.h
+++ b/src/COREMOD_arith/image_arith__im_im__im.h
@@ -21,33 +21,52 @@ int arith_image_maxv_byID(long ID1, long ID2, long IDout);
 int arith_image_fmod(const char *ID1_name,
                      const char *ID2_name,
                      const char *ID_out);
+int arith_image_fmod_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
+
 int arith_image_pow(const char *ID1_name,
                     const char *ID2_name,
                     const char *ID_out);
+int arith_image_pow_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
+
 int arith_image_add(const char *ID1_name,
                     const char *ID2_name,
                     const char *ID_out);
+int arith_image_add_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
+
 int arith_image_sub(const char *ID1_name,
                     const char *ID2_name,
                     const char *ID_out);
+int arith_image_sub_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
+
 int arith_image_mult(const char *ID1_name,
                      const char *ID2_name,
                      const char *ID_out);
+int arith_image_mult_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
+
 int arith_image_div(const char *ID1_name,
                     const char *ID2_name,
                     const char *ID_out);
+int arith_image_div_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
+
 int arith_image_minv(const char *ID1_name,
                      const char *ID2_name,
                      const char *ID_out);
+int arith_image_minv_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
+
 int arith_image_maxv(const char *ID1_name,
                      const char *ID2_name,
                      const char *ID_out);
+int arith_image_maxv_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
+
 int arith_image_testlt(const char *ID1_name,
                        const char *ID2_name,
                        const char *ID_out);
+int arith_image_testlt_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
+
 int arith_image_testmt(const char *ID1_name,
                        const char *ID2_name,
                        const char *ID_out);
+int arith_image_testmt_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
 
 int arith_image_fmod_inplace_byID(long ID1, long ID2);
 int arith_image_pow_inplace_byID(long ID1, long ID2);

--- a/src/COREMOD_arith/image_dxdy.c
+++ b/src/COREMOD_arith/image_dxdy.c
@@ -7,121 +7,114 @@
 #include <assert.h>
 
 #include "CommandLineInterface/CLIcore.h"
+#include "image_dxdy.h"
 
 #include "COREMOD_memory/COREMOD_memory.h"
 
-imageID arith_image_dx(const char *ID_name, const char *IDout_name)
+imageID arith_image_dx_IMGID(IMGID *imgin, IMGID *imgout)
 {
-    imageID   ID;
-    imageID   IDout;
-    uint32_t *naxes = NULL;
-    uint8_t   naxis;
-    uint8_t   datatype;
+    DEBUG_TRACE_FSTART();
 
-    ID       = image_ID(ID_name);
-    datatype = data.image[ID].md[0].datatype;
-    naxis    = data.image[ID].md[0].naxis;
+    resolveIMGID(imgin, ERRMODE_ABORT);
+    uint8_t   datatype = imgin->md[0].datatype;
+    uint8_t   naxis    = imgin->md[0].naxis;
     if(naxis != 2)
     {
         PRINT_ERROR("Function only supports 2-D images\n");
         abort();
     }
 
-    assert(naxis != 0);
-    naxes = (uint32_t *) malloc(sizeof(uint32_t) * naxis);
-    if(naxes == NULL)
+    imgout->naxis = 2;
+    imgout->size[0] = imgin->md[0].size[0];
+    imgout->size[1] = imgin->md[0].size[1];
+    imgout->datatype = datatype;
+    imgout->shared = data.SHARED_DFT;
+    imgout->NBkw   = NB_KEYWNODE_MAX;
+
+    imcreateIMGID(imgout);
+
+    uint32_t xsize = imgout->size[0];
+    uint32_t ysize = imgout->size[1];
+
+    for(uint32_t jj = 0; jj < ysize; jj++)
     {
-        PRINT_ERROR("malloc error. size %d", (int) naxis);
+        for(uint32_t ii = 1; ii < xsize - 1; ii++)
+            imgout->im->array.F[jj * xsize + ii] =
+                (imgin->im->array.F[jj * xsize + ii + 1] -
+                 imgin->im->array.F[jj * xsize + ii - 1]) /
+                2.0;
+        imgout->im->array.F[jj * xsize] =
+            imgin->im->array.F[jj * xsize + 1] -
+            imgin->im->array.F[jj * xsize];
+        imgout->im->array.F[jj * xsize + xsize - 1] =
+            imgin->im->array.F[jj * xsize + xsize - 1] -
+            imgin->im->array.F[jj * xsize + xsize - 2];
+    }
+
+    DEBUG_TRACE_FEXIT();
+    return imgout->ID;
+}
+
+imageID arith_image_dx(const char *ID_name, const char *IDout_name)
+{
+    IMGID imgin = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(IDout_name);
+
+    return arith_image_dx_IMGID(&imgin, &imgout);
+}
+
+imageID arith_image_dy_IMGID(IMGID *imgin, IMGID *imgout)
+{
+    DEBUG_TRACE_FSTART();
+
+    resolveIMGID(imgin, ERRMODE_ABORT);
+    uint8_t   datatype = imgin->md[0].datatype;
+    uint8_t   naxis    = imgin->md[0].naxis;
+    if(naxis != 2)
+    {
+        PRINT_ERROR("Function only supports 2-D images\n");
         abort();
     }
 
-    naxes[0] = data.image[ID].md[0].size[0];
-    naxes[1] = data.image[ID].md[0].size[1];
+    imgout->naxis = 2;
+    imgout->size[0] = imgin->md[0].size[0];
+    imgout->size[1] = imgin->md[0].size[1];
+    imgout->datatype = datatype;
+    imgout->shared = data.SHARED_DFT;
+    imgout->NBkw   = NB_KEYWNODE_MAX;
 
-    create_image_ID(IDout_name,
-                    naxis,
-                    naxes,
-                    datatype,
-                    data.SHARED_DFT,
-                    NB_KEYWNODE_MAX,
-                    0,
-                    &IDout);
-    for(uint32_t jj = 0; jj < naxes[1]; jj++)
+    imcreateIMGID(imgout);
+
+    uint32_t xsize = imgout->size[0];
+    uint32_t ysize = imgout->size[1];
+
+    for(uint32_t ii = 0; ii < xsize; ii++)
     {
-        for(uint32_t ii = 1; ii < naxes[0] - 1; ii++)
-            data.image[IDout].array.F[jj * naxes[0] + ii] =
-                (data.image[ID].array.F[jj * naxes[0] + ii + 1] -
-                 data.image[ID].array.F[jj * naxes[0] + ii - 1]) /
+        for(uint32_t jj = 1; jj < ysize - 1; jj++)
+        {
+            imgout->im->array.F[jj * xsize + ii] =
+                (imgin->im->array.F[(jj + 1) * xsize + ii] -
+                 imgin->im->array.F[(jj - 1) * xsize + ii]) /
                 2.0;
-        data.image[IDout].array.F[jj * naxes[0]] =
-            data.image[ID].array.F[jj * naxes[0] + 1] -
-            data.image[ID].array.F[jj * naxes[0]];
-        data.image[IDout].array.F[jj * naxes[0] + naxes[0] - 1] =
-            data.image[ID].array.F[jj * naxes[0] + naxes[0] - 1] -
-            data.image[ID].array.F[jj * naxes[0] + naxes[0] - 2];
+        }
+
+        imgout->im->array.F[ii] =
+            imgin->im->array.F[1 * xsize + ii] -
+            imgin->im->array.F[ii];
+
+        imgout->im->array.F[(ysize - 1) * xsize + ii] =
+            imgin->im->array.F[(ysize - 1) * xsize + ii] -
+            imgin->im->array.F[(ysize - 2) * xsize + ii];
     }
 
-    free(naxes);
-
-    return IDout;
+    DEBUG_TRACE_FEXIT();
+    return imgout->ID;
 }
 
 imageID arith_image_dy(const char *ID_name, const char *IDout_name)
 {
-    imageID   ID;
-    imageID   IDout;
-    uint32_t *naxes = NULL;
-    uint8_t   naxis;
-    uint8_t   datatype;
+    IMGID imgin = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(IDout_name);
 
-    ID       = image_ID(ID_name);
-    datatype = data.image[ID].md[0].datatype;
-    naxis    = data.image[ID].md[0].naxis;
-    if(naxis != 2)
-    {
-        PRINT_ERROR("Function only supports 2-D images\n");
-        abort();
-    }
-
-    assert(naxis != 0);
-    naxes = (uint32_t *) malloc(sizeof(uint32_t) * naxis);
-    if(naxes == NULL)
-    {
-        PRINT_ERROR("malloc error. size %d", (int) naxis);
-        abort();
-    }
-
-    naxes[0] = data.image[ID].md[0].size[0];
-    naxes[1] = data.image[ID].md[0].size[1];
-
-    create_image_ID(IDout_name,
-                    naxis,
-                    naxes,
-                    datatype,
-                    data.SHARED_DFT,
-                    NB_KEYWNODE_MAX,
-                    0,
-                    &IDout);
-    for(uint32_t ii = 0; ii < naxes[0]; ii++)
-    {
-        for(uint32_t jj = 1; jj < naxes[1] - 1; jj++)
-        {
-            data.image[IDout].array.F[jj * naxes[0] + ii] =
-                (data.image[ID].array.F[(jj + 1) * naxes[0] + ii] -
-                 data.image[ID].array.F[(jj - 1) * naxes[0] + ii]) /
-                2.0;
-        }
-
-        data.image[IDout].array.F[ii] =
-            data.image[ID].array.F[1 * naxes[0] + ii] -
-            data.image[ID].array.F[ii];
-
-        data.image[IDout].array.F[(naxes[1] - 1) * naxes[0] + ii] =
-            data.image[ID].array.F[(naxes[1] - 1) * naxes[0] + ii] -
-            data.image[ID].array.F[(naxes[1] - 2) * naxes[0] + ii];
-    }
-
-    free(naxes);
-
-    return IDout;
+    return arith_image_dy_IMGID(&imgin, &imgout);
 }

--- a/src/COREMOD_arith/image_dxdy.h
+++ b/src/COREMOD_arith/image_dxdy.h
@@ -3,5 +3,7 @@
  */
 
 imageID arith_image_dx(const char *ID_name, const char *IDout_name);
+imageID arith_image_dx_IMGID(IMGID *imgin, IMGID *imgout);
 
 imageID arith_image_dy(const char *ID_name, const char *IDout_name);
+imageID arith_image_dy_IMGID(IMGID *imgin, IMGID *imgout);

--- a/src/COREMOD_arith/image_norm.c
+++ b/src/COREMOD_arith/image_norm.c
@@ -1,6 +1,7 @@
 #include <math.h>
 
 #include "CommandLineInterface/CLIcore.h"
+#include "image_norm.h"
 #include "COREMOD_memory/COREMOD_memory.h"
 
 
@@ -69,24 +70,24 @@ static errno_t help_function()
 
 
 
-errno_t image_slicenorm(
-    IMGID inimg,
+errno_t image_slicenorm_IMGID(
+    IMGID *inimg,
     IMGID *outimg,
     uint8_t sliceaxis
 )
 {
     DEBUG_TRACE_FSTART();
 
-    resolveIMGID(&inimg, ERRMODE_ABORT);
+    resolveIMGID(inimg, ERRMODE_ABORT);
 
 
     resolveIMGID(outimg, ERRMODE_NULL);
     if( outimg->ID == -1)
     {
-        copyIMGID(&inimg, outimg);
+        copyIMGID(inimg, outimg);
     }
 
-    for ( uint8_t axis = 0; axis < inimg.md->naxis; axis++ )
+    for ( uint8_t axis = 0; axis < inimg->md->naxis; axis++ )
     {
         if ( axis != sliceaxis )
         {
@@ -99,14 +100,14 @@ errno_t image_slicenorm(
 
 
     uint32_t sizescan[3];
-    sizescan[0] = inimg.md->size[0];
-    sizescan[1] = inimg.md->size[1];
-    sizescan[2] = inimg.md->size[2];
-    if( inimg.md->naxis < 3 )
+    sizescan[0] = inimg->md->size[0];
+    sizescan[1] = inimg->md->size[1];
+    sizescan[2] = inimg->md->size[2];
+    if( inimg->md->naxis < 3 )
     {
         sizescan[2] = 1;
     }
-    if( inimg.md->naxis < 2 )
+    if( inimg->md->naxis < 2 )
     {
         sizescan[1] = 1;
     }
@@ -114,7 +115,7 @@ errno_t image_slicenorm(
 
 
     double * __restrict normarray = (double*) malloc(sizeof(double) * sizescan[sliceaxis]);
-    for( uint32_t ii=0; ii<inimg.md->size[sliceaxis]; ii++)
+    for( uint32_t ii=0; ii<inimg->md->size[sliceaxis]; ii++)
     {
         normarray[ii] = 0.0;
     }
@@ -135,38 +136,38 @@ errno_t image_slicenorm(
                 pixi += jj * sizescan[0];
                 pixi += ii;
 
-                double val;
-                switch ( inimg.datatype )
+                double val = 0.0;
+                switch ( inimg->datatype )
                 {
                 case _DATATYPE_UINT8 :
-                    val = inimg.im->array.UI8[pixi] * inimg.im->array.UI8[pixi];
+                    val = inimg->im->array.UI8[pixi] * inimg->im->array.UI8[pixi];
                     break;
                 case _DATATYPE_INT8 :
-                    val = inimg.im->array.SI8[pixi] * inimg.im->array.SI8[pixi];
+                    val = inimg->im->array.SI8[pixi] * inimg->im->array.SI8[pixi];
                     break;
                 case _DATATYPE_UINT16 :
-                    val = inimg.im->array.UI16[pixi] * inimg.im->array.UI16[pixi];
+                    val = inimg->im->array.UI16[pixi] * inimg->im->array.UI16[pixi];
                     break;
                 case _DATATYPE_INT16 :
-                    val = inimg.im->array.SI16[pixi] * inimg.im->array.SI16[pixi];
+                    val = inimg->im->array.SI16[pixi] * inimg->im->array.SI16[pixi];
                     break;
                 case _DATATYPE_UINT32 :
-                    val = inimg.im->array.UI32[pixi] * inimg.im->array.UI32[pixi];
+                    val = inimg->im->array.UI32[pixi] * inimg->im->array.UI32[pixi];
                     break;
                 case _DATATYPE_INT32 :
-                    val = inimg.im->array.SI32[pixi] * inimg.im->array.SI32[pixi];
+                    val = inimg->im->array.SI32[pixi] * inimg->im->array.SI32[pixi];
                     break;
                 case _DATATYPE_UINT64 :
-                    val = inimg.im->array.UI64[pixi] * inimg.im->array.UI64[pixi];
+                    val = inimg->im->array.UI64[pixi] * inimg->im->array.UI64[pixi];
                     break;
                 case _DATATYPE_INT64 :
-                    val = inimg.im->array.SI64[pixi] * inimg.im->array.SI64[pixi];
+                    val = inimg->im->array.SI64[pixi] * inimg->im->array.SI64[pixi];
                     break;
                 case _DATATYPE_FLOAT :
-                    val = inimg.im->array.F[pixi] * inimg.im->array.F[pixi];
+                    val = inimg->im->array.F[pixi] * inimg->im->array.F[pixi];
                     break;
                 case _DATATYPE_DOUBLE :
-                    val = inimg.im->array.D[pixi] * inimg.im->array.D[pixi];
+                    val = inimg->im->array.D[pixi] * inimg->im->array.D[pixi];
                     break;
                 }
                 normarray[pixcoord[sliceaxis]] += val;
@@ -185,6 +186,18 @@ errno_t image_slicenorm(
 
     DEBUG_TRACE_FEXIT();
     return RETURN_SUCCESS;
+}
+
+errno_t image_slicenorm(
+    const char *inname,
+    const char *outname,
+    uint8_t sliceaxis
+)
+{
+    IMGID inimg = mkIMGID_from_name(inname);
+    IMGID outimg = mkIMGID_from_name(outname);
+
+    return image_slicenorm_IMGID(&inimg, &outimg, sliceaxis);
 }
 
 
@@ -208,8 +221,8 @@ static errno_t compute_function()
     INSERT_STD_PROCINFO_COMPUTEFUNC_LOOPSTART
     {
 
-        image_slicenorm(
-            inimg,
+        image_slicenorm_IMGID(
+            &inimg,
             &outimg,
             *sliceaxis
         );

--- a/src/COREMOD_arith/image_norm.h
+++ b/src/COREMOD_arith/image_norm.h
@@ -3,4 +3,7 @@
 
 errno_t CLIADDCMD_COREMOD_arith__image_normslice();
 
+errno_t image_slicenorm(const char *inname, const char *outname, uint8_t sliceaxis);
+errno_t image_slicenorm_IMGID(IMGID *inimg, IMGID *outimg, uint8_t sliceaxis);
+
 #endif

--- a/src/COREMOD_arith/image_setzero.c
+++ b/src/COREMOD_arith/image_setzero.c
@@ -1,6 +1,6 @@
 
 #include "CommandLineInterface/CLIcore.h"
-
+#include "image_setzero.h"
 
 static char *inimname;
 
@@ -37,24 +37,31 @@ static errno_t help_function()
 
 
 
-errno_t image_setzero(
-    IMGID inimg
+errno_t image_setzero_IMGID(
+    IMGID *inimg
 )
 {
     DEBUG_TRACE_FSTART();
 
-    long nelem = inimg.md->nelement;
-    int typesize = ImageStreamIO_typesize(inimg.md->datatype);
+    resolveIMGID(inimg, ERRMODE_ABORT);
+
+    long nelem = inimg->md->nelement;
+    int typesize = ImageStreamIO_typesize(inimg->md->datatype);
     if(typesize == -1)
     {
-        PRINT_ERROR("cannot detect image type for image %s",  inimg.name);
+        PRINT_ERROR("cannot detect image type for image %s",  inimg->name);
         exit(0);
     }
-    memset(inimg.im->array.raw, 0, typesize * nelem);
+    memset(inimg->im->array.raw, 0, typesize * nelem);
 
 
     DEBUG_TRACE_FEXIT();
     return RETURN_SUCCESS;
+}
+
+errno_t image_setzero(IMGID inimg)
+{
+    return image_setzero_IMGID(&inimg);
 }
 
 
@@ -70,7 +77,7 @@ static errno_t compute_function()
 
     INSERT_STD_PROCINFO_COMPUTEFUNC_START
     {
-        image_setzero(inimg);
+        image_setzero_IMGID(&inimg);
         processinfo_update_output_stream(processinfo, inimg.ID);
 
     }

--- a/src/COREMOD_arith/image_setzero.h
+++ b/src/COREMOD_arith/image_setzero.h
@@ -2,9 +2,8 @@
 #define COREMOD_MODULE_ARITH_IMSETZERO_H
 
 
-errno_t image_setzero(
-    IMGID inimg
-);
+errno_t image_setzero(IMGID inimg);
+errno_t image_setzero_IMGID(IMGID *inimg);
 
 errno_t CLIADDCMD_COREMOD_arith__imsetzero();
 

--- a/src/COREMOD_arith/image_stats.c
+++ b/src/COREMOD_arith/image_stats.c
@@ -6,6 +6,7 @@
  */
 
 #include "CommandLineInterface/CLIcore.h"
+#include "image_stats.h"
 
 #include "COREMOD_memory/COREMOD_memory.h"
 
@@ -13,39 +14,43 @@
 
 #include "image_total.h"
 
-double arith_image_mean(const char *ID_name)
+double arith_image_mean_IMGID(IMGID *imgin)
 {
     double  value;
-    imageID ID;
 
-    ID = image_ID(ID_name);
+    resolveIMGID(imgin, ERRMODE_ABORT);
 
     value =
-        (double)(arith_image_total(ID_name) / data.image[ID].md[0].nelement);
+        (double)(arith_image_total_IMGID(imgin) / imgin->md[0].nelement);
 
     return (value);
 }
 
-double arith_image_min(const char *ID_name)
+double arith_image_mean(const char *ID_name)
 {
-    imageID  ID;
+    IMGID imgin = mkIMGID_from_name(ID_name);
+    return arith_image_mean_IMGID(&imgin);
+}
+
+double arith_image_min_IMGID(IMGID *imgin)
+{
     uint64_t nelement;
     uint8_t  datatype;
     int      OK = 0;
 
-    ID       = image_ID(ID_name);
-    datatype = data.image[ID].md[0].datatype;
+    resolveIMGID(imgin, ERRMODE_ABORT);
+    datatype = imgin->md[0].datatype;
 
-    nelement = data.image[ID].md[0].nelement;
+    nelement = imgin->md[0].nelement;
 
     if(datatype == _DATATYPE_FLOAT)
     {
         float value;
 
-        value = data.image[ID].array.F[0];
+        value = imgin->im->array.F[0];
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            float value1 = data.image[ID].array.F[ii];
+            float value1 = imgin->im->array.F[ii];
             if(value1 < value)
             {
                 value = value1;
@@ -59,10 +64,10 @@ double arith_image_min(const char *ID_name)
     {
         double value;
 
-        value = data.image[ID].array.D[0];
+        value = imgin->im->array.D[0];
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            double value1 = data.image[ID].array.D[ii];
+            double value1 = imgin->im->array.D[ii];
             if(value1 < value)
             {
                 value = value1;
@@ -76,10 +81,10 @@ double arith_image_min(const char *ID_name)
     {
         uint8_t value;
 
-        value = data.image[ID].array.UI8[0];
+        value = imgin->im->array.UI8[0];
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            uint8_t value1 = data.image[ID].array.UI8[ii];
+            uint8_t value1 = imgin->im->array.UI8[ii];
             if(value1 < value)
             {
                 value = value1;
@@ -93,10 +98,10 @@ double arith_image_min(const char *ID_name)
     {
         uint16_t value;
 
-        value = data.image[ID].array.UI16[0];
+        value = imgin->im->array.UI16[0];
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            uint16_t value1 = data.image[ID].array.UI16[ii];
+            uint16_t value1 = imgin->im->array.UI16[ii];
             if(value1 < value)
             {
                 value = value1;
@@ -110,10 +115,10 @@ double arith_image_min(const char *ID_name)
     {
         uint32_t value;
 
-        value = data.image[ID].array.UI32[0];
+        value = imgin->im->array.UI32[0];
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            uint32_t value1 = data.image[ID].array.UI32[ii];
+            uint32_t value1 = imgin->im->array.UI32[ii];
             if(value1 < value)
             {
                 value = value1;
@@ -127,10 +132,10 @@ double arith_image_min(const char *ID_name)
     {
         uint64_t value;
 
-        value = data.image[ID].array.UI64[0];
+        value = imgin->im->array.UI64[0];
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            uint64_t value1 = data.image[ID].array.UI64[ii];
+            uint64_t value1 = imgin->im->array.UI64[ii];
             if(value1 < value)
             {
                 value = value1;
@@ -144,10 +149,10 @@ double arith_image_min(const char *ID_name)
     {
         int8_t value;
 
-        value = data.image[ID].array.SI8[0];
+        value = imgin->im->array.SI8[0];
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            int8_t value1 = data.image[ID].array.SI8[ii];
+            int8_t value1 = imgin->im->array.SI8[ii];
             if(value1 < value)
             {
                 value = value1;
@@ -161,10 +166,10 @@ double arith_image_min(const char *ID_name)
     {
         int16_t value;
 
-        value = (double) data.image[ID].array.SI16[0];
+        value = (double) imgin->im->array.SI16[0];
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            int16_t value1 = data.image[ID].array.SI16[ii];
+            int16_t value1 = imgin->im->array.SI16[ii];
             if(value1 < value)
             {
                 value = value1;
@@ -178,10 +183,10 @@ double arith_image_min(const char *ID_name)
     {
         int32_t value;
 
-        value = data.image[ID].array.SI32[0];
+        value = imgin->im->array.SI32[0];
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            int32_t value1 = data.image[ID].array.SI32[ii];
+            int32_t value1 = imgin->im->array.SI32[ii];
             if(value1 < value)
             {
                 value = value1;
@@ -195,10 +200,10 @@ double arith_image_min(const char *ID_name)
     {
         int64_t value;
 
-        value = data.image[ID].array.SI64[0];
+        value = imgin->im->array.SI64[0];
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            int64_t value1 = data.image[ID].array.SI64[ii];
+            int64_t value1 = imgin->im->array.SI64[ii];
             if(value1 < value)
             {
                 value = value1;
@@ -216,27 +221,32 @@ double arith_image_min(const char *ID_name)
     return (0);
 }
 
-double arith_image_max(const char *ID_name)
+double arith_image_min(const char *ID_name)
 {
-    imageID ID;
+    IMGID imgin = mkIMGID_from_name(ID_name);
+    return arith_image_min_IMGID(&imgin);
+}
+
+double arith_image_max_IMGID(IMGID *imgin)
+{
     long    ii;
     long    nelement;
     uint8_t datatype;
     int     OK = 0;
 
-    ID       = image_ID(ID_name);
-    datatype = data.image[ID].md[0].datatype;
+    resolveIMGID(imgin, ERRMODE_ABORT);
+    datatype = imgin->md[0].datatype;
 
-    nelement = data.image[ID].md[0].nelement;
+    nelement = imgin->md[0].nelement;
 
     if(datatype == _DATATYPE_FLOAT)
     {
         float value, value1;
 
-        value = data.image[ID].array.F[0];
+        value = imgin->im->array.F[0];
         for(ii = 0; ii < nelement; ii++)
         {
-            value1 = data.image[ID].array.F[ii];
+            value1 = imgin->im->array.F[ii];
             if(value1 > value)
             {
                 value = value1;
@@ -250,10 +260,10 @@ double arith_image_max(const char *ID_name)
     {
         double value, value1;
 
-        value = data.image[ID].array.D[0];
+        value = imgin->im->array.D[0];
         for(ii = 0; ii < nelement; ii++)
         {
-            value1 = data.image[ID].array.D[ii];
+            value1 = imgin->im->array.D[ii];
             if(value1 > value)
             {
                 value = value1;
@@ -267,10 +277,10 @@ double arith_image_max(const char *ID_name)
     {
         uint8_t value, value1;
 
-        value = data.image[ID].array.UI8[0];
+        value = imgin->im->array.UI8[0];
         for(ii = 0; ii < nelement; ii++)
         {
-            value1 = data.image[ID].array.UI8[ii];
+            value1 = imgin->im->array.UI8[ii];
             if(value1 > value)
             {
                 value = value1;
@@ -284,10 +294,10 @@ double arith_image_max(const char *ID_name)
     {
         uint16_t value, value1;
 
-        value = data.image[ID].array.UI16[0];
+        value = imgin->im->array.UI16[0];
         for(ii = 0; ii < nelement; ii++)
         {
-            value1 = data.image[ID].array.UI16[ii];
+            value1 = imgin->im->array.UI16[ii];
             if(value1 > value)
             {
                 value = value1;
@@ -301,10 +311,10 @@ double arith_image_max(const char *ID_name)
     {
         uint32_t value, value1;
 
-        value = data.image[ID].array.UI32[0];
+        value = imgin->im->array.UI32[0];
         for(ii = 0; ii < nelement; ii++)
         {
-            value1 = data.image[ID].array.UI32[ii];
+            value1 = imgin->im->array.UI32[ii];
             if(value1 > value)
             {
                 value = value1;
@@ -318,10 +328,10 @@ double arith_image_max(const char *ID_name)
     {
         uint64_t value, value1;
 
-        value = data.image[ID].array.UI64[0];
+        value = imgin->im->array.UI64[0];
         for(ii = 0; ii < nelement; ii++)
         {
-            value1 = data.image[ID].array.UI64[ii];
+            value1 = imgin->im->array.UI64[ii];
             if(value1 > value)
             {
                 value = value1;
@@ -335,10 +345,10 @@ double arith_image_max(const char *ID_name)
     {
         int8_t value, value1;
 
-        value = data.image[ID].array.SI8[0];
+        value = imgin->im->array.SI8[0];
         for(ii = 0; ii < nelement; ii++)
         {
-            value1 = data.image[ID].array.SI8[ii];
+            value1 = imgin->im->array.SI8[ii];
             if(value1 > value)
             {
                 value = value1;
@@ -352,10 +362,10 @@ double arith_image_max(const char *ID_name)
     {
         int16_t value, value1;
 
-        value = (double) data.image[ID].array.SI16[0];
+        value = (double) imgin->im->array.SI16[0];
         for(ii = 0; ii < nelement; ii++)
         {
-            value1 = data.image[ID].array.SI16[ii];
+            value1 = imgin->im->array.SI16[ii];
             if(value1 > value)
             {
                 value = value1;
@@ -369,10 +379,10 @@ double arith_image_max(const char *ID_name)
     {
         int32_t value, value1;
 
-        value = data.image[ID].array.SI32[0];
+        value = imgin->im->array.SI32[0];
         for(ii = 0; ii < nelement; ii++)
         {
-            value1 = data.image[ID].array.SI32[ii];
+            value1 = imgin->im->array.SI32[ii];
             if(value1 > value)
             {
                 value = value1;
@@ -386,10 +396,10 @@ double arith_image_max(const char *ID_name)
     {
         int64_t value, value1;
 
-        value = data.image[ID].array.SI64[0];
+        value = imgin->im->array.SI64[0];
         for(ii = 0; ii < nelement; ii++)
         {
-            value1 = data.image[ID].array.SI64[ii];
+            value1 = imgin->im->array.SI64[ii];
             if(value1 > value)
             {
                 value = value1;
@@ -406,9 +416,14 @@ double arith_image_max(const char *ID_name)
     return (0);
 }
 
-double arith_image_percentile(const char *ID_name, double fraction)
+double arith_image_max(const char *ID_name)
 {
-    imageID         ID;
+    IMGID imgin = mkIMGID_from_name(ID_name);
+    return arith_image_max_IMGID(&imgin);
+}
+
+double arith_image_percentile_IMGID(IMGID *imgin, double fraction)
+{
     long            ii;
     double          value  = 0;
     long           *arrayL = NULL;
@@ -419,10 +434,10 @@ double arith_image_percentile(const char *ID_name, double fraction)
     uint8_t         datatype;
     int             atypeOK = 1;
 
-    ID       = image_ID(ID_name);
-    datatype = data.image[ID].md[0].datatype;
+    resolveIMGID(imgin, ERRMODE_ABORT);
+    datatype = imgin->md[0].datatype;
 
-    nelement = data.image[ID].md[0].nelement;
+    nelement = imgin->md[0].nelement;
 
 
     void *array_raw = malloc(ImageStreamIO_typesize(datatype) * nelement);
@@ -431,7 +446,7 @@ double arith_image_percentile(const char *ID_name, double fraction)
         PRINT_ERROR("malloc() error");
         exit(EXIT_FAILURE);
     }
-    memcpy(array_raw, data.image[ID].array.raw,
+    memcpy(array_raw, imgin->im->array.raw,
            ImageStreamIO_typesize(datatype) * nelement);
 
 
@@ -458,7 +473,7 @@ double arith_image_percentile(const char *ID_name, double fraction)
             }
             for(ii = 0; ii < nelement; ii++)
             {
-                arrayU[ii] = data.image[ID].array.UI8[ii];
+                arrayU[ii] = imgin->im->array.UI8[ii];
             }
             quick_sort_ushort(arrayU, nelement);
             value = arrayU[(long)(fraction * nelement)];
@@ -474,7 +489,7 @@ double arith_image_percentile(const char *ID_name, double fraction)
             }
             for(ii = 0; ii < nelement; ii++)
             {
-                arrayU[ii] = data.image[ID].array.UI16[ii];
+                arrayU[ii] = imgin->im->array.UI16[ii];
             }
             quick_sort_ushort(arrayU, nelement);
             value = arrayU[(long)(fraction * nelement)];
@@ -483,14 +498,14 @@ double arith_image_percentile(const char *ID_name, double fraction)
 
         case _DATATYPE_UINT32:
             arrayL = (long *) malloc(sizeof(long) * nelement);
-            if(arrayU == NULL)
+            if(arrayL == NULL)
             {
                 PRINT_ERROR("malloc() error");
                 exit(EXIT_FAILURE);
             }
             for(ii = 0; ii < nelement; ii++)
             {
-                arrayL[ii] = data.image[ID].array.UI32[ii];
+                arrayL[ii] = imgin->im->array.UI32[ii];
             }
             quick_sort_long(arrayL, nelement);
             value = arrayL[(long)(fraction * nelement)];
@@ -499,14 +514,14 @@ double arith_image_percentile(const char *ID_name, double fraction)
 
         case _DATATYPE_UINT64:
             arrayL = (long *) malloc(sizeof(long) * nelement);
-            if(arrayU == NULL)
+            if(arrayL == NULL)
             {
                 PRINT_ERROR("malloc() error");
                 exit(EXIT_FAILURE);
             }
             for(ii = 0; ii < nelement; ii++)
             {
-                arrayL[ii] = data.image[ID].array.UI64[ii];
+                arrayL[ii] = imgin->im->array.UI64[ii];
             }
             quick_sort_long(arrayL, nelement);
             value = arrayL[(long)(fraction * nelement)];
@@ -522,7 +537,7 @@ double arith_image_percentile(const char *ID_name, double fraction)
             }
             for(ii = 0; ii < nelement; ii++)
             {
-                arrayL[ii] = (long) data.image[ID].array.SI8[ii];
+                arrayL[ii] = (long) imgin->im->array.SI8[ii];
             }
             quick_sort_long(arrayL, nelement);
             value = (double) arrayL[(long)(fraction * nelement)];
@@ -538,7 +553,7 @@ double arith_image_percentile(const char *ID_name, double fraction)
             }
             for(ii = 0; ii < nelement; ii++)
             {
-                arrayL[ii] = (long) data.image[ID].array.SI16[ii];
+                arrayL[ii] = (long) imgin->im->array.SI16[ii];
             }
             quick_sort_long(arrayL, nelement);
             value = (double) arrayL[(long)(fraction * nelement)];
@@ -554,7 +569,7 @@ double arith_image_percentile(const char *ID_name, double fraction)
             }
             for(ii = 0; ii < nelement; ii++)
             {
-                arrayL[ii] = (long) data.image[ID].array.SI32[ii];
+                arrayL[ii] = (long) imgin->im->array.SI32[ii];
             }
             quick_sort_long(arrayL, nelement);
             value = (double) arrayL[(long)(fraction * nelement)];
@@ -570,7 +585,7 @@ double arith_image_percentile(const char *ID_name, double fraction)
             }
             for(ii = 0; ii < nelement; ii++)
             {
-                arrayL[ii] = (long) data.image[ID].array.SI64[ii];
+                arrayL[ii] = (long) imgin->im->array.SI64[ii];
             }
             quick_sort_long(arrayL, nelement);
             value = (double) arrayL[(long)(fraction * nelement)];
@@ -591,11 +606,23 @@ double arith_image_percentile(const char *ID_name, double fraction)
     return (value);
 }
 
-double arith_image_median(const char *ID_name)
+double arith_image_percentile(const char *ID_name, double fraction)
+{
+    IMGID imgin = mkIMGID_from_name(ID_name);
+    return arith_image_percentile_IMGID(&imgin, fraction);
+}
+
+double arith_image_median_IMGID(IMGID *imgin)
 {
     double value = 0.0;
 
-    value = arith_image_percentile(ID_name, 0.5);
+    value = arith_image_percentile_IMGID(imgin, 0.5);
 
     return (value);
+}
+
+double arith_image_median(const char *ID_name)
+{
+    IMGID imgin = mkIMGID_from_name(ID_name);
+    return arith_image_median_IMGID(&imgin);
 }

--- a/src/COREMOD_arith/image_stats.h
+++ b/src/COREMOD_arith/image_stats.h
@@ -5,11 +5,16 @@
  */
 
 double arith_image_mean(const char *ID_name);
+double arith_image_mean_IMGID(IMGID *imgin);
 
 double arith_image_min(const char *ID_name);
+double arith_image_min_IMGID(IMGID *imgin);
 
 double arith_image_max(const char *ID_name);
+double arith_image_max_IMGID(IMGID *imgin);
 
 double arith_image_percentile(const char *ID_name, double fraction);
+double arith_image_percentile_IMGID(IMGID *imgin, double fraction);
 
 double arith_image_median(const char *ID_name);
+double arith_image_median_IMGID(IMGID *imgin);

--- a/src/COREMOD_arith/image_total.c
+++ b/src/COREMOD_arith/image_total.c
@@ -6,20 +6,20 @@
  */
 
 #include "CommandLineInterface/CLIcore.h"
+#include "image_total.h"
 
 #include "COREMOD_memory/COREMOD_memory.h"
 
-double arith_image_total(const char *ID_name)
+double arith_image_total_IMGID(IMGID *imgin)
 {
     long double lvalue; // uses long double internally
-    imageID     ID;
     uint64_t    nelement;
     uint8_t     datatype;
 
-    ID       = image_ID(ID_name);
-    datatype = data.image[ID].md[0].datatype;
+    resolveIMGID(imgin, ERRMODE_ABORT);
+    datatype = imgin->md[0].datatype;
 
-    nelement = data.image[ID].md[0].nelement;
+    nelement = imgin->md[0].nelement;
 
     lvalue = 0.0;
 
@@ -27,70 +27,181 @@ double arith_image_total(const char *ID_name)
     {
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            lvalue += (long double) data.image[ID].array.F[ii];
+            lvalue += (long double) imgin->im->array.F[ii];
         }
     }
     else if(datatype == _DATATYPE_DOUBLE)
     {
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            lvalue += (long double) data.image[ID].array.D[ii];
+            lvalue += (long double) imgin->im->array.D[ii];
         }
     }
     else if(datatype == _DATATYPE_UINT8)
     {
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            lvalue += (long double) data.image[ID].array.UI8[ii];
+            lvalue += (long double) imgin->im->array.UI8[ii];
         }
     }
     else if(datatype == _DATATYPE_UINT16)
     {
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            lvalue += (long double) data.image[ID].array.UI16[ii];
+            lvalue += (long double) imgin->im->array.UI16[ii];
         }
     }
     else if(datatype == _DATATYPE_UINT32)
     {
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            lvalue += (long double) data.image[ID].array.UI32[ii];
+            lvalue += (long double) imgin->im->array.UI32[ii];
         }
     }
     else if(datatype == _DATATYPE_UINT64)
     {
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            lvalue += (long double) data.image[ID].array.UI64[ii];
+            lvalue += (long double) imgin->im->array.UI64[ii];
         }
     }
     else if(datatype == _DATATYPE_INT8)
     {
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            lvalue += (long double) data.image[ID].array.SI8[ii];
+            lvalue += (long double) imgin->im->array.SI8[ii];
         }
     }
     else if(datatype == _DATATYPE_INT16)
     {
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            lvalue += (long double) data.image[ID].array.SI16[ii];
+            lvalue += (long double) imgin->im->array.SI16[ii];
         }
     }
     else if(datatype == _DATATYPE_INT32)
     {
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            lvalue += (long double) data.image[ID].array.SI32[ii];
+            lvalue += (long double) imgin->im->array.SI32[ii];
         }
     }
     else if(datatype == _DATATYPE_INT64)
     {
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            lvalue += (long double) data.image[ID].array.SI64[ii];
+            lvalue += (long double) imgin->im->array.SI64[ii];
+        }
+    }
+    else
+    {
+        PRINT_ERROR("invalid data type");
+        exit(0);
+    }
+
+    double value;
+    value = (double) lvalue;
+
+    return (value);
+}
+
+double arith_image_total(const char *ID_name)
+{
+    IMGID imgin = mkIMGID_from_name(ID_name);
+    return arith_image_total_IMGID(&imgin);
+}
+
+double arith_image_sumsquare_IMGID(IMGID *imgin)
+{
+    long double lvalue; // uses long double internally
+    uint64_t    nelement;
+    uint8_t     datatype;
+
+    resolveIMGID(imgin, ERRMODE_ABORT);
+    datatype = imgin->md[0].datatype;
+
+    nelement = imgin->md[0].nelement;
+
+    lvalue = 0.0;
+
+    if(datatype == _DATATYPE_FLOAT)
+    {
+        for(uint64_t ii = 0; ii < nelement; ii++)
+        {
+            lvalue += (long double)(imgin->im->array.F[ii] *
+                                    imgin->im->array.F[ii]);
+        }
+    }
+    else if(datatype == _DATATYPE_DOUBLE)
+    {
+        for(uint64_t ii = 0; ii < nelement; ii++)
+        {
+            lvalue += (long double)(imgin->im->array.D[ii] *
+                                    imgin->im->array.D[ii]);
+        }
+    }
+    else if(datatype == _DATATYPE_UINT8)
+    {
+        for(uint64_t ii = 0; ii < nelement; ii++)
+        {
+            lvalue += (long double)(imgin->im->array.UI8[ii] *
+                                    imgin->im->array.UI8[ii]);
+        }
+    }
+    else if(datatype == _DATATYPE_UINT16)
+    {
+        for(uint64_t ii = 0; ii < nelement; ii++)
+        {
+            lvalue += (long double)(imgin->im->array.UI16[ii] *
+                                    imgin->im->array.UI16[ii]);
+        }
+    }
+    else if(datatype == _DATATYPE_UINT32)
+    {
+        for(uint64_t ii = 0; ii < nelement; ii++)
+        {
+            lvalue += (long double)(imgin->im->array.UI32[ii] *
+                                    imgin->im->array.UI32[ii]);
+        }
+    }
+    else if(datatype == _DATATYPE_UINT64)
+    {
+        for(uint64_t ii = 0; ii < nelement; ii++)
+        {
+            lvalue += (long double)(imgin->im->array.UI64[ii] *
+                                    imgin->im->array.UI64[ii]);
+        }
+    }
+    else if(datatype == _DATATYPE_INT8)
+    {
+        for(uint64_t ii = 0; ii < nelement; ii++)
+        {
+            lvalue += (long double)(imgin->im->array.SI8[ii] *
+                                    imgin->im->array.SI8[ii]);
+        }
+    }
+    else if(datatype == _DATATYPE_INT16)
+    {
+        for(uint64_t ii = 0; ii < nelement; ii++)
+        {
+            lvalue += (long double)(imgin->im->array.SI16[ii] *
+                                    imgin->im->array.SI16[ii]);
+        }
+    }
+    else if(datatype == _DATATYPE_INT32)
+    {
+        for(uint64_t ii = 0; ii < nelement; ii++)
+        {
+            lvalue += (long double)(imgin->im->array.SI32[ii] *
+                                    imgin->im->array.SI32[ii]);
+        }
+    }
+    else if(datatype == _DATATYPE_INT64)
+    {
+        for(uint64_t ii = 0; ii < nelement; ii++)
+        {
+            lvalue += (long double)(imgin->im->array.SI64[ii] *
+                                    imgin->im->array.SI64[ii]);
         }
     }
     else
@@ -107,106 +218,6 @@ double arith_image_total(const char *ID_name)
 
 double arith_image_sumsquare(const char *ID_name)
 {
-    long double lvalue; // uses long double internally
-    imageID     ID;
-    uint64_t    nelement;
-    uint8_t     datatype;
-
-    ID       = image_ID(ID_name);
-    datatype = data.image[ID].md[0].datatype;
-
-    nelement = data.image[ID].md[0].nelement;
-
-    lvalue = 0.0;
-
-    if(datatype == _DATATYPE_FLOAT)
-    {
-        for(uint64_t ii = 0; ii < nelement; ii++)
-        {
-            lvalue += (long double)(data.image[ID].array.F[ii] *
-                                    data.image[ID].array.F[ii]);
-        }
-    }
-    else if(datatype == _DATATYPE_DOUBLE)
-    {
-        for(uint64_t ii = 0; ii < nelement; ii++)
-        {
-            lvalue += (long double)(data.image[ID].array.D[ii] *
-                                    data.image[ID].array.D[ii]);
-        }
-    }
-    else if(datatype == _DATATYPE_UINT8)
-    {
-        for(uint64_t ii = 0; ii < nelement; ii++)
-        {
-            lvalue += (long double)(data.image[ID].array.UI8[ii] *
-                                    data.image[ID].array.UI8[ii]);
-        }
-    }
-    else if(datatype == _DATATYPE_UINT16)
-    {
-        for(uint64_t ii = 0; ii < nelement; ii++)
-        {
-            lvalue += (long double)(data.image[ID].array.UI16[ii] *
-                                    data.image[ID].array.UI16[ii]);
-        }
-    }
-    else if(datatype == _DATATYPE_UINT32)
-    {
-        for(uint64_t ii = 0; ii < nelement; ii++)
-        {
-            lvalue += (long double)(data.image[ID].array.UI32[ii] *
-                                    data.image[ID].array.UI32[ii]);
-        }
-    }
-    else if(datatype == _DATATYPE_UINT64)
-    {
-        for(uint64_t ii = 0; ii < nelement; ii++)
-        {
-            lvalue += (long double)(data.image[ID].array.UI64[ii] *
-                                    data.image[ID].array.UI64[ii]);
-        }
-    }
-    else if(datatype == _DATATYPE_INT8)
-    {
-        for(uint64_t ii = 0; ii < nelement; ii++)
-        {
-            lvalue += (long double)(data.image[ID].array.SI8[ii] *
-                                    data.image[ID].array.SI8[ii]);
-        }
-    }
-    else if(datatype == _DATATYPE_INT16)
-    {
-        for(uint64_t ii = 0; ii < nelement; ii++)
-        {
-            lvalue += (long double)(data.image[ID].array.SI16[ii] *
-                                    data.image[ID].array.SI16[ii]);
-        }
-    }
-    else if(datatype == _DATATYPE_INT32)
-    {
-        for(uint64_t ii = 0; ii < nelement; ii++)
-        {
-            lvalue += (long double)(data.image[ID].array.SI32[ii] *
-                                    data.image[ID].array.SI32[ii]);
-        }
-    }
-    else if(datatype == _DATATYPE_INT64)
-    {
-        for(uint64_t ii = 0; ii < nelement; ii++)
-        {
-            lvalue += (long double)(data.image[ID].array.SI64[ii] *
-                                    data.image[ID].array.SI64[ii]);
-        }
-    }
-    else
-    {
-        PRINT_ERROR("invalid data type");
-        exit(0);
-    }
-
-    double value;
-    value = (double) lvalue;
-
-    return (value);
+    IMGID imgin = mkIMGID_from_name(ID_name);
+    return arith_image_sumsquare_IMGID(&imgin);
 }

--- a/src/COREMOD_arith/image_total.h
+++ b/src/COREMOD_arith/image_total.h
@@ -4,5 +4,7 @@
  */
 
 double arith_image_total(const char *ID_name);
+double arith_image_total_IMGID(IMGID *imgin);
 
 double arith_image_sumsquare(const char *ID_name);
+double arith_image_sumsquare_IMGID(IMGID *imgin);

--- a/src/COREMOD_arith/imfunctions.c
+++ b/src/COREMOD_arith/imfunctions.c
@@ -28,166 +28,151 @@
 
   ------------------------------------------------------------------------- */
 
-errno_t arith_image_function_im_im__d_d(
-    const char * __restrict ID_name,
-    const char * __restrict ID_out,
+errno_t arith_image_function_im_im__d_d_IMGID(
+    IMGID *imgin,
+    IMGID *imgout,
     double (*pt2function)(double))
 {
-    imageID   ID;
-    imageID   IDout;
-    long      naxis;
+    resolveIMGID(imgin, ERRMODE_ABORT);
 
-    uint8_t   datatype, datatypeout;
+    DEBUG_TRACEPOINT("arith_image_function_d_d  %s %s\n", imgin->name, imgout->name);
 
-
-    DEBUG_TRACEPOINT("arith_image_function_d_d  %s %s\n", ID_name, ID_out);
-
-    ID       = image_ID(ID_name);
-    datatype = data.image[ID].md[0].datatype;
-    naxis    = data.image[ID].md[0].naxis;
-    uint32_t naxes[3];
-
-
-    for(uint8_t i = 0; i < naxis; i++)
+    imgout->naxis = imgin->md->naxis;
+    for(uint8_t i = 0; i < imgin->md->naxis; i++)
     {
-        naxes[i] = data.image[ID].md[0].size[i];
+        imgout->size[i] = imgin->md->size[i];
     }
 
-    datatypeout = _DATATYPE_FLOAT;
-    if(datatype == _DATATYPE_DOUBLE)
+    imgout->datatype = _DATATYPE_FLOAT;
+    if(imgin->md->datatype == _DATATYPE_DOUBLE)
     {
-        datatypeout = _DATATYPE_DOUBLE;
+        imgout->datatype = _DATATYPE_DOUBLE;
     }
+    imgout->shared = data.SHARED_DFT;
+    imgout->NBkw   = NB_KEYWNODE_MAX;
 
-    create_image_ID(ID_out,
-                    naxis,
-                    naxes,
-                    datatypeout,
-                    data.SHARED_DFT,
-                    NB_KEYWNODE_MAX,
-                    0,
-                    &IDout);
+    imcreateIMGID(imgout);
 
-
-    uint_fast64_t nelement = data.image[ID].md[0].nelement;
+    uint_fast64_t nelement = imgin->md->nelement;
+    uint8_t       datatype = imgin->md->datatype;
 
 #ifdef _OPENMP
     #pragma omp parallel if (nelement > OMP_NELEMENT_LIMIT)
     {
 #endif
 
-        if(datatype == _DATATYPE_UINT8)
-        {
+    if(datatype == _DATATYPE_UINT8)
+    {
 #ifdef _OPENMP
-            #pragma omp for
+        #pragma omp for
 #endif
-            for(uint_fast64_t ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] = (float) pt2function(
-                                                    (double)(data.image[ID].array.UI8[ii]));
-            }
-        }
-        if(datatype == _DATATYPE_UINT16)
+        for(uint_fast64_t ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(uint_fast64_t ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] = (float) pt2function(
-                                                    (double)(data.image[ID].array.UI16[ii]));
-            }
+            imgout->im->array.F[ii] = (float) pt2function(
+                                          (double)(imgin->im->array.UI8[ii]));
         }
-        if(datatype == _DATATYPE_UINT32)
+    }
+    if(datatype == _DATATYPE_UINT16)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(uint_fast64_t ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(uint_fast64_t ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] = (float) pt2function(
-                                                    (double)(data.image[ID].array.UI32[ii]));
-            }
+            imgout->im->array.F[ii] = (float) pt2function(
+                                          (double)(imgin->im->array.UI16[ii]));
         }
-        if(datatype == _DATATYPE_UINT64)
+    }
+    if(datatype == _DATATYPE_UINT32)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(uint_fast64_t ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(uint_fast64_t ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] = (float) pt2function(
-                                                    (double)(data.image[ID].array.UI64[ii]));
-            }
+            imgout->im->array.F[ii] = (float) pt2function(
+                                          (double)(imgin->im->array.UI32[ii]));
         }
+    }
+    if(datatype == _DATATYPE_UINT64)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(uint_fast64_t ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.F[ii] = (float) pt2function(
+                                          (double)(imgin->im->array.UI64[ii]));
+        }
+    }
 
-        if(datatype == _DATATYPE_INT8)
-        {
+    if(datatype == _DATATYPE_INT8)
+    {
 #ifdef _OPENMP
-            #pragma omp for
+        #pragma omp for
 #endif
-            for(uint_fast64_t ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] = (float) pt2function(
-                                                    (double)(data.image[ID].array.SI8[ii]));
-            }
-        }
-        if(datatype == _DATATYPE_INT16)
+        for(uint_fast64_t ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(uint_fast64_t ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] = (float) pt2function(
-                                                    (double)(data.image[ID].array.SI16[ii]));
-            }
+            imgout->im->array.F[ii] = (float) pt2function(
+                                          (double)(imgin->im->array.SI8[ii]));
         }
-        if(datatype == _DATATYPE_INT32)
+    }
+    if(datatype == _DATATYPE_INT16)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(uint_fast64_t ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(uint_fast64_t ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] = (float) pt2function(
-                                                    (double)(data.image[ID].array.SI32[ii]));
-            }
+            imgout->im->array.F[ii] = (float) pt2function(
+                                          (double)(imgin->im->array.SI16[ii]));
         }
-        if(datatype == _DATATYPE_INT64)
+    }
+    if(datatype == _DATATYPE_INT32)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(uint_fast64_t ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(uint_fast64_t ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] = (float) pt2function(
-                                                    (double)(data.image[ID].array.SI64[ii]));
-            }
+            imgout->im->array.F[ii] = (float) pt2function(
+                                          (double)(imgin->im->array.SI32[ii]));
         }
+    }
+    if(datatype == _DATATYPE_INT64)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(uint_fast64_t ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.F[ii] = (float) pt2function(
+                                          (double)(imgin->im->array.SI64[ii]));
+        }
+    }
 
-        if(datatype == _DATATYPE_FLOAT)
-        {
+    if(datatype == _DATATYPE_FLOAT)
+    {
 #ifdef _OPENMP
-            #pragma omp for
+        #pragma omp for
 #endif
-            for(uint_fast64_t ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    (float) pt2function((double)(data.image[ID].array.F[ii]));
-            }
-        }
-        if(datatype == _DATATYPE_DOUBLE)
+        for(uint_fast64_t ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(uint_fast64_t ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.D[ii] =
-                    pt2function(data.image[ID].array.D[ii]);
-            }
+            imgout->im->array.F[ii] =
+                (float) pt2function((double)(imgin->im->array.F[ii]));
         }
+    }
+    if(datatype == _DATATYPE_DOUBLE)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(uint_fast64_t ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.D[ii] =
+                pt2function(imgin->im->array.D[ii]);
+        }
+    }
 #ifdef _OPENMP
     }
 #endif
@@ -197,184 +182,363 @@ errno_t arith_image_function_im_im__d_d(
     return RETURN_SUCCESS;
 }
 
+errno_t arith_image_function_im_im__d_d(
+    const char *__restrict ID_name,
+    const char *__restrict ID_out,
+    double (*pt2function)(double))
+{
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+
+    return arith_image_function_im_im__d_d_IMGID(&imgin, &imgout, pt2function);
+}
 
 
 
 
-errno_t arith_image_function_imd_im__dd_d(
-    const char * __restrict ID_name,
-    double      v0,
-    const char * __restrict ID_out,
+
+errno_t arith_image_function_imd_im__dd_d_IMGID(
+    IMGID *imgin,
+    double v0,
+    IMGID *imgout,
     double (*pt2function)(double, double))
 {
-    imageID   ID;
-    imageID   IDout;
-    uint32_t *naxes = NULL;
-    long      naxis;
-    long      ii;
-    long      nelement;
-    uint8_t   datatype, datatypeout;
-    long      i;
+    long ii;
 
-    ID       = image_ID(ID_name);
-    datatype = data.image[ID].md[0].datatype;
-    naxis    = data.image[ID].md[0].naxis;
-    naxes    = (uint32_t *) malloc(sizeof(uint32_t) * naxis);
-    if(naxes == NULL)
+    resolveIMGID(imgin, ERRMODE_ABORT);
+
+    imgout->naxis = imgin->md->naxis;
+    for(int i = 0; i < imgin->md->naxis; i++)
     {
-        PRINT_ERROR("malloc() error");
-        exit(0);
+        imgout->size[i] = imgin->md->size[i];
     }
 
-    for(i = 0; i < naxis; i++)
+    imgout->datatype = _DATATYPE_FLOAT;
+    if(imgin->md->datatype == _DATATYPE_DOUBLE)
     {
-        naxes[i] = data.image[ID].md[0].size[i];
+        imgout->datatype = _DATATYPE_DOUBLE;
     }
+    imgout->shared = data.SHARED_DFT;
+    imgout->NBkw   = NB_KEYWNODE_MAX;
 
-    datatypeout = _DATATYPE_FLOAT;
-    if(datatype == _DATATYPE_DOUBLE)
-    {
-        datatypeout = _DATATYPE_DOUBLE;
-    }
+    imcreateIMGID(imgout);
 
-    create_image_ID(ID_out,
-                    naxis,
-                    naxes,
-                    datatypeout,
-                    data.SHARED_DFT,
-                    NB_KEYWNODE_MAX,
-                    0,
-                    &IDout);
-    free(naxes);
-
-    nelement = data.image[ID].md[0].nelement;
+    uint_fast64_t nelement = imgin->md->nelement;
+    uint8_t       datatype = imgin->md->datatype;
 
 #ifdef _OPENMP
     #pragma omp parallel if (nelement > OMP_NELEMENT_LIMIT)
     {
 #endif
 
-        if(datatype == _DATATYPE_UINT8)
-        {
+    if(datatype == _DATATYPE_UINT8)
+    {
 #ifdef _OPENMP
-            #pragma omp for
+        #pragma omp for
 #endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    (float) pt2function((double)(data.image[ID].array.UI8[ii]),
-                                        v0);
-            }
-        }
-        if(datatype == _DATATYPE_UINT16)
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] = (float) pt2function(
-                                                    (double)(data.image[ID].array.UI16[ii]),
-                                                    v0);
-            }
+            imgout->im->array.F[ii] =
+                (float) pt2function((double)(imgin->im->array.UI8[ii]),
+                                    v0);
         }
-        if(datatype == _DATATYPE_UINT32)
+    }
+    if(datatype == _DATATYPE_UINT16)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] = (float) pt2function(
-                                                    (double)(data.image[ID].array.UI32[ii]),
-                                                    v0);
-            }
+            imgout->im->array.F[ii] = (float) pt2function(
+                                          (double)(imgin->im->array.UI16[ii]),
+                                          v0);
         }
-        if(datatype == _DATATYPE_UINT64)
+    }
+    if(datatype == _DATATYPE_UINT32)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] = (float) pt2function(
-                                                    (double)(data.image[ID].array.UI64[ii]),
-                                                    v0);
-            }
+            imgout->im->array.F[ii] = (float) pt2function(
+                                          (double)(imgin->im->array.UI32[ii]),
+                                          v0);
         }
+    }
+    if(datatype == _DATATYPE_UINT64)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.F[ii] = (float) pt2function(
+                                          (double)(imgin->im->array.UI64[ii]),
+                                          v0);
+        }
+    }
 
-        if(datatype == _DATATYPE_INT8)
-        {
+    if(datatype == _DATATYPE_INT8)
+    {
 #ifdef _OPENMP
-            #pragma omp for
+        #pragma omp for
 #endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    (float) pt2function((double)(data.image[ID].array.SI8[ii]),
-                                        v0);
-            }
-        }
-        if(datatype == _DATATYPE_INT16)
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] = (float) pt2function(
-                                                    (double)(data.image[ID].array.SI16[ii]),
-                                                    v0);
-            }
+            imgout->im->array.F[ii] =
+                (float) pt2function((double)(imgin->im->array.SI8[ii]),
+                                    v0);
         }
-        if(datatype == _DATATYPE_INT32)
+    }
+    if(datatype == _DATATYPE_INT16)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] = (float) pt2function(
-                                                    (double)(data.image[ID].array.SI32[ii]),
-                                                    v0);
-            }
+            imgout->im->array.F[ii] = (float) pt2function(
+                                          (double)(imgin->im->array.SI16[ii]),
+                                          v0);
         }
-        if(datatype == _DATATYPE_INT64)
+    }
+    if(datatype == _DATATYPE_INT32)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] = (float) pt2function(
-                                                    (double)(data.image[ID].array.SI64[ii]),
-                                                    v0);
-            }
+            imgout->im->array.F[ii] = (float) pt2function(
+                                          (double)(imgin->im->array.SI32[ii]),
+                                          v0);
         }
+    }
+    if(datatype == _DATATYPE_INT64)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.F[ii] = (float) pt2function(
+                                          (double)(imgin->im->array.SI64[ii]),
+                                          v0);
+        }
+    }
 
-        if(datatype == _DATATYPE_FLOAT)
-        {
+    if(datatype == _DATATYPE_FLOAT)
+    {
 #ifdef _OPENMP
-            #pragma omp for
+        #pragma omp for
 #endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    (float) pt2function((double)(data.image[ID].array.F[ii]),
-                                        v0);
-            }
-        }
-        if(datatype == _DATATYPE_DOUBLE)
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.D[ii] =
-                    pt2function(data.image[ID].array.D[ii], v0);
-            }
+            imgout->im->array.F[ii] =
+                (float) pt2function((double)(imgin->im->array.F[ii]),
+                                    v0);
         }
+    }
+    if(datatype == _DATATYPE_DOUBLE)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.D[ii] =
+                pt2function(imgin->im->array.D[ii], v0);
+        }
+    }
+#ifdef _OPENMP
+    }
+#endif
+
+    DEBUG_TRACEPOINT("arith_image_function_d_d  DONE\n");
+
+    return RETURN_SUCCESS;
+}
+
+errno_t arith_image_function_imd_im__dd_d(
+    const char *__restrict ID_name,
+    double      v0,
+    const char *__restrict ID_out,
+    double (*pt2function)(double, double))
+{
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+
+    return arith_image_function_imd_im__dd_d_IMGID(&imgin, v0, &imgout, pt2function);
+}
+
+errno_t arith_image_function_imdd_im__ddd_d_IMGID(IMGID *imgin,
+        double      v0,
+        double      v1,
+        IMGID      *imgout,
+        double (*pt2function)(double,
+                              double,
+                              double))
+{
+    long      ii;
+
+    resolveIMGID(imgin, ERRMODE_ABORT);
+
+    imgout->naxis = imgin->md->naxis;
+    for(int i = 0; i < imgin->md->naxis; i++)
+    {
+        imgout->size[i] = imgin->md->size[i];
+    }
+
+    imgout->datatype = _DATATYPE_FLOAT;
+    if(imgin->md->datatype == _DATATYPE_DOUBLE)
+    {
+        imgout->datatype = _DATATYPE_DOUBLE;
+    }
+    imgout->shared = data.SHARED_DFT;
+    imgout->NBkw   = NB_KEYWNODE_MAX;
+
+    imcreateIMGID(imgout);
+
+    uint_fast64_t nelement = imgin->md->nelement;
+    uint8_t       datatype = imgin->md->datatype;
+
+#ifdef _OPENMP
+    #pragma omp parallel if (nelement > OMP_NELEMENT_LIMIT)
+    {
+#endif
+
+    if(datatype == _DATATYPE_UINT8)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.F[ii] =
+                (float) pt2function((double)(imgin->im->array.UI8[ii]),
+                                    v0,
+                                    v1);
+        }
+    }
+    if(datatype == _DATATYPE_UINT16)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.F[ii] = (float) pt2function(
+                                          (double)(imgin->im->array.UI16[ii]),
+                                          v0,
+                                          v1);
+        }
+    }
+    if(datatype == _DATATYPE_UINT32)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.F[ii] = (float) pt2function(
+                                          (double)(imgin->im->array.UI32[ii]),
+                                          v0,
+                                          v1);
+        }
+    }
+    if(datatype == _DATATYPE_UINT64)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.F[ii] = (float) pt2function(
+                                          (double)(imgin->im->array.UI64[ii]),
+                                          v0,
+                                          v1);
+        }
+    }
+
+    if(datatype == _DATATYPE_INT8)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.F[ii] =
+                (float) pt2function((double)(imgin->im->array.SI8[ii]),
+                                    v0,
+                                    v1);
+        }
+    }
+    if(datatype == _DATATYPE_INT16)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.F[ii] = (float) pt2function(
+                                          (double)(imgin->im->array.SI16[ii]),
+                                          v0,
+                                          v1);
+        }
+    }
+    if(datatype == _DATATYPE_INT32)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.F[ii] = (float) pt2function(
+                                          (double)(imgin->im->array.SI32[ii]),
+                                          v0,
+                                          v1);
+        }
+    }
+    if(datatype == _DATATYPE_INT64)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.F[ii] = (float) pt2function(
+                                          (double)(imgin->im->array.SI64[ii]),
+                                          v0,
+                                          v1);
+        }
+    }
+
+    if(datatype == _DATATYPE_FLOAT)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.F[ii] =
+                (float) pt2function((double)(imgin->im->array.F[ii]),
+                                    v0,
+                                    v1);
+        }
+    }
+    if(datatype == _DATATYPE_DOUBLE)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.D[ii] =
+                pt2function(imgin->im->array.D[ii], v0, v1);
+        }
+    }
 #ifdef _OPENMP
     }
 #endif
@@ -392,190 +556,10 @@ errno_t arith_image_function_imdd_im__ddd_d(const char *ID_name,
                               double,
                               double))
 {
-    imageID   ID;
-    imageID   IDout;
-    uint32_t *naxes = NULL;
-    long      naxis;
-    long      ii;
-    long      nelement;
-    uint8_t   datatype, datatypeout;
-    long      i;
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
 
-    ID       = image_ID(ID_name);
-    datatype = data.image[ID].md[0].datatype;
-    naxis    = data.image[ID].md[0].naxis;
-    naxes    = (uint32_t *) malloc(sizeof(uint32_t) * naxis);
-    if(naxes == NULL)
-    {
-        PRINT_ERROR("malloc() error");
-        exit(0);
-    }
-
-    for(i = 0; i < naxis; i++)
-    {
-        naxes[i] = data.image[ID].md[0].size[i];
-    }
-
-    datatypeout = _DATATYPE_FLOAT;
-    if(datatype == _DATATYPE_DOUBLE)
-    {
-        datatypeout = _DATATYPE_DOUBLE;
-    }
-
-    create_image_ID(ID_out,
-                    naxis,
-                    naxes,
-                    datatypeout,
-                    data.SHARED_DFT,
-                    NB_KEYWNODE_MAX,
-                    0,
-                    &IDout);
-    free(naxes);
-
-    nelement = data.image[ID].md[0].nelement;
-
-#ifdef _OPENMP
-    #pragma omp parallel if (nelement > OMP_NELEMENT_LIMIT)
-    {
-#endif
-
-        if(datatype == _DATATYPE_UINT8)
-        {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    (float) pt2function((double)(data.image[ID].array.UI8[ii]),
-                                        v0,
-                                        v1);
-            }
-        }
-        if(datatype == _DATATYPE_UINT16)
-        {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] = (float) pt2function(
-                                                    (double)(data.image[ID].array.UI16[ii]),
-                                                    v0,
-                                                    v1);
-            }
-        }
-        if(datatype == _DATATYPE_UINT32)
-        {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] = (float) pt2function(
-                                                    (double)(data.image[ID].array.UI32[ii]),
-                                                    v0,
-                                                    v1);
-            }
-        }
-        if(datatype == _DATATYPE_UINT64)
-        {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] = (float) pt2function(
-                                                    (double)(data.image[ID].array.UI64[ii]),
-                                                    v0,
-                                                    v1);
-            }
-        }
-
-        if(datatype == _DATATYPE_INT8)
-        {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    (float) pt2function((double)(data.image[ID].array.SI8[ii]),
-                                        v0,
-                                        v1);
-            }
-        }
-        if(datatype == _DATATYPE_INT16)
-        {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] = (float) pt2function(
-                                                    (double)(data.image[ID].array.SI16[ii]),
-                                                    v0,
-                                                    v1);
-            }
-        }
-        if(datatype == _DATATYPE_INT32)
-        {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] = (float) pt2function(
-                                                    (double)(data.image[ID].array.SI32[ii]),
-                                                    v0,
-                                                    v1);
-            }
-        }
-        if(datatype == _DATATYPE_INT64)
-        {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] = (float) pt2function(
-                                                    (double)(data.image[ID].array.SI64[ii]),
-                                                    v0,
-                                                    v1);
-            }
-        }
-
-        if(datatype == _DATATYPE_FLOAT)
-        {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    (float) pt2function((double)(data.image[ID].array.F[ii]),
-                                        v0,
-                                        v1);
-            }
-        }
-        if(datatype == _DATATYPE_DOUBLE)
-        {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.D[ii] =
-                    pt2function(data.image[ID].array.D[ii], v0, v1);
-            }
-        }
-#ifdef _OPENMP
-    }
-#endif
-
-    DEBUG_TRACEPOINT("arith_image_function_d_d  DONE\n");
-
-    return RETURN_SUCCESS;
+    return arith_image_function_imdd_im__ddd_d_IMGID(&imgin, v0, v1, &imgout, pt2function);
 }
 
 /* ------------------------------------------------------------------------- */
@@ -745,177 +729,166 @@ errno_t arith_image_function_1_1_byID(imageID ID,
     return RETURN_SUCCESS;
 }
 
-errno_t arith_image_function_1_1(const char *ID_name,
-                                 const char *ID_out,
-                                 double (*pt2function)(double))
+errno_t arith_image_function_1_1_IMGID(IMGID *imgin,
+                                       IMGID *imgout,
+                                       double (*pt2function)(double))
 {
-    imageID   ID;
-    imageID   IDout;
-    uint32_t *naxes = NULL;
-    long      naxis;
-    long      ii;
-    long      nelement;
-    uint8_t   datatype, datatypeout;
-    long      i;
+    long ii;
 
-    //  printf("arith_image_function_1_1\n");
+    resolveIMGID(imgin, ERRMODE_ABORT);
 
-    ID       = image_ID(ID_name);
-    datatype = data.image[ID].md[0].datatype;
-    naxis    = data.image[ID].md[0].naxis;
-    naxes    = (uint32_t *) malloc(sizeof(uint32_t) * naxis);
-    if(naxes == NULL)
+    imgout->naxis = imgin->md->naxis;
+    for(int i = 0; i < imgin->md->naxis; i++)
     {
-        PRINT_ERROR("malloc() error");
-        exit(0);
+        imgout->size[i] = imgin->md->size[i];
     }
 
-    for(i = 0; i < naxis; i++)
+    imgout->datatype = _DATATYPE_FLOAT;
+    if(imgin->md->datatype == _DATATYPE_DOUBLE)
     {
-        naxes[i] = data.image[ID].md[0].size[i];
+        imgout->datatype = _DATATYPE_DOUBLE;
     }
+    imgout->shared = data.SHARED_DFT;
+    imgout->NBkw   = NB_KEYWNODE_MAX;
 
-    datatypeout = _DATATYPE_FLOAT;
-    if(datatype == _DATATYPE_DOUBLE)
-    {
-        datatypeout = _DATATYPE_DOUBLE;
-    }
+    imcreateIMGID(imgout);
 
-    create_image_ID(ID_out,
-                    naxis,
-                    naxes,
-                    datatypeout,
-                    data.SHARED_DFT,
-                    NB_KEYWNODE_MAX,
-                    0,
-                    &IDout);
-    free(naxes);
-
-    nelement = data.image[ID].md[0].nelement;
+    uint_fast64_t nelement = imgin->md->nelement;
+    uint8_t       datatype = imgin->md->datatype;
 
 #ifdef _OPENMP
     #pragma omp parallel if (nelement > OMP_NELEMENT_LIMIT)
     {
 #endif
 
-        if(datatype == _DATATYPE_UINT8)
-        {
+    if(datatype == _DATATYPE_UINT8)
+    {
 #ifdef _OPENMP
-            #pragma omp for
+        #pragma omp for
 #endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.UI8[ii]));
-            }
-        }
-        if(datatype == _DATATYPE_UINT16)
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.UI16[ii]));
-            }
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.UI8[ii]));
         }
-        if(datatype == _DATATYPE_UINT32)
+    }
+    if(datatype == _DATATYPE_UINT16)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.UI32[ii]));
-            }
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.UI16[ii]));
         }
-        if(datatype == _DATATYPE_UINT64)
+    }
+    if(datatype == _DATATYPE_UINT32)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.UI64[ii]));
-            }
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.UI32[ii]));
         }
+    }
+    if(datatype == _DATATYPE_UINT64)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.UI64[ii]));
+        }
+    }
 
-        if(datatype == _DATATYPE_INT8)
-        {
+    if(datatype == _DATATYPE_INT8)
+    {
 #ifdef _OPENMP
-            #pragma omp for
+        #pragma omp for
 #endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.SI8[ii]));
-            }
-        }
-        if(datatype == _DATATYPE_INT16)
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.SI16[ii]));
-            }
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.SI8[ii]));
         }
-        if(datatype == _DATATYPE_INT32)
+    }
+    if(datatype == _DATATYPE_INT16)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.SI32[ii]));
-            }
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.SI16[ii]));
         }
-        if(datatype == _DATATYPE_INT64)
+    }
+    if(datatype == _DATATYPE_INT32)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.SI64[ii]));
-            }
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.SI32[ii]));
         }
+    }
+    if(datatype == _DATATYPE_INT64)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.SI64[ii]));
+        }
+    }
 
-        if(datatype == _DATATYPE_FLOAT)
-        {
+    if(datatype == _DATATYPE_FLOAT)
+    {
 #ifdef _OPENMP
-            #pragma omp for
+        #pragma omp for
 #endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.F[ii]));
-            }
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.F[ii]));
         }
+    }
 
-        if(datatype == _DATATYPE_DOUBLE)
-        {
+    if(datatype == _DATATYPE_DOUBLE)
+    {
 #ifdef _OPENMP
-            #pragma omp for
+        #pragma omp for
 #endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.D[ii] =
-                    (double) pt2function((double)(data.image[ID].array.D[ii]));
-            }
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.D[ii] =
+                (double) pt2function((double)(imgin->im->array.D[ii]));
         }
+    }
 #ifdef _OPENMP
     }
 #endif
 
     return RETURN_SUCCESS;
+}
+
+errno_t arith_image_function_1_1(const char *ID_name,
+                                 const char *ID_out,
+                                 double (*pt2function)(double))
+{
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+
+    return arith_image_function_1_1_IMGID(&imgin, &imgout, pt2function);
 }
 
 // imagein -> imagein (in place)
@@ -1223,33 +1196,33 @@ errno_t arith_image_function_1_1_inplace(const char *ID_name,
 /* image, image  -> image                                                    */
 /* ------------------------------------------------------------------------- */
 
-errno_t arith_img_function_2_1(
-    IMGID inimg1,
-    IMGID inimg2,
+errno_t arith_image_function_2_1_IMGID(
+    IMGID *inimg1,
+    IMGID *inimg2,
     IMGID *outimg,
     double (*pt2function)(double, double)
 )
 {
     DEBUG_TRACE_FSTART();
 
-    resolveIMGID(&inimg1, ERRMODE_ABORT);
-    resolveIMGID(&inimg2, ERRMODE_ABORT);
+    resolveIMGID(inimg1, ERRMODE_ABORT);
+    resolveIMGID(inimg2, ERRMODE_ABORT);
 
 
     resolveIMGID(outimg, ERRMODE_NULL);
     if( outimg->ID == -1)
     {
-        copyIMGID(&inimg1, outimg);
+        copyIMGID(inimg1, outimg);
     }
 
     // toggles to 1 if image sizes are incompatible
     int axiserror = 0;
 
     // output naxis is max of inputs
-    outimg->naxis = inimg1.md->naxis;
-    if ( inimg2.md->naxis > inimg1.md->naxis )
+    outimg->naxis = inimg1->md->naxis;
+    if ( inimg2->md->naxis > inimg1->md->naxis )
     {
-        outimg->naxis = inimg2.md->naxis;
+        outimg->naxis = inimg2->md->naxis;
     }
 
     // axis expansion flags
@@ -1271,9 +1244,9 @@ errno_t arith_img_function_2_1(
         // convention: size=1 if > naxis
 
         uint32_t size1;
-        if(axis < inimg1.md->naxis)
+        if(axis < inimg1->md->naxis)
         {
-            size1 = inimg1.md->size[axis];
+            size1 = inimg1->md->size[axis];
         }
         else
         {
@@ -1282,9 +1255,9 @@ errno_t arith_img_function_2_1(
         nbpix1 *= size1;
 
         uint32_t size2;
-        if(axis < inimg2.md->naxis)
+        if(axis < inimg2->md->naxis)
         {
-            size2 = inimg2.md->size[axis];
+            size2 = inimg2->md->size[axis];
         }
         else
         {
@@ -1333,13 +1306,13 @@ errno_t arith_img_function_2_1(
     // other cases
 
     // DOUBLE * -> DOUBLE
-    if(inimg1.md->datatype == _DATATYPE_DOUBLE)
+    if(inimg1->md->datatype == _DATATYPE_DOUBLE)
     {
         outimg->datatype = _DATATYPE_DOUBLE;
     }
 
     // * DOUBLE -> DOUBLE
-    if(inimg2.md->datatype == _DATATYPE_DOUBLE)
+    if(inimg2->md->datatype == _DATATYPE_DOUBLE)
     {
         outimg->datatype = _DATATYPE_DOUBLE;
     }
@@ -1371,12 +1344,12 @@ errno_t arith_img_function_2_1(
                 uint32_t kk1 = kk * in1expand[2];
                 uint32_t kk2 = kk * in2expand[2];
 
-                inpix1[outpixi] =  kk1 * inimg1.md->size[1] * inimg1.md->size[0];
-                inpix1[outpixi] += jj1 * inimg1.md->size[0];
+                inpix1[outpixi] =  kk1 * inimg1->md->size[1] * inimg1->md->size[0];
+                inpix1[outpixi] += jj1 * inimg1->md->size[0];
                 inpix1[outpixi] += ii1;
 
-                inpix2[outpixi] =  kk2 * inimg2.md->size[1] * inimg2.md->size[0];
-                inpix2[outpixi] += jj2 * inimg2.md->size[0];
+                inpix2[outpixi] =  kk2 * inimg2->md->size[1] * inimg2->md->size[0];
+                inpix2[outpixi] += jj2 * inimg2->md->size[0];
                 inpix2[outpixi] += ii2;
             }
         }
@@ -1388,54 +1361,54 @@ errno_t arith_img_function_2_1(
 
     double * ptr1array;
     int ptr1allocate = 0;
-    if ( inimg1.md->datatype == _DATATYPE_DOUBLE )
+    if ( inimg1->md->datatype == _DATATYPE_DOUBLE )
     {
-        ptr1array = inimg1.im->array.D;
+        ptr1array = inimg1->im->array.D;
     }
     else
     {
         ptr1allocate = 1;
         ptr1array = (double *) malloc(sizeof(double) * nbpix1);
 
-        if(inimg1.md->datatype == _DATATYPE_UINT8) {
+        if(inimg1->md->datatype == _DATATYPE_UINT8) {
             for(uint64_t ii = 0; ii < nbpix1; ii++)
-                ptr1array[ii] = (double) (inimg1.im->array.UI8[inpix1[ii]]);
+                ptr1array[ii] = (double) (inimg1->im->array.UI8[ii]);
         }
-        if(inimg1.md->datatype == _DATATYPE_INT8) {
+        if(inimg1->md->datatype == _DATATYPE_INT8) {
             for(uint64_t ii = 0; ii < nbpix1; ii++)
-                ptr1array[ii] = (double) (inimg1.im->array.SI8[inpix1[ii]]);
-        }
-
-        if(inimg1.md->datatype == _DATATYPE_UINT16) {
-            for(uint64_t ii = 0; ii < nbpix1; ii++)
-                ptr1array[ii] = (double) (inimg1.im->array.UI16[inpix1[ii]]);
-        }
-        if(inimg1.md->datatype == _DATATYPE_INT16) {
-            for(uint64_t ii = 0; ii < nbpix1; ii++)
-                ptr1array[ii] = (double) (inimg1.im->array.SI16[inpix1[ii]]);
+                ptr1array[ii] = (double) (inimg1->im->array.SI8[ii]);
         }
 
-        if(inimg1.md->datatype == _DATATYPE_UINT32) {
+        if(inimg1->md->datatype == _DATATYPE_UINT16) {
             for(uint64_t ii = 0; ii < nbpix1; ii++)
-                ptr1array[ii] = (double) (inimg1.im->array.UI32[inpix1[ii]]);
+                ptr1array[ii] = (double) (inimg1->im->array.UI16[ii]);
         }
-        if(inimg1.md->datatype == _DATATYPE_INT32) {
+        if(inimg1->md->datatype == _DATATYPE_INT16) {
             for(uint64_t ii = 0; ii < nbpix1; ii++)
-                ptr1array[ii] = (double) (inimg1.im->array.SI32[inpix1[ii]]);
-        }
-
-        if(inimg1.md->datatype == _DATATYPE_UINT64) {
-            for(uint64_t ii = 0; ii < nbpix1; ii++)
-                ptr1array[ii] = (double) (inimg1.im->array.UI64[inpix1[ii]]);
-        }
-        if(inimg1.md->datatype == _DATATYPE_INT64) {
-            for(uint64_t ii = 0; ii < nbpix1; ii++)
-                ptr1array[ii] = (double) (inimg1.im->array.SI64[inpix1[ii]]);
+                ptr1array[ii] = (double) (inimg1->im->array.SI16[ii]);
         }
 
-        if(inimg1.md->datatype == _DATATYPE_FLOAT) {
+        if(inimg1->md->datatype == _DATATYPE_UINT32) {
             for(uint64_t ii = 0; ii < nbpix1; ii++)
-                ptr1array[ii] = (double) (inimg1.im->array.F[inpix1[ii]]);
+                ptr1array[ii] = (double) (inimg1->im->array.UI32[ii]);
+        }
+        if(inimg1->md->datatype == _DATATYPE_INT32) {
+            for(uint64_t ii = 0; ii < nbpix1; ii++)
+                ptr1array[ii] = (double) (inimg1->im->array.SI32[ii]);
+        }
+
+        if(inimg1->md->datatype == _DATATYPE_UINT64) {
+            for(uint64_t ii = 0; ii < nbpix1; ii++)
+                ptr1array[ii] = (double) (inimg1->im->array.UI64[ii]);
+        }
+        if(inimg1->md->datatype == _DATATYPE_INT64) {
+            for(uint64_t ii = 0; ii < nbpix1; ii++)
+                ptr1array[ii] = (double) (inimg1->im->array.SI64[ii]);
+        }
+
+        if(inimg1->md->datatype == _DATATYPE_FLOAT) {
+            for(uint64_t ii = 0; ii < nbpix1; ii++)
+                ptr1array[ii] = (double) (inimg1->im->array.F[ii]);
         }
     }
 
@@ -1446,54 +1419,54 @@ errno_t arith_img_function_2_1(
 
     double * ptr2array;
     int ptr2allocate = 0;
-    if ( inimg2.md->datatype == _DATATYPE_DOUBLE )
+    if ( inimg2->md->datatype == _DATATYPE_DOUBLE )
     {
-        ptr2array = inimg2.im->array.D;
+        ptr2array = inimg2->im->array.D;
     }
     else
     {
         ptr2allocate = 1;
         ptr2array = (double *) malloc(sizeof(double) * nbpix2);
 
-        if(inimg2.md->datatype == _DATATYPE_UINT8) {
+        if(inimg2->md->datatype == _DATATYPE_UINT8) {
             for(uint64_t ii = 0; ii < nbpix2; ii++)
-                ptr2array[ii] = (double) (inimg2.im->array.UI8[inpix1[ii]]);
+                ptr2array[ii] = (double) (inimg2->im->array.UI8[ii]);
         }
-        if(inimg2.md->datatype == _DATATYPE_INT8) {
+        if(inimg2->md->datatype == _DATATYPE_INT8) {
             for(uint64_t ii = 0; ii < nbpix2; ii++)
-                ptr2array[ii] = (double) (inimg2.im->array.SI8[inpix1[ii]]);
-        }
-
-        if(inimg2.md->datatype == _DATATYPE_UINT16) {
-            for(uint64_t ii = 0; ii < nbpix2; ii++)
-                ptr2array[ii] = (double) (inimg2.im->array.UI16[inpix1[ii]]);
-        }
-        if(inimg2.md->datatype == _DATATYPE_INT16) {
-            for(uint64_t ii = 0; ii < nbpix2; ii++)
-                ptr2array[ii] = (double) (inimg2.im->array.SI16[inpix1[ii]]);
+                ptr2array[ii] = (double) (inimg2->im->array.SI8[ii]);
         }
 
-        if(inimg2.md->datatype == _DATATYPE_UINT32) {
+        if(inimg2->md->datatype == _DATATYPE_UINT16) {
             for(uint64_t ii = 0; ii < nbpix2; ii++)
-                ptr2array[ii] = (double) (inimg2.im->array.UI32[inpix1[ii]]);
+                ptr2array[ii] = (double) (inimg2->im->array.UI16[ii]);
         }
-        if(inimg2.md->datatype == _DATATYPE_INT32) {
+        if(inimg2->md->datatype == _DATATYPE_INT16) {
             for(uint64_t ii = 0; ii < nbpix2; ii++)
-                ptr2array[ii] = (double) (inimg2.im->array.SI32[inpix1[ii]]);
-        }
-
-        if(inimg2.md->datatype == _DATATYPE_UINT64) {
-            for(uint64_t ii = 0; ii < nbpix2; ii++)
-                ptr2array[ii] = (double) (inimg2.im->array.UI64[inpix1[ii]]);
-        }
-        if(inimg2.md->datatype == _DATATYPE_INT64) {
-            for(uint64_t ii = 0; ii < nbpix2; ii++)
-                ptr2array[ii] = (double) (inimg2.im->array.SI64[inpix1[ii]]);
+                ptr2array[ii] = (double) (inimg2->im->array.SI16[ii]);
         }
 
-        if(inimg2.md->datatype == _DATATYPE_FLOAT) {
+        if(inimg2->md->datatype == _DATATYPE_UINT32) {
             for(uint64_t ii = 0; ii < nbpix2; ii++)
-                ptr2array[ii] = (double) (inimg2.im->array.F[inpix1[ii]]);
+                ptr2array[ii] = (double) (inimg2->im->array.UI32[ii]);
+        }
+        if(inimg2->md->datatype == _DATATYPE_INT32) {
+            for(uint64_t ii = 0; ii < nbpix2; ii++)
+                ptr2array[ii] = (double) (inimg2->im->array.SI32[ii]);
+        }
+
+        if(inimg2->md->datatype == _DATATYPE_UINT64) {
+            for(uint64_t ii = 0; ii < nbpix2; ii++)
+                ptr2array[ii] = (double) (inimg2->im->array.UI64[ii]);
+        }
+        if(inimg2->md->datatype == _DATATYPE_INT64) {
+            for(uint64_t ii = 0; ii < nbpix2; ii++)
+                ptr2array[ii] = (double) (inimg2->im->array.SI64[ii]);
+        }
+
+        if(inimg2->md->datatype == _DATATYPE_FLOAT) {
+            for(uint64_t ii = 0; ii < nbpix2; ii++)
+                ptr2array[ii] = (double) (inimg2->im->array.F[ii]);
         }
     }
 
@@ -1542,6 +1515,16 @@ errno_t arith_img_function_2_1(
     return RETURN_SUCCESS;
 }
 
+errno_t arith_img_function_2_1(
+    IMGID inimg1,
+    IMGID inimg2,
+    IMGID *outimg,
+    double (*pt2function)(double, double)
+)
+{
+    return arith_image_function_2_1_IMGID(&inimg1, &inimg2, outimg, pt2function);
+}
+
 
 
 
@@ -1558,21 +1541,10 @@ errno_t arith_image_function_2_1(
 )
 {
     IMGID inimg1 = mkIMGID_from_name(ID_name1);
-    resolveIMGID(&inimg1, ERRMODE_ABORT);
-
     IMGID inimg2 = mkIMGID_from_name(ID_name2);
-    resolveIMGID(&inimg2, ERRMODE_ABORT);
-
     IMGID outimg = mkIMGID_from_name(ID_out);
 
-    arith_img_function_2_1(
-        inimg1,
-        inimg2,
-        &outimg,
-        pt2function
-    );
-
-    return RETURN_SUCCESS;
+    return arith_image_function_2_1_IMGID(&inimg1, &inimg2, &outimg, pt2function);
 }
 
 
@@ -2086,179 +2058,168 @@ errno_t arith_image_function_CD_CD__CD(
 /* image, double  -> image                                                */
 /* ------------------------------------------------------------------------- */
 
-int arith_image_function_1f_1(const char *ID_name,
-                              double      f1,
-                              const char *ID_out,
-                              double (*pt2function)(double, double))
+int arith_image_function_1f_1_IMGID(IMGID *imgin,
+                                    double f1,
+                                    IMGID *imgout,
+                                    double (*pt2function)(double, double))
 {
-    long      ID;
-    long      IDout;
-    long      ii;
-    uint32_t *naxes = NULL;
-    long      nelement;
-    long      naxis;
-    uint8_t   datatype, datatypeout;
-    long      i;
+    long ii;
 
+    resolveIMGID(imgin, ERRMODE_ABORT);
 
-    printf("%s [%d] f1=%f\n", __FILE__, __LINE__, f1);//TBE
-
-    ID       = image_ID(ID_name);
-    datatype = data.image[ID].md[0].datatype;
-    naxis    = data.image[ID].md[0].naxis;
-    naxes    = (uint32_t *) malloc(sizeof(uint32_t) * naxis);
-    if(naxes == NULL)
+    imgout->naxis = imgin->md->naxis;
+    for(int i = 0; i < imgin->md->naxis; i++)
     {
-        PRINT_ERROR("malloc() error");
-        exit(0);
+        imgout->size[i] = imgin->md->size[i];
     }
 
-    for(i = 0; i < naxis; i++)
+    imgout->datatype = _DATATYPE_FLOAT;
+    if(imgin->md->datatype == _DATATYPE_DOUBLE)
     {
-        naxes[i] = data.image[ID].md->size[i];
+        imgout->datatype = _DATATYPE_DOUBLE;
     }
+    imgout->shared = data.SHARED_DFT;
+    imgout->NBkw   = NB_KEYWNODE_MAX;
 
-    datatypeout = _DATATYPE_FLOAT;
-    if(datatype == _DATATYPE_DOUBLE)
-    {
-        datatypeout = _DATATYPE_DOUBLE;
-    }
+    imcreateIMGID(imgout);
 
-    create_image_ID(ID_out,
-                    naxis,
-                    naxes,
-                    datatypeout,
-                    data.SHARED_DFT,
-                    NB_KEYWNODE_MAX,
-                    0,
-                    &IDout);
-
-    free(naxes);
-    nelement = data.image[ID].md->nelement;
+    uint_fast64_t nelement = imgin->md->nelement;
+    uint8_t       datatype = imgin->md->datatype;
 
 #ifdef _OPENMP
     #pragma omp parallel if (nelement > OMP_NELEMENT_LIMIT)
     {
 #endif
 
-        if(datatype == _DATATYPE_UINT8)
-        {
+    if(datatype == _DATATYPE_UINT8)
+    {
 #ifdef _OPENMP
-            #pragma omp for
+        #pragma omp for
 #endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.UI8[ii]), f1);
-            }
-        }
-        if(datatype == _DATATYPE_UINT16)
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.UI16[ii]), f1);
-            }
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.UI8[ii]), f1);
         }
-        if(datatype == _DATATYPE_UINT32)
+    }
+    if(datatype == _DATATYPE_UINT16)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.UI32[ii]), f1);
-            }
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.UI16[ii]), f1);
         }
-        if(datatype == _DATATYPE_UINT64)
+    }
+    if(datatype == _DATATYPE_UINT32)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.UI64[ii]), f1);
-            }
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.UI32[ii]), f1);
         }
+    }
+    if(datatype == _DATATYPE_UINT64)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.UI64[ii]), f1);
+        }
+    }
 
-        if(datatype == _DATATYPE_INT8)
-        {
+    if(datatype == _DATATYPE_INT8)
+    {
 #ifdef _OPENMP
-            #pragma omp for
+        #pragma omp for
 #endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.SI8[ii]), f1);
-            }
-        }
-        if(datatype == _DATATYPE_INT16)
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.SI16[ii]), f1);
-            }
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.SI8[ii]), f1);
         }
-        if(datatype == _DATATYPE_INT32)
+    }
+    if(datatype == _DATATYPE_INT16)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.SI32[ii]), f1);
-            }
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.SI16[ii]), f1);
         }
-        if(datatype == _DATATYPE_INT64)
+    }
+    if(datatype == _DATATYPE_INT32)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.SI64[ii]), f1);
-            }
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.SI32[ii]), f1);
         }
+    }
+    if(datatype == _DATATYPE_INT64)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.SI64[ii]), f1);
+        }
+    }
 
-        if(datatype == _DATATYPE_FLOAT)
-        {
+    if(datatype == _DATATYPE_FLOAT)
+    {
 #ifdef _OPENMP
-            #pragma omp for
+        #pragma omp for
 #endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.F[ii]), f1);
-            }
-        }
-        if(datatype == _DATATYPE_DOUBLE)
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.D[ii] =
-                    (double) pt2function((double)(data.image[ID].array.D[ii]),
-                                         f1);
-            }
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.F[ii]), f1);
         }
+    }
+    if(datatype == _DATATYPE_DOUBLE)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.D[ii] =
+                (double) pt2function((double)(imgin->im->array.D[ii]),
+                                     f1);
+        }
+    }
 #ifdef _OPENMP
     }
 #endif
 
     return EXIT_SUCCESS;
+}
+
+int arith_image_function_1f_1(const char *ID_name,
+                              double      f1,
+                              const char *ID_out,
+                              double (*pt2function)(double, double))
+{
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+
+    return arith_image_function_1f_1_IMGID(&imgin, f1, &imgout, pt2function);
 }
 
 int arith_image_function_1f_1_inplace_byID(
@@ -2410,191 +2371,169 @@ int arith_image_function_1f_1_inplace(const char *ID_name,
 /* image, double, double -> image                                      */
 /* ------------------------------------------------------------------------- */
 
-int arith_image_function_1ff_1(const char *ID_name,
-                               double      f1,
-                               double      f2,
-                               const char *ID_out,
-                               double (*pt2function)(double, double, double))
+int arith_image_function_1ff_1_IMGID(IMGID *imgin,
+                                     double f1,
+                                     double f2,
+                                     IMGID *imgout,
+                                     double (*pt2function)(double, double, double))
 {
-    long      ID;
-    long      IDout;
-    long      ii;
-    uint32_t *naxes = NULL;
-    long      nelement;
-    long      naxis;
-    uint8_t   datatype;
-    uint8_t   datatypeout;
-    long      i;
+    long ii;
+    uint8_t datatype;
 
-    ID       = image_ID(ID_name);
-    datatype = data.image[ID].md[0].datatype;
-    naxis    = data.image[ID].md[0].naxis;
-    naxes    = (uint32_t *) malloc(sizeof(uint32_t) * naxis);
-    if(naxes == NULL)
-    {
-        PRINT_ERROR("malloc() error");
-        exit(0);
-    }
+    resolveIMGID(imgin, ERRMODE_ABORT);
 
-    for(i = 0; i < naxis; i++)
+    imgout->naxis = imgin->md->naxis;
+    for(int i = 0; i < imgin->md->naxis; i++)
     {
-        naxes[i] = data.image[ID].md[0].size[i];
+        imgout->size[i] = imgin->md->size[i];
     }
-    datatypeout = _DATATYPE_FLOAT;
-    if(datatype == _DATATYPE_DOUBLE)
+    imgout->datatype = _DATATYPE_FLOAT;
+    if(imgin->md->datatype == _DATATYPE_DOUBLE)
     {
-        datatypeout = _DATATYPE_DOUBLE;
+        imgout->datatype = _DATATYPE_DOUBLE;
     }
+    imgout->shared = data.SHARED_DFT;
+    imgout->NBkw   = NB_KEYWNODE_MAX;
 
-    create_image_ID(ID_out,
-                    naxis,
-                    naxes,
-                    datatypeout,
-                    data.SHARED_DFT,
-                    NB_KEYWNODE_MAX,
-                    0,
-                    &IDout);
-    free(naxes);
-    nelement = data.image[ID].md[0].nelement;
+    imcreateIMGID(imgout);
+
+    uint_fast64_t nelement = imgin->md->nelement;
+    datatype               = imgin->md->datatype;
 
 #ifdef _OPENMP
     #pragma omp parallel if (nelement > OMP_NELEMENT_LIMIT)
     {
 #endif
 
-        if(datatype == _DATATYPE_UINT8)
-        {
+    if(datatype == _DATATYPE_UINT8)
+    {
 #ifdef _OPENMP
-            #pragma omp for
+        #pragma omp for
 #endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.UI8[ii]),
-                                f1,
-                                f2);
-            }
-        }
-        if(datatype == _DATATYPE_UINT16)
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.UI16[ii]),
-                                f1,
-                                f2);
-            }
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.UI8[ii]), f1, f2);
         }
-        if(datatype == _DATATYPE_UINT32)
+    }
+    if(datatype == _DATATYPE_UINT16)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.UI32[ii]),
-                                f1,
-                                f2);
-            }
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.UI16[ii]), f1, f2);
         }
-        if(datatype == _DATATYPE_UINT64)
+    }
+    if(datatype == _DATATYPE_UINT32)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.UI64[ii]),
-                                f1,
-                                f2);
-            }
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.UI32[ii]), f1, f2);
         }
+    }
+    if(datatype == _DATATYPE_UINT64)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.UI64[ii]), f1, f2);
+        }
+    }
 
-        if(datatype == _DATATYPE_INT8)
-        {
+    if(datatype == _DATATYPE_INT8)
+    {
 #ifdef _OPENMP
-            #pragma omp for
+        #pragma omp for
 #endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.SI8[ii]),
-                                f1,
-                                f2);
-            }
-        }
-        if(datatype == _DATATYPE_INT16)
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.SI16[ii]),
-                                f1,
-                                f2);
-            }
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.SI8[ii]), f1, f2);
         }
-        if(datatype == _DATATYPE_INT32)
+    }
+    if(datatype == _DATATYPE_INT16)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.SI32[ii]),
-                                f1,
-                                f2);
-            }
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.SI16[ii]), f1, f2);
         }
-        if(datatype == _DATATYPE_INT64)
+    }
+    if(datatype == _DATATYPE_INT32)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.SI64[ii]),
-                                f1,
-                                f2);
-            }
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.SI32[ii]), f1, f2);
         }
+    }
+    if(datatype == _DATATYPE_INT64)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.SI64[ii]), f1, f2);
+        }
+    }
 
-        if(datatype == _DATATYPE_FLOAT)
-        {
+    if(datatype == _DATATYPE_FLOAT)
+    {
 #ifdef _OPENMP
-            #pragma omp for
+        #pragma omp for
 #endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.F[ii] =
-                    pt2function((double)(data.image[ID].array.F[ii]), f1, f2);
-            }
-        }
-        if(datatype == _DATATYPE_DOUBLE)
+        for(ii = 0; ii < nelement; ii++)
         {
-#ifdef _OPENMP
-            #pragma omp for
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                data.image[IDout].array.D[ii] =
-                    pt2function((double)(data.image[ID].array.D[ii]), f1, f2);
-            }
+            imgout->im->array.F[ii] =
+                pt2function((double)(imgin->im->array.F[ii]), f1, f2);
         }
+    }
+    if(datatype == _DATATYPE_DOUBLE)
+    {
+#ifdef _OPENMP
+        #pragma omp for
+#endif
+        for(ii = 0; ii < nelement; ii++)
+        {
+            imgout->im->array.D[ii] =
+                pt2function((double)(imgin->im->array.D[ii]), f1, f2);
+        }
+    }
 #ifdef _OPENMP
     }
 #endif
 
     return (0);
+}
+
+int arith_image_function_1ff_1(const char *ID_name,
+                               double f1,
+                               double f2,
+                               const char *ID_out,
+                               double (*pt2function)(double, double, double))
+{
+    IMGID imgin  = mkIMGID_from_name(ID_name);
+    IMGID imgout = mkIMGID_from_name(ID_out);
+
+    return arith_image_function_1ff_1_IMGID(&imgin, f1, f2, &imgout, pt2function);
 }
 
 int arith_image_function_1ff_1_inplace(const char *ID_name,

--- a/src/COREMOD_arith/imfunctions.h
+++ b/src/COREMOD_arith/imfunctions.h
@@ -10,11 +10,20 @@ errno_t arith_image_function_im_im__d_d(const char *ID_name,
                                         const char *ID_out,
                                         double (*pt2function)(double));
 
+errno_t arith_image_function_im_im__d_d_IMGID(IMGID *imgin,
+        IMGID *imgout,
+        double (*pt2function)(double));
+
 errno_t arith_image_function_imd_im__dd_d(const char *ID_name,
         double      v0,
         const char *ID_out,
         double (*pt2function)(double,
                               double));
+
+errno_t arith_image_function_imd_im__dd_d_IMGID(IMGID *imgin,
+        double v0,
+        IMGID *imgout,
+        double (*pt2function)(double, double));
 
 errno_t arith_image_function_imdd_im__ddd_d(const char *ID_name,
         double      v0,
@@ -24,6 +33,12 @@ errno_t arith_image_function_imdd_im__ddd_d(const char *ID_name,
                               double,
                               double));
 
+errno_t arith_image_function_imdd_im__ddd_d_IMGID(IMGID *imgin,
+        double v0,
+        double v1,
+        IMGID *imgout,
+        double (*pt2function)(double, double, double));
+
 errno_t arith_image_function_1_1_byID(imageID ID,
                                       imageID IDout,
                                       double (*pt2function)(double));
@@ -31,6 +46,10 @@ errno_t arith_image_function_1_1_byID(imageID ID,
 errno_t arith_image_function_1_1(const char *ID_name,
                                  const char *ID_out,
                                  double (*pt2function)(double));
+
+errno_t arith_image_function_1_1_IMGID(IMGID *imgin,
+                                       IMGID *imgout,
+                                       double (*pt2function)(double));
 
 // imagein -> imagein (in place)
 errno_t arith_image_function_1_1_inplace_byID(imageID ID,
@@ -44,6 +63,18 @@ errno_t arith_image_function_2_1(const char *ID_name1,
                                  const char *ID_name2,
                                  const char *ID_out,
                                  double (*pt2function)(double, double));
+
+errno_t arith_image_function_2_1_IMGID(IMGID *imgin1,
+                                       IMGID *imgin2,
+                                       IMGID *imgout,
+                                       double (*pt2function)(double, double));
+
+errno_t arith_img_function_2_1(
+    IMGID inimg1,
+    IMGID inimg2,
+    IMGID *outimg,
+    double (*pt2function)(double, double)
+);
 
 errno_t arith_image_function_2_1_inplace_byID(
     imageID ID1, imageID ID2, double (*pt2function)(double, double));
@@ -69,6 +100,11 @@ int arith_image_function_1f_1(const char *ID_name,
                               const char *ID_out,
                               double (*pt2function)(double, double));
 
+int arith_image_function_1f_1_IMGID(IMGID *imgin,
+                                    double f1,
+                                    IMGID *imgout,
+                                    double (*pt2function)(double, double));
+
 int arith_image_function_1f_1_inplace_byID(
     long ID, double f1, double (*pt2function)(double, double));
 
@@ -81,6 +117,12 @@ int arith_image_function_1ff_1(const char *ID_name,
                                double      f2,
                                const char *ID_out,
                                double (*pt2function)(double, double, double));
+
+int arith_image_function_1ff_1_IMGID(IMGID *imgin,
+                                     double f1,
+                                     double f2,
+                                     IMGID *imgout,
+                                     double (*pt2function)(double, double, double));
 
 int arith_image_function_1ff_1_inplace(const char *ID_name,
                                        double      f1,

--- a/src/COREMOD_iofits/loadfits.c
+++ b/src/COREMOD_iofits/loadfits.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 
 #include "CommandLineInterface/CLIcore.h"
+#include "loadfits.h"
 
 #include "COREMOD_iofits_common.h"
 #include "COREMOD_memory/COREMOD_memory.h"
@@ -82,11 +83,10 @@ static errno_t help_function()
 /// LOADFITS_ERRMODE_ERROR   (2) return error
 /// LOADFITS_ERRMODE_EXIT    (3) exit program at error
 
-errno_t load_fits(
+errno_t load_fits_IMGID(
     const char *__restrict file_name,
-    const char *__restrict ID_name,
-    int      errmode,
-    imageID *IDout
+    IMGID *imgout,
+    int      errmode
 )
 {
     DEBUG_TRACE_FSTART();
@@ -104,8 +104,6 @@ errno_t load_fits(
     //    unsigned short *sarray = NULL;
     //    long      NDR = 1; /* non-destructive reads */
 
-    imageID ID;
-
     nulval = 0;
     anynul = 0;
     bscale = 1;
@@ -115,7 +113,7 @@ errno_t load_fits(
     naxes[1] = 0;
     naxes[2] = 0;
 
-    DEBUG_TRACEPOINT("FARG \"%s\" %s %d", file_name, ID_name, errmode);
+    DEBUG_TRACEPOINT("FARG \"%s\" %s %d", file_name, imgout->name, errmode);
 
     {
         // Open fitsio file pointer
@@ -158,7 +156,7 @@ errno_t load_fits(
                         }
                     }
 
-                    ID = -1;
+                    imgout->ID = -1;
                 }
                 else
                 {
@@ -174,10 +172,7 @@ errno_t load_fits(
         if(fileOK == 0)
         {
             // if image not loaded, set output identifier to -1
-            if(IDout != NULL)
-            {
-                *IDout = -1;
-            }
+            imgout->ID = -1;
 
             if(errmode == 0)
             {
@@ -189,7 +184,7 @@ errno_t load_fits(
             {
                 PRINT_WARNING(
                     "Image \"%s\" could not be loaded from file \"%s\"",
-                    ID_name,
+                    imgout->name,
                     file_name);
                 DEBUG_TRACE_FEXIT();
                 return RETURN_SUCCESS;
@@ -199,7 +194,7 @@ errno_t load_fits(
             {
                 FUNC_RETURN_FAILURE(
                     "Image \"%s\" could not be loaded from file \"%s\"",
-                    ID_name,
+                    imgout->name,
                     file_name);
             }
 
@@ -300,14 +295,14 @@ errno_t load_fits(
     /* bitpix = -32  TFLOAT */
     if(bitpix == -32)
     {
-        create_image_ID(ID_name,
+        create_image_ID(imgout->name,
                         naxis,
                         naxes,
                         _DATATYPE_FLOAT,
                         data.SHARED_DFT,
                         NB_KEYWNODE_MAX,
                         0,
-                        &ID);
+                        &imgout->ID);
 
         {
             int status = 0;
@@ -316,7 +311,7 @@ errno_t load_fits(
                           fpixel,
                           nelements,
                           &nulval,
-                          data.image[ID].array.F,
+                          data.image[imgout->ID].array.F,
                           &anynul,
                           &status);
             FITSIO_CHECK_ERROR(status,
@@ -329,14 +324,14 @@ errno_t load_fits(
     /* bitpix = -64  TDOUBLE */
     if(bitpix == -64)
     {
-        create_image_ID(ID_name,
+        create_image_ID(imgout->name,
                         naxis,
                         naxes,
                         _DATATYPE_DOUBLE,
                         data.SHARED_DFT,
                         NB_KEYWNODE_MAX,
                         0,
-                        &ID);
+                        &imgout->ID);
 
         {
             int status = 0;
@@ -345,7 +340,7 @@ errno_t load_fits(
                           fpixel,
                           nelements,
                           &nulval,
-                          data.image[ID].array.D,
+                          data.image[imgout->ID].array.D,
                           &anynul,
                           &status);
             FITSIO_CHECK_ERROR(status,
@@ -359,14 +354,14 @@ errno_t load_fits(
     if(bitpix == 16)
     {
         // ID = create_image_ID(ID_name, naxis, naxes, Dtype, data.SHARED_DFT, data.NBKEWORD_DFT);
-        create_image_ID(ID_name,
+        create_image_ID(imgout->name,
                         naxis,
                         naxes,
                         _DATATYPE_UINT16,
                         data.SHARED_DFT,
                         NB_KEYWNODE_MAX,
                         0,
-                        &ID);
+                        &imgout->ID);
 
         //           fits_read_img(fptr, 20, fpixel, nelements, &nulval, sarray, &anynul, &FITSIO_status);
         {
@@ -376,7 +371,7 @@ errno_t load_fits(
                           fpixel,
                           nelements,
                           &nulval,
-                          data.image[ID].array.UI16,
+                          data.image[imgout->ID].array.UI16,
                           &anynul,
                           &status);
             FITSIO_CHECK_ERROR(status,
@@ -389,14 +384,14 @@ errno_t load_fits(
     /* bitpix = 32   TLONG */
     if(bitpix == 32)
     {
-        create_image_ID(ID_name,
+        create_image_ID(imgout->name,
                         naxis,
                         naxes,
                         _DATATYPE_INT32,
                         data.SHARED_DFT,
                         NB_KEYWNODE_MAX,
                         0,
-                        &ID);
+                        &imgout->ID);
         larray = (long *) malloc(sizeof(long) * nelements);
         if(larray == NULL)
         {
@@ -422,7 +417,7 @@ errno_t load_fits(
         bzero = 0.0;
         for(uint_fast64_t ii = 0; ii < (uint_fast64_t) nelements; ii++)
         {
-            data.image[ID].array.SI32[ii] = larray[ii] * bscale + bzero;
+            data.image[imgout->ID].array.SI32[ii] = larray[ii] * bscale + bzero;
         }
         free(larray);
         larray = NULL;
@@ -431,14 +426,14 @@ errno_t load_fits(
     /* bitpix = 64   TLONG  */
     if(bitpix == 64)
     {
-        create_image_ID(ID_name,
+        create_image_ID(imgout->name,
                         naxis,
                         naxes,
                         _DATATYPE_INT64,
                         data.SHARED_DFT,
                         NB_KEYWNODE_MAX,
                         0,
-                        &ID);
+                        &imgout->ID);
         larray = (long *) malloc(sizeof(long) * nelements);
         if(larray == NULL)
         {
@@ -465,7 +460,7 @@ errno_t load_fits(
         bzero = 0.0;
         for(uint_fast64_t ii = 0; ii < (uint_fast64_t) nelements; ii++)
         {
-            data.image[ID].array.SI64[ii] = larray[ii] * bscale + bzero;
+            data.image[imgout->ID].array.SI64[ii] = larray[ii] * bscale + bzero;
         }
         free(larray);
         larray = NULL;
@@ -474,14 +469,14 @@ errno_t load_fits(
     /* bitpix = 8   TBYTE */
     if(bitpix == 8)
     {
-        create_image_ID(ID_name,
+        create_image_ID(imgout->name,
                         naxis,
                         naxes,
                         _DATATYPE_FLOAT,
                         data.SHARED_DFT,
                         NB_KEYWNODE_MAX,
                         0,
-                        &ID);
+                        &imgout->ID);
         barray = (unsigned char *) malloc(sizeof(unsigned char) * naxes[1] *
                                           naxes[0]);
         if(barray == NULL)
@@ -508,13 +503,13 @@ errno_t load_fits(
 
         for(uint_fast64_t ii = 0; ii < (uint_fast64_t) nelements; ii++)
         {
-            data.image[ID].array.F[ii] = (1.0 * barray[ii] * bscale + bzero);
+            data.image[imgout->ID].array.F[ii] = (1.0 * barray[ii] * bscale + bzero);
         }
         free(barray);
         barray = NULL;
     }
 
-    IMGID img = makesetIMGID(ID_name, ID);
+    resolveIMGID(imgout, errmode);
 
 // keywords to ignore
     char *keywordignore[] = {"BITPIX",
@@ -577,7 +572,7 @@ errno_t load_fits(
                        keyname,
                        kwlongval,
                        kwcomment);*/
-                image_keyword_addL(img, keyname, kwlongval, kwcomment);
+                image_keyword_addL(*imgout, keyname, kwlongval, kwcomment);
             }
 
             if(kwtypeOK == 0)
@@ -592,7 +587,7 @@ errno_t load_fits(
                            keyname,
                            kwdoubleval,
                            kwcomment);*/
-                    image_keyword_addD(img, keyname, kwdoubleval, kwcomment);
+                    image_keyword_addD(*imgout, keyname, kwdoubleval, kwcomment);
                 }
 
                 if(kwtypeOK == 0)
@@ -607,7 +602,7 @@ errno_t load_fits(
                     kwvaluestr[strlen(kwvaluestr) - 1] = '\0';
                     char *kwvaluestr1;
                     kwvaluestr1 = kwvaluestr + 1;
-                    image_keyword_addS(img, keyname, kwvaluestr1, kwcomment);
+                    image_keyword_addS(*imgout, keyname, kwvaluestr1, kwcomment);
                 }
             }
         }
@@ -622,15 +617,29 @@ errno_t load_fits(
                            file_name);
     }
 
-    if(IDout != NULL)
-    {
-        *IDout = ID;
-    }
-
-    DEBUG_TRACEPOINT("FOUT IDout %ld", ID);
+    DEBUG_TRACEPOINT("FOUT IDout %ld", imgout->ID);
 
     DEBUG_TRACE_FEXIT();
     return RETURN_SUCCESS;
+}
+
+errno_t load_fits(
+    const char *__restrict file_name,
+    const char *__restrict ID_name,
+    int      errmode,
+    imageID *IDout
+)
+{
+    IMGID imgout = mkIMGID_from_name(ID_name);
+
+    errno_t retval = load_fits_IMGID(file_name, &imgout, errmode);
+
+    if(IDout != NULL)
+    {
+        *IDout = imgout.ID;
+    }
+
+    return retval;
 }
 
 
@@ -641,7 +650,8 @@ static errno_t compute_function()
 
     INSERT_STD_PROCINFO_COMPUTEFUNC_START
 
-    FUNC_CHECK_RETURN(load_fits(infilename, outimname, *FITSIOerrmode, NULL));
+    IMGID imgout = mkIMGID_from_name(outimname);
+    FUNC_CHECK_RETURN(load_fits_IMGID(infilename, &imgout, *FITSIOerrmode));
 
     INSERT_STD_PROCINFO_COMPUTEFUNC_END
 

--- a/src/COREMOD_iofits/loadfits.h
+++ b/src/COREMOD_iofits/loadfits.h
@@ -17,4 +17,8 @@ errno_t load_fits(const char *restrict file_name,
                   int      errmode,
                   imageID *ID);
 
+errno_t load_fits_IMGID(const char *restrict file_name,
+                        IMGID *imgout,
+                        int errmode);
+
 #endif

--- a/src/COREMOD_iofits/savefits.c
+++ b/src/COREMOD_iofits/savefits.c
@@ -4,6 +4,7 @@
  */
 
 #include "CommandLineInterface/CLIcore.h"
+#include "savefits.h"
 
 #include <pthread.h>
 
@@ -29,7 +30,7 @@ static char *inheader; // import header from this file
 
 
 // CLI function arguments and parameters
-static CLICMDARGDEF farg[] = {{
+static CLICMDARGDEF farg[] = {{ 
         CLIARG_IMG,
         ".in_name",
         "input image",
@@ -51,10 +52,7 @@ static CLICMDARGDEF farg[] = {{
         // non-CLI parameter
         CLIARG_INT64,
         ".bitpix",
-        "0: auto\n"
-        "8 /(10) : (un)sig   8-b int\n"
-        "16/(20) 32/(40) 64/(80) : (un)sig int\n"
-        "-32/-64 : 32/64-b flt\n",
+        "0: auto\n8 /(10) : (un)sig   8-b int\n16/(20) 32/(40) 64/(80) : (un)sig int\n-32/-64 : 32/64-b flt\n",
         "0",
         CLIARG_HIDDEN_DEFAULT,
         (void **) &outbitpix,
@@ -91,12 +89,10 @@ static errno_t help_function()
 
 
 
-
 /**
- * @brief Write FITS file - wrapper kept for backwards compatibility before introducing
- * optional input image truncation
+ * @brief Write FITS file - implementation using IMGID
  *
- * @param inputimname       input image name
+ * @param imgin             input image
  * @param truncate          truncate input image to truncate first slices - -1 to ignore
  * @param outputFITSname    output FITS file name
  * @param outputbitpix      bitpix of output image. 0 if match input
@@ -106,8 +102,8 @@ static errno_t help_function()
  * @param FITSIOext         extension to pass instructions to FITSIO
  * @return errno_t
  */
-errno_t saveFITS_opt_trunc(
-    const char *__restrict inputimname,
+errno_t saveFITS_opt_trunc_IMGID(
+    IMGID *imgin,
     int truncate,
     const char *__restrict outputFITSname,
     int outputbitpix,
@@ -121,7 +117,7 @@ errno_t saveFITS_opt_trunc(
 
     DEBUG_TRACE_FSTART();
     DEBUG_TRACEPOINT("Saving image %s to file %s, bitpix = %d, slice truncation %d\n",
-                     inputimname,
+                     imgin->name,
                      outputFITSname,
                      outputbitpix,
                      truncate);
@@ -133,14 +129,7 @@ errno_t saveFITS_opt_trunc(
 
     char fnametmp[STRINGMAXLEN_FILENAME];
 
-    DEBUG_TRACEPOINT(">> saving %s to %s\n", inputimname, outputFITSname);
-    /*
-        WRITE_FILENAME(fnametmp,
-                       "_savefits_atomic_%s_%d_%ld.tmp.fits",
-                       inputimname,
-                       (int) getpid(),
-                       (long) self_id);
-    */
+    DEBUG_TRACEPOINT(">> saving %s to %s\n", imgin->name, outputFITSname);
 
     WRITE_FILENAME(fnametmp,
                    "%s.%d.%ld.tmp",
@@ -158,19 +147,18 @@ errno_t saveFITS_opt_trunc(
                    FITSIOext
                   );
 
-    IMGID imgin = mkIMGID_from_name(inputimname);
-    resolveIMGID(&imgin, ERRMODE_WARN);
-    if(imgin.ID == -1)
+    resolveIMGID(imgin, ERRMODE_WARN);
+    if(imgin->ID == -1)
     {
         PRINT_WARNING("Image %s does not exist in memory - cannot save to FITS",
-                      inputimname);
+                      imgin->name);
         DEBUG_TRACE_FEXIT();
         return RETURN_SUCCESS;
     }
 
     // data types
-    uint8_t datatype       = imgin.md->datatype;
-    char *datainptr = (char *) imgin.im->array.raw;
+    uint8_t datatype       = imgin->md->datatype;
+    char *datainptr = (char *) imgin->im->array.raw;
 
     // default
     int     bitpix = FLOAT_IMG;
@@ -217,12 +205,12 @@ errno_t saveFITS_opt_trunc(
         abort();
     }
 
-    int  naxis = imgin.md->naxis;
+    int  naxis = imgin->md->naxis;
     long nelements = 1;
     long naxesl[3];
     for(int i = 0; i < naxis; i++)
     {
-        naxesl[i] = (long) imgin.md->size[i];
+        naxesl[i] = (long) imgin->md->size[i];
         if (truncate >= 0 && i == naxis -1) {
             naxesl[naxis - 1] = truncate;
             DEBUG_TRACEPOINT("-------------- TRUNCATE TO %d\n", truncate);
@@ -323,7 +311,7 @@ errno_t saveFITS_opt_trunc(
                     fits_write_record(fptr,
                                       fitscard,
                                       &COREMOD_iofits_data.FITSIO_status);
-                    if(check_FITSIO_status(__FILE__, __func__, __LINE__, 1) !=
+                    if(check_FITSIO_status(__FILE__, __func__, __LINE__, 1) != 
                             0)
                     {
                         PRINT_ERROR(
@@ -362,61 +350,61 @@ errno_t saveFITS_opt_trunc(
     // These are technical keywords that shouldn't be propagated to FITS.
 
     {
-        int NBkw  = imgin.md->NBkw;
+        int NBkw  = imgin->md->NBkw;
         int kwcnt = 0;
         DEBUG_TRACEPOINT("----------- NUMBER KW = %d ---------------\n", NBkw);
         for(int kw = 0; kw < NBkw; kw++)
         {
-            if(imgin.im->kw[kw].name[0] == '_')
+            if(imgin->im->kw[kw].name[0] == '_')
             {
                 // Skip keywords that start with a "_"
                 continue;
             }
-            if(imgin.im->kw[kw].name[0] == ' ')
+            if(imgin->im->kw[kw].name[0] == ' ')
             {
                 // Abort when we hit an empty keyword.
                 break;
             }
 
             char tmpkwvalstr[81];
-            switch(imgin.im->kw[kw].type)
+            switch(imgin->im->kw[kw].type)
             {
                 case 'L':
                     DEBUG_TRACEPOINT("writing keyword [L] %-8s= %20ld / %s\n",
-                                     imgin.im->kw[kw].name,
-                                     imgin.im->kw[kw].value.numl,
-                                     imgin.im->kw[kw].comment);
+                                     imgin->im->kw[kw].name,
+                                     imgin->im->kw[kw].value.numl,
+                                     imgin->im->kw[kw].comment);
                     COREMOD_iofits_data.FITSIO_status = 0;
                     fits_update_key(fptr,
                                     TLONG,
-                                    imgin.im->kw[kw].name,
-                                    &imgin.im->kw[kw].value.numl,
-                                    imgin.im->kw[kw].comment,
+                                    imgin->im->kw[kw].name,
+                                    &imgin->im->kw[kw].value.numl,
+                                    imgin->im->kw[kw].comment,
                                     &COREMOD_iofits_data.FITSIO_status);
                     kwcnt++;
                     break;
 
                 case 'D':
                     DEBUG_TRACEPOINT("writing keyword [D] %-8s= %20g / %s\n",
-                                     imgin.im->kw[kw].name,
-                                     imgin.im->kw[kw].value.numf,
-                                     imgin.im->kw[kw].comment);
+                                     imgin->im->kw[kw].name,
+                                     imgin->im->kw[kw].value.numf,
+                                     imgin->im->kw[kw].comment);
                     COREMOD_iofits_data.FITSIO_status = 0;
                     fits_update_key(fptr,
                                     TDOUBLE,
-                                    imgin.im->kw[kw].name,
-                                    &imgin.im->kw[kw].value.numf,
-                                    imgin.im->kw[kw].comment,
+                                    imgin->im->kw[kw].name,
+                                    &imgin->im->kw[kw].value.numf,
+                                    imgin->im->kw[kw].comment,
                                     &COREMOD_iofits_data.FITSIO_status);
                     kwcnt++;
                     break;
 
                 case 'S':
-                    snprintf(tmpkwvalstr, 81, "'%s'", imgin.im->kw[kw].value.valstr);
+                    snprintf(tmpkwvalstr, 81, "'%s'", imgin->im->kw[kw].value.valstr);
                     DEBUG_TRACEPOINT("writing keyword [S] %-8s= %20s / %s\n",
-                                     imgin.im->kw[kw].name,
+                                     imgin->im->kw[kw].name,
                                      tmpkwvalstr,
-                                     imgin.im->kw[kw].comment);
+                                     imgin->im->kw[kw].comment);
                     COREMOD_iofits_data.FITSIO_status = 0;
                     // MIND THAT WE ADDED SINGLE QUOTES JUST ABOVE IN snprintf!!
                     if((strncmp("'#TRUE#'", tmpkwvalstr, 8) == 0) ||
@@ -427,9 +415,9 @@ errno_t saveFITS_opt_trunc(
                             strncmp("'#TRUE#'", tmpkwvalstr, 6) == 0;
                         fits_update_key(fptr,
                                         TLOGICAL,
-                                        imgin.im->kw[kw].name,
+                                        imgin->im->kw[kw].name,
                                         &tmpval_is_true,
-                                        imgin.im->kw[kw].comment,
+                                        imgin->im->kw[kw].comment,
                                         &COREMOD_iofits_data.FITSIO_status);
                     }
                     else
@@ -437,9 +425,9 @@ errno_t saveFITS_opt_trunc(
                         // Normal string
                         fits_update_key(fptr,
                                         TSTRING,
-                                        imgin.im->kw[kw].name,
-                                        imgin.im->kw[kw].value.valstr,
-                                        imgin.im->kw[kw].comment,
+                                        imgin->im->kw[kw].name,
+                                        imgin->im->kw[kw].value.valstr,
+                                        imgin->im->kw[kw].comment,
                                         &COREMOD_iofits_data.FITSIO_status);
                     }
                     kwcnt++;
@@ -452,7 +440,7 @@ errno_t saveFITS_opt_trunc(
             if(check_FITSIO_status(__FILE__, __func__, __LINE__, 1) != 0)
             {
                 PRINT_ERROR("fits_update_key error on keyword %s",
-                            imgin.im->kw[kw].name);
+                            imgin->im->kw[kw].name);
                 abort();
             }
         }
@@ -612,6 +600,29 @@ errno_t saveFITS_opt_trunc(
     return RETURN_SUCCESS;
 }
 
+errno_t saveFITS_opt_trunc(
+    const char *__restrict inputimname,
+    int truncate,
+    const char *__restrict outputFITSname,
+    int outputbitpix,
+    const char *__restrict importheaderfile,
+    IMAGE_KEYWORD *kwarray,
+    int            kwarraysize,
+    const char *__restrict FITSIOext
+)
+{
+    IMGID imgin = mkIMGID_from_name(inputimname);
+
+    return saveFITS_opt_trunc_IMGID(&imgin,
+                                    truncate,
+                                    outputFITSname,
+                                    outputbitpix,
+                                    importheaderfile,
+                                    kwarray,
+                                    kwarraysize,
+                                    FITSIOext);
+}
+
 
 
 /**
@@ -634,8 +645,10 @@ errno_t saveFITS(
     IMAGE_KEYWORD *kwarray,
     int            kwarraysize)
 {
-    return saveFITS_opt_trunc(
-               inputimname,
+    IMGID imgin = mkIMGID_from_name(inputimname);
+
+    return saveFITS_opt_trunc_IMGID(
+               &imgin,
                -1,
                outputFITSname,
                outputbitpix,
@@ -675,13 +688,15 @@ errno_t saveall_fits(
 
 
 errno_t save_fits(
-    const char *__restrict savedirname,
+    const char *__restrict inputimname,
     const char *__restrict outputFITSname
 )
 {
     DEBUG_TRACE_FSTART();
 
-    FUNC_CHECK_RETURN(saveFITS(savedirname, outputFITSname, 0, "", NULL, 0));
+    IMGID imgin = mkIMGID_from_name(inputimname);
+
+    FUNC_CHECK_RETURN(saveFITS_opt_trunc_IMGID(&imgin, -1, outputFITSname, 0, "", NULL, 0, ""));
 
     DEBUG_TRACE_FEXIT();
     return RETURN_SUCCESS;
@@ -689,13 +704,15 @@ errno_t save_fits(
 
 
 errno_t save_fl_fits(
-    const char *__restrict savedirname,
+    const char *__restrict inputimname,
     const char *__restrict outputFITSname
 )
 {
     DEBUG_TRACE_FSTART();
 
-    FUNC_CHECK_RETURN(saveFITS(savedirname, outputFITSname, -32, "", NULL, 0));
+    IMGID imgin = mkIMGID_from_name(inputimname);
+
+    FUNC_CHECK_RETURN(saveFITS_opt_trunc_IMGID(&imgin, -1, outputFITSname, -32, "", NULL, 0, ""));
 
     DEBUG_TRACE_FEXIT();
     return RETURN_SUCCESS;
@@ -703,13 +720,15 @@ errno_t save_fl_fits(
 
 
 errno_t save_db_fits(
-    const char *__restrict savedirname,
+    const char *__restrict inputimname,
     const char *__restrict outputFITSname
 )
 {
     DEBUG_TRACE_FSTART();
 
-    FUNC_CHECK_RETURN(saveFITS(savedirname, outputFITSname, -64, "", NULL, 0));
+    IMGID imgin = mkIMGID_from_name(inputimname);
+
+    FUNC_CHECK_RETURN(saveFITS_opt_trunc_IMGID(&imgin, -1, outputFITSname, -64, "", NULL, 0, ""));
 
     DEBUG_TRACE_FEXIT();
     return RETURN_SUCCESS;
@@ -722,7 +741,8 @@ static errno_t compute_function()
 
     INSERT_STD_PROCINFO_COMPUTEFUNC_START
 
-    saveFITS(inimname, outfname, *outbitpix, inheader, NULL, 0);
+    IMGID imgin = mkIMGID_from_name(inimname);
+    saveFITS_opt_trunc_IMGID(&imgin, -1, outfname, *outbitpix, inheader, NULL, 0, "");
 
     INSERT_STD_PROCINFO_COMPUTEFUNC_END
 

--- a/src/COREMOD_iofits/savefits.h
+++ b/src/COREMOD_iofits/savefits.h
@@ -25,6 +25,15 @@ errno_t saveFITS_opt_trunc(const char *__restrict inputimname,
                            int            kwarraysize,
                            const char *__restrict FITSIOext);
 
+errno_t saveFITS_opt_trunc_IMGID(IMGID *imgin,
+                                 int truncate,
+                                 const char *__restrict outputFITSname,
+                                 int outputbitpix,
+                                 const char *__restrict importheaderfile,
+                                 IMAGE_KEYWORD *kwarray,
+                                 int            kwarraysize,
+                                 const char *__restrict FITSIOext);
+
 errno_t save_fits(const char *__restrict inputimname,
                   const char *__restrict outputFITSname);
 

--- a/src/COREMOD_memory/create_image.c
+++ b/src/COREMOD_memory/create_image.c
@@ -4,6 +4,7 @@
  */
 
 #include "CommandLineInterface/CLIcore.h"
+#include "create_image.h"
 #include "image_ID.h"
 #include "list_image.h"
 #include "stream_sem.h"
@@ -17,8 +18,72 @@
 
 /* creates an image ID */
 /* all images should be created by this function */
+errno_t create_image_ID_IMGID(
+    IMGID *img
+)
+{
+    DEBUG_TRACE_FSTART();
+    DEBUG_TRACEPOINT("FARG %s %ld %d %d %d %d",
+                     img->name,
+                     (long) img->naxis,
+                     (int) img->datatype,
+                     img->shared,
+                     img->NBkw,
+                     img->CBsize);
+
+    if(image_ID(img->name) == -1)
+    {
+        img->ID = next_avail_image_ID(img->ID);
+
+        ImageStreamIO_createIm(&data.image[img->ID],
+                               img->name,
+                               img->naxis,
+                               img->size,
+                               img->datatype,
+                               img->shared,
+                               img->NBkw,
+                               img->CBsize);
+    }
+    else
+    {
+        // Cannot create image : name already in use
+        img->ID = image_ID(img->name);
+
+        if(data.image[img->ID].md->datatype != img->datatype)
+        {
+            FUNC_RETURN_FAILURE("Pre-existing image \"%s\" has wrong type",
+                                img->name);
+        }
+        if(data.image[img->ID].md->naxis != img->naxis)
+        {
+            FUNC_RETURN_FAILURE("Pre-existing image \"%s\" has wrong naxis",
+                                img->name);
+        }
+
+        for(int i = 0; i < img->naxis; i++)
+            if(data.image[img->ID].md->size[i] != img->size[i])
+            {
+                FUNC_RETURN_FAILURE(
+                    "Pre-existing image \"%s\" has wrong size: axis %d "
+                    ":  %ld  %ld",
+                    img->name,
+                    i,
+                    (long) data.image[img->ID].md->size[i],
+                    (long) img->size[i]);
+            }
+    }
+
+    if(data.MEM_MONITOR == 1)
+    {
+        list_image_ID_ncurses();
+    }
+
+    DEBUG_TRACE_FEXIT();
+    return RETURN_SUCCESS;
+}
+
 errno_t create_image_ID(
-    const char * __restrict name,
+    const char *__restrict name,
     long        naxis,
     uint32_t   *size,
     uint8_t     datatype,
@@ -28,527 +93,1681 @@ errno_t create_image_ID(
     imageID    *outID
 )
 {
-    DEBUG_TRACE_FSTART();
-    DEBUG_TRACEPOINT("FARG %s %ld %d %d %d %d",
-                     name,
-                     naxis,
-                     (int) datatype,
-                     shared,
-                     NBkw,
-                     CBsize);
-
-    imageID ID;
-    if(image_ID(name) == -1)
+    IMGID img;
+    strncpy(img.name, name, STRINGMAXLEN_IMAGE_NAME - 1);
+    img.naxis    = naxis;
+    img.datatype = datatype;
+    img.shared   = shared;
+    img.NBkw     = NBkw;
+    img.CBsize   = CBsize;
+    for(int i = 0; i < naxis; i++)
     {
-        ID = next_avail_image_ID(*outID);
-
-        ImageStreamIO_createIm(&data.image[ID],
-                               name,
-                               naxis,
-                               size,
-                               datatype,
-                               shared,
-                               NBkw,
-                               CBsize);
+        img.size[i] = size[i];
     }
-    else
-    {
-        // Cannot create image : name already in use
-        ID = image_ID(name);
+    img.ID = (outID != NULL) ? *outID : -1;
 
-        if(data.image[ID].md->datatype != datatype)
-        {
-            FUNC_RETURN_FAILURE("Pre-existing image \"%s\" has wrong type",
-                                name);
-        }
-        if(data.image[ID].md->naxis != naxis)
-        {
-            FUNC_RETURN_FAILURE("Pre-existing image \"%s\" has wrong naxis",
-                                name);
-        }
-
-        for(int i = 0; i < naxis; i++)
-            if(data.image[ID].md->size[i] != size[i])
-            {
-                FUNC_RETURN_FAILURE(
-                    "Pre-existing image \"%s\" has wrong size: axis %d "
-                    ":  %ld  %ld",
-                    name,
-                    i,
-                    (long) data.image[ID].md->size[i],
-                    (long) size[i]);
-            }
-    }
-
-    if(data.MEM_MONITOR == 1)
-    {
-        list_image_ID_ncurses();
-    }
+    errno_t retval = create_image_ID_IMGID(&img);
 
     if(outID != NULL)
     {
-        *outID = ID;
+        *outID = img.ID;
     }
 
-    DEBUG_TRACE_FEXIT();
-    return RETURN_SUCCESS;
+    return retval;
 }
+
+
+
+errno_t create_1Dimage_ID_IMGID(
+
+
+
+    IMGID *img
+
+
+
+)
+
+
+
+{
+
+
+
+    img->naxis  = 1;
+
+
+
+    img->shared = data.SHARED_DFT;
+
+
+
+    img->NBkw   = NB_KEYWNODE_MAX;
+
+
+
+    img->CBsize = 0;
+
+
+
+
+
+
+
+    if(data.precision == 0)
+
+
+
+    {
+
+
+
+        img->datatype = _DATATYPE_FLOAT;
+
+
+
+    }
+
+
+
+    if(data.precision == 1)
+
+
+
+    {
+
+
+
+        img->datatype = _DATATYPE_DOUBLE;
+
+
+
+    }
+
+
+
+
+
+
+
+    return create_image_ID_IMGID(img);
+
+
+
+}
+
+
+
+
 
 
 
 errno_t create_1Dimage_ID(
-    const char * restrict ID_name,
+
+
+
+    const char *restrict ID_name,
+
+
+
     uint32_t xsize,
+
+
+
     imageID *outID
+
+
+
 )
+
+
+
 {
-    DEBUG_TRACE_FSTART();
 
-    imageID  ID    = -1;
-    long     naxis = 1;
-    uint32_t naxes[1];
 
-    naxes[0] = xsize;
 
-    if(data.precision == 0)
-    {
-        // single precision
-        FUNC_CHECK_RETURN(create_image_ID(ID_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_FLOAT,
-                                          data.SHARED_DFT,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &ID));
-    }
-    if(data.precision == 1)
-    {
-        // double precision
-        FUNC_CHECK_RETURN(create_image_ID(ID_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_DOUBLE,
-                                          data.SHARED_DFT,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &ID));
-    }
+    IMGID img;
+
+
+
+    strncpy(img.name, ID_name, STRINGMAXLEN_IMAGE_NAME - 1);
+
+
+
+    img.size[0] = xsize;
+
+
+
+    img.ID      = (outID != NULL) ? *outID : -1;
+
+
+
+
+
+
+
+    errno_t retval = create_1Dimage_ID_IMGID(&img);
+
+
+
+
+
+
 
     if(outID != NULL)
+
+
+
     {
-        *outID = ID;
+
+
+
+        *outID = img.ID;
+
+
+
     }
 
-    DEBUG_TRACE_FEXIT();
-    return RETURN_SUCCESS;
+
+
+
+
+
+
+    return retval;
+
+
+
 }
+
+
+
+
+
+
+
+errno_t create_1DCimage_ID_IMGID(
+
+
+
+    IMGID *img
+
+
+
+)
+
+
+
+{
+
+
+
+    img->naxis  = 1;
+
+
+
+    img->shared = data.SHARED_DFT;
+
+
+
+    img->NBkw   = NB_KEYWNODE_MAX;
+
+
+
+    img->CBsize = 0;
+
+
+
+
+
+
+
+    if(data.precision == 0)
+
+
+
+    {
+
+
+
+        img->datatype = _DATATYPE_COMPLEX_FLOAT;
+
+
+
+    }
+
+
+
+    if(data.precision == 1)
+
+
+
+    {
+
+
+
+        img->datatype = _DATATYPE_COMPLEX_DOUBLE;
+
+
+
+    }
+
+
+
+
+
+
+
+    return create_image_ID_IMGID(img);
+
+
+
+}
+
+
+
+
 
 
 
 errno_t create_1DCimage_ID(
-    const char * __restrict ID_name,
+
+
+
+    const char *__restrict ID_name,
+
+
+
     uint32_t xsize,
+
+
+
     imageID *outID
+
+
+
 )
+
+
+
 {
-    DEBUG_TRACE_FSTART();
 
-    imageID  ID    = -1;
-    long     naxis = 1;
-    uint32_t naxes[1];
 
-    naxes[0] = xsize;
 
-    if(data.precision == 0)
-    {
-        // single precision
-        FUNC_CHECK_RETURN(create_image_ID(ID_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_COMPLEX_FLOAT,
-                                          data.SHARED_DFT,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &ID));
-    }
-    if(data.precision == 1)
-    {
-        // double precision
-        FUNC_CHECK_RETURN(create_image_ID(ID_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_COMPLEX_DOUBLE,
-                                          data.SHARED_DFT,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &ID));
-    }
+    IMGID img;
+
+
+
+    strncpy(img.name, ID_name, STRINGMAXLEN_IMAGE_NAME - 1);
+
+
+
+    img.size[0] = xsize;
+
+
+
+    img.ID      = (outID != NULL) ? *outID : -1;
+
+
+
+
+
+
+
+    errno_t retval = create_1DCimage_ID_IMGID(&img);
+
+
+
+
+
+
 
     if(outID != NULL)
+
+
+
     {
-        *outID = ID;
+
+
+
+        *outID = img.ID;
+
+
+
     }
 
-    DEBUG_TRACE_FEXIT();
-    return RETURN_SUCCESS;
+
+
+
+
+
+
+    return retval;
+
+
+
 }
+
+
+
+
+
+
+
+errno_t create_2Dimage_ID_IMGID(
+
+
+
+    IMGID *img
+
+
+
+)
+
+
+
+{
+
+
+
+    img->naxis = 2;
+
+
+
+    img->shared = data.SHARED_DFT;
+
+
+
+    img->NBkw   = NB_KEYWNODE_MAX;
+
+
+
+    img->CBsize = 0;
+
+
+
+
+
+
+
+    if(data.precision == 0)
+
+
+
+    {
+
+
+
+        img->datatype = _DATATYPE_FLOAT;
+
+
+
+    }
+
+
+
+    else if(data.precision == 1)
+
+
+
+    {
+
+
+
+        img->datatype = _DATATYPE_DOUBLE;
+
+
+
+    }
+
+
+
+    else
+
+
+
+    {
+
+
+
+        img->datatype = _DATATYPE_FLOAT;
+
+
+
+    }
+
+
+
+
+
+
+
+    return create_image_ID_IMGID(img);
+
+
+
+}
+
+
+
+
 
 
 
 errno_t create_2Dimage_ID(
-    const char * __restrict ID_name,
+
+
+
+    const char *__restrict ID_name,
+
+
+
     uint32_t    xsize,
+
+
+
     uint32_t    ysize,
+
+
+
     imageID    *outID)
+
+
+
 {
-    DEBUG_TRACE_FSTART();
 
-    imageID  ID    = -1;
-    long     naxis = 2;
-    uint32_t naxes[2] = { xsize, ysize };
 
-    if(data.precision == 0)
-    {
-        // single precision
-        FUNC_CHECK_RETURN(create_image_ID(ID_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_FLOAT,
-                                          data.SHARED_DFT,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &ID));
-    }
-    else if(data.precision == 1)
-    {
-        // double precision
-        FUNC_CHECK_RETURN(create_image_ID(ID_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_DOUBLE,
-                                          data.SHARED_DFT,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &ID));
-    }
-    else
-    {
-        // single precision
-        printf(
-            "Default precision (%d) invalid value: assuming single "
-            "precision\n",
-            data.precision);
-        FUNC_CHECK_RETURN(create_image_ID(ID_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_FLOAT,
-                                          data.SHARED_DFT,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &ID));
-    }
+
+    IMGID img;
+
+
+
+    strncpy(img.name, ID_name, STRINGMAXLEN_IMAGE_NAME - 1);
+
+
+
+    img.size[0] = xsize;
+
+
+
+    img.size[1] = ysize;
+
+
+
+    img.ID      = (outID != NULL) ? *outID : -1;
+
+
+
+
+
+
+
+    errno_t retval = create_2Dimage_ID_IMGID(&img);
+
+
+
+
+
+
 
     if(outID != NULL)
+
+
+
     {
-        *outID = ID;
+
+
+
+        *outID = img.ID;
+
+
+
     }
 
-    DEBUG_TRACE_FEXIT();
-    return RETURN_SUCCESS;
+
+
+
+
+
+
+    return retval;
+
+
+
 }
+
+
+
+
+
+
+
+errno_t create_2Dimage_ID_double_IMGID(
+
+
+
+    IMGID *img
+
+
+
+)
+
+
+
+{
+
+
+
+    img->naxis    = 2;
+
+
+
+    img->datatype = _DATATYPE_DOUBLE;
+
+
+
+    img->shared   = data.SHARED_DFT;
+
+
+
+    img->NBkw     = NB_KEYWNODE_MAX;
+
+
+
+    img->CBsize   = 0;
+
+
+
+
+
+
+
+    return create_image_ID_IMGID(img);
+
+
+
+}
+
+
+
+
+
 
 
 errno_t create_2Dimage_ID_double(
-    const char * __restrict ID_name,
+
+
+
+    const char *__restrict ID_name,
+
+
+
     uint32_t    xsize,
+
+
+
     uint32_t    ysize,
+
+
+
     imageID    *outID)
+
+
+
 {
-    DEBUG_TRACE_FSTART();
-
-    imageID  ID    = -1;
-    long     naxis = 2;
-    uint32_t naxes[2] = { xsize, ysize };
 
 
-    FUNC_CHECK_RETURN(create_image_ID(ID_name,
-                                      naxis,
-                                      naxes,
-                                      _DATATYPE_DOUBLE,
-                                      data.SHARED_DFT,
-                                      NB_KEYWNODE_MAX,
-                                      0,
-                                      &ID));
+
+    IMGID img;
+
+
+
+    strncpy(img.name, ID_name, STRINGMAXLEN_IMAGE_NAME - 1);
+
+
+
+    img.size[0] = xsize;
+
+
+
+    img.size[1] = ysize;
+
+
+
+    img.ID      = (outID != NULL) ? *outID : -1;
+
+
+
+
+
+
+
+    errno_t retval = create_2Dimage_ID_double_IMGID(&img);
+
+
+
+
+
+
 
     if(outID != NULL)
+
+
+
     {
-        *outID = ID;
+
+
+
+        *outID = img.ID;
+
+
+
     }
 
-    DEBUG_TRACE_FEXIT();
-    return RETURN_SUCCESS;
+
+
+
+
+
+
+    return retval;
+
+
+
 }
 
 
 
-/* 2D complex image */
-errno_t create_2DCimage_ID(
-    const char * __restrict ID_name,
-    uint32_t    xsize,
-    uint32_t    ysize,
-    imageID    *outID)
-{
-    DEBUG_TRACE_FSTART();
 
-    imageID  ID    = -1;
-    long     naxis = 2;
-    uint32_t naxes[2] = { xsize, ysize };
+
+
+
+errno_t create_2DCimage_ID_IMGID(
+
+
+
+    IMGID *img
+
+
+
+)
+
+
+
+{
+
+
+
+    img->naxis  = 2;
+
+
+
+    img->shared = data.SHARED_DFT;
+
+
+
+    img->NBkw   = NB_KEYWNODE_MAX;
+
+
+
+    img->CBsize = 0;
+
+
+
+
+
+
 
     if(data.precision == 0)
+
+
+
     {
-        // single precision
-        FUNC_CHECK_RETURN(create_image_ID(ID_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_COMPLEX_FLOAT,
-                                          data.SHARED_DFT,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &ID));
+
+
+
+        img->datatype = _DATATYPE_COMPLEX_FLOAT;
+
+
+
     }
+
+
+
     if(data.precision == 1)
+
+
+
     {
-        // double precision
-        FUNC_CHECK_RETURN(create_image_ID(ID_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_COMPLEX_DOUBLE,
-                                          data.SHARED_DFT,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &ID));
+
+
+
+        img->datatype = _DATATYPE_COMPLEX_DOUBLE;
+
+
+
     }
 
-    if(outID != NULL)
-    {
-        *outID = ID;
-    }
 
-    DEBUG_TRACE_FEXIT();
-    return RETURN_SUCCESS;
+
+
+
+
+
+    return create_image_ID_IMGID(img);
+
+
+
 }
+
+
+
+
 
 
 
 /* 2D complex image */
-errno_t create_2DCimage_ID_double(
-    const char * __restrict ID_name,
+
+
+
+errno_t create_2DCimage_ID(
+
+
+
+    const char *__restrict ID_name,
+
+
+
     uint32_t    xsize,
+
+
+
     uint32_t    ysize,
+
+
+
     imageID    *outID)
+
+
+
 {
-    DEBUG_TRACE_FSTART();
-
-    imageID  ID    = -1;
-    long     naxis = 2;
-    uint32_t naxes[2]  = { xsize, ysize };
 
 
-    FUNC_CHECK_RETURN(create_image_ID(ID_name,
-                                      naxis,
-                                      naxes,
-                                      _DATATYPE_COMPLEX_DOUBLE,
-                                      data.SHARED_DFT,
-                                      NB_KEYWNODE_MAX,
-                                      0,
-                                      &ID));
+
+    IMGID img;
+
+
+
+    strncpy(img.name, ID_name, STRINGMAXLEN_IMAGE_NAME - 1);
+
+
+
+    img.size[0] = xsize;
+
+
+
+    img.size[1] = ysize;
+
+
+
+    img.ID      = (outID != NULL) ? *outID : -1;
+
+
+
+
+
+
+
+    errno_t retval = create_2DCimage_ID_IMGID(&img);
+
+
+
+
+
+
 
     if(outID != NULL)
+
+
+
     {
-        *outID = ID;
+
+
+
+        *outID = img.ID;
+
+
+
     }
 
-    DEBUG_TRACE_FEXIT();
-    return RETURN_SUCCESS;
+
+
+
+
+
+
+    return retval;
+
+
+
 }
+
+
+
+
+
+
+
+errno_t create_2DCimage_ID_double_IMGID(
+
+
+
+    IMGID *img
+
+
+
+)
+
+
+
+{
+
+
+
+    img->naxis    = 2;
+
+
+
+    img->datatype = _DATATYPE_COMPLEX_DOUBLE;
+
+
+
+    img->shared   = data.SHARED_DFT;
+
+
+
+    img->NBkw     = NB_KEYWNODE_MAX;
+
+
+
+    img->CBsize   = 0;
+
+
+
+
+
+
+
+    return create_image_ID_IMGID(img);
+
+
+
+}
+
+
+
+
+
+
+
+/* 2D complex image */
+
+
+
+errno_t create_2DCimage_ID_double(
+
+
+
+    const char *__restrict ID_name,
+
+
+
+    uint32_t    xsize,
+
+
+
+    uint32_t    ysize,
+
+
+
+    imageID    *outID)
+
+
+
+{
+
+
+
+    IMGID img;
+
+
+
+    strncpy(img.name, ID_name, STRINGMAXLEN_IMAGE_NAME - 1);
+
+
+
+    img.size[0] = xsize;
+
+
+
+    img.size[1] = ysize;
+
+
+
+    img.ID      = (outID != NULL) ? *outID : -1;
+
+
+
+
+
+
+
+    errno_t retval = create_2DCimage_ID_double_IMGID(&img);
+
+
+
+
+
+
+
+    if(outID != NULL)
+
+
+
+    {
+
+
+
+        *outID = img.ID;
+
+
+
+    }
+
+
+
+
+
+
+
+    return retval;
+
+
+
+}
+
+
+
+
+
+
+
+errno_t create_3Dimage_ID_float_IMGID(
+
+
+
+    IMGID *img
+
+
+
+)
+
+
+
+{
+
+
+
+    img->naxis    = 3;
+
+
+
+    img->datatype = _DATATYPE_FLOAT;
+
+
+
+    img->shared   = data.SHARED_DFT;
+
+
+
+    img->NBkw     = NB_KEYWNODE_MAX;
+
+
+
+    img->CBsize   = 0;
+
+
+
+
+
+
+
+    return create_image_ID_IMGID(img);
+
+
+
+}
+
+
+
+
+
 
 
 /* 3D image, single precision */
+
+
+
 errno_t create_3Dimage_ID_float(
-    const char * __restrict ID_name,
+
+
+
+    const char *__restrict ID_name,
+
+
+
     uint32_t    xsize,
+
+
+
     uint32_t    ysize,
+
+
+
     uint32_t    zsize,
+
+
+
     imageID    *outID)
+
+
+
 {
-    DEBUG_TRACE_FSTART();
 
-    imageID  ID    = -1;
-    long     naxis = 3;
-    uint32_t naxes[3] = { xsize, ysize, zsize };
 
-    //  printf("CREATING 3D IMAGE: %s %ld %ld %ld\n", ID_name, xsize, ysize, zsize);
-    //  fflush(stdout);
 
-    FUNC_CHECK_RETURN(create_image_ID(ID_name,
-                                      naxis,
-                                      naxes,
-                                      _DATATYPE_FLOAT,
-                                      data.SHARED_DFT,
-                                      NB_KEYWNODE_MAX,
-                                      0,
-                                      &ID));
+    IMGID img;
 
-    //  printf("IMAGE CREATED WITH ID = %ld\n",ID);
-    //  fflush(stdout);
+
+
+    strncpy(img.name, ID_name, STRINGMAXLEN_IMAGE_NAME - 1);
+
+
+
+    img.size[0] = xsize;
+
+
+
+    img.size[1] = ysize;
+
+
+
+    img.size[2] = zsize;
+
+
+
+    img.ID      = (outID != NULL) ? *outID : -1;
+
+
+
+
+
+
+
+    errno_t retval = create_3Dimage_ID_float_IMGID(&img);
+
+
+
+
+
+
 
     if(outID != NULL)
+
+
+
     {
-        *outID = ID;
+
+
+
+        *outID = img.ID;
+
+
+
     }
 
-    DEBUG_TRACE_FEXIT();
-    return RETURN_SUCCESS;
+
+
+
+
+
+
+    return retval;
+
+
+
 }
+
+
+
+
+
+
+
+errno_t create_3Dimage_ID_double_IMGID(
+
+
+
+    IMGID *img
+
+
+
+)
+
+
+
+{
+
+
+
+    img->naxis    = 3;
+
+
+
+    img->datatype = _DATATYPE_DOUBLE;
+
+
+
+    img->shared   = data.SHARED_DFT;
+
+
+
+    img->NBkw     = NB_KEYWNODE_MAX;
+
+
+
+    img->CBsize   = 0;
+
+
+
+
+
+
+
+    return create_image_ID_IMGID(img);
+
+
+
+}
+
+
+
+
 
 
 
 /* 3D image, double precision */
+
+
+
 errno_t create_3Dimage_ID_double(
-    const char * __restrict ID_name,
+
+
+
+    const char *__restrict ID_name,
+
+
+
     uint32_t    xsize,
+
+
+
     uint32_t    ysize,
+
+
+
     uint32_t    zsize,
+
+
+
     imageID    *outID)
+
+
+
 {
-    DEBUG_TRACE_FSTART();
 
-    imageID  ID;
-    long     naxis = 3;
-    uint32_t naxes[3] = { xsize, ysize, zsize };
 
-    FUNC_CHECK_RETURN(create_image_ID(ID_name,
-                                      naxis,
-                                      naxes,
-                                      _DATATYPE_DOUBLE,
-                                      data.SHARED_DFT,
-                                      NB_KEYWNODE_MAX,
-                                      0,
-                                      &ID));
+
+    IMGID img;
+
+
+
+    strncpy(img.name, ID_name, STRINGMAXLEN_IMAGE_NAME - 1);
+
+
+
+    img.size[0] = xsize;
+
+
+
+    img.size[1] = ysize;
+
+
+
+    img.size[2] = zsize;
+
+
+
+    img.ID      = (outID != NULL) ? *outID : -1;
+
+
+
+
+
+
+
+    errno_t retval = create_3Dimage_ID_double_IMGID(&img);
+
+
+
+
+
+
 
     if(outID != NULL)
+
+
+
     {
-        *outID = ID;
+
+
+
+        *outID = img.ID;
+
+
+
     }
 
-    DEBUG_TRACE_FEXIT();
-    return RETURN_SUCCESS;
+
+
+
+
+
+
+    return retval;
+
+
+
 }
+
+
+
+
+
+
+
+errno_t create_3Dimage_ID_IMGID(
+
+
+
+    IMGID *img
+
+
+
+)
+
+
+
+{
+
+
+
+    img->naxis  = 3;
+
+
+
+    img->shared = data.SHARED_DFT;
+
+
+
+    img->NBkw   = NB_KEYWNODE_MAX;
+
+
+
+    img->CBsize = 0;
+
+
+
+
+
+
+
+    if(data.precision == 0)
+
+
+
+    {
+
+
+
+        img->datatype = _DATATYPE_FLOAT;
+
+
+
+    }
+
+
+
+    if(data.precision == 1)
+
+
+
+    {
+
+
+
+        img->datatype = _DATATYPE_DOUBLE;
+
+
+
+    }
+
+
+
+
+
+
+
+    return create_image_ID_IMGID(img);
+
+
+
+}
+
+
+
 
 
 
 
 /* 3D image, default precision */
+
+
+
 errno_t create_3Dimage_ID(
-    const char * __restrict ID_name,
+
+
+
+    const char *__restrict ID_name,
+
+
+
     uint32_t    xsize,
+
+
+
     uint32_t    ysize,
+
+
+
     uint32_t    zsize,
+
+
+
     imageID    *outID)
+
+
+
 {
-    DEBUG_TRACE_FSTART();
-
-    imageID   ID    = -1;
-    long      naxis = 3;
-
-    uint32_t naxes[3] = { xsize, ysize, zsize };
 
 
-    printf("CREATE 3D IMAGE SIZE %u %u %u\n", xsize, ysize, zsize);
 
-    if(data.precision == 0)
-    {
-        // single precision
-        FUNC_CHECK_RETURN(create_image_ID(ID_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_FLOAT,
-                                          data.SHARED_DFT,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &ID));
-    }
+    IMGID img;
 
-    if(data.precision == 1)
-    {
-        // double precision
-        FUNC_CHECK_RETURN(create_image_ID(ID_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_DOUBLE,
-                                          data.SHARED_DFT,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &ID));
-    }
+
+
+    strncpy(img.name, ID_name, STRINGMAXLEN_IMAGE_NAME - 1);
+
+
+
+    img.size[0] = xsize;
+
+
+
+    img.size[1] = ysize;
+
+
+
+    img.size[2] = zsize;
+
+
+
+    img.ID      = (outID != NULL) ? *outID : -1;
+
+
+
+
+
+
+
+    errno_t retval = create_3Dimage_ID_IMGID(&img);
+
+
+
+
+
+
 
     if(outID != NULL)
+
+
+
     {
-        *outID = ID;
+
+
+
+        *outID = img.ID;
+
+
+
     }
 
-    DEBUG_TRACE_FEXIT();
-    return RETURN_SUCCESS;
+
+
+
+
+
+
+    return retval;
+
+
+
 }
+
+
+
+
+
+
+
+errno_t create_3DCimage_ID_IMGID(
+
+
+
+    IMGID *img
+
+
+
+)
+
+
+
+{
+
+
+
+    img->naxis  = 3;
+
+
+
+    img->shared = data.SHARED_DFT;
+
+
+
+    img->NBkw   = NB_KEYWNODE_MAX;
+
+
+
+    img->CBsize = 0;
+
+
+
+
+
+
+
+    if(data.precision == 0)
+
+
+
+    {
+
+
+
+        img->datatype = _DATATYPE_COMPLEX_FLOAT;
+
+
+
+    }
+
+
+
+    if(data.precision == 1)
+
+
+
+    {
+
+
+
+        img->datatype = _DATATYPE_COMPLEX_DOUBLE;
+
+
+
+    }
+
+
+
+
+
+
+
+    return create_image_ID_IMGID(img);
+
+
+
+}
+
+
+
+
+
 
 
 /* 3D complex image */
+
+
+
 errno_t create_3DCimage_ID(
-    const char * __restrict ID_name,
+
+
+
+    const char *__restrict ID_name,
+
+
+
     uint32_t    xsize,
+
+
+
     uint32_t    ysize,
+
+
+
     uint32_t    zsize,
+
+
+
     imageID    *outID)
+
+
+
 {
-    DEBUG_TRACE_FSTART();
 
-    imageID   ID    = -1;
-    long      naxis = 3;
-    uint32_t naxes[3] = { xsize, ysize, zsize };
 
-    if(data.precision == 0)
-    {
-        // single precision
-        FUNC_CHECK_RETURN(create_image_ID(ID_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_COMPLEX_FLOAT,
-                                          data.SHARED_DFT,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &ID));
-    }
 
-    if(data.precision == 1)
-    {
-        // double precision
-        FUNC_CHECK_RETURN(create_image_ID(ID_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_COMPLEX_DOUBLE,
-                                          data.SHARED_DFT,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &ID));
-    }
+    IMGID img;
+
+
+
+    strncpy(img.name, ID_name, STRINGMAXLEN_IMAGE_NAME - 1);
+
+
+
+    img.size[0] = xsize;
+
+
+
+    img.size[1] = ysize;
+
+
+
+    img.size[2] = zsize;
+
+
+
+    img.ID      = (outID != NULL) ? *outID : -1;
+
+
+
+
+
+
+
+    errno_t retval = create_3DCimage_ID_IMGID(&img);
+
+
+
+
+
 
 
     if(outID != NULL)
+
+
+
     {
-        *outID = ID;
+
+
+
+        *outID = img.ID;
+
+
+
     }
 
-    DEBUG_TRACE_FEXIT();
-    return RETURN_SUCCESS;
+
+
+
+
+
+
+    return retval;
+
+
+
 }
+
+
+
+

--- a/src/COREMOD_memory/create_image.h
+++ b/src/COREMOD_memory/create_image.h
@@ -10,51 +10,62 @@ errno_t create_image_ID(const char *name,
                         int         nbkw,
                         int         CBsize,
                         imageID    *outID);
+errno_t create_image_ID_IMGID(IMGID *img);
 
 errno_t create_1Dimage_ID(const char *ID_name, uint32_t xsize, imageID *outID);
+errno_t create_1Dimage_ID_IMGID(IMGID *img);
 
 errno_t create_1DCimage_ID(const char *ID_name, uint32_t xsize, imageID *outID);
+errno_t create_1DCimage_ID_IMGID(IMGID *img);
 
 errno_t create_2Dimage_ID(const char *ID_name,
                           uint32_t    xsize,
                           uint32_t    ysize,
                           imageID    *outID);
+errno_t create_2Dimage_ID_IMGID(IMGID *img);
 
 errno_t create_2Dimage_ID_double(const char *ID_name,
                                  uint32_t    xsize,
                                  uint32_t    ysize,
                                  imageID    *outID);
+errno_t create_2Dimage_ID_double_IMGID(IMGID *img);
 
 errno_t create_2DCimage_ID(const char *ID_name,
                            uint32_t    xsize,
                            uint32_t    ysize,
                            imageID    *outID);
+errno_t create_2DCimage_ID_IMGID(IMGID *img);
 
 errno_t create_2DCimage_ID_double(const char *ID_name,
                                   uint32_t    xsize,
                                   uint32_t    ysize,
                                   imageID    *outID);
+errno_t create_2DCimage_ID_double_IMGID(IMGID *img);
 
 errno_t create_3Dimage_ID(const char *ID_name,
                           uint32_t    xsize,
                           uint32_t    ysize,
                           uint32_t    zsize,
                           imageID    *outID);
+errno_t create_3Dimage_ID_IMGID(IMGID *img);
 
 errno_t create_3Dimage_ID_float(const char *ID_name,
                                 uint32_t    xsize,
                                 uint32_t    ysize,
                                 uint32_t    zsize,
                                 imageID    *outID);
+errno_t create_3Dimage_ID_float_IMGID(IMGID *img);
 
 errno_t create_3Dimage_ID_double(const char *ID_name,
                                  uint32_t    xsize,
                                  uint32_t    ysize,
                                  uint32_t    zsize,
                                  imageID    *outID);
+errno_t create_3Dimage_ID_double_IMGID(IMGID *img);
 
 errno_t create_3DCimage_ID(const char *ID_name,
                            uint32_t    xsize,
                            uint32_t    ysize,
                            uint32_t    zsize,
                            imageID    *outID);
+errno_t create_3DCimage_ID_IMGID(IMGID *img);

--- a/src/COREMOD_memory/delete_image.c
+++ b/src/COREMOD_memory/delete_image.c
@@ -60,7 +60,8 @@ static errno_t compute_function()
 
     INSERT_STD_PROCINFO_COMPUTEFUNC_START
 
-    FUNC_CHECK_RETURN(delete_image_ID(imname, (int) *errmode));
+    IMGID img = mkIMGID_from_name(imname);
+    FUNC_CHECK_RETURN(delete_image_IMGID(&img, (int) *errmode));
 
     INSERT_STD_PROCINFO_COMPUTEFUNC_END
 
@@ -94,6 +95,23 @@ CLIADDCMD_COREMOD_memory__delete_image()
  * DELETE_IMAGE_ERRMODE_EXIT
  *
  */
+errno_t delete_image_IMGID(
+    IMGID *img,
+    int errmode
+)
+{
+    return delete_image(img, errmode);
+}
+
+/** @brief deletes an ID
+ *
+ * errmode values:
+ * DELETE_IMAGE_ERRMODE_IGNORE
+ * DELETE_IMAGE_ERRMODE_WARNING
+ * DELETE_IMAGE_ERRMODE_ERROR
+ * DELETE_IMAGE_ERRMODE_EXIT
+ *
+ */
 errno_t delete_image(
     IMGID *img,
     int errmode
@@ -116,15 +134,15 @@ errno_t delete_image(
 
         if(errmode == DELETE_IMAGE_ERRMODE_WARNING)
         {
-            PRINT_WARNING("Image \"%s\" does not exist", imname);
+            PRINT_WARNING("Image \"%s\" does not exist", img->name);
             DEBUG_TRACE_FEXIT();
             return RETURN_SUCCESS;
         }
 
         if(errmode == DELETE_IMAGE_ERRMODE_ERROR)
         {
-            PRINT_WARNING("Image \"%s\" does not exist", imname);
-            FUNC_RETURN_FAILURE("Image \"%s\" does not exist", imname);
+            PRINT_WARNING("Image \"%s\" does not exist", img->name);
+            FUNC_RETURN_FAILURE("Image \"%s\" does not exist", img->name);
         }
 
         if(errmode == DELETE_IMAGE_ERRMODE_EXIT)
@@ -169,14 +187,14 @@ errno_t delete_image(
             {
                 EXECUTE_SYSTEM_COMMAND("rm /dev/shm/sem.%s.%s_sem*",
                                        data.shmsemdirname,
-                                       imname);
+                                       img->name);
                 WRITE_FULLFILENAME(fname,
                                    "/dev/shm/sem.%s.%s_semlog",
                                    data.shmsemdirname,
-                                   imname);
+                                   img->name);
                 remove(fname);
 
-                EXECUTE_SYSTEM_COMMAND("rm %s/%s.im.shm", data.shmdir, imname);
+                EXECUTE_SYSTEM_COMMAND("rm %s/%s.im.shm", data.shmdir, img->name);
             }
         }
         else
@@ -283,7 +301,7 @@ errno_t delete_image_ID(
     DEBUG_TRACE_FSTART();
 
     IMGID   img = mkIMGID_from_name(imname);
-    imageID ID  = resolveIMGID(&img, ERRMODE_WARN);
+    imageID ID  = resolveIMGID(&img, errmode);
 
     if(ID != -1)
     {

--- a/src/COREMOD_memory/delete_image.h
+++ b/src/COREMOD_memory/delete_image.h
@@ -8,6 +8,8 @@
 
 errno_t CLIADDCMD_COREMOD_memory__delete_image();
 
+errno_t delete_image_IMGID(IMGID *img, int errmode);
+
 errno_t delete_image(IMGID *img, int errmode);
 
 errno_t delete_image_ID(const char *imname, int errmode);

--- a/src/COREMOD_memory/image_complex.c
+++ b/src/COREMOD_memory/image_complex.c
@@ -11,20 +11,69 @@
 #include "image_ID.h"
 #include "stream_sem.h"
 
+#include "image_complex.h"
+#include "image_mk_complex_from_amph.h"
+#include "image_mk_complex_from_reim.h"
+#include "image_mk_amph_from_complex.h"
+#include "image_mk_reim_from_complex.h"
+
+errno_t mk_reim_from_amph_IMGID(
+    IMGID *imgam,
+    IMGID *imgph,
+    IMGID *imgre,
+    IMGID *imgim
+)
+{
+    DEBUG_TRACE_FSTART();
+
+    IMGID imgC = mkIMGID_from_name("Ctmp");
+    imgC.shared = 0;
+
+    FUNC_CHECK_RETURN(mk_complex_from_amph_IMGID(imgam, imgph, &imgC));
+
+    FUNC_CHECK_RETURN(
+        mk_reim_from_complex_IMGID(&imgC, imgre, imgim));
+
+    FUNC_CHECK_RETURN(delete_image_IMGID(&imgC, DELETE_IMAGE_ERRMODE_WARNING));
+
+    DEBUG_TRACE_FEXIT();
+    return RETURN_SUCCESS;
+}
+
 errno_t mk_reim_from_amph(const char *am_name,
                           const char *ph_name,
                           const char *re_out_name,
                           const char *im_out_name,
                           int         sharedmem)
 {
+    IMGID imgam = mkIMGID_from_name(am_name);
+    IMGID imgph = mkIMGID_from_name(ph_name);
+    IMGID imgre = mkIMGID_from_name(re_out_name);
+    IMGID imgim = mkIMGID_from_name(im_out_name);
+    imgre.shared = sharedmem;
+    imgim.shared = sharedmem;
+
+    return mk_reim_from_amph_IMGID(&imgam, &imgph, &imgre, &imgim);
+}
+
+errno_t mk_amph_from_reim_IMGID(
+    IMGID *imgre,
+    IMGID *imgim,
+    IMGID *imgam,
+    IMGID *imgph
+)
+{
     DEBUG_TRACE_FSTART();
 
-    FUNC_CHECK_RETURN(mk_complex_from_amph(am_name, ph_name, "Ctmp", 0));
+    IMGID imgC = mkIMGID_from_name("Ctmp");
+    imgC.shared = 0;
+
+    FUNC_CHECK_RETURN(mk_complex_from_reim_IMGID(imgre, imgim, &imgC));
 
     FUNC_CHECK_RETURN(
-        mk_reim_from_complex("Ctmp", re_out_name, im_out_name, sharedmem));
+        mk_amph_from_complex_IMGID(&imgC, imgam, imgph));
 
-    FUNC_CHECK_RETURN(delete_image_ID("Ctmp", DELETE_IMAGE_ERRMODE_WARNING));
+    FUNC_CHECK_RETURN(delete_image_IMGID(&imgC, DELETE_IMAGE_ERRMODE_WARNING));
 
     DEBUG_TRACE_FEXIT();
     return RETURN_SUCCESS;
@@ -36,15 +85,12 @@ errno_t mk_amph_from_reim(const char *re_name,
                           const char *ph_out_name,
                           int         sharedmem)
 {
-    DEBUG_TRACE_FSTART();
+    IMGID imgre = mkIMGID_from_name(re_name);
+    IMGID imgim = mkIMGID_from_name(im_name);
+    IMGID imgam = mkIMGID_from_name(am_out_name);
+    IMGID imgph = mkIMGID_from_name(ph_out_name);
+    imgam.shared = sharedmem;
+    imgph.shared = sharedmem;
 
-    FUNC_CHECK_RETURN(mk_complex_from_reim(re_name, im_name, "Ctmp", 0));
-
-    FUNC_CHECK_RETURN(
-        mk_amph_from_complex("Ctmp", am_out_name, ph_out_name, sharedmem));
-
-    FUNC_CHECK_RETURN(delete_image_ID("Ctmp", DELETE_IMAGE_ERRMODE_WARNING));
-
-    DEBUG_TRACE_FEXIT();
-    return RETURN_SUCCESS;
+    return mk_amph_from_reim_IMGID(&imgre, &imgim, &imgam, &imgph);
 }

--- a/src/COREMOD_memory/image_complex.h
+++ b/src/COREMOD_memory/image_complex.h
@@ -7,10 +7,20 @@ errno_t mk_reim_from_amph(const char *am_name,
                           const char *im_out_name,
                           int         sharedmem);
 
+errno_t mk_reim_from_amph_IMGID(IMGID *imgam,
+                                IMGID *imgph,
+                                IMGID *imgre,
+                                IMGID *imgim);
+
 errno_t mk_amph_from_reim(const char *re_name,
                           const char *im_name,
                           const char *am_out_name,
                           const char *ph_out_name,
                           int         sharedmem);
+
+errno_t mk_amph_from_reim_IMGID(IMGID *imgre,
+                                IMGID *imgim,
+                                IMGID *imgam,
+                                IMGID *imgph);
 
 #endif

--- a/src/COREMOD_memory/image_copy.c
+++ b/src/COREMOD_memory/image_copy.c
@@ -10,21 +10,20 @@
 #include "list_image.h"
 #include "read_shmim.h"
 #include "stream_sem.h"
-#include "variable_ID.h"
+#include "image_copy.h"
 
 // ==========================================
 // Forward declaration(s)
 // ==========================================
 
 imageID copy_image_ID(const char *name, const char *newname, int shared);
-
-
+imageID copy_image_ID_IMGID(IMGID *imgin, IMGID *imgout, int shared);
 
 imageID chname_image_ID(const char *ID_name, const char *new_name);
-
-
+imageID chname_image_ID_IMGID(IMGID *imgin, const char *new_name);
 
 errno_t COREMOD_MEMORY_cp2shm(const char *IDname, const char *IDshmname);
+errno_t COREMOD_MEMORY_cp2shm_IMGID(IMGID *imgin, IMGID *imgout);
 
 
 
@@ -125,147 +124,114 @@ errno_t image_copy_addCLIcmd()
 
 
 
-imageID copy_image_ID(
-    const char * restrict name,
-    const char * restrict newname,
+imageID copy_image_ID_IMGID(
+    IMGID *imgin,
+    IMGID *imgout,
     int shared
 )
 {
-    imageID   ID;
-    imageID   IDout;
-    long      naxis;
-    uint32_t *size = NULL;
-    uint8_t   datatype;
-    long      nelement;
-    long      i;
-    int       newim = 0;
+    resolveIMGID(imgin, ERRMODE_ABORT);
 
-    ID = image_ID(name);
-    if(ID == -1)
+    uint32_t naxis = imgin->md[0].naxis;
+    uint32_t size[3];
+    for(uint32_t i = 0; i < naxis; i++)
     {
-        PRINT_ERROR("image \"%s\" does not exist", name);
-        exit(0);
+        size[i] = imgin->md[0].size[i];
     }
-    naxis = data.image[ID].md[0].naxis;
+    uint8_t  datatype = imgin->md[0].datatype;
+    uint64_t nelement = imgin->md[0].nelement;
 
-    size = (uint32_t *) malloc(sizeof(uint32_t) * naxis);
-    if(size == NULL)
+    resolveIMGID(imgout, ERRMODE_NULL);
+
+    int newim = 0;
+    if(imgout->ID != -1)
     {
-        PRINT_ERROR("malloc error");
-        exit(0);
-    }
-
-    for(i = 0; i < naxis; i++)
-    {
-        size[i] = data.image[ID].md[0].size[i];
-    }
-    datatype = data.image[ID].md[0].datatype;
-
-    nelement = data.image[ID].md[0].nelement;
-
-    IDout = image_ID(newname);
-
-    if(IDout != -1)
-    {
-        // verify newname has the right size and type
-        if(data.image[ID].md[0].nelement != data.image[IDout].md[0].nelement)
+        // verify imgout has the right size and type
+        if(imgin->md[0].nelement != imgout->md[0].nelement)
         {
             fprintf(stderr,
-                    "ERROR [copy_image_ID]: images %s and %s do not have "
+                    "ERROR [copy_image_ID_IMGID]: images %s and %s do not have "
                     "the same size -> deleting and re-creating image\n",
-                    name,
-                    newname);
+                    imgin->name,
+                    imgout->name);
             newim = 1;
         }
 
-        if(data.image[ID].md[0].datatype != data.image[IDout].md[0].datatype)
+        if(imgin->md[0].datatype != imgout->md[0].datatype)
         {
             fprintf(stderr,
-                    "ERROR [copy_image_ID]: images %s and %s do not have "
+                    "ERROR [copy_image_ID_IMGID]: images %s and %s do not have "
                     "the same type -> deleting and re-creating image\n",
-                    name,
-                    newname);
+                    imgin->name,
+                    imgout->name);
             newim = 1;
         }
 
         if(newim == 1)
         {
-            delete_image_ID(newname, DELETE_IMAGE_ERRMODE_WARNING);
-            IDout = -1;
+            delete_image_ID(imgout->name, DELETE_IMAGE_ERRMODE_WARNING);
+            imgout->ID = -1;
         }
     }
 
-    if(IDout == -1)
+    if(imgout->ID == -1)
     {
-        create_image_ID(newname,
+        create_image_ID(imgout->name,
                         naxis,
                         size,
                         datatype,
                         shared,
                         NB_KEYWNODE_MAX,
                         0,
-                        NULL);
-        IDout = image_ID(newname);
+                        &imgout->ID);
+        resolveIMGID(imgout, ERRMODE_ABORT);
     }
-    else
-    {
-        // verify newname has the right size and type
-        if(data.image[ID].md[0].nelement != data.image[IDout].md[0].nelement)
-        {
-            fprintf(stderr,
-                    "ERROR [copy_image_ID]: images %s and %s do not "
-                    "have the same size\n",
-                    name,
-                    newname);
-            exit(0);
-        }
-        if(data.image[ID].md[0].datatype != data.image[IDout].md[0].datatype)
-        {
-            fprintf(stderr,
-                    "ERROR [copy_image_ID]: images %s and %s do not "
-                    "have the same type\n",
-                    name,
-                    newname);
-            exit(0);
-        }
-    }
-    data.image[IDout].md[0].write = 1;
 
-    memcpy(data.image[IDout].array.raw,
-           data.image[ID].array.raw,
+    imgout->md[0].write = 1;
+
+    memcpy(imgout->im->array.raw,
+           imgin->im->array.raw,
            ImageStreamIO_typesize(datatype) * nelement);
 
-    COREMOD_MEMORY_image_set_sempost_byID(IDout, -1);
+    COREMOD_MEMORY_image_set_sempost_byID(imgout->ID, -1);
 
-    data.image[IDout].md[0].write = 0;
-    data.image[IDout].md[0].cnt0++;
+    imgout->md[0].write = 0;
+    imgout->md[0].cnt0++;
 
-    free(size);
+    return imgout->ID;
+}
 
-    return IDout;
+imageID copy_image_ID(
+    const char *restrict name,
+    const char *restrict newname,
+    int shared
+)
+{
+    IMGID imgin  = mkIMGID_from_name(name);
+    IMGID imgout = mkIMGID_from_name(newname);
+
+    return copy_image_ID_IMGID(&imgin, &imgout, shared);
 }
 
 
 
 
-imageID chname_image_ID(
-    const char * restrict ID_name,
-    const char * restrict new_name
+imageID chname_image_ID_IMGID(
+    IMGID *imgin,
+    const char *new_name
 )
 {
-    imageID ID;
+    resolveIMGID(imgin, ERRMODE_ABORT);
 
-    ID = -1;
     if((image_ID(new_name) == -1) && (variable_ID(new_name) == -1))
     {
-        ID = image_ID(ID_name);
-        strcpy(data.image[ID].name, new_name);
-        //      if ( Debug > 0 ) { printf("change image name %s -> %s\n",ID_name,new_name);}
+        strcpy(imgin->im->name, new_name);
+        strcpy(imgin->name, new_name);
     }
     else
     {
         printf("Cannot change name %s -> %s : new name already in use\n",
-               ID_name,
+               imgin->name,
                new_name);
     }
 
@@ -274,7 +240,17 @@ imageID chname_image_ID(
         list_image_ID_ncurses();
     }
 
-    return ID;
+    return imgin->ID;
+}
+
+imageID chname_image_ID(
+    const char *restrict ID_name,
+    const char *restrict new_name
+)
+{
+    IMGID imgin = mkIMGID_from_name(ID_name);
+
+    return chname_image_ID_IMGID(&imgin, new_name);
 }
 
 
@@ -283,77 +259,76 @@ imageID chname_image_ID(
  *
  *
  */
-errno_t COREMOD_MEMORY_cp2shm(
-    const char * restrict IDname,
-    const char * restrict IDshmname
+errno_t COREMOD_MEMORY_cp2shm_IMGID(
+    IMGID *imgin,
+    IMGID *imgout
 )
 {
-    imageID   ID;
-    imageID   IDshm;
-    uint8_t   datatype;
-    long      naxis;
-    uint32_t *sizearray;
-    long      k;
-    int       axis;
-    int       shmOK;
+    resolveIMGID(imgin, ERRMODE_ABORT);
 
-    ID    = image_ID(IDname);
-    naxis = data.image[ID].md[0].naxis;
-
-    sizearray = (uint32_t *) malloc(sizeof(uint32_t) * naxis);
-    datatype  = data.image[ID].md[0].datatype;
-    for(k = 0; k < naxis; k++)
+    uint32_t naxis = imgin->md[0].naxis;
+    uint32_t size[3];
+    for(uint32_t k = 0; k < naxis; k++)
     {
-        sizearray[k] = data.image[ID].md[0].size[k];
+        size[k] = imgin->md[0].size[k];
     }
+    uint8_t datatype = imgin->md[0].datatype;
 
-    shmOK = 1;
-    IDshm = read_sharedmem_image(IDshmname);
-    if(IDshm != -1)
+    int shmOK = 1;
+    resolveIMGID(imgout, ERRMODE_NULL);
+    if(imgout->ID != -1)
     {
         // verify type and size
-        if(data.image[ID].md[0].naxis != data.image[IDshm].md[0].naxis)
+        if(imgin->md[0].naxis != imgout->md[0].naxis)
         {
             shmOK = 0;
         }
         if(shmOK == 1)
         {
-            for(axis = 0; axis < data.image[IDshm].md[0].naxis; axis++)
-                if(data.image[ID].md[0].size[axis] !=
-                        data.image[IDshm].md[0].size[axis])
+            for(int axis = 0; axis < imgin->md[0].naxis; axis++)
+                if(imgin->md[0].size[axis] !=
+                        imgout->md[0].size[axis])
                 {
                     shmOK = 0;
                 }
         }
-        if(data.image[ID].md[0].datatype != data.image[IDshm].md[0].datatype)
+        if(imgin->md[0].datatype != imgout->md[0].datatype)
         {
             shmOK = 0;
         }
 
         if(shmOK == 0)
         {
-            delete_image_ID(IDshmname, DELETE_IMAGE_ERRMODE_WARNING);
-            IDshm = -1;
+            delete_image_ID(imgout->name, DELETE_IMAGE_ERRMODE_WARNING);
+            imgout->ID = -1;
         }
     }
 
-    if(IDshm == -1)
+    if(imgout->ID == -1)
     {
-        create_image_ID(IDshmname, naxis, sizearray, datatype, 1, 0, 0, &IDshm);
+        create_image_ID(imgout->name, naxis, size, datatype, 1, 0, 0, &imgout->ID);
+        resolveIMGID(imgout, ERRMODE_ABORT);
     }
-    free(sizearray);
 
-    //data.image[IDshm].md[0].nelement = data.image[ID].md[0].nelement;
-    //printf("======= %ld %ld ============\n", data.image[ID].md[0].nelement, data.image[IDshm].md[0].nelement);
+    imgout->md[0].write = 1;
 
-    data.image[IDshm].md[0].write = 1;
+    memcpy(imgout->im->array.raw, imgin->im->array.raw,
+           ImageStreamIO_typesize(datatype) * imgin->md[0].nelement);
 
-    memcpy(data.image[IDshm].array.raw, data.image[ID].array.raw,
-           ImageStreamIO_typesize(datatype) * data.image[ID].md[0].nelement);
-
-    COREMOD_MEMORY_image_set_sempost_byID(IDshm, -1);
-    data.image[IDshm].md[0].cnt0++;
-    data.image[IDshm].md[0].write = 0;
+    COREMOD_MEMORY_image_set_sempost_byID(imgout->ID, -1);
+    imgout->md[0].cnt0++;
+    imgout->md[0].write = 0;
 
     return RETURN_SUCCESS;
+}
+
+errno_t COREMOD_MEMORY_cp2shm(
+    const char *restrict IDname,
+    const char *restrict IDshmname
+)
+{
+    IMGID imgin  = mkIMGID_from_name(IDname);
+    IMGID imgout = mkIMGID_from_name(IDshmname);
+
+    return COREMOD_MEMORY_cp2shm_IMGID(&imgin, &imgout);
 }

--- a/src/COREMOD_memory/image_copy.h
+++ b/src/COREMOD_memory/image_copy.h
@@ -5,7 +5,10 @@
 errno_t image_copy_addCLIcmd();
 
 imageID copy_image_ID(const char *name, const char *newname, int shared);
+imageID copy_image_ID_IMGID(IMGID *imgin, IMGID *imgout, int shared);
 
 imageID chname_image_ID(const char *ID_name, const char *new_name);
+imageID chname_image_ID_IMGID(IMGID *imgin, const char *new_name);
 
 errno_t COREMOD_MEMORY_cp2shm(const char *IDname, const char *IDshmname);
+errno_t COREMOD_MEMORY_cp2shm_IMGID(IMGID *imgin, IMGID *imgout);

--- a/src/COREMOD_memory/image_copy_shm.c
+++ b/src/COREMOD_memory/image_copy_shm.c
@@ -46,57 +46,67 @@ static errno_t help_function()
 
 
 // copy image to shared memory
-static errno_t image_copy_shm(
-    IMGID img,
-    const char * restrict outshmname
+errno_t image_copy_shm_IMGID(
+    IMGID *img,
+    IMGID *imgshm
 )
 {
-    resolveIMGID(&img, ERRMODE_ABORT);
+    resolveIMGID(img, ERRMODE_ABORT);
 
     // check if shared memory destination exists
-    IMGID imgshm = read_sharedmem_img(outshmname);
-    if( imgshm.ID != -1)
+    resolveIMGID(imgshm, ERRMODE_NULL);
+    if( imgshm->ID != -1)
     {
         // image exists - checking if compatible size and type
-        if( IMGIDmdcompare(img, imgshm) > 0 )
+        if( IMGIDmdcompare(*img, *imgshm) > 0 )
         {
             // image formats are incompatible
             // delete output
-            printf("Image %s already exist in shm, but wrong size/format -> deleting\n", outshmname);
+            printf("Image %s already exist in shm, but wrong size/format -> deleting\n", imgshm->name);
 
-            ImageStreamIO_destroyIm(imgshm.im);
-            imgshm.ID = -1;
+            ImageStreamIO_destroyIm(imgshm->im);
+            imgshm->ID = -1;
         }
         else
         {
-            printf("re-using existing shm %s\n", outshmname);
+            printf("re-using existing shm %s\n", imgshm->name);
         }
     }
 
 
-    if ( imgshm.ID == -1 )
+    if ( imgshm->ID == -1 )
     {
-        copyIMGID( &img, &imgshm );
-        strcpy(imgshm.name, outshmname);
-        imgshm.shared = 1;
+        copyIMGID( img, imgshm );
+        imgshm->shared = 1;
 
-        createimagefromIMGID(&imgshm);
+        createimagefromIMGID(imgshm);
     }
 
 
-    imgshm.md->write = 1;
+    imgshm->md->write = 1;
     // copy data array
-    memcpy(imgshm.im->array.raw,
-           img.im->array.raw,
-           ImageStreamIO_typesize(img.md->datatype)* img.md->nelement);
+    memcpy(imgshm->im->array.raw,
+           img->im->array.raw,
+           ImageStreamIO_typesize(img->md->datatype)* img->md->nelement);
     // copy keywords
-    memcpy(imgshm.im->kw, img.im->kw, sizeof(IMAGE_KEYWORD) * img.md->NBkw);
+    memcpy(imgshm->im->kw, img->im->kw, sizeof(IMAGE_KEYWORD) * img->md->NBkw);
 
-    COREMOD_MEMORY_image_set_sempost_byID(imgshm.ID, -1);
-    imgshm.md->cnt0++;
-    imgshm.md->write = 0;
+    COREMOD_MEMORY_image_set_sempost_byID(imgshm->ID, -1);
+    imgshm->md->cnt0++;
+    imgshm->md->write = 0;
 
     return RETURN_SUCCESS;
+}
+
+errno_t image_copy_shm(
+    const char *inname,
+    const char *outname
+)
+{
+    IMGID imgin = mkIMGID_from_name(inname);
+    IMGID imgshm = mkIMGID_from_name(outname);
+
+    return image_copy_shm_IMGID(&imgin, &imgshm);
 }
 
 
@@ -109,9 +119,10 @@ static errno_t compute_function()
 
     INSERT_STD_PROCINFO_COMPUTEFUNC_START
 
-    image_copy_shm(
-        mkIMGID_from_name(inimname),
-        outimname);
+    IMGID imgin = mkIMGID_from_name(inimname);
+    IMGID imgshm = mkIMGID_from_name(outimname);
+
+    image_copy_shm_IMGID(&imgin, &imgshm);
 
     INSERT_STD_PROCINFO_COMPUTEFUNC_END
 

--- a/src/COREMOD_memory/image_copy_shm.h
+++ b/src/COREMOD_memory/image_copy_shm.h
@@ -3,4 +3,7 @@
 
 errno_t CLIADDCMD_COREMOD_memory__image_copy_shm();
 
+errno_t image_copy_shm(const char *inname, const char *outname);
+errno_t image_copy_shm_IMGID(IMGID *imgin, IMGID *imgout);
+
 #endif

--- a/src/COREMOD_memory/image_make2D.c
+++ b/src/COREMOD_memory/image_make2D.c
@@ -1,4 +1,5 @@
 #include "CommandLineInterface/CLIcore.h"
+#include "image_make2D.h"
 
 // Local variables pointers
 static char     *outimname;
@@ -64,12 +65,18 @@ static errno_t help_function()
     return RETURN_SUCCESS;
 }
 
-static imageID make_2Dimage(IMGID *img)
+imageID make_2Dimage_IMGID(IMGID *img)
 {
     // Create image if needed
     imcreateIMGID(img);
 
     return (img->ID);
+}
+
+imageID make_2Dimage(const char *name, uint32_t xsize, uint32_t ysize)
+{
+    IMGID img = makeIMGID_2D(name, xsize, ysize);
+    return make_2Dimage_IMGID(&img);
 }
 
 static errno_t compute_function()
@@ -80,7 +87,7 @@ static errno_t compute_function()
 
     INSERT_STD_PROCINFO_COMPUTEFUNC_START
 
-    make_2Dimage(&img);
+    make_2Dimage_IMGID(&img);
 
     processinfo_update_output_stream(processinfo, img.ID);
     INSERT_STD_PROCINFO_COMPUTEFUNC_END

--- a/src/COREMOD_memory/image_make2D.h
+++ b/src/COREMOD_memory/image_make2D.h
@@ -3,4 +3,7 @@
 
 errno_t CLIADDCMD_COREMOD_memory__mk2Dim();
 
+imageID make_2Dimage(const char *name, uint32_t xsize, uint32_t ysize);
+imageID make_2Dimage_IMGID(IMGID *img);
+
 #endif

--- a/src/COREMOD_memory/image_make3D.c
+++ b/src/COREMOD_memory/image_make3D.c
@@ -1,4 +1,5 @@
 #include "CommandLineInterface/CLIcore.h"
+#include "image_make3D.h"
 
 // Local variables pointers
 static char     *outimname;
@@ -59,12 +60,18 @@ static errno_t help_function()
     return RETURN_SUCCESS;
 }
 
-static imageID make_3Dimage(IMGID *img)
+imageID make_3Dimage_IMGID(IMGID *img)
 {
     // Create image if needed
     imcreateIMGID(img);
 
     return (img->ID);
+}
+
+imageID make_3Dimage(const char *name, uint32_t xsize, uint32_t ysize, uint32_t zsize)
+{
+    IMGID img = makeIMGID_3D(name, xsize, ysize, zsize);
+    return make_3Dimage_IMGID(&img);
 }
 
 static errno_t compute_function()
@@ -75,7 +82,7 @@ static errno_t compute_function()
 
     INSERT_STD_PROCINFO_COMPUTEFUNC_START
 
-    make_3Dimage(&img);
+    make_3Dimage_IMGID(&img);
 
     processinfo_update_output_stream(processinfo, img.ID);
     INSERT_STD_PROCINFO_COMPUTEFUNC_END

--- a/src/COREMOD_memory/image_make3D.h
+++ b/src/COREMOD_memory/image_make3D.h
@@ -3,4 +3,7 @@
 
 errno_t CLIADDCMD_COREMOD_memory__mk3Dim();
 
+imageID make_3Dimage(const char *name, uint32_t xsize, uint32_t ysize, uint32_t zsize);
+imageID make_3Dimage_IMGID(IMGID *img);
+
 #endif

--- a/src/COREMOD_memory/image_mk_amph_from_complex.c
+++ b/src/COREMOD_memory/image_mk_amph_from_complex.c
@@ -47,134 +47,112 @@ static errno_t help_function()
     return RETURN_SUCCESS;
 }
 
-errno_t mk_amph_from_complex(const char *in_name,
-                             const char *am_name,
-                             const char *ph_name,
-                             int         sharedmem)
+errno_t mk_amph_from_complex_IMGID(
+    IMGID *imgin,
+    IMGID *imgamp,
+    IMGID *imgpha
+)
 {
     DEBUG_TRACE_FSTART();
 
-    imageID  IDam;
-    imageID  IDph;
-    imageID  IDin;
-    uint32_t naxes[3];
-    uint8_t  datatype;
-
-    IDin          = image_ID(in_name);
-    datatype      = data.image[IDin].md[0].datatype;
-    uint8_t naxis = data.image[IDin].md[0].naxis;
+    resolveIMGID(imgin, ERRMODE_ABORT);
+    uint8_t datatype = imgin->md[0].datatype;
+    uint8_t naxis    = imgin->md[0].naxis;
 
     for(uint8_t i = 0; i < naxis; i++)
     {
-        naxes[i] = data.image[IDin].md[0].size[i];
+        imgamp->size[i] = imgin->md[0].size[i];
+        imgpha->size[i] = imgin->md[0].size[i];
     }
-    uint64_t nelement = data.image[IDin].md[0].nelement;
+    imgamp->naxis = naxis;
+    imgpha->naxis = naxis;
+
+    uint64_t nelement = imgin->md[0].nelement;
 
     if(datatype == _DATATYPE_COMPLEX_FLOAT)  // single precision
     {
-        FUNC_CHECK_RETURN(create_image_ID(am_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_FLOAT,
-                                          sharedmem,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &IDam));
+        imgamp->datatype = _DATATYPE_FLOAT;
+        createimagefromIMGID(imgamp);
 
-        FUNC_CHECK_RETURN(create_image_ID(ph_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_FLOAT,
-                                          sharedmem,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &IDph));
+        imgpha->datatype = _DATATYPE_FLOAT;
+        createimagefromIMGID(imgpha);
 
-        data.image[IDam].md[0].write = 1;
-        data.image[IDph].md[0].write = 1;
+        imgamp->md[0].write = 1;
+        imgpha->md[0].write = 1;
 #ifdef _OPENMP
-        #pragma omp parallel if (nelement >                                            \
-        OMP_NELEMENT_LIMIT) private(ii, amp_f, pha_f)
+        #pragma omp parallel if (nelement > OMP_NELEMENT_LIMIT)
         {
             #pragma omp for
 #endif
             for(uint64_t ii = 0; ii < nelement; ii++)
             {
                 float amp_f =
-                    (float) sqrt(data.image[IDin].array.CF[ii].re *
-                                 data.image[IDin].array.CF[ii].re +
-                                 data.image[IDin].array.CF[ii].im *
-                                 data.image[IDin].array.CF[ii].im);
-                float pha_f = (float) atan2(data.image[IDin].array.CF[ii].im,
-                                            data.image[IDin].array.CF[ii].re);
-                data.image[IDam].array.F[ii] = amp_f;
-                data.image[IDph].array.F[ii] = pha_f;
+                    (float) sqrt(imgin->im->array.CF[ii].re *
+                                 imgin->im->array.CF[ii].re +
+                                 imgin->im->array.CF[ii].im *
+                                 imgin->im->array.CF[ii].im);
+                float pha_f = (float) atan2(imgin->im->array.CF[ii].im,
+                                            imgin->im->array.CF[ii].re);
+                imgamp->im->array.F[ii] = amp_f;
+                imgpha->im->array.F[ii] = pha_f;
             }
 #ifdef _OPENMP
         }
 #endif
-        if(sharedmem == 1)
-    {
-        FUNC_CHECK_RETURN(COREMOD_MEMORY_image_set_sempost_byID(IDam, -1));
-
-            FUNC_CHECK_RETURN(COREMOD_MEMORY_image_set_sempost_byID(IDph, -1));
+        if(imgamp->md[0].shared == 1)
+        {
+            FUNC_CHECK_RETURN(COREMOD_MEMORY_image_set_sempost_byID(imgamp->ID, -1));
         }
-        data.image[IDam].md[0].cnt0++;
-        data.image[IDph].md[0].cnt0++;
-        data.image[IDam].md[0].write = 0;
-        data.image[IDph].md[0].write = 0;
+        if(imgpha->md[0].shared == 1)
+        {
+            FUNC_CHECK_RETURN(COREMOD_MEMORY_image_set_sempost_byID(imgpha->ID, -1));
+        }
+        imgamp->md[0].cnt0++;
+        imgpha->md[0].cnt0++;
+        imgamp->md[0].write = 0;
+        imgpha->md[0].write = 0;
     }
     else if(datatype == _DATATYPE_COMPLEX_DOUBLE)  // double precision
     {
-        FUNC_CHECK_RETURN(create_image_ID(am_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_DOUBLE,
-                                          sharedmem,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &IDam));
+        imgamp->datatype = _DATATYPE_DOUBLE;
+        createimagefromIMGID(imgamp);
 
-        FUNC_CHECK_RETURN(create_image_ID(ph_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_DOUBLE,
-                                          sharedmem,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &IDph));
+        imgpha->datatype = _DATATYPE_DOUBLE;
+        createimagefromIMGID(imgpha);
 
-        data.image[IDam].md[0].write = 1;
-        data.image[IDph].md[0].write = 1;
+        imgamp->md[0].write = 1;
+        imgpha->md[0].write = 1;
 #ifdef _OPENMP
-        #pragma omp parallel if (nelement >                                            \
-        OMP_NELEMENT_LIMIT) private(ii, amp_d, pha_d)
+        #pragma omp parallel if (nelement > OMP_NELEMENT_LIMIT)
         {
             #pragma omp for
 #endif
             for(uint64_t ii = 0; ii < nelement; ii++)
             {
-                double amp_d = sqrt(data.image[IDin].array.CD[ii].re *
-                                    data.image[IDin].array.CD[ii].re +
-                                    data.image[IDin].array.CD[ii].im *
-                                    data.image[IDin].array.CD[ii].im);
-                double pha_d = atan2(data.image[IDin].array.CD[ii].im,
-                                     data.image[IDin].array.CD[ii].re);
-                data.image[IDam].array.D[ii] = amp_d;
-                data.image[IDph].array.D[ii] = pha_d;
+                double amp_d = sqrt(imgin->im->array.CD[ii].re *
+                                    imgin->im->array.CD[ii].re +
+                                    imgin->im->array.CD[ii].im *
+                                    imgin->im->array.CD[ii].im);
+                double pha_d = atan2(imgin->im->array.CD[ii].im,
+                                     imgin->im->array.CD[ii].re);
+                imgamp->im->array.D[ii] = amp_d;
+                imgpha->im->array.D[ii] = pha_d;
             }
 #ifdef _OPENMP
         }
 #endif
-        if(sharedmem == 1)
-    {
-        COREMOD_MEMORY_image_set_sempost_byID(IDam, -1);
-            COREMOD_MEMORY_image_set_sempost_byID(IDph, -1);
+        if(imgamp->md[0].shared == 1)
+        {
+            COREMOD_MEMORY_image_set_sempost_byID(imgamp->ID, -1);
         }
-        data.image[IDam].md[0].cnt0++;
-        data.image[IDph].md[0].cnt0++;
-        data.image[IDam].md[0].write = 0;
-        data.image[IDph].md[0].write = 0;
+        if(imgpha->md[0].shared == 1)
+        {
+            COREMOD_MEMORY_image_set_sempost_byID(imgpha->ID, -1);
+        }
+        imgamp->md[0].cnt0++;
+        imgpha->md[0].cnt0++;
+        imgamp->md[0].write = 0;
+        imgpha->md[0].write = 0;
     }
     else
     {
@@ -186,13 +164,31 @@ errno_t mk_amph_from_complex(const char *in_name,
     return RETURN_SUCCESS;
 }
 
+errno_t mk_amph_from_complex(const char *in_name,
+                             const char *am_name,
+                             const char *ph_name,
+                             int         sharedmem)
+{
+    IMGID imgin = mkIMGID_from_name(in_name);
+    IMGID imgamp = mkIMGID_from_name(am_name);
+    IMGID imgpha = mkIMGID_from_name(ph_name);
+    imgamp.shared = sharedmem;
+    imgpha.shared = sharedmem;
+
+    return mk_amph_from_complex_IMGID(&imgin, &imgamp, &imgpha);
+}
+
 static errno_t compute_function()
 {
     DEBUG_TRACE_FSTART();
 
     INSERT_STD_PROCINFO_COMPUTEFUNC_START
 
-    mk_amph_from_complex(inimname, outampimname, outphaimname, 0);
+    IMGID imgin = mkIMGID_from_name(inimname);
+    IMGID imgamp = mkIMGID_from_name(outampimname);
+    IMGID imgpha = mkIMGID_from_name(outphaimname);
+
+    mk_amph_from_complex_IMGID(&imgin, &imgamp, &imgpha);
 
     INSERT_STD_PROCINFO_COMPUTEFUNC_END
 

--- a/src/COREMOD_memory/image_mk_amph_from_complex.h
+++ b/src/COREMOD_memory/image_mk_amph_from_complex.h
@@ -6,6 +6,10 @@ errno_t mk_amph_from_complex(const char *in_name,
                              const char *ph_name,
                              int         sharedmem);
 
+errno_t mk_amph_from_complex_IMGID(IMGID *imgin,
+                                   IMGID *imgamp,
+                                   IMGID *imgpha);
+
 errno_t CLIADDCMD_COREMOD__mk_amph_from_complex();
 
 #endif

--- a/src/COREMOD_memory/image_mk_complex_from_amph.c
+++ b/src/COREMOD_memory/image_mk_complex_from_amph.c
@@ -52,31 +52,31 @@ static errno_t help_function()
 
 
 
-errno_t mk_complexIMG_from_amphIMG(
-    IMGID imginamp,
-    IMGID imginpha,
+errno_t mk_complex_from_amph_IMGID(
+    IMGID *imginamp,
+    IMGID *imginpha,
     IMGID *imgoutC
 )
 {
     DEBUG_TRACE_FSTART();
 
-    uint32_t naxes[3];
+    resolveIMGID(imginamp, ERRMODE_ABORT);
+    resolveIMGID(imginpha, ERRMODE_ABORT);
 
+    uint8_t datatype_am = imginamp->md->datatype;
+    uint8_t datatype_ph = imginpha->md->datatype;
 
-    uint8_t datatype_am = imginamp.md->datatype;
-    uint8_t datatype_ph = imginpha.md->datatype;
-
-    uint8_t naxisamp = imginamp.md->naxis;
-    uint8_t naxispha = imginpha.md->naxis;
-    uint64_t xysize = imginamp.md->size[0];
-    imgoutC->size[0] = imginamp.md->size[0];
+    uint8_t naxisamp = imginamp->md->naxis;
+    uint8_t naxispha = imginpha->md->naxis;
+    uint64_t xysize = imginamp->md->size[0];
+    imgoutC->size[0] = imginamp->md->size[0];
     imgoutC->size[1] = 1;
 
     uint8_t naxis = naxisamp;
     if(naxisamp > 1)
     {
-        xysize *= imginamp.md->size[1];
-        imgoutC->size[1] = imginamp.md->size[1];
+        xysize *= imginamp->md->size[1];
+        imgoutC->size[1] = imginamp->md->size[1];
     }
     if(naxispha > naxisamp)
     {
@@ -90,11 +90,11 @@ errno_t mk_complexIMG_from_amphIMG(
     uint32_t zsizepha = 1;
     if(naxisamp > 2)
     {
-        zsizeamp = imginamp.md->size[2];
+        zsizeamp = imginamp->md->size[2];
     }
     if(naxispha > 2)
     {
-        zsizepha = imginpha.md->size[2];
+        zsizepha = imginpha->md->size[2];
     }
     zsize = zsizeamp;
     if(zsizepha > zsizeamp)
@@ -138,12 +138,12 @@ errno_t mk_complexIMG_from_amphIMG(
                 for(uint64_t ii = 0; ii < xysize; ii++)
                 {
                     imgoutC->im->array.CF[kk*xysize + ii].re =
-                        imginamp.im->array.F[kkamp*xysize + ii] *
-                        ((float) cos(imginpha.im->array.F[kkpha*xysize + ii]));
+                        imginamp->im->array.F[kkamp*xysize + ii] *
+                        ((float) cos(imginpha->im->array.F[kkpha*xysize + ii]));
 
                     imgoutC->im->array.CF[kk*xysize +ii].im =
-                        imginamp.im->array.F[kkamp*xysize + ii] *
-                        ((float) sin(imginpha.im->array.F[kkpha*xysize + ii]));
+                        imginamp->im->array.F[kkamp*xysize + ii] *
+                        ((float) sin(imginpha->im->array.F[kkpha*xysize + ii]));
                 }
             }
 #ifdef _OPENMP
@@ -182,12 +182,12 @@ errno_t mk_complexIMG_from_amphIMG(
                 for(uint64_t ii = 0; ii < xysize; ii++)
                 {
                     imgoutC->im->array.CD[kk*xysize + ii].re =
-                        imginamp.im->array.F[kkamp*xysize + ii] *
-                        cos(imginpha.im->array.D[kkpha*xysize + ii]);
+                        imginamp->im->array.F[kkamp*xysize + ii] *
+                        cos(imginpha->im->array.D[kkpha*xysize + ii]);
 
                     imgoutC->im->array.CD[kk*xysize + ii].im =
-                        imginamp.im->array.F[kkamp*xysize + ii] *
-                        sin(imginpha.im->array.D[kkpha*xysize + ii]);
+                        imginamp->im->array.F[kkamp*xysize + ii] *
+                        sin(imginpha->im->array.D[kkpha*xysize + ii]);
                 }
             }
 #ifdef _OPENMP
@@ -226,12 +226,12 @@ errno_t mk_complexIMG_from_amphIMG(
                 for(uint64_t ii = 0; ii < xysize; ii++)
                 {
                     imgoutC->im->array.CD[kk*xysize + ii].re =
-                        imginamp.im->array.D[kkamp*xysize + ii] *
-                        cos(imginpha.im->array.F[kkpha*xysize + ii]);
+                        imginamp->im->array.D[kkamp*xysize + ii] *
+                        cos(imginpha->im->array.F[kkpha*xysize + ii]);
 
                     imgoutC->im->array.CD[kk*xysize + ii].im =
-                        imginamp.im->array.D[kkamp*xysize + ii] *
-                        sin(imginpha.im->array.F[kkpha*xysize + ii]);
+                        imginamp->im->array.D[kkamp*xysize + ii] *
+                        sin(imginpha->im->array.F[kkpha*xysize + ii]);
                 }
             }
 #ifdef _OPENMP
@@ -270,12 +270,12 @@ errno_t mk_complexIMG_from_amphIMG(
                 for(uint64_t ii = 0; ii < xysize; ii++)
                 {
                     imgoutC->im->array.CD[kk*xysize + ii].re =
-                        imginamp.im->array.D[kkamp*xysize + ii] *
-                        cos(imginpha.im->array.D[kkpha*xysize + ii]);
+                        imginamp->im->array.D[kkamp*xysize + ii] *
+                        cos(imginpha->im->array.D[kkpha*xysize + ii]);
 
                     imgoutC->im->array.CD[kk*xysize + ii].im =
-                        imginamp.im->array.D[kkamp*xysize + ii] *
-                        sin(imginpha.im->array.D[kkpha*xysize + ii]);
+                        imginamp->im->array.D[kkamp*xysize + ii] *
+                        sin(imginpha->im->array.D[kkpha*xysize + ii]);
                 }
             }
 #ifdef _OPENMP
@@ -306,17 +306,11 @@ errno_t mk_complex_from_amph(
 )
 {
     IMGID imgamp = mkIMGID_from_name(am_name);
-    resolveIMGID(&imgamp, ERRMODE_ABORT);
-
     IMGID imgpha = mkIMGID_from_name(ph_name);
-    resolveIMGID(&imgpha, ERRMODE_ABORT);
-
     IMGID imgoutC  = mkIMGID_from_name(out_name);
     imgoutC.shared = sharedmem;
 
-    mk_complexIMG_from_amphIMG(imgamp, imgpha, &imgoutC);
-
-    return RETURN_SUCCESS;
+    return mk_complex_from_amph_IMGID(&imgamp, &imgpha, &imgoutC);
 }
 
 
@@ -327,11 +321,7 @@ static errno_t compute_function()
     DEBUG_TRACE_FSTART();
 
     IMGID imgamp = mkIMGID_from_name(inampimname);
-    resolveIMGID(&imgamp, ERRMODE_ABORT);
-
     IMGID imgpha = mkIMGID_from_name(inphaimname);
-    resolveIMGID(&imgpha, ERRMODE_ABORT);
-
     IMGID imgoutC  = mkIMGID_from_name(outimname);
 
 
@@ -341,9 +331,7 @@ static errno_t compute_function()
     INSERT_STD_PROCINFO_COMPUTEFUNC_LOOPSTART
     {
 
-        //mk_complex_from_amph(inampimname, inphaimname, outimname, 0);
-
-        mk_complexIMG_from_amphIMG(imgamp, imgpha, &imgoutC);
+        mk_complex_from_amph_IMGID(&imgamp, &imgpha, &imgoutC);
 
     }
     INSERT_STD_PROCINFO_COMPUTEFUNC_END

--- a/src/COREMOD_memory/image_mk_complex_from_amph.h
+++ b/src/COREMOD_memory/image_mk_complex_from_amph.h
@@ -1,18 +1,14 @@
 #ifndef COREMOD_MEMORY_IMAGE_MK_COMPLEX_FROM_AMPH_H
 #define COREMOD_MEMORY_IMAGE_MK_COMPLEX_FROM_AMPH_H
 
-errno_t mk_complexIMG_from_amphIMG(
-    IMGID imginamp,
-    IMGID imginpha,
-    IMGID *imgoutC
-);
+errno_t mk_complex_from_amph_IMGID(IMGID *imginamp,
+                                   IMGID *imginpha,
+                                   IMGID *imgoutC);
 
-errno_t mk_complex_from_amph(
-    const char *am_name,
-    const char *ph_name,
-    const char *out_name,
-    int         sharedmem
-);
+errno_t mk_complex_from_amph(const char *am_name,
+                             const char *ph_name,
+                             const char *out_name,
+                             int         sharedmem);
 
 errno_t CLIADDCMD_COREMOD__mk_complex_from_amph();
 

--- a/src/COREMOD_memory/image_mk_complex_from_reim.c
+++ b/src/COREMOD_memory/image_mk_complex_from_reim.c
@@ -47,111 +47,80 @@ static errno_t help_function()
     return RETURN_SUCCESS;
 }
 
-errno_t mk_complex_from_reim(const char *re_name,
-                             const char *im_name,
-                             const char *out_name,
-                             int         sharedmem)
+errno_t mk_complex_from_reim_IMGID(
+    IMGID *imgre,
+    IMGID *imgim,
+    IMGID *imgout
+)
 {
     DEBUG_TRACE_FSTART();
 
-    imageID   IDre;
-    imageID   IDim;
-    imageID   IDout;
-    uint32_t *naxes = NULL;
-    int8_t    naxis;
     uint8_t   datatype_re;
     uint8_t   datatype_im;
     uint8_t   datatype_out;
 
-    IDre = image_ID(re_name);
-    IDim = image_ID(im_name);
+    resolveIMGID(imgre, ERRMODE_ABORT);
+    resolveIMGID(imgim, ERRMODE_ABORT);
 
-    datatype_re = data.image[IDre].md[0].datatype;
-    datatype_im = data.image[IDim].md[0].datatype;
-    naxis       = data.image[IDre].md[0].naxis;
+    datatype_re = imgre->md[0].datatype;
+    datatype_im = imgim->md[0].datatype;
 
-    naxes = (uint32_t *) malloc(sizeof(uint32_t) * naxis);
-    if(naxes == NULL)
+    imgout->naxis = imgre->md[0].naxis;
+    for(int8_t i = 0; i < imgout->naxis; i++)
     {
-        PRINT_ERROR("malloc error");
-        abort();
+        imgout->size[i] = imgre->md[0].size[i];
     }
-
-    for(int8_t i = 0; i < naxis; i++)
-    {
-        naxes[i] = data.image[IDre].md[0].size[i];
-    }
-    uint64_t nelement = data.image[IDre].md[0].nelement;
+    uint64_t nelement = imgre->md[0].nelement;
 
     if((datatype_re == _DATATYPE_FLOAT) && (datatype_im == _DATATYPE_FLOAT))
     {
         datatype_out = _DATATYPE_COMPLEX_FLOAT;
-        FUNC_CHECK_RETURN(create_image_ID(out_name,
-                                          naxis,
-                                          naxes,
-                                          datatype_out,
-                                          sharedmem,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &IDout));
+        imgout->datatype = datatype_out;
+        createimagefromIMGID(imgout);
+
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            data.image[IDout].array.CF[ii].re = data.image[IDre].array.F[ii];
-            data.image[IDout].array.CF[ii].im = data.image[IDim].array.F[ii];
+            imgout->im->array.CF[ii].re = imgre->im->array.F[ii];
+            imgout->im->array.CF[ii].im = imgim->im->array.F[ii];
         }
     }
     else if((datatype_re == _DATATYPE_FLOAT) &&
             (datatype_im == _DATATYPE_DOUBLE))
     {
         datatype_out = _DATATYPE_COMPLEX_DOUBLE;
-        FUNC_CHECK_RETURN(create_image_ID(out_name,
-                                          naxis,
-                                          naxes,
-                                          datatype_out,
-                                          sharedmem,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &IDout));
+        imgout->datatype = datatype_out;
+        createimagefromIMGID(imgout);
+
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            data.image[IDout].array.CD[ii].re = data.image[IDre].array.F[ii];
-            data.image[IDout].array.CD[ii].im = data.image[IDim].array.D[ii];
+            imgout->im->array.CD[ii].re = imgre->im->array.F[ii];
+            imgout->im->array.CD[ii].im = imgim->im->array.D[ii];
         }
     }
     else if((datatype_re == _DATATYPE_DOUBLE) &&
             (datatype_im == _DATATYPE_FLOAT))
     {
         datatype_out = _DATATYPE_COMPLEX_DOUBLE;
-        FUNC_CHECK_RETURN(create_image_ID(out_name,
-                                          naxis,
-                                          naxes,
-                                          datatype_out,
-                                          sharedmem,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &IDout));
+        imgout->datatype = datatype_out;
+        createimagefromIMGID(imgout);
+
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            data.image[IDout].array.CD[ii].re = data.image[IDre].array.D[ii];
-            data.image[IDout].array.CD[ii].im = data.image[IDim].array.F[ii];
+            imgout->im->array.CD[ii].re = imgre->im->array.D[ii];
+            imgout->im->array.CD[ii].im = imgim->im->array.F[ii];
         }
     }
     else if((datatype_re == _DATATYPE_DOUBLE) &&
             (datatype_im == _DATATYPE_DOUBLE))
     {
         datatype_out = _DATATYPE_COMPLEX_DOUBLE;
-        FUNC_CHECK_RETURN(create_image_ID(out_name,
-                                          naxis,
-                                          naxes,
-                                          datatype_out,
-                                          sharedmem,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &IDout));
+        imgout->datatype = datatype_out;
+        createimagefromIMGID(imgout);
+
         for(uint64_t ii = 0; ii < nelement; ii++)
         {
-            data.image[IDout].array.CD[ii].re = data.image[IDre].array.D[ii];
-            data.image[IDout].array.CD[ii].im = data.image[IDim].array.D[ii];
+            imgout->im->array.CD[ii].re = imgre->im->array.D[ii];
+            imgout->im->array.CD[ii].im = imgim->im->array.D[ii];
         }
     }
     else
@@ -161,10 +130,21 @@ errno_t mk_complex_from_reim(const char *re_name,
     }
     // Note: openMP doesn't help here
 
-    free(naxes);
-
     DEBUG_TRACE_FEXIT();
     return RETURN_SUCCESS;
+}
+
+errno_t mk_complex_from_reim(const char *re_name,
+                             const char *im_name,
+                             const char *out_name,
+                             int         sharedmem)
+{
+    IMGID imgre = mkIMGID_from_name(re_name);
+    IMGID imgim = mkIMGID_from_name(im_name);
+    IMGID imgout = mkIMGID_from_name(out_name);
+    imgout.shared = sharedmem;
+
+    return mk_complex_from_reim_IMGID(&imgre, &imgim, &imgout);
 }
 
 static errno_t compute_function()
@@ -173,7 +153,11 @@ static errno_t compute_function()
 
     INSERT_STD_PROCINFO_COMPUTEFUNC_START
 
-    mk_complex_from_reim(inreimname, inimimname, outimname, 0);
+    IMGID imgre = mkIMGID_from_name(inreimname);
+    IMGID imgim = mkIMGID_from_name(inimimname);
+    IMGID imgout = mkIMGID_from_name(outimname);
+
+    mk_complex_from_reim_IMGID(&imgre, &imgim, &imgout);
 
     INSERT_STD_PROCINFO_COMPUTEFUNC_END
 

--- a/src/COREMOD_memory/image_mk_complex_from_reim.h
+++ b/src/COREMOD_memory/image_mk_complex_from_reim.h
@@ -6,6 +6,10 @@ errno_t mk_complex_from_reim(const char *re_name,
                              const char *out_name,
                              int         sharedmem);
 
+errno_t mk_complex_from_reim_IMGID(IMGID *imgre,
+                                   IMGID *imgim,
+                                   IMGID *imgout);
+
 errno_t CLIADDCMD_COREMOD__mk_complex_from_reim();
 
 #endif

--- a/src/COREMOD_memory/image_mk_reim_from_complex.c
+++ b/src/COREMOD_memory/image_mk_reim_from_complex.c
@@ -47,53 +47,39 @@ static errno_t help_function()
     return RETURN_SUCCESS;
 }
 
-errno_t mk_reim_from_complex(const char *in_name,
-                             const char *re_name,
-                             const char *im_name,
-                             int         sharedmem)
+errno_t mk_reim_from_complex_IMGID(
+    IMGID *imgin,
+    IMGID *imgre,
+    IMGID *imgim
+)
 {
     DEBUG_TRACE_FSTART();
 
-    imageID  IDre;
-    imageID  IDim;
-    imageID  IDin;
-    uint32_t naxes[3];
-    long     naxis;
-    uint64_t nelement;
-    long     i;
     uint8_t  datatype;
 
-    IDin     = image_ID(in_name);
-    datatype = data.image[IDin].md[0].datatype;
-    naxis    = data.image[IDin].md[0].naxis;
-    for(i = 0; i < naxis; i++)
+    resolveIMGID(imgin, ERRMODE_ABORT);
+    datatype = imgin->md[0].datatype;
+    uint8_t naxis    = imgin->md[0].naxis;
+    for(int i = 0; i < naxis; i++)
     {
-        naxes[i] = data.image[IDin].md[0].size[i];
+        imgre->size[i] = imgin->md[0].size[i];
+        imgim->size[i] = imgin->md[0].size[i];
     }
-    nelement = data.image[IDin].md[0].nelement;
+    imgre->naxis = naxis;
+    imgim->naxis = naxis;
+
+    uint64_t nelement = imgin->md[0].nelement;
 
     if(datatype == _DATATYPE_COMPLEX_FLOAT)  // single precision
     {
-        FUNC_CHECK_RETURN(create_image_ID(re_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_FLOAT,
-                                          sharedmem,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &IDre));
+        imgre->datatype = _DATATYPE_FLOAT;
+        createimagefromIMGID(imgre);
 
-        FUNC_CHECK_RETURN(create_image_ID(im_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_FLOAT,
-                                          sharedmem,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &IDim));
+        imgim->datatype = _DATATYPE_FLOAT;
+        createimagefromIMGID(imgim);
 
-        data.image[IDre].md[0].write = 1;
-        data.image[IDim].md[0].write = 1;
+        imgre->md[0].write = 1;
+        imgim->md[0].write = 1;
 #ifdef _OPENMP
         #pragma omp parallel if (nelement > OMP_NELEMENT_LIMIT)
         {
@@ -101,43 +87,35 @@ errno_t mk_reim_from_complex(const char *in_name,
 #endif
             for(uint64_t ii = 0; ii < nelement; ii++)
             {
-                data.image[IDre].array.F[ii] = data.image[IDin].array.CF[ii].re;
-                data.image[IDim].array.F[ii] = data.image[IDin].array.CF[ii].im;
+                imgre->im->array.F[ii] = imgin->im->array.CF[ii].re;
+                imgim->im->array.F[ii] = imgin->im->array.CF[ii].im;
             }
 #ifdef _OPENMP
         }
 #endif
-        if(sharedmem == 1)
+        if(imgre->md[0].shared == 1)
         {
-            COREMOD_MEMORY_image_set_sempost_byID(IDre, -1);
-            COREMOD_MEMORY_image_set_sempost_byID(IDim, -1);
+            COREMOD_MEMORY_image_set_sempost_byID(imgre->ID, -1);
         }
-        data.image[IDre].md[0].cnt0++;
-        data.image[IDim].md[0].cnt0++;
-        data.image[IDre].md[0].write = 0;
-        data.image[IDim].md[0].write = 0;
+        if(imgim->md[0].shared == 1)
+        {
+            COREMOD_MEMORY_image_set_sempost_byID(imgim->ID, -1);
+        }
+        imgre->md[0].cnt0++;
+        imgim->md[0].cnt0++;
+        imgre->md[0].write = 0;
+        imgim->md[0].write = 0;
     }
     else if(datatype == _DATATYPE_COMPLEX_DOUBLE)  // double precision
     {
-        FUNC_CHECK_RETURN(create_image_ID(re_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_DOUBLE,
-                                          sharedmem,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &IDre));
+        imgre->datatype = _DATATYPE_DOUBLE;
+        createimagefromIMGID(imgre);
 
-        FUNC_CHECK_RETURN(create_image_ID(im_name,
-                                          naxis,
-                                          naxes,
-                                          _DATATYPE_DOUBLE,
-                                          sharedmem,
-                                          NB_KEYWNODE_MAX,
-                                          0,
-                                          &IDim));
-        data.image[IDre].md[0].write = 1;
-        data.image[IDim].md[0].write = 1;
+        imgim->datatype = _DATATYPE_DOUBLE;
+        createimagefromIMGID(imgim);
+
+        imgre->md[0].write = 1;
+        imgim->md[0].write = 1;
 #ifdef _OPENMP
         #pragma omp parallel if (nelement > OMP_NELEMENT_LIMIT)
         {
@@ -145,21 +123,24 @@ errno_t mk_reim_from_complex(const char *in_name,
 #endif
             for(uint64_t ii = 0; ii < nelement; ii++)
             {
-                data.image[IDre].array.D[ii] = data.image[IDin].array.CD[ii].re;
-                data.image[IDim].array.D[ii] = data.image[IDin].array.CD[ii].im;
+                imgre->im->array.D[ii] = imgin->im->array.CD[ii].re;
+                imgim->im->array.D[ii] = imgin->im->array.CD[ii].im;
             }
 #ifdef _OPENMP
         }
 #endif
-        if(sharedmem == 1)
+        if(imgre->md[0].shared == 1)
         {
-            COREMOD_MEMORY_image_set_sempost_byID(IDre, -1);
-            COREMOD_MEMORY_image_set_sempost_byID(IDim, -1);
+            COREMOD_MEMORY_image_set_sempost_byID(imgre->ID, -1);
         }
-        data.image[IDre].md[0].cnt0++;
-        data.image[IDim].md[0].cnt0++;
-        data.image[IDre].md[0].write = 0;
-        data.image[IDim].md[0].write = 0;
+        if(imgim->md[0].shared == 1)
+        {
+            COREMOD_MEMORY_image_set_sempost_byID(imgim->ID, -1);
+        }
+        imgre->md[0].cnt0++;
+        imgim->md[0].cnt0++;
+        imgre->md[0].write = 0;
+        imgim->md[0].write = 0;
     }
     else
     {
@@ -171,13 +152,31 @@ errno_t mk_reim_from_complex(const char *in_name,
     return RETURN_SUCCESS;
 }
 
+errno_t mk_reim_from_complex(const char *in_name,
+                             const char *re_name,
+                             const char *im_name,
+                             int         sharedmem)
+{
+    IMGID imgin = mkIMGID_from_name(in_name);
+    IMGID imgre = mkIMGID_from_name(re_name);
+    IMGID imgim = mkIMGID_from_name(im_name);
+    imgre.shared = sharedmem;
+    imgim.shared = sharedmem;
+
+    return mk_reim_from_complex_IMGID(&imgin, &imgre, &imgim);
+}
+
 static errno_t compute_function()
 {
     DEBUG_TRACE_FSTART();
 
     INSERT_STD_PROCINFO_COMPUTEFUNC_START
 
-    mk_reim_from_complex(inimname, outreimname, outimimname, 0);
+    IMGID imgin = mkIMGID_from_name(inimname);
+    IMGID imgre = mkIMGID_from_name(outreimname);
+    IMGID imgim = mkIMGID_from_name(outimimname);
+
+    mk_reim_from_complex_IMGID(&imgin, &imgre, &imgim);
 
     INSERT_STD_PROCINFO_COMPUTEFUNC_END
 

--- a/src/COREMOD_memory/image_mk_reim_from_complex.h
+++ b/src/COREMOD_memory/image_mk_reim_from_complex.h
@@ -6,6 +6,10 @@ errno_t mk_reim_from_complex(const char *in_name,
                              const char *im_name,
                              int         sharedmem);
 
+errno_t mk_reim_from_complex_IMGID(IMGID *imgin,
+                                   IMGID *imgre,
+                                   IMGID *imgim);
+
 errno_t CLIADDCMD_COREMOD__mk_reim_from_complex();
 
 #endif


### PR DESCRIPTION
Whenever possible, refer to images by pointers to their IMGID.
This change has not yet been applied to plugins, so the previous (string arguments) functions calls are maintained for compatibility. 