### PR TITLE
feat: add MkDocs frontend tags

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - architecture
+  - core-concepts
+---
+
 # Software Architecture
 
 This document presents a hierarchical overview of the

--- a/docs/cli/CLI_Overview.md
+++ b/docs/cli/CLI_Overview.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - cli
+  - getting-started
+---
+
 # CLI Overview
 
 `milk` compiles into multiple executables:

--- a/docs/developer/WorkingWithGit.md
+++ b/docs/developer/WorkingWithGit.md
@@ -24,6 +24,7 @@ to external source trees or git submodules.
 All code changes **must** go through a pull request. Never commit directly to `framework-dev` (or `main`).
 
 **CRITICAL BRANCHING RULE:**
+
 - You are **STRICTLY FORBIDDEN** from modifying or pushing to the `dev` branch for `milk`, `cacao`, and `ImageStreamIO`.
 - You must **ONLY** push to and merge into `framework-dev` or feature branches derived from `framework-dev`.
 
@@ -82,10 +83,12 @@ When releasing a new version from `framework-dev` (or the equivalent stable bran
 
 Merge `framework-dev` into `main`, then tag:
 
-	$ git checkout main
-	$ git merge framework-dev
-	$ git tag -a vX.YY.ZZ -m "milk version X.YY.ZZ"
-	$ git push origin main --tags
+```bash
+$ git checkout main
+$ git merge framework-dev
+$ git tag -a vX.YY.ZZ -m "milk version X.YY.ZZ"
+$ git push origin main --tags
+```
 
 > [!NOTE]
 > Modules that are shared between packages (e.g., `milk` and `cacao`) can have

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - performance
+  - optimization
+  - developer-guide
+---
+
 # Performance Tuning
 
 Guidelines for optimizing `milk` pipeline throughput and

--- a/docs/programmers_guide.md
+++ b/docs/programmers_guide.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - developer-guide
+  - architecture
+  - c-api
+---
+
 # Programmer's Guide to `milk`
 
 Welcome to `milk`. This document serves as an overview of its core architecture and programming model. If you are reading this while setting up a new module, debugging, or wanting to write a custom module, this guide will orient you on the core concepts.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - scripts
+  - cli
+  - automation
+---
+
 # Scripts Reference
 
 `milk` includes shell scripts for common operations. Scripts


### PR DESCRIPTION
This PR introduces tags to the MkDocs documentation.

- Enabled `tags` plugin in `mkdocs.yml`.
- Validated `docs/tags.md` index exists.
- Added YAML frontmatter with `tags:` to core documentation pages (`docs/cli/CLI_Overview.md`, `docs/performance.md`, `docs/programmers_guide.md`, `docs/architecture.md`, `docs/scripts.md`).
- Fixed pre-existing formatting errors in `docs/developer/WorkingWithGit.md` flagged by markdownlint.