### PR TITLE
fix(docs): add language to fenced code block in code_assist.md

### DIFF
--- a/docs/code_assist.md
+++ b/docs/code_assist.md
@@ -10,7 +10,7 @@ The `milk` project includes **agent rules** and
 (Gemini, Copilot, etc.) to follow project
 conventions automatically. They live under:
 
-```
+```text
 .agents/
 ├── rules/        # Always-on guardrails
 └── workflows/    # On-demand task templates


### PR DESCRIPTION
Resolves MD040 markdownlint error in docs/code_assist.md.