### PR TITLE
fix: render markdown tables inside details blocks on MkDocs

### DIFF
--- a/docs/FPS_Standalone_CMD_Modes.md
+++ b/docs/FPS_Standalone_CMD_Modes.md
@@ -89,7 +89,7 @@ in `fps.h`.
 Standalone executables support two layers of argument
 parsing:
 
-<details>
+<details markdown="1">
 <summary><b>A. Standard FPS Process Control Commands</b></summary>
 
 Before mapping to business logic, the executable looks
@@ -116,7 +116,7 @@ segment.
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>B. Direct Execution (Positional Arguments)</b></summary>
 
 If the user passes positional arguments that do not

--- a/docs/cli/CLIcore.md
+++ b/docs/cli/CLIcore.md
@@ -67,7 +67,7 @@ The CLI reads commands from `cmdfile.txt` if it exists,
 executing them top-to-bottom and removing each line as it
 is read.
 
-<details>
+<details markdown="1">
 <summary><b>Help Commands</b></summary>
 
 ```text
@@ -84,7 +84,7 @@ milk-cli > h? <str>                # search commands by string
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>Important Commands</b></summary>
 
 ```text
@@ -100,7 +100,7 @@ milk-cli > creaim <im> <xs> <ys>   # create 2D image
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>FITS Files I/O</b></summary>
 
 FITSIO is used for FITS file I/O. See also `COREMOD_memory`
@@ -129,7 +129,7 @@ milk-cli > save_fl im1 im1.fits.gz      # save compressed
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>Integration with Standard Linux Tools</b></summary>
 
 ### Using `cmdfile.txt` to drive milk-cli

--- a/docs/dependency_graph.md
+++ b/docs/dependency_graph.md
@@ -337,7 +337,7 @@ COREMOD_iofits ── Core+FITS           ← USE_CFITSIO
 
 ## 5. Detailed Dependency Tables
 
-<details>
+<details markdown="1">
 <summary><b>Engine Tier — Core Libraries</b></summary>
 
 | Target | Links to | Optional |
@@ -349,7 +349,7 @@ COREMOD_iofits ── Core+FITS           ← USE_CFITSIO
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>Framework Libraries</b></summary>
 
 | Target | Links to | Optional |
@@ -363,7 +363,7 @@ COREMOD_iofits ── Core+FITS           ← USE_CFITSIO
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>Core Tier — COREMOD Libraries</b></summary>
 
 | Target | Links to | Conditional |
@@ -384,7 +384,7 @@ COREMOD_iofits ── Core+FITS           ← USE_CFITSIO
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>Full Tier — milk-extra Plugins</b></summary>
 
 | Target | Links to | Optional |
@@ -417,7 +417,7 @@ COREMOD_iofits ── Core+FITS           ← USE_CFITSIO
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>Full Tier — Cacao Modules</b></summary>
 
 | Target | Links to | Optional |
@@ -434,7 +434,7 @@ COREMOD_iofits ── Core+FITS           ← USE_CFITSIO
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>Executables</b></summary>
 
 | Target | Links to |
@@ -452,7 +452,7 @@ COREMOD_iofits ── Core+FITS           ← USE_CFITSIO
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>Standalone CMake Functions</b></summary>
 
 | Function | Base link set |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -7,7 +7,7 @@ running `milk`.
 
 ## 1. Installation
 
-<details>
+<details markdown="1">
 <summary><b>CMake cannot find cfitsio</b></summary>
 
 ```
@@ -33,7 +33,7 @@ See [Build Tiers](install/build_tiers.md) and
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>Build fails with missing readline/ncurses</b></summary>
 
 ```
@@ -51,7 +51,7 @@ $ cmake .. -DUSE_CLI=OFF
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>Library not found at runtime</b></summary>
 
 ```
@@ -78,7 +78,7 @@ export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 See also: [Streams](streams.md)
 
-<details>
+<details markdown="1">
 <summary><b>Permission denied when accessing /milk/shm</b></summary>
 
 ```
@@ -99,7 +99,7 @@ $ sudo mount /milk/shm
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>Stale shared memory files</b></summary>
 
 Old `.im.shm` files from crashed processes can interfere.
@@ -112,7 +112,7 @@ $ milk-shmim-rm <streamname>   # remove a specific stream
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>SHM directory location</b></summary>
 
 The default shared memory directory is `/milk/shm`. Override with:
@@ -130,7 +130,7 @@ See also: [FPS](fps.md) ·
 [Process Info](procinfo.md) ·
 [FPS Standalone Modes](FPS_Standalone_CMD_Modes.md)
 
-<details>
+<details markdown="1">
 <summary><b>FPS process won't start — "FPS already exists"</b></summary>
 
 ```
@@ -144,7 +144,7 @@ $ milk-fps-set <fpsname> ..delete
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>milk-fpsCTRL shows no processes</b></summary>
 
 Ensure the processinfo SHM directory exists and processes are
@@ -156,7 +156,7 @@ $ milk-procinfo-list             # scan for processes
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>tmux dispatch not working</b></summary>
 
 If standalone executables launched with `-tmux` don't appear:
@@ -173,7 +173,7 @@ If standalone executables launched with `-tmux` don't appear:
 
 See also: [CLI Reference](cli/CLIcore.md)
 
-<details>
+<details markdown="1">
 <summary><b>milk-cli prompt jumps to bottom of terminal</b></summary>
 
 This can happen when the startup banner clears the screen.
@@ -183,7 +183,7 @@ stabilize after the first command.
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>Command not found — "Unknown command"</b></summary>
 
 ```
@@ -205,7 +205,7 @@ file is in the library path.
 
 ## 5. Performance
 
-<details>
+<details markdown="1">
 <summary><b>Real-time scheduling</b></summary>
 
 For latency-critical applications (AO loops), configure
@@ -218,7 +218,7 @@ $ milk-cli -p 90               # launch with high priority
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>Semaphore loop speed</b></summary>
 
 Benchmark semaphore performance:

--- a/docs/install/compile.md
+++ b/docs/install/compile.md
@@ -59,7 +59,7 @@ $ sudo mount /milk/shm
 | **pkg-config** | Locates installed libraries |
 | **pthreads** | POSIX threading (provided by libc) |
 
-<details>
+<details markdown="1">
 <summary><b>Optional dependencies</b></summary>
 
 ### 4.2. Optional
@@ -79,7 +79,7 @@ See [Build Tiers](build_tiers.md) for details.
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>Package installation commands</b></summary>
 
 **Ubuntu / Debian:**
@@ -98,7 +98,7 @@ $ sudo yum install \
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>cfitsio from source (alternative)</b></summary>
 
 If your distribution does not package cfitsio, install it
@@ -117,7 +117,7 @@ $ sudo make install
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>GPU acceleration (optional)</b></summary>
 
 For GPU-accelerated linear algebra:
@@ -136,7 +136,7 @@ export PKG_CONFIG_PATH=/usr/local/magma/lib/pkgconfig
 
 ---
 
-<details>
+<details markdown="1">
 <summary><b>Running multiple versions side by side</b></summary>
 
 **⚠️ Warning:** Untested — may require tweaking.

--- a/docs/programmers_guide.md
+++ b/docs/programmers_guide.md
@@ -146,7 +146,7 @@ Standalones are specifically designed to execute one compute unit in isolation w
 
 ## 5. Dependency Architecture
 
-<details>
+<details markdown="1">
 <summary><b>Header Hierarchy</b></summary>
 
 Compute unit source files use conditional includes to support both CLI and standalone builds:
@@ -170,7 +170,7 @@ Compute unit source files use conditional includes to support both CLI and stand
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>Library Link Patterns — Dual Architecture</b></summary>
 
 The build system maintains two library variants
@@ -213,7 +213,7 @@ CLIcore.
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>Compile-Time Guards</b></summary>
 
 | Macro | Set by | Effect |
@@ -236,7 +236,7 @@ It is also integrated as a CTest (`standalone-dep-check`) and runs automatically
 Use `src/milk_module_example/CMakeLists.txt` as the template
 for new modules.
 
-<details>
+<details markdown="1">
 <summary><b>Standard CMakeLists.txt layout</b></summary>
 
 ```
@@ -270,7 +270,7 @@ add_test(...)
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>Standalone helper functions</b></summary>
 
 Defined in `cmake/MilkStandalone.cmake` (included by root CMakeLists):
@@ -285,7 +285,7 @@ Defined in `cmake/MilkStandalone.cmake` (included by root CMakeLists):
 
 ## 7. C Source File Conventions
 
-<details>
+<details markdown="1">
 <summary><b>File header template</b></summary>
 
 Every `.c` file should start with a kernel-doc header:
@@ -302,7 +302,7 @@ Every `.c` file should start with a kernel-doc header:
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>Dual-mode files</b></summary>
 
 Files compiled both as part of a shared library (CLI mode)
@@ -319,7 +319,7 @@ and as standalone executables use conditional includes:
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>Function documentation</b></summary>
 
 Document functions with kernel-doc style above the function
@@ -340,7 +340,7 @@ body in `.c` files:
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><b>Module README</b></summary>
 
 Each module directory should have a `README.md` with:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
 
 markdown_extensions:
   - admonition
+  - md_in_html
   - pymdownx.details
   - pymdownx.superfences:
       custom_fences:


### PR DESCRIPTION
Fix markdown tables and code blocks inside `<details>` collapsible sections not rendering on the MkDocs site.

**Root cause:** Python-Markdown doesn't process markdown inside raw HTML blocks without the `md_in_html` extension.

**Fix:**
1. Enable `md_in_html` extension in `mkdocs.yml`
2. Add `markdown="1"` attribute to all 40 `<details>` tags across 6 docs files

**Verified:** Built locally, confirmed `<table>` elements render properly in the HTML output.