### PR TITLE
docs: Move Git Worktrees guide to Developer Guide

### DIFF
--- a/docs/developer/WorkingWithGit.md
+++ b/docs/developer/WorkingWithGit.md
@@ -19,41 +19,71 @@ Some plugin directories (e.g., `plugins/cacao-src`) may be symbolic links
 to external source trees or git submodules.
 
 
-## 1.1. Standard development workflow
+## 2. Standard Development Workflow
 
-The primary branches are:
+All code changes **must** go through a pull request. Never commit directly to `framework-dev` (or `main`).
 
-- **`main`**: Stable release branch.
-- **`dev`**: Active development branch.
+**CRITICAL BRANCHING RULE:**
+- You are **STRICTLY FORBIDDEN** from modifying or pushing to the `dev` branch for `milk`, `cacao`, and `ImageStreamIO`.
+- You must **ONLY** push to and merge into `framework-dev` or feature branches derived from `framework-dev`.
 
-When developing, work in the `dev` branch:
+### Required Steps
 
-	$ git checkout dev
-	$ git pull
-	# ... make changes ...
-	$ git push
+1. **Create a feature branch** from `framework-dev`:
+   - Use a descriptive name, e.g., `feat/new-stream-processor`, `fix/imfunctions-else-if`, `perf/mvm-blas-upgrade`, `docs/update-guide`.
 
+2. **Make commits** on the feature branch. Keep commits atomic and well-described.
+3. **Push** the feature branch to origin.
+4. **Create a PR** targeting `framework-dev`. Include a clear title and description of the changes.
+5. **Do not merge** — let the maintainer review and merge.
 
-## 1.2. Updating main branch
+## 3. Parallel Development using Git Worktrees
 
-To synchronize `main` to latest `dev`:
+The `milk` project enforces strict branching rules where all work must occur on feature branches off of `framework-dev`. If you need to work on multiple tracks simultaneously (e.g., optimizing performance while also updating documentation or fixing a CLI bug), you should use **Git Worktrees**.
 
-	$ git checkout main
-	$ git merge dev
-	$ git push
+Git worktrees allow you to have multiple isolated working directories that share the exact same underlying local `.git` repository.
 
+### Best Practices
 
-## 1.3. Releasing a new version
+1. **Keep the Main Clone Clean:**
+   Keep your primary repository (e.g., `~/src/milk`) checked out to `framework-dev`.
 
-In `dev` branch:
+2. **Create Track-Specific Worktrees:**
+   Create sibling directories for your parallel tracks.
+
+   ```bash
+   cd ~/src/milk
+   git worktree add ../milk-docs -b docs/my-task framework-dev
+   git worktree add ../milk-cli -b feat/my-cli-task framework-dev
+   ```
+
+3. **Isolate Builds:**
+   Each worktree should have its own dedicated `_build` directory. This ensures CMake caches and compiled object files do not interfere with each other when you context-switch.
+
+4. **Reusing Worktrees:**
+   When you finish a task (e.g., your CLI feature is merged), **do not** delete the worktree. Reuse it for your next CLI task to preserve your CMake build cache:
+
+   ```bash
+   cd ~/src/milk-cli
+   git checkout framework-dev
+   git pull --ff-only origin framework-dev
+   git checkout -b feat/my-next-cli-task
+   ```
+
+> [!TIP]
+> A helper script `milk-setup-worktrees` is available to automatically scaffold this directory layout and initialize the build directories for you.
+
+## 4. Releasing a New Version
+
+When releasing a new version from `framework-dev` (or the equivalent stable branch):
 
 - Update version number in `CMakeLists.txt`
 - Update version information in `README.md`
 
-Merge `dev` into `main`, then tag:
+Merge `framework-dev` into `main`, then tag:
 
 	$ git checkout main
-	$ git merge dev
+	$ git merge framework-dev
 	$ git tag -a vX.YY.ZZ -m "milk version X.YY.ZZ"
 	$ git push origin main --tags
 
@@ -62,12 +92,10 @@ Merge `dev` into `main`, then tag:
 > parallel version number histories. Any new version, regardless of which
 > package it is associated with, includes all previous changes.
 
-
-
 ***
 
 
-## 2. Source Code Documentation (doxygen)
+## 5. Source Code Documentation (doxygen)
 
 For generating HTML source code documentation via Doxygen, refer to the
 up-to-date guide in [DocumentingCode.md](DocumentingCode.md).

--- a/docs/programmers_guide.md
+++ b/docs/programmers_guide.md
@@ -356,42 +356,6 @@ Each module directory should have a `README.md` with:
 
 </details>
 
-## 8. Parallel Development using Git Worktrees
-
-The `milk` project enforces strict branching rules where all work must occur on feature branches off of `framework-dev`. If you need to work on multiple tracks simultaneously (e.g., optimizing performance while also updating documentation or fixing a CLI bug), you should use **Git Worktrees**.
-
-Git worktrees allow you to have multiple isolated working directories that share the exact same underlying local `.git` repository.
-
-### Best Practices
-
-1. **Keep the Main Clone Clean:**
-   Keep your primary repository (e.g., `~/src/milk`) checked out to `framework-dev`.
-
-2. **Create Track-Specific Worktrees:**
-   Create sibling directories for your parallel tracks.
-
-   ```bash
-   cd ~/src/milk
-   git worktree add ../milk-docs -b docs/my-task framework-dev
-   git worktree add ../milk-cli -b feat/my-cli-task framework-dev
-   ```
-
-3. **Isolate Builds:**
-   Each worktree should have its own dedicated `_build` directory. This ensures CMake caches and compiled object files do not interfere with each other when you context-switch.
-
-4. **Reusing Worktrees:**
-   When you finish a task (e.g., your CLI feature is merged), **do not** delete the worktree. Reuse it for your next CLI task to preserve your CMake build cache:
-
-   ```bash
-   cd ~/src/milk-cli
-   git checkout framework-dev
-   git pull --ff-only origin framework-dev
-   git checkout -b feat/my-next-cli-task
-   ```
-
-> [!TIP]
-> A helper script `milk-setup-worktrees` is available to automatically scaffold this directory layout and initialize the build directories for you.
-
 ***
 
 


### PR DESCRIPTION
Moved the "Parallel Development using Git Worktrees" documentation from the Programmer's Guide to the Developer Guide to minimize duplication and keep all Git guidelines in `WorkingWithGit.md`. Also updated the branching rules in `WorkingWithGit.md` to reference `framework-dev` instead of the old `dev/main` workflow.