### PR TITLE
ci: add path filters to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,11 +7,25 @@ on:
       - master
       - dev
       - framework-dev
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'Doxyfile'
+      - 'src/**/*.h'
+      - 'plugins/**/*.h'
+      - '.github/workflows/docs.yml'
   pull_request:
     branches:
       - main
       - master
       - dev
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'Doxyfile'
+      - 'src/**/*.h'
+      - 'plugins/**/*.h'
+      - '.github/workflows/docs.yml'
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
Add `paths:` filters to the docs workflow so it only runs when documentation-relevant files change (docs, headers, Doxyfile, mkdocs.yml), saving CI minutes on code-only pushes.