### PR TITLE
Perf: Optimization Sweep 4 - Pointer Aliasing, Memory Built-ins, and Prefetching

### DIFF
--- a/.agents/rules/performance-practices.md
+++ b/.agents/rules/performance-practices.md
@@ -13,7 +13,7 @@ non-GCC compilers.
 
 - Use `restrict` (or `MILK_RESTRICT`) on all
   non-aliased pixel/array data pointer parameters
-  in compute-heavy functions. This allows GCC to
+  in `compute_function` signatures and compute-heavy helper functions. This allows GCC to
   vectorize loops over those pointers.
 - Use `MILK_ASSUME_ALIGNED(ptr)` to inform GCC
   that a restricted pointer is aligned to a 64-byte
@@ -100,6 +100,10 @@ non-GCC compilers.
 - Hoist invariant FPS parameter dereferences
   (`*ptr`) into local variables before the
   inner loop to avoid repeated pointer chasing.
+
+## Struct Copying & Data Movement
+
+- Replace manual struct copies or small array copies in hot paths with `__builtin_memcpy(dest, src, size)`. This allows GCC to emit optimal inline move instructions instead of calling libc `memcpy` or generating sub-optimal loop code.
 
 ## Datatype Dispatch
 

--- a/src/coremods/COREMOD_arith/imfunctions.c
+++ b/src/coremods/COREMOD_arith/imfunctions.c
@@ -104,13 +104,15 @@ errno_t arith_image_function_im_im__d_d_IMGID(
     }
     else if(datatype == _DATATYPE_UINT16)
     {
+        uint16_t * MILK_RESTRICT out_ptr = MILK_ASSUME_ALIGNED(imgout->im->array.UI16);
+        const uint16_t * MILK_RESTRICT in_ptr = MILK_ASSUME_ALIGNED(imgin->im->array.UI16);
 #ifdef _OPENMP
         #pragma omp for simd
 #endif
         for(uint_fast64_t ii = 0; ii < nelement; ii++)
         {
             imgout->im->array.F[ii] = (float) pt2function(
-                                          (double)(imgin->im->array.UI16[ii]));
+                                          (double)(in_ptr[ii]));
         }
     }
     else if(datatype == _DATATYPE_UINT32)
@@ -181,13 +183,15 @@ errno_t arith_image_function_im_im__d_d_IMGID(
     }
     else if(datatype == _DATATYPE_FLOAT)
     {
+        float * MILK_RESTRICT out_ptr = MILK_ASSUME_ALIGNED(imgout->im->array.F);
+        const float * MILK_RESTRICT in_ptr = MILK_ASSUME_ALIGNED(imgin->im->array.F);
 #ifdef _OPENMP
         #pragma omp for simd
 #endif
         for(uint_fast64_t ii = 0; ii < nelement; ii++)
         {
-            imgout->im->array.F[ii] =
-                (float) pt2function((double)(imgin->im->array.F[ii]));
+            out_ptr[ii] =
+                (float) pt2function((double)(in_ptr[ii]));
         }
     }
     else if(datatype == _DATATYPE_DOUBLE)

--- a/src/coremods/COREMOD_memory/stream_ave.c
+++ b/src/coremods/COREMOD_memory/stream_ave.c
@@ -108,95 +108,53 @@ static MILK_HOT errno_t fpsexec(
         imgin->md[0].size[0]
         * imgin->md[0].size[1];
 
-    if (streamave_cntindex == 0) {
-        for (uint64_t i = 0;
-             i < xysize; i++)
-        {
-            double v = 0;
-            switch (imgin->md[0].datatype)
-            {
-            case _DATATYPE_UINT8:
-                v = imgin->array.UI8[i];
-                break;
-            case _DATATYPE_INT8:
-                v = imgin->array.SI8[i];
-                break;
-            case _DATATYPE_UINT16:
-                v = imgin->array.UI16[i];
-                break;
-            case _DATATYPE_INT16:
-                v = imgin->array.SI16[i];
-                break;
-            case _DATATYPE_UINT32:
-                v = imgin->array.UI32[i];
-                break;
-            case _DATATYPE_INT32:
-                v = imgin->array.SI32[i];
-                break;
-            case _DATATYPE_UINT64:
-                v = imgin->array.UI64[i];
-                break;
-            case _DATATYPE_INT64:
-                v = imgin->array.SI64[i];
-                break;
-            case _DATATYPE_FLOAT:
-                v = imgin->array.F[i];
-                break;
-            case _DATATYPE_DOUBLE:
-                v = imgin->array.D[i];
-                break;
-            }
-            imdataarray[i] = v;
-            if (streamave_comprms) {
-                imdataarrayPOW[i] =
-                    v * v;
-            }
-        }
-    } else {
-        for (uint64_t i = 0;
-             i < xysize; i++)
-        {
-            double v = 0;
-            switch (imgin->md[0].datatype)
-            {
-            case _DATATYPE_UINT8:
-                v = imgin->array.UI8[i];
-                break;
-            case _DATATYPE_INT8:
-                v = imgin->array.SI8[i];
-                break;
-            case _DATATYPE_UINT16:
-                v = imgin->array.UI16[i];
-                break;
-            case _DATATYPE_INT16:
-                v = imgin->array.SI16[i];
-                break;
-            case _DATATYPE_UINT32:
-                v = imgin->array.UI32[i];
-                break;
-            case _DATATYPE_INT32:
-                v = imgin->array.SI32[i];
-                break;
-            case _DATATYPE_UINT64:
-                v = imgin->array.UI64[i];
-                break;
-            case _DATATYPE_INT64:
-                v = imgin->array.SI64[i];
-                break;
-            case _DATATYPE_FLOAT:
-                v = imgin->array.F[i];
-                break;
-            case _DATATYPE_DOUBLE:
-                v = imgin->array.D[i];
-                break;
-            }
-            imdataarray[i] += v;
-            if (streamave_comprms) {
-                imdataarrayPOW[i] +=
-                    v * v;
-            }
-        }
+    #define STREAM_AVE_LOOP(VTYPE, ARRAY_MEMBER) \
+    { \
+        const VTYPE * MILK_RESTRICT in = MILK_ASSUME_ALIGNED(imgin->array.ARRAY_MEMBER); \
+        if (streamave_cntindex == 0) { \
+            for (uint64_t i = 0; i < xysize; i++) { \
+                MILK_PREFETCH(&in[i + 8], 0, 0); \
+                double v = (double)in[i]; \
+                imdataarray[i] = v; \
+                if (streamave_comprms) { \
+                    imdataarrayPOW[i] = v * v; \
+                } \
+            } \
+        } else { \
+            for (uint64_t i = 0; i < xysize; i++) { \
+                MILK_PREFETCH(&in[i + 8], 0, 0); \
+                double v = (double)in[i]; \
+                imdataarray[i] += v; \
+                if (streamave_comprms) { \
+                    imdataarrayPOW[i] += v * v; \
+                } \
+            } \
+        } \
     }
+
+    if (imgin->md[0].datatype == _DATATYPE_FLOAT) {
+        STREAM_AVE_LOOP(float, F);
+    } else if (imgin->md[0].datatype == _DATATYPE_UINT16) {
+        STREAM_AVE_LOOP(uint16_t, UI16);
+    } else if (imgin->md[0].datatype == _DATATYPE_UINT8) {
+        STREAM_AVE_LOOP(uint8_t, UI8);
+    } else if (imgin->md[0].datatype == _DATATYPE_INT8) {
+        STREAM_AVE_LOOP(int8_t, SI8);
+    } else if (imgin->md[0].datatype == _DATATYPE_INT16) {
+        STREAM_AVE_LOOP(int16_t, SI16);
+    } else if (imgin->md[0].datatype == _DATATYPE_UINT32) {
+        STREAM_AVE_LOOP(uint32_t, UI32);
+    } else if (imgin->md[0].datatype == _DATATYPE_INT32) {
+        STREAM_AVE_LOOP(int32_t, SI32);
+    } else if (imgin->md[0].datatype == _DATATYPE_UINT64) {
+        STREAM_AVE_LOOP(uint64_t, UI64);
+    } else if (imgin->md[0].datatype == _DATATYPE_INT64) {
+        STREAM_AVE_LOOP(int64_t, SI64);
+    } else if (imgin->md[0].datatype == _DATATYPE_DOUBLE) {
+        STREAM_AVE_LOOP(double, D);
+    }
+
+    #undef STREAM_AVE_LOOP
 
     (streamave_cntindex)++;
 

--- a/src/coremods/COREMOD_memory/stream_copy.c
+++ b/src/coremods/COREMOD_memory/stream_copy.c
@@ -110,16 +110,11 @@ static MILK_HOT errno_t compute_function()
             const float * MILK_RESTRICT in =
                 MILK_ASSUME_ALIGNED(
                     imgin.im->array.F);
-            uint64_t nelem =
-                byte_copy_size / sizeof(float);
 
-            #pragma omp parallel for simd \
-                if (nelem > 20000)
-            for (uint64_t i = 0;
-                 i < nelem; i++)
-            {
-                out[i] = in[i];
-            }
+            __builtin_memcpy(
+                out,
+                in,
+                byte_copy_size);
         }
         else if (imgin.im->md->datatype
                  == _DATATYPE_UINT16)
@@ -130,16 +125,11 @@ static MILK_HOT errno_t compute_function()
             const uint16_t * MILK_RESTRICT in =
                 MILK_ASSUME_ALIGNED(
                     imgin.im->array.UI16);
-            uint64_t nelem =
-                byte_copy_size
-                / sizeof(uint16_t);
 
-            MILK_IVDEP
-            for (uint64_t i = 0;
-                 i < nelem; i++)
-            {
-                out[i] = in[i];
-            }
+            __builtin_memcpy(
+                out,
+                in,
+                byte_copy_size);
         }
         else
         {


### PR DESCRIPTION
Implementation of the 4th performance optimization sweep, resolving memory throughput issues by adding `__builtin_memcpy` to stream copies, explicitly typed `MILK_RESTRICT` pointers, and `MILK_PREFETCH` for stream averages in `milk`'s arithmetic and memory core modules.