### PR TITLE
fix(docs): resolve additional typos caught by spell checker

### DIFF
--- a/docs/developer/LoadingModules.md
+++ b/docs/developer/LoadingModules.md
@@ -156,7 +156,7 @@ Upon startup, milk will read the CLI_ADD_LIBS environment variable to link share
 will link modules `MyFirstModule` and `MySecondModule`.
 
 > [!NOTE]
-> Shared object names can be separated by space, semicolumn, or comma.
+> Shared object names can be separated by space, semicolon, or comma.
 
 
 

--- a/docs/developer/templatemodule/templatemodule.c
+++ b/docs/developer/templatemodule/templatemodule.c
@@ -13,7 +13,7 @@
  *
  * ## Other files of interest
  * Each module should include :
- * - souce code (.c file)
+ * - source code (.c file)
  * - header file (.h file)
  *
  * ## Change log


### PR DESCRIPTION
Fix 'semicolumn' and 'souce' typos.