### PR TITLE
docs: fix obsolete CLI syntax in documentation files

### DIFF
--- a/docs/cli/CLIcore.md
+++ b/docs/cli/CLIcore.md
@@ -71,7 +71,7 @@ milk-cli > <command> <arg1> <arg2>   # comment
 
 ```text
 milk-cli > mem.<TAB>           # list commands starting with mem.
-milk-cli > loadfits my<TAB>    # complete filename starting with my
+milk-cli > iofits.loadfits my<TAB>    # complete filename starting with my
 ```
 
 ## 4. Ghost Suggestions
@@ -123,11 +123,11 @@ dim for source file paths.
 
 ```text
 milk-cli > ci                      # compilation info & memory usage
-milk-cli > listim                  # list all images in memory
+milk-cli > mem.listim                  # list all images in memory
 milk-cli > listimf <file>          # list images, write to file
 milk-cli > !<syscmd>               # execute system command
 milk-cli > quit                    # exit (or: exit, exitCLI)
-milk-cli > creaim <im> <xs> <ys>   # create 2D image
+milk-cli > mem.mk2Dim <im> <xs> <ys>   # create 2D image
 milk-cli > usleep <usec>           # sleep for <usec> microseconds
 milk-cli > dpsingle                # set default precision to float
 milk-cli > dpdouble                # set default precision to double
@@ -141,11 +141,11 @@ FITSIO is used for FITS file I/O. Requires `USE_CFITSIO=ON`.
 See [Build Tiers](../install/build_tiers.md).
 
 ```text
-milk-cli > loadfits im1.fits imf1       # load as "imf1"
-milk-cli > loadfits im1.fits            # auto-name from filename
-milk-cli > loadfits im1.fits.gz im1     # load compressed FITS
-milk-cli > save_fl im1 imf1.fits        # save as float
-milk-cli > save_fl im1 "!im1.fits"      # overwrite existing file
+milk-cli > iofits.loadfits im1.fits imf1       # load as "imf1"
+milk-cli > iofits.loadfits im1.fits            # auto-name from filename
+milk-cli > iofits.loadfits im1.fits.gz im1     # load compressed FITS
+milk-cli > iofits.save_fl im1 imf1.fits        # save as float
+milk-cli > iofits.save_fl im1 "!im1.fits"      # overwrite existing file
 ```
 
 ## 10. Persistent History
@@ -175,18 +175,18 @@ The expanded command is printed with a `>>` prefix before
 execution.
 
 ```text
-milk-cli > loadfits im1.fits im1
-milk-cli > !!                   # re-runs: loadfits im1.fits im1
-milk-cli > save_fl !$           # expands to: save_fl im1
+milk-cli > iofits.loadfits im1.fits im1
+milk-cli > !!                   # re-runs: iofits.loadfits im1.fits im1
+milk-cli > iofits.save_fl !$    # expands to: iofits.save_fl im1
 ```
 
 ## 12. Fuzzy History Search
 
 ```text
-milk-cli > searchhist listim
+milk-cli > searchhist mem.listim
 ```
 
-Finds all history entries containing "listim" (case-
+Finds all history entries containing "mem.listim" (case-
 insensitive) and highlights the matching substring in
 yellow. Shows match count at the end.
 
@@ -428,13 +428,13 @@ the CLI.
 **From inside `milk-cli`:**
 
 ```text
-milk-cli > !ls im*.fits | xargs -I {} echo loadfits {} > cmdfile.txt
+milk-cli > !ls im*.fits | xargs -I {} echo iofits.loadfits {} > cmdfile.txt
 ```
 
 **From a separate shell (while `milk-cli` is running):**
 
 ```bash
-$ ls im*.fits | xargs -I {} echo loadfits {} > cmdfile.txt
+$ ls im*.fits | xargs -I {} echo iofits.loadfits {} > cmdfile.txt
 ```
 
 ### Using `imlist.txt` and `cmdfile.txt`
@@ -444,7 +444,7 @@ filter and act on the list:
 
 ```text
 milk-cli > !awk '{if ($4>200) print $2}' imlist.txt \
-        | xargs -I {} echo save_fl {} {}_tmp.fits > cmdfile.txt
+        | xargs -I {} echo iofits.save_fl {} {}_tmp.fits > cmdfile.txt
 ```
 
 ---

--- a/docs/cli/help.txt
+++ b/docs/cli/help.txt
@@ -90,7 +90,7 @@ IMPORTANT COMMANDS
 
 > ci
 	# compilation time and memory usage
-> listim
+> mem.listim
 	# list all images in memory
 > listimf <filename>
 	# list all images in memory and write output to file <filename>
@@ -100,7 +100,7 @@ IMPORTANT COMMANDS
 	# prints history of all commands
 > quit
 	# exit program (exit also works)
-> mk2Dim <im> <xs> <ys>
+> mem.mk2Dim <im> <xs> <ys>
 	# creates a 2D image named <im>, size = <xs> x <ys> pixels
 
 -----------------------------------------------------------------------------------
@@ -110,28 +110,28 @@ FITSIO is used for FITS files I/O, see FITSIO documentation for more detailed in
 
 LOADING FILES
 
-> loadfits <fname> <imname>
+> iofits.loadfits <fname> <imname>
 	# load FITS file <fname> into image <imname>
-> loadfits im1.fits imf1
+> iofits.loadfits im1.fits imf1
 	# load file im1.fits in memory with name imf1
-> loadfits im1.fits
+> iofits.loadfits im1.fits
 	# load file im1.fits in memory with name im1 (default name is composed of all chars before first ".")
-> loadfits im1.fits.gz im1
+> iofits.loadfits im1.fits.gz im1
 	# load compressed file
 
 SAVING FILES
 
-> savefits  <imname> <fname>
+> iofits.saveFITS  <imname> <fname>
 	# save image <imname> into FITS file <fname>
-> savefits im1 imf1.fits
+> iofits.saveFITS im1 imf1.fits
 	# write image im1 to disk file imf1.fits
-> savefits im1
+> iofits.saveFITS im1
 	# write image im1 to disk file im1.fits (default file name = image name + ".fits")
-> savefits im1 "!im1.fits"
+> iofits.saveFITS im1 "!im1.fits"
 	# overwrite file im1.fits if it exists
-> savefits im1 "../dir2/im1.fits"
+> iofits.saveFITS im1 "../dir2/im1.fits"
 	# specify full path
-> savefits im1 im1.fits.gz
+> iofits.saveFITS im1 im1.fits.gz
 	# save compressed image
 
 -----------------------------------------------------------------------------------
@@ -150,14 +150,14 @@ cat myscript.txt > clififo
 More complex commands can be issued within the executable using the fifo.
 For example, to load all im*.fits files in memory, you can type within the executable:
 
-> !ls im*.fits | xargs -I {} echo loadfits {} >> clififo
+> !ls im*.fits | xargs -I {} echo iofits.loadfits {} >> clififo
 
 
 USING "imlist.txt" AND fifo
 
 If you start the executable with the "--listimf" option,  the file "imlist.txt" contains the list of images currently in memory in a ASCII table. You can use standard unix tools to process this list and issue commands. For example, if you want to save all images with x size > 200 onto disk as single precision FITS files :
 
-> !awk '{if ($4>200) print $2}' imlist.txt| xargs -I {} echo saveflfits {} {}_tmp.fits >> clififo
+> !awk '{if ($4>200) print $2}' imlist.txt| xargs -I {} echo iofits.saveFITS {} {}_tmp.fits >> clififo
 
 Note that if you launch several instances of the executable in the same directory, they will share the same fifo - this is generally a bad idea, as there is no easy way to control wich of the programs will read and execute the fifo commands.
 

--- a/docs/developer/LoadingModules.md
+++ b/docs/developer/LoadingModules.md
@@ -98,7 +98,7 @@ Lets run it :
 	milk-cli > mex.func1 im1 1.2
 
 	# check the image is in memory
-	milk-cli > listim
+	milk-cli > mem.listim
 
 
 

--- a/docs/install/build_tiers.md
+++ b/docs/install/build_tiers.md
@@ -87,7 +87,7 @@ are compiled out via `#ifdef USE_CFITSIO` guards:
 
 | Module | Effect |
 |--------|--------|
-| `COREMOD_iofits` | Not built — `loadfits` / `saveFITS` unavailable |
+| `COREMOD_iofits` | Not built — `iofits.loadfits` / `iofits.saveFITS` unavailable |
 | `COREMOD_memory` | `logshmim`, `saveall`, `stream_pixmapdecode` print a warning instead of writing FITS |
 | `COREMOD_arith` | No impact (never used cfitsio) |
 | `COREMOD_tools` | No impact |


### PR DESCRIPTION
Fixes obsolete CLI syntax in the documentation files.

Replaced old interactive CLI commands with their namespaced equivalents:
- `listim` -> `mem.listim`
- `creaim` -> `mem.mk2Dim`
- `loadfits` -> `iofits.loadfits`
- `save_fl` / `savefits` -> `iofits.save_fl` / `iofits.saveFITS`

Updated:
- `docs/cli/CLIcore.md`
- `docs/cli/help.txt`
- `docs/developer/LoadingModules.md`
- `docs/install/build_tiers.md`