### PR TITLE
feat(cli): FPS parameter tab-completion + argument hints docs

### DIFF
--- a/docs/cli/CLIcore.md
+++ b/docs/cli/CLIcore.md
@@ -55,9 +55,21 @@ milk-cli > <command> <arg1> <arg2>   # comment
 ## 3. Tab Completion
 
 - **First argument:** matches command → image → filename
-- **Additional arguments:** matches image → filename
+- **Additional arguments:** context-aware based on command's
+  parameter types:
+  - `FILENAME` / `FITSFILENAME` args → filesystem paths
+  - `FPSNAME` args → scan `/dev/shm/fps.*.shm` entries
+  - Other args → match image stream names
+- Fuzzy (substring) matching automatically kicks in when
+  prefix matching finds nothing
 
-## 4. Input
+## 4. Argument Hints
+
+When a known command is typed, the bottom line shows the
+command's syntax with `<angle bracket>` parameter tokens.
+The active argument position is highlighted in bold cyan.
+
+## 5. Input
 
 GNU readline is used for line editing. Type `helprl` at the
 prompt for a quick reference. See

--- a/src/cli/CLIcore/CLIcore/CLIcore_UI.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI.c
@@ -28,6 +28,7 @@
 #define CLICOMPLETIONMODE_IMAGES   1
 #define CLICOMPLETIONMODE_CMDARGS  2
 #define CLICOMPLETIONMODE_FILES    3
+#define CLICOMPLETIONMODE_FPSPARAMS 4
 
 // COLORRESET removed to prevent redefinition with fps.h
 #define COLORRED       "\001\033[31m\002" /* Red */
@@ -362,6 +363,64 @@ retry_fuzzy:
         }
     }
 
+    if(data.CLImatchMode == CLICOMPLETIONMODE_FPSPARAMS)
+    {
+        /*
+         * FPS parameter name completion.
+         * Scan /dev/shm for fps.* entries,
+         * strip "fps." prefix and ".shm"
+         * suffix, offer as completions.
+         */
+        static DIR *fps_dirp = NULL;
+
+        if(!state)
+        {
+            if(fps_dirp != NULL)
+            {
+                closedir(fps_dirp);
+                fps_dirp = NULL;
+            }
+            fps_dirp = opendir("/dev/shm");
+        }
+
+        if(fps_dirp != NULL)
+        {
+            struct dirent *ent;
+            while((ent = readdir(fps_dirp))
+                    != NULL)
+            {
+                /* Only fps.*.shm entries */
+                if(strncmp(ent->d_name,
+                           "fps.", 4) != 0)
+                {
+                    continue;
+                }
+                /* Strip "fps." prefix */
+                char fpsname[256];
+                strncpy(fpsname,
+                        ent->d_name + 4,
+                        sizeof(fpsname) - 1);
+                fpsname[
+                    sizeof(fpsname) - 1]
+                    = '\0';
+                /* Strip ".shm" suffix */
+                char *dot = strstr(
+                    fpsname, ".shm");
+                if(dot != NULL)
+                {
+                    *dot = '\0';
+                }
+                if(strncmp(fpsname, text,
+                           len) == 0)
+                {
+                    return dupstr(fpsname);
+                }
+            }
+            closedir(fps_dirp);
+            fps_dirp = NULL;
+        }
+    }
+
     /* Fuzzy fallback: if prefix pass found nothing,
      * restart with substring matching */
     if(generator_fuzzy_pass == 0 &&
@@ -487,6 +546,11 @@ CLI_completion(const char *text, int start, int __attribute__((unused)) end)
                         {
                             matched_file = 1;
                         }
+                        if(atype == CLIARG_FPSNAME)
+                        {
+                            data.CLImatchMode =
+                                CLICOMPLETIONMODE_FPSPARAMS;
+                        }
                         break;
                     }
                     cli_ai++;
@@ -502,7 +566,8 @@ CLI_completion(const char *text, int start, int __attribute__((unused)) end)
                 rl_completion_append_character
                     = '\0';
             }
-            else
+            else if(data.CLImatchMode
+                    != CLICOMPLETIONMODE_FPSPARAMS)
             {
                 data.CLImatchMode =
                     CLICOMPLETIONMODE_IMAGES;


### PR DESCRIPTION
## CLI Round 3 — Advanced Features

### FPS Parameter Tab-Completion
- New `CLICOMPLETIONMODE_FPSPARAMS` (mode 4) in `CLI_generator`
- Scans `/dev/shm/fps.*.shm` entries, strips prefix/suffix, offers FPS names
- Triggered when command argument has type `CLIARG_FPSNAME`
- Guarded against mode overwrite by IMAGE fallback

### Documentation
- Updated tab-completion docs with all 4 modes (command, image, file, FPS)
- Added new "Argument Hints" section documenting the syntax hint area
- Renumbered sections for consistency