### PR TITLE
docs: add documentation-site rule and update-docs-site workflow

### DIFF
--- a/.agents/rules/documentation-site.md
+++ b/.agents/rules/documentation-site.md
@@ -1,0 +1,75 @@
+---
+description: Documentation site structure, MkDocs config,
+  and deployment pipeline awareness.
+---
+
+# Documentation Site Structure
+
+The milk documentation is published at
+`https://milk-org.github.io/milk/` using two tools:
+
+| Tool | URL path | Source |
+|------|----------|--------|
+| MkDocs Material | `/` (root) | `docs/` directory |
+| Doxygen | `/api/html/` | C headers (`*.h`) |
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `mkdocs.yml` | MkDocs configuration (nav, theme, extensions) |
+| `docs/` | Markdown source files for MkDocs |
+| `docs/stylesheets/extra.css` | Custom CSS overrides |
+| `docs/index.md` | Homepage content |
+| `Doxyfile` | Doxygen configuration |
+| `.github/workflows/docs.yml` | CI: builds + deploys both |
+
+## Navigation Tabs
+
+The site uses top-level navigation tabs defined in the
+`nav:` section of `mkdocs.yml`:
+
+1. **Home** — landing page
+2. **Getting Started** — install, build tiers, CLI overview, FAQ
+3. **User Guide** — streams, FPS, procinfo, CLI, scripts, Python
+4. **Developer Guide** — tutorial, coding standards, plugins
+5. **Architecture** — programmer's guide, dependency graph
+6. **Operations** — performance, PGO/LTO, debugging
+7. **API Reference** — links to Doxygen at `/api/html/`
+
+## When Adding a New Documentation Page
+
+1. Create the `.md` file under `docs/` in the appropriate
+   subdirectory.
+2. Add the page to the correct tab section in `mkdocs.yml`
+   under `nav:`.
+3. Also add the page to `docs/index.md` in the appropriate
+   section.
+4. Use `<details markdown="1">` (not bare `<details>`) for
+   any collapsible sections — the `md_in_html` extension
+   requires the `markdown="1"` attribute.
+5. Run the `/update-docs-site` workflow to test locally.
+
+## Deployment Pipeline
+
+- **Workflow**: `.github/workflows/docs.yml`
+- **Trigger**: Push to `framework-dev` when files in
+  `docs/**`, `mkdocs.yml`, `Doxyfile`, `src/**/*.h`,
+  `plugins/**/*.h`, or the workflow itself change.
+- **Deploy**: Only from `framework-dev` branch pushes
+  (not PRs).
+- **Build**: MkDocs builds to `_site/`, Doxygen builds
+  to `_site/api/`, both deployed to `gh-pages` branch.
+
+## Markdown Extensions Available
+
+These extensions are enabled in `mkdocs.yml` and can be
+used in any docs page:
+
+- **Admonitions**: `!!! note`, `!!! warning`, etc.
+- **Details**: `??? note "Title"` or `<details markdown="1">`
+- **Mermaid diagrams**: ` ```mermaid ` code blocks
+- **Code highlighting**: with line numbers and copy button
+- **Content tabs**: `=== "Tab 1"` / `=== "Tab 2"` syntax
+- **Tables**: standard markdown tables
+- **Attribute lists**: `{ .class #id }` syntax

--- a/.agents/rules/documentation-standards.md
+++ b/.agents/rules/documentation-standards.md
@@ -34,8 +34,12 @@ When creating or editing markdown documentation in the
 2. **Plugin READMEs:** Must follow the standardized
    template with: one-line module description, source file
    table (`| File | Description |`), and dependency list.
-3. **New topic pages:** Must be added to `docs/index.md`
-   in the appropriate section.
+3. **New topic pages:** Must be added to both
+   `docs/index.md` and the `nav:` section of `mkdocs.yml`
+   under the appropriate tab.
+4. **MkDocs details blocks:** Use `<details markdown="1">`
+   (not bare `<details>`) so markdown content inside
+   renders correctly. See `documentation-site.md` rule.
 
 ## Before Committing
 

--- a/.agents/workflows/update-docs-site.md
+++ b/.agents/workflows/update-docs-site.md
@@ -1,0 +1,116 @@
+---
+description: Add or update pages on the MkDocs
+  documentation site
+---
+
+# Update Documentation Site
+
+Use this workflow when adding, removing, or modifying
+pages on the MkDocs documentation site.
+
+## Prerequisites
+
+Install MkDocs Material in a Python virtual environment
+(one-time setup):
+
+```bash
+$ python3 -m venv /tmp/mkdocs-venv
+$ /tmp/mkdocs-venv/bin/pip install mkdocs-material
+```
+
+## Steps
+
+### 1. Create or edit the markdown file
+
+Place new files under `docs/` in the appropriate
+subdirectory:
+
+| Content type | Directory |
+|-------------|-----------|
+| Installation / setup | `docs/install/` |
+| CLI documentation | `docs/cli/` |
+| Developer guides | `docs/developer/` |
+| Top-level concepts | `docs/` (root) |
+
+Use `<details markdown="1">` (not bare `<details>`) for
+collapsible sections containing markdown tables or code.
+
+### 2. Update `mkdocs.yml` navigation
+
+Add the new page to the correct tab section in the
+`nav:` key of `mkdocs.yml`:
+
+```yaml
+nav:
+  - Home: index.md
+  - Getting Started:    # install, build, CLI overview, FAQ
+  - User Guide:         # streams, FPS, procinfo, CLI, scripts
+  - Developer Guide:    # tutorial, coding standards, plugins
+  - Architecture:       # programmer's guide, dep graph
+  - Operations:         # performance, PGO/LTO, debugging
+  - API Reference: api/html/index.html
+```
+
+### 3. Update `docs/index.md`
+
+Add the new page link to the appropriate section on
+the homepage so it appears in the landing page index.
+
+// turbo
+### 4. Test the build locally
+
+```bash
+$ /tmp/mkdocs-venv/bin/mkdocs build --strict -d /tmp/mkdocs-test
+```
+
+Fix any warnings about broken links or missing files.
+Warnings about `../` links to files outside `docs/` are
+expected and can be ignored.
+
+// turbo
+### 5. Preview locally (optional)
+
+```bash
+$ /tmp/mkdocs-venv/bin/mkdocs serve -a 127.0.0.1:8123
+```
+
+Open `http://127.0.0.1:8123/milk/` in a browser to
+verify the page renders correctly.
+
+### 6. Commit and push
+
+Follow the standard git workflow: create a feature
+branch from `framework-dev`, commit, push, and create
+a PR targeting `framework-dev`.
+
+The documentation CI workflow triggers automatically
+when files matching these paths change:
+- `docs/**`
+- `mkdocs.yml`
+- `Doxyfile`
+- `src/**/*.h`
+- `plugins/**/*.h`
+- `.github/workflows/docs.yml`
+
+Deployment to GitHub Pages only happens on push to
+`framework-dev` (not from PRs).
+
+## Updating the Doxygen API Reference
+
+Doxygen is configured in `Doxyfile` at the repo root.
+It automatically indexes all `*.h` files in `src/` and
+`plugins/`. The CI workflow builds Doxygen output into
+`_site/api/` and deploys alongside MkDocs.
+
+To test Doxygen locally:
+
+```bash
+$ mkdir -p /tmp/doxygen-test
+$ ( cat Doxyfile; echo "OUTPUT_DIRECTORY=/tmp/doxygen-test" ) \
+    | doxygen -
+```
+
+## Updating Custom Styles
+
+Custom CSS lives at `docs/stylesheets/extra.css` and is
+loaded via the `extra_css` key in `mkdocs.yml`.


### PR DESCRIPTION
Add agent awareness of the MkDocs documentation site structure.

**New rule** (`.agents/rules/documentation-site.md`):
- MkDocs config location, nav tab structure, key files
- Deployment pipeline details (paths, triggers, deploy branch)
- How to add new pages (mkdocs.yml nav + docs/index.md)
- Available markdown extensions

**New workflow** (`.agents/workflows/update-docs-site.md`):
- Step-by-step: create file → update nav → update index → test build → preview → commit
- Local build/preview commands
- Path filter awareness

**Updated** `documentation-standards.md`:
- New pages must be added to both `docs/index.md` and `mkdocs.yml` nav
- Require `<details markdown="1">` attribute for collapsible sections