### PR TITLE
feat: add PROCESSINFO_TRIGGERMODE_CNT2 for demand-driven sync

### DIFF
--- a/src/CommandLineInterface/CLIcore/CLIcore_help.c
+++ b/src/CommandLineInterface/CLIcore/CLIcore_help.c
@@ -708,6 +708,9 @@ errno_t help_command(
                     case PROCESSINFO_TRIGGERMODE_DELAY:
                         printf("DELAY");
                         break;
+                    case PROCESSINFO_TRIGGERMODE_CNT2:
+                        printf("CNT2");
+                        break;
                     default:
                         printf("unknown");
                         break;

--- a/src/CommandLineInterface/procCTRL/procCTRL_TUI.c
+++ b/src/CommandLineInterface/procCTRL/procCTRL_TUI.c
@@ -2645,6 +2645,14 @@ errno_t processinfo_CTRLscreen()
                                         ->triggermode);
                                     break;
 
+                                case PROCESSINFO_TRIGGERMODE_CNT2:
+                                    TUI_printfw(
+                                        "%2d:"
+                                        "CNT2 ",
+                                        procinfoproc.pinfoarray[pindex]
+                                        ->triggermode);
+                                    break;
+
                                 case PROCESSINFO_TRIGGERMODE_SEMAPHORE:
                                     TUI_printfw(
                                         "%2d:"

--- a/src/CommandLineInterface/processtools_trigger.c
+++ b/src/CommandLineInterface/processtools_trigger.c
@@ -93,6 +93,22 @@ errno_t processinfo_waitoninputstream_init(
             data.image[processinfo->triggerstreamID].md[0].cnt1;
     }
 
+    if(triggermode == PROCESSINFO_TRIGGERMODE_CNT2)
+    {
+        DEBUG_TRACEPOINT("trigger mode %d = cnt2 of ID %ld",
+                         PROCESSINFO_TRIGGERMODE_CNT2,
+                         trigID);
+
+        if(trigID == -1)
+        {
+            FUNC_RETURN_FAILURE("missing trigger ID");
+        }
+        // trigger on cnt0 < cnt2
+        processinfo->triggermode = PROCESSINFO_TRIGGERMODE_CNT2;
+        processinfo->triggerstreamcnt =
+            data.image[processinfo->triggerstreamID].md[0].cnt0;
+    }
+
     if(triggermode == PROCESSINFO_TRIGGERMODE_IMMEDIATE)
     {
         DEBUG_TRACEPOINT("trigger mode %d = immediate",
@@ -214,6 +230,32 @@ errno_t processinfo_waitoninputstream(PROCESSINFO *processinfo)
         // update trigger counter
         processinfo->triggerstreamcnt =
             data.image[processinfo->triggerstreamID].md[0].cnt1;
+
+        processinfo->triggermissedframe_cumul +=
+            processinfo->triggermissedframe;
+
+        processinfo->triggerstatus = PROCESSINFO_TRIGGERSTATUS_RECEIVED;
+
+        return RETURN_SUCCESS;
+    }
+
+    if(processinfo->triggermode == PROCESSINFO_TRIGGERMODE_CNT2)
+    {
+        // use cnt2
+
+        processinfo->triggerstatus = PROCESSINFO_TRIGGERSTATUS_WAITING;
+
+        while(data.image[processinfo->triggerstreamID].md[0].cnt0 >=
+                data.image[processinfo->triggerstreamID].md[0].cnt2)
+        {
+            // wait until we are allowed to proceed
+            usleep(5);
+        }
+        processinfo->triggermissedframe = 0;
+
+        // update trigger counter
+        processinfo->triggerstreamcnt =
+            data.image[processinfo->triggerstreamID].md[0].cnt0;
 
         processinfo->triggermissedframe_cumul +=
             processinfo->triggermissedframe;

--- a/src/CommandLineInterface/processtools_trigger.h
+++ b/src/CommandLineInterface/processtools_trigger.h
@@ -29,6 +29,9 @@
 // trigger when semaphore is posted AND propagate the timeout (i.e. enter the execution anyway)
 #define PROCESSINFO_TRIGGERMODE_SEMAPHORE_PROP_TIMEOUTS 5
 
+// trigger when cnt0 < cnt2 (demand-driven / flow control)
+#define PROCESSINFO_TRIGGERMODE_CNT2 6
+
 // trigger is currently waiting for input
 #define PROCESSINFO_TRIGGERSTATUS_WAITING 1
 // trigger has been received and we're executing the loop

--- a/src/CommandLineInterface/streamCTRL/streamCTRL_TUI.c
+++ b/src/CommandLineInterface/streamCTRL/streamCTRL_TUI.c
@@ -1596,6 +1596,10 @@ errno_t streamCTRL_CTRLscreen()
                                     snprintf(string, stringlen, "(%7lu C1 ", inode);
                                     break;
 
+                                case PROCESSINFO_TRIGGERMODE_CNT2:
+                                    snprintf(string, stringlen, "(%7lu C2 ", inode);
+                                    break;
+
                                 case PROCESSINFO_TRIGGERMODE_SEMAPHORE:
                                     snprintf(string, stringlen, "(%7lu %02d ", inode, sem);
                                     break;

--- a/src/CommandLineInterface/streamCTRL/streamCTRL_print_trace.c
+++ b/src/CommandLineInterface/streamCTRL/streamCTRL_print_trace.c
@@ -144,6 +144,13 @@ errno_t streamCTRL_print_SPTRACE_details(
                         "DELA");
             break;
 
+        case PROCESSINFO_TRIGGERMODE_CNT2:
+            TUI_printfw("%d%*s",
+                        streamCTRLimages[ID].streamproctrace[spti].triggermode,
+                        Disp_type_NBchar - 1,
+                        "CNT2");
+            break;
+
         default:
             TUI_printfw("%d%*s",
                         streamCTRLimages[ID].streamproctrace[spti].triggermode,


### PR DESCRIPTION
This introduces a new trigger mode (value 6) where process execution is gated by the condition cnt0 < cnt2. This mechanism enables reader-driven flow control.

This does not require any change to ImageStreamIO (other than editing a comment to clarify cnt2's role, which I just pushed).

This new feature allows a writer to wait for reader to complete its job. This will not be used in real-time AO computations (driven by input camera speed), but is useful for setting up computation pipelines or AO simulations.