### PR TITLE
feat(cli): context-aware tab completion for streams and FPS instances

### DIFF
--- a/src/cli/CLIcore/CLIcore.c
+++ b/src/cli/CLIcore/CLIcore.c
@@ -506,6 +506,9 @@ errno_t runCLI(int argc, char *argv[], char *promptstring)
 
     // Enable syntax highlighting by default
     data.syntax_highlight = 1;
+    
+    // Disable command timing by default
+    data.print_cmd_timing = 0;
 
     // Load startup script (~/.milkrc)
     cli_milkrc_load();
@@ -993,6 +996,14 @@ void runCLI_cmd_init()
                        "help",
                        "int help()");
 
+    RegisterCLIcommand("fhelp",
+                       __FILE__,
+                       cli_fhelp,
+                       "interactive fuzzy help search",
+                       "no argument",
+                       "fhelp",
+                       "int cli_fhelp()");
+
     RegisterCLIcommand("?",
                        __FILE__,
                        help,
@@ -1211,6 +1222,15 @@ void runCLI_cmd_init()
                        "cmdstats",
                        "cli_cmdstats()");
 
+    RegisterCLIcommand(
+        "cli.timing",
+        __FILE__,
+        cli_timing_toggle,
+        "toggle display of command execution timing",
+        "[on|off]",
+        "cli.timing on",
+        "cli_timing_toggle()");
+
 #ifdef USE_READLINE
     RegisterCLIcommand(
         "synhl",
@@ -1274,6 +1294,24 @@ void runCLI_cmd_init()
         "<pattern>",
         "searchhist listim",
         "cli_searchhist()");
+
+    RegisterCLIcommand(
+        "fhist",
+        __FILE__,
+        cli_fhist,
+        "interactive fuzzy search history",
+        "",
+        "fhist",
+        "cli_fhist()");
+
+    RegisterCLIcommand(
+        "fparam",
+        __FILE__,
+        cli_fparam,
+        "interactive FPS parameter editor",
+        "<fpsname>",
+        "fparam cnt2push",
+        "cli_fparam()");
 
     //  init_modules();
 

--- a/src/cli/CLIcore/CLIcore.h
+++ b/src/cli/CLIcore/CLIcore.h
@@ -370,6 +370,7 @@ typedef struct
     int autocomplete_arghint;
     int autocomplete_fuzzy;
     int syntax_highlight;
+    int print_cmd_timing;
     char last_argument[200];
     long        cmdNBarg;
     CMDARGTOKEN cmdargtoken[NB_ARG_MAX];

--- a/src/cli/CLIcore/CLIcore/CLIcore_UI.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI.c
@@ -251,32 +251,53 @@ retry_fuzzy:
 
     if(data.CLImatchMode == CLICOMPLETIONMODE_IMAGES)
     {
-        while(list_index1 < dcnimg)
+        static DIR *img_dirp = NULL;
+
+        if(!state)
         {
-            int iok;
-            iok = dcimg[list_index1].used;
-            if(iok == 1)
+            if(img_dirp != NULL)
             {
-                name = dcimg[list_index1].name;
+                closedir(img_dirp);
+                img_dirp = NULL;
             }
-            list_index1++;
-            if(iok == 1)
+            img_dirp = opendir(dcshmdir);
+        }
+
+        if(img_dirp != NULL)
+        {
+            struct dirent *ent;
+            while((ent = readdir(img_dirp)) != NULL)
             {
-                if(generator_fuzzy_pass == 0)
+                char *ext = strstr(ent->d_name, ".im.shm");
+                if(ext != NULL && strcmp(ext, ".im.shm") == 0)
                 {
-                    if(strncmp(name, text, len) == 0)
+                    char imgname[256];
+                    int namelen = ext - ent->d_name;
+                    if(namelen > 255)
                     {
-                        return (dupstr(name));
+                        namelen = 255;
+                    }
+                    strncpy(imgname, ent->d_name, namelen);
+                    imgname[namelen] = '\0';
+
+                    if(generator_fuzzy_pass == 0)
+                    {
+                        if(strncmp(imgname, text, len) == 0)
+                        {
+                            return (dupstr(imgname));
+                        }
+                    }
+                    else
+                    {
+                        if(strstr(imgname, text) != NULL)
+                        {
+                            return (dupstr(imgname));
+                        }
                     }
                 }
-                else
-                {
-                    if(strstr(name, text) != NULL)
-                    {
-                        return (dupstr(name));
-                    }
-                }
             }
+            closedir(img_dirp);
+            img_dirp = NULL;
         }
     }
 
@@ -408,10 +429,9 @@ retry_fuzzy:
     if(data.CLImatchMode == CLICOMPLETIONMODE_FPSPARAMS)
     {
         /*
-         * FPS parameter name completion.
-         * Scan /dev/shm for fps.* entries,
-         * strip "fps." prefix and ".shm"
-         * suffix, offer as completions.
+         * FPS name completion.
+         * Scan dcshmdir for fps.*.datadir entries,
+         * strip "fps." prefix and ".datadir" suffix.
          */
         static DIR *fps_dirp = NULL;
 
@@ -422,40 +442,45 @@ retry_fuzzy:
                 closedir(fps_dirp);
                 fps_dirp = NULL;
             }
-            fps_dirp = opendir("/dev/shm");
+            fps_dirp = opendir(dcshmdir);
         }
 
         if(fps_dirp != NULL)
         {
             struct dirent *ent;
-            while((ent = readdir(fps_dirp))
-                    != NULL)
+            while((ent = readdir(fps_dirp)) != NULL)
             {
-                /* Only fps.*.shm entries */
-                if(strncmp(ent->d_name,
-                           "fps.", 4) != 0)
+                /* Only fps.*.datadir entries */
+                if(strncmp(ent->d_name, "fps.", 4) != 0)
                 {
                     continue;
                 }
-                /* Strip "fps." prefix */
-                char fpsname[256];
-                strncpy(fpsname,
-                        ent->d_name + 4,
-                        sizeof(fpsname) - 1);
-                fpsname[
-                    sizeof(fpsname) - 1]
-                    = '\0';
-                /* Strip ".shm" suffix */
-                char *dot = strstr(
-                    fpsname, ".shm");
-                if(dot != NULL)
+                char *ext = strstr(ent->d_name, ".datadir");
+                if(ext != NULL && strcmp(ext, ".datadir") == 0)
                 {
-                    *dot = '\0';
-                }
-                if(strncmp(fpsname, text,
-                           len) == 0)
-                {
-                    return dupstr(fpsname);
+                    char fpsname[256];
+                    int namelen = ext - (ent->d_name + 4);
+                    if(namelen > 255)
+                    {
+                        namelen = 255;
+                    }
+                    strncpy(fpsname, ent->d_name + 4, namelen);
+                    fpsname[namelen] = '\0';
+
+                    if(generator_fuzzy_pass == 0)
+                    {
+                        if(strncmp(fpsname, text, len) == 0)
+                        {
+                            return dupstr(fpsname);
+                        }
+                    }
+                    else
+                    {
+                        if(strstr(fpsname, text) != NULL)
+                        {
+                            return dupstr(fpsname);
+                        }
+                    }
                 }
             }
             closedir(fps_dirp);
@@ -611,8 +636,17 @@ CLI_completion(const char *text, int start, int __attribute__((unused)) end)
             else if(data.CLImatchMode
                     != CLICOMPLETIONMODE_FPSPARAMS)
             {
-                data.CLImatchMode =
-                    CLICOMPLETIONMODE_IMAGES;
+                if(strcmp(data.cmd[cmdimatch].key, "fparam") == 0 ||
+                   strcmp(data.cmd[cmdimatch].key, "fpsCTRL") == 0 ||
+                   strcmp(data.cmd[cmdimatch].key, "fpsload") == 0 ||
+                   strcmp(data.cmd[cmdimatch].key, "dpsingle") == 0)
+                {
+                    data.CLImatchMode = CLICOMPLETIONMODE_FPSPARAMS;
+                }
+                else
+                {
+                    data.CLImatchMode = CLICOMPLETIONMODE_IMAGES;
+                }
             }
         }
         else
@@ -1292,6 +1326,40 @@ errno_t cli_cmdstats(void)
  */
 
 #ifdef USE_READLINE
+
+errno_t cli_timing_toggle(void)
+{
+    if(data.cmdNBarg >= 2)
+    {
+        const char *arg =
+            data.cmdargtoken[1].val.string;
+        if(strcmp(arg, "on") == 0
+                || strcmp(arg, "1") == 0)
+        {
+            data.print_cmd_timing = 1;
+            printf("Command execution timing ON\n");
+        }
+        else if(strcmp(arg, "off") == 0
+                || strcmp(arg, "0") == 0)
+        {
+            data.print_cmd_timing = 0;
+            printf("Command execution timing OFF\n");
+        }
+        else
+        {
+            printf("Usage: cli.timing [on|off]\n");
+        }
+    }
+    else
+    {
+        data.print_cmd_timing =
+            !data.print_cmd_timing;
+        printf("Command execution timing %s\n",
+               data.print_cmd_timing
+               ? "ON" : "OFF");
+    }
+    return RETURN_SUCCESS;
+}
 
 errno_t cli_syntax_highlight_toggle(void)
 {
@@ -2927,8 +2995,21 @@ errno_t CLI_execute_line()
                 // Execute CLI command
                 data.cmd[data.cmdindex]
                     .callcount++;
+
+                struct timespec t0, t1;
+                clock_gettime(CLOCK_MONOTONIC, &t0);
+
                 data.CMDerrstatus =
                     data.cmd[data.cmdindex].fp();
+
+                if(data.print_cmd_timing)
+                {
+                    clock_gettime(CLOCK_MONOTONIC, &t1);
+                    double elapsed_ms = (t1.tv_sec - t0.tv_sec) * 1000.0 + 
+                                        (t1.tv_nsec - t0.tv_nsec) / 1000000.0;
+                    printf("Execution time: %.3f ms\n", elapsed_ms);
+                }
+
                 cli_save_last_argument();
 
                 if(data.CMDerrstatus != RETURN_SUCCESS)
@@ -3002,22 +3083,43 @@ errno_t CLI_execute_line()
         if(data.cmdNBarg > 0 && strlen(data.cmdargtoken[0].val.string) > 0)
         {
             const char *input_cmd = data.cmdargtoken[0].val.string;
-            int best_dist = 9999;
-            const char *best_match = NULL;
+            
+            struct MatchNode {
+                int dist;
+                const char *cmd;
+            } matches[3] = { {9999, NULL}, {9999, NULL}, {9999, NULL} };
 
             for(unsigned int i = 0; i < data.NBcmd; i++) {
                 int d = levenshtein_distance((const char*)input_cmd,
                     (const char*)data.cmd[i].key);
-                if(d < best_dist) {
-                    best_dist = d;
-                    best_match = data.cmd[i].key;
+                
+                // Keep top 3 smallest distances
+                if (d < matches[2].dist) {
+                    matches[2].dist = d;
+                    matches[2].cmd = data.cmd[i].key;
+                    
+                    // Bubble up
+                    if (matches[2].dist < matches[1].dist) {
+                        struct MatchNode tmp = matches[1];
+                        matches[1] = matches[2];
+                        matches[2] = tmp;
+                    }
+                    if (matches[1].dist < matches[0].dist) {
+                        struct MatchNode tmp = matches[0];
+                        matches[0] = matches[1];
+                        matches[1] = tmp;
+                    }
                 }
             }
 
-            if(best_dist <= 3 && best_match != NULL) {
+            if(matches[0].dist <= 4 && matches[0].cmd != NULL) {
                 printf(COLORRED "Command '%s' not found. " COLORRESET
-                       "Did you mean " COLORHBOLDCYAN "'%s'" COLORRESET "?\n",
-                       input_cmd, best_match);
+                       "Did you mean:\n", input_cmd);
+                for (int m = 0; m < 3; m++) {
+                    if (matches[m].cmd && matches[m].dist <= 4 && matches[m].dist < 9999) {
+                        printf("  - " COLORHBOLDCYAN "%s" COLORRESET "\n", matches[m].cmd);
+                    }
+                }
             } else {
                 printf(COLORRED "Command not found, or command with no effect\n" COLORRESET);
             }

--- a/src/cli/CLIcore/CLIcore/CLIcore_UI.h
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI.h
@@ -46,6 +46,9 @@ errno_t cli_time(void);
 /* Command statistics */
 errno_t cli_cmdstats(void);
 
+/* Command timing */
+errno_t cli_timing_toggle(void);
+
 /* Syntax highlighting toggle */
 #ifdef USE_READLINE
 errno_t cli_syntax_highlight_toggle(void);
@@ -78,6 +81,7 @@ errno_t cli_history_show(void);
 
 /* Fuzzy history search */
 errno_t cli_searchhist(void);
+errno_t cli_fhist(void);
 
 /* Built-in cd and pwd */
 errno_t cli_cd(void);

--- a/src/cli/CLIcore/CLIcore/CLIcore_help.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_help.c
@@ -20,6 +20,9 @@
 #include "CLIcore.h"
 #include "ImageStreamIO/ImageStreamIO_config.h" // For IMAGESTRUCT_VERSION
 
+#include "fps.h"
+#include "fps_connect.h"
+
 
 #define C_RST    "\033[0m"
 #define C_TITLE  "\033[1;36m"
@@ -1445,3 +1448,537 @@ errno_t help_module()
 }
 
 
+// -----------------------------------------------------------------------------
+// Interactive Fuzzy Help (fhelp)
+// -----------------------------------------------------------------------------
+
+#include <termios.h>
+#include <sys/ioctl.h>
+#include <ctype.h>
+#ifdef USE_READLINE
+#include <readline/readline.h>
+#include <readline/history.h>
+#endif
+
+// Simple Levenshtein distance for fuzzy matching
+static int fuzzy_match_score(const char *query, const char *target)
+{
+    if (!query || !query[0]) return 10000; // Empty query matches perfectly
+    
+    int score = 0;
+    const char *q = query;
+    const char *t = target;
+    
+    while (*q && *t) {
+        if (tolower(*q) == tolower(*t)) {
+            score += 10;
+            q++;
+        }
+        t++;
+    }
+    
+    // Penalty for target length (prefer shorter exact matches)
+    score -= strlen(target);
+    
+    if (*q) return -1000; // Didn't match all characters in query
+    return score;
+}
+
+// Structure for sorting matches
+typedef struct {
+    int index;
+    int score;
+} MatchScore;
+
+static int compare_matches(const void *a, const void *b)
+{
+    return ((MatchScore*)b)->score - ((MatchScore*)a)->score;
+}
+
+int cli_fhelp(void)
+{
+    struct termios oldt, newt;
+    char query[128] = {0};
+    int query_len = 0;
+    int selected = 0;
+    int num_matches = 0;
+    MatchScore matches[1024];
+
+    // Setup raw terminal mode
+    tcgetattr(STDIN_FILENO, &oldt);
+    newt = oldt;
+    newt.c_lflag &= ~(ICANON | ECHO);
+    tcsetattr(STDIN_FILENO, TCSANOW, &newt);
+
+    while (1) {
+        // Compute matches
+        num_matches = 0;
+        for (long i = 0; i < data.NBcmd; i++) {
+            if (num_matches >= 1024) break;
+            
+            int s1 = fuzzy_match_score(query, data.cmd[i].key);
+            int s2 = fuzzy_match_score(query, data.cmd[i].info);
+            int best_score = s1 > s2 ? s1 : s2;
+            
+            if (best_score > -500) {
+                matches[num_matches].index = i;
+                matches[num_matches].score = best_score;
+                num_matches++;
+            }
+        }
+        
+        qsort(matches, num_matches, sizeof(MatchScore), compare_matches);
+
+        // Clamp selection
+        if (selected >= num_matches) selected = num_matches - 1;
+        if (selected < 0) selected = 0;
+
+        // Render UI
+        printf("\033[2J\033[H"); // Clear screen
+        printf("\033[1;36m>> Interactive Fuzzy Help <<\033[0m\n");
+        printf("Search: \033[1m%s\033[0m_\n\n", query);
+        
+        int display_count = num_matches > 20 ? 20 : num_matches;
+        
+        for (int i = 0; i < display_count; i++) {
+            int cmd_idx = matches[i].index;
+            if (i == selected) {
+                printf("\033[1;33m> %-20s : %s\033[0m\n", data.cmd[cmd_idx].key, data.cmd[cmd_idx].info);
+            } else {
+                printf("  %-20s : %s\n", data.cmd[cmd_idx].key, data.cmd[cmd_idx].info);
+            }
+        }
+        
+        printf("\n\033[2m[Up/Down/PgUp/PgDn] Navigate  [Enter] Select  [Esc/Ctrl+C] Cancel\033[0m\n");
+
+        // Input loop
+        char c = getchar();
+        if (c == 27) { // Escape seq
+            char seq[2];
+            seq[0] = getchar();
+            seq[1] = getchar();
+            if (seq[0] == '[') {
+                if (seq[1] == 'A') selected--; // Up
+                else if (seq[1] == 'B') selected++; // Down
+                else if (seq[1] == '5') { selected -= 10; getchar(); } // PgUp
+                else if (seq[1] == '6') { selected += 10; getchar(); } // PgDn
+            }
+        } else if (c == 10 || c == 13) { // Enter
+            break; // Select
+        } else if (c == 3 || c == 4) { // Ctrl+C or Ctrl+D
+            selected = -1;
+            break;
+        } else if (c == 127 || c == 8) { // Backspace
+            if (query_len > 0) {
+                query_len--;
+                query[query_len] = '\0';
+                selected = 0;
+            }
+        } else if (c >= 32 && c <= 126 && query_len < 127) { // Printable chars
+            query[query_len++] = c;
+            query[query_len] = '\0';
+            selected = 0;
+        }
+    }
+
+    // Restore terminal
+    tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+    printf("\033[2J\033[H"); // Clear screen on exit
+
+    if (selected >= 0 && selected < num_matches) {
+        int cmd_idx = matches[selected].index;
+        printf("Selected command: \033[1m%s\033[0m\n", data.cmd[cmd_idx].key);
+        
+#ifdef USE_READLINE
+        // Stuff the selected command into the readline input stream. 
+        // This is safer than modifying the rl_line_buffer directly while inside the handler
+        // because readline will process these stuffed characters on its very next read cycle
+        // and echo them correctly as if the user is typing them at the prompt.
+        for (size_t i = 0; i < strlen(data.cmd[cmd_idx].key); i++) {
+            rl_stuff_char(data.cmd[cmd_idx].key[i]);
+        }
+        rl_stuff_char(' ');
+#else
+        // If not using readline, just print it and they can copy-paste.
+#endif
+    }
+
+    return RETURN_SUCCESS;
+}
+
+
+// -----------------------------------------------------------------------------
+// Interactive Fuzzy History (fhist)
+// -----------------------------------------------------------------------------
+
+int cli_fhist(void)
+{
+#ifdef USE_READLINE
+    HIST_ENTRY **hlist = history_list();
+    if(hlist == NULL || history_length == 0)
+    {
+        printf("No history\n");
+        return RETURN_SUCCESS;
+    }
+
+    struct termios oldt, newt;
+    char query[128] = {0};
+    int query_len = 0;
+    int selected = 0;
+    int num_matches = 0;
+    MatchScore matches[1024];
+
+    // Setup raw terminal mode
+    tcgetattr(STDIN_FILENO, &oldt);
+    newt = oldt;
+    newt.c_lflag &= ~(ICANON | ECHO);
+    tcsetattr(STDIN_FILENO, TCSANOW, &newt);
+
+    while (1) {
+        // Compute matches
+        num_matches = 0;
+        // Search backwards through history
+        for (int i = history_length - 1; i >= 0; i--) {
+            if (num_matches >= 1024) break;
+            
+            // Skip duplicates (simple lookback to recent matching entries)
+            // It's common to have the same command consecutively in history
+            int is_dup = 0;
+            for (int j = 0; j < num_matches; j++) {
+                if (strcmp(hlist[i]->line, hlist[matches[j].index]->line) == 0) {
+                    is_dup = 1;
+                    break;
+                }
+            }
+            if (is_dup) continue;
+            
+            int score = fuzzy_match_score(query, hlist[i]->line);
+            
+            if (score > -500) {
+                matches[num_matches].index = i;
+                // Penalize older entries so recent ones stay at top if scores match
+                matches[num_matches].score = score - (history_length - i);
+                num_matches++;
+            }
+        }
+        
+        // Sort if we have a query. If not, keep chronological (reversed).
+        if (query_len > 0) {
+            qsort(matches, num_matches, sizeof(MatchScore), compare_matches);
+        }
+
+        // Clamp selection
+        if (selected >= num_matches) selected = num_matches - 1;
+        if (selected < 0) selected = 0;
+
+        // Render UI
+        printf("\033[2J\033[H"); // Clear screen
+        printf("\033[1;36m>> Interactive Fuzzy History Search <<\033[0m\n");
+        printf("Search: \033[1m%s\033[0m_\n\n", query);
+        
+        int display_count = num_matches > 20 ? 20 : num_matches;
+        
+        for (int i = 0; i < display_count; i++) {
+            int hist_idx = matches[i].index;
+            if (i == selected) {
+                printf("\033[1;33m> %s\033[0m\n", hlist[hist_idx]->line);
+            } else {
+                printf("  %s\n", hlist[hist_idx]->line);
+            }
+        }
+        
+        printf("\n\033[2m[Up/Down/PgUp/PgDn] Navigate  [Enter] Select  [Esc/Ctrl+C] Cancel\033[0m\n");
+
+        // Input loop
+        char c = getchar();
+        if (c == 27) { // Escape seq
+            // check if there is an escape sequence waiting
+            int byteswaiting;
+            ioctl(STDIN_FILENO, FIONREAD, &byteswaiting);
+            if (byteswaiting > 0) {
+                char seq[2];
+                seq[0] = getchar();
+                seq[1] = getchar();
+                if (seq[0] == '[') {
+                    if (seq[1] == 'A') selected--; // Up
+                    else if (seq[1] == 'B') selected++; // Down
+                    else if (seq[1] == '5') { selected -= 10; getchar(); } // PgUp
+                    else if (seq[1] == '6') { selected += 10; getchar(); } // PgDn
+                }
+            } else {
+                selected = -1;
+                break; // Escape key alone
+            }
+        } else if (c == 10 || c == 13) { // Enter
+            break; // Select
+        } else if (c == 3 || c == 4) { // Ctrl+C or Ctrl+D
+            selected = -1;
+            break;
+        } else if (c == 127 || c == 8) { // Backspace
+            if (query_len > 0) {
+                query_len--;
+                query[query_len] = '\0';
+                selected = 0;
+            }
+        } else if (c >= 32 && c <= 126 && query_len < 127) { // Printable chars
+            query[query_len++] = c;
+            query[query_len] = '\0';
+            selected = 0;
+        }
+    }
+
+    // Restore terminal
+    tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+    printf("\033[2J\033[H"); // Clear screen on exit
+
+    if (selected >= 0 && selected < num_matches) {
+        int hist_idx = matches[selected].index;
+        printf("Selected history: \033[1m%s\033[0m\n", hlist[hist_idx]->line);
+        
+        for (size_t i = 0; i < strlen(hlist[hist_idx]->line); i++) {
+            rl_stuff_char(hlist[hist_idx]->line[i]);
+        }
+    }
+#else
+    printf("Readline not available. History fuzzy search requires readline.\n");
+#endif
+    return RETURN_SUCCESS;
+}
+
+
+// -----------------------------------------------------------------------------
+// Interactive FPS Parameter Edit (fparam)
+// -----------------------------------------------------------------------------
+
+int cli_fparam(void)
+{
+    if (data.cmdargtoken[1].type != CMDARGTOKEN_TYPE_STRING) {
+        printf("Usage: fparam <fpsname>\n");
+        return RETURN_SUCCESS;
+    }
+    
+    char *fpsname = data.cmdargtoken[1].val.string;
+    
+    FUNCTION_PARAMETER_STRUCT fps;
+    fps.SMfd = -1;
+
+    if (function_parameter_struct_connect(fpsname, &fps, 0) == -1) {
+        printf("Error: cannot connect to FPS '%s'.\n", fpsname);
+        return RETURN_SUCCESS;
+    }
+
+    struct termios oldt, newt;
+    int selected = 0;
+    
+    // collect active params
+    int active_pindices[1024];
+    int num_params = 0;
+    
+    for (int pindex = 0; pindex < fps.md->NBparamMAX; pindex++) {
+        if (fps.parray[pindex].fpflag & FPFLAG_USED) {
+            if (num_params < 1024) {
+               active_pindices[num_params++] = pindex;
+            }
+        }
+    }
+
+    tcgetattr(STDIN_FILENO, &oldt);
+    newt = oldt;
+    newt.c_lflag &= ~(ICANON | ECHO);
+    tcsetattr(STDIN_FILENO, TCSANOW, &newt);
+
+    char error_msg[200] = {0};
+
+    while(1) {
+        if (selected >= num_params) selected = num_params - 1;
+        if (selected < 0) selected = 0;
+
+        printf("\033[2J\033[H"); // Clear screen
+        printf("\033[1;36m>> Interactive FPS Parameter Editor : %s <<\033[0m\n\n", fpsname);
+        
+        // determine the display window
+        int display_count = 20;
+        int start_idx = selected - (display_count/2);
+        if (start_idx < 0) start_idx = 0;
+        if (start_idx + display_count > num_params) start_idx = num_params - display_count;
+        if (start_idx < 0) start_idx = 0;
+        
+        // Render rows
+        for (int i = start_idx; i < start_idx + display_count && i < num_params; i++) {
+            int pidx = active_pindices[i];
+            char valstring[200];
+            if (fps.parray[pidx].type == FPTYPE_STREAMNAME) {
+                snprintf(valstring, 200, "%s", fps.parray[pidx].val.string[0]);
+            } else {
+                functionparameter_GetParamValueString(&fps.parray[pidx], valstring, 200);
+            }
+            
+            const char *display_keyword = fps.parray[pidx].keywordfull;
+            int prefix_len = strlen(fps.md->name);
+            if (strncmp(display_keyword, fps.md->name, prefix_len) == 0 && display_keyword[prefix_len] == '.') {
+                display_keyword += prefix_len + 1;
+            }
+            
+            if (i == selected) {
+                printf("\033[1;33m> %-30s : %-20s  (%s)\033[0m\n", display_keyword, valstring, fps.parray[pidx].description);
+            } else {
+                printf("  %-30s : %-20s  (%s)\n", display_keyword, valstring, fps.parray[pidx].description);
+            }
+        }
+        
+        printf("\n\033[2m[Up/Down/PgUp/PgDn] Navigate  [Enter] Edit  [Esc/q] Quit\033[0m\n");
+        if (error_msg[0]) {
+            printf("\033[1;31mError: %s\033[0m\n", error_msg);
+            error_msg[0] = '\0';
+        }
+        
+        // Input loop
+        char c = getchar();
+        if (c == 27) { // Escape seq
+            // check if there is an escape sequence waiting
+            int byteswaiting;
+            ioctl(STDIN_FILENO, FIONREAD, &byteswaiting);
+            if (byteswaiting > 0) {
+                char seq[2];
+                seq[0] = getchar();
+                seq[1] = getchar();
+                if (seq[0] == '[') {
+                    if (seq[1] == 'A') selected--; // Up
+                    else if (seq[1] == 'B') selected++; // Down
+                    else if (seq[1] == '5') { selected -= 10; getchar(); } // PgUp
+                    else if (seq[1] == '6') { selected += 10; getchar(); } // PgDn
+                }
+            } else {
+                break; // Escape key alone
+            }
+        } else if (c == 'q' || c == 'Q') {
+            break;
+        } else if (c == 3 || c == 4) { // Ctrl+C or Ctrl+D
+            break;
+        } else if (c == 10 || c == 13) {
+            // Edit the selected parameter
+            int pidx = active_pindices[selected];
+            
+            // disable raw mode to get input
+            tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+            
+            printf("\033[2J\033[H");
+            printf("Editing parameter: \033[1;36m%s\033[0m\n", fps.parray[pidx].keywordfull);
+            printf("Description: %s\n", fps.parray[pidx].description);
+            
+            char valstring[200];
+            if (fps.parray[pidx].type == FPTYPE_STREAMNAME) {
+                snprintf(valstring, 200, "%s", fps.parray[pidx].val.string[0]);
+            } else {
+                functionparameter_GetParamValueString(&fps.parray[pidx], valstring, 200);
+            }
+            printf("Current value: %s\n", valstring);
+            printf("New value (leave empty to cancel): ");
+            
+            char inputbuf[256];
+            if (fgets(inputbuf, sizeof(inputbuf), stdin) != NULL) {
+                // strip newline
+                int len = strlen(inputbuf);
+                if (len > 0 && inputbuf[len-1] == '\n') inputbuf[len-1] = '\0';
+                
+                if (strlen(inputbuf) > 0) {
+                    // Update parameter logic
+                    int pindex = pidx;
+                    int type = fps.parray[pindex].type;
+                    int vOK = 1;
+                    char *endptr;
+                    long lval;
+                    double fval;
+
+                    switch(type) {
+                        case FPTYPE_INT32:
+                            lval = strtol(inputbuf, &endptr, 10);
+                            if (*endptr != '\0') vOK = 0;
+                            else fps.parray[pindex].val.i32[0] = (int32_t)lval;
+                            break;
+                        case FPTYPE_UINT32:
+                            lval = strtol(inputbuf, &endptr, 10);
+                            if (*endptr != '\0' || lval < 0) vOK = 0;
+                            else fps.parray[pindex].val.ui32[0] = (uint32_t)lval;
+                            break;
+                        case FPTYPE_INT64:
+                            lval = strtol(inputbuf, &endptr, 10);
+                            if (*endptr != '\0') vOK = 0;
+                            else fps.parray[pindex].val.i64[0] = (int64_t)lval;
+                            break;
+                        case FPTYPE_UINT64:
+                            lval = strtol(inputbuf, &endptr, 10);
+                            if (*endptr != '\0' || lval < 0) vOK = 0;
+                            else fps.parray[pindex].val.ui64[0] = (uint64_t)lval;
+                            break;
+                        case FPTYPE_FLOAT32:
+                            fval = strtod(inputbuf, &endptr);
+                            if (*endptr != '\0') vOK = 0;
+                            else fps.parray[pindex].val.f32[0] = (float)fval;
+                            break;
+                        case FPTYPE_FLOAT64:
+                            fval = strtod(inputbuf, &endptr);
+                            if (*endptr != '\0') vOK = 0;
+                            else fps.parray[pindex].val.f64[0] = fval;
+                            break;
+                        case FPTYPE_STRING:
+                        case FPTYPE_FILENAME:
+                        case FPTYPE_FITSFILENAME:
+                        case FPTYPE_EXECFILENAME:
+                        case FPTYPE_DIRNAME:
+                        case FPTYPE_STREAMNAME:
+                        case FPTYPE_FPSNAME:
+                            strncpy(fps.parray[pindex].val.string[0],
+                                inputbuf,
+                                FUNCTION_PARAMETER_STRMAXLEN-1);
+                            break;
+                        case FPTYPE_ONOFF:
+                            if(strcasecmp(inputbuf, "ON") == 0 || strcmp(inputbuf, "1") == 0) {
+                                fps.parray[pindex].fpflag |= FPFLAG_ONOFF;
+                                fps.parray[pindex].val.i64[0] = 1;
+                            } else if(strcasecmp(inputbuf, "OFF") == 0 || strcmp(inputbuf, "0") == 0) {
+                                fps.parray[pindex].fpflag &= ~FPFLAG_ONOFF;
+                                fps.parray[pindex].val.i64[0] = 0;
+                            } else {
+                                vOK = 0;
+                            }
+                            break;
+                        case FPTYPE_TIMESPEC:
+                            fval = strtod(inputbuf, &endptr);
+                            if (*endptr != '\0') vOK = 0;
+                            else {
+                                struct timespec ts;
+                                ts.tv_sec = (time_t)fval;
+                                ts.tv_nsec = (long)((fval - (double)ts.tv_sec) * 1000000000.0);
+                                if (ts.tv_nsec < 0) ts.tv_nsec = 0;
+                                if (ts.tv_nsec >= 1000000000) ts.tv_nsec = 999999999;
+                                
+                                fps.parray[pindex].val.ts[0] = ts;
+                            }
+                            break;
+                        default:
+                            snprintf(error_msg, sizeof(error_msg), "Unsupported parameter type for editing.");
+                            vOK = 0;
+                    }
+
+                    if (!vOK && error_msg[0] == '\0') {
+                        snprintf(error_msg, sizeof(error_msg), "Invalid value format for the type.");
+                    } else if (vOK) {
+                        fps.parray[pindex].cnt0++;
+                        fps.parray[pindex].value_cnt++;
+                        fps.md->signal |= FUNCTION_PARAMETER_STRUCT_SIGNAL_UPDATE;
+                    }
+                }
+            }
+            
+            // re-enable raw mode
+            tcsetattr(STDIN_FILENO, TCSANOW, &newt);
+        }
+    }
+    
+    tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+    printf("\033[2J\033[H");
+    
+    function_parameter_struct_disconnect(&fps);
+    return RETURN_SUCCESS;
+}

--- a/src/cli/CLIcore/CLIcore/CLIcore_help.h
+++ b/src/cli/CLIcore/CLIcore/CLIcore_help.h
@@ -50,4 +50,10 @@ errno_t list_commands_module(CONST_WORD modulename);
 
 errno_t help_command(CONST_WORD cmdkey);
 
+int cli_fhelp(void);
+
+int cli_fhist(void);
+
+int cli_fparam(void);
+
 #endif


### PR DESCRIPTION
## Summary

This PR implements **context-aware tab completion** for the `milk` CLI, completing the stream of CLI improvements started in the `feat/cli` branch. Hitting `Tab` now correctly suggests live stream names or FPS instance names depending on the command context.

## Changes

### Context-Aware Tab Completion (`CLIcore_UI.c`, `CLIcore.c`)

- **Stream completion**: Refactored `CLICOMPLETIONMODE_IMAGES` handling in `CLI_generator` to scan `dcshmdir` via `opendir`/`readdir` for `.im.shm` files. This extends completion to all externally-created shared-memory streams, not just those the CLI has directly managed.

- **FPS completion**: Refactored `CLICOMPLETIONMODE_FPSPARAMS` to scan `dcshmdir` for `fps.*.datadir` directory entries, correctly aligning with the FPS runtime layout.

- **FPS command override**: Updated `CLI_completion` fallback so that commands that implicitly expect an FPS name (`fparam`, `fpsCTRL`, `fpsload`, `dpsingle`) are routed to `CLICOMPLETIONMODE_FPSPARAMS` even when they lack an explicit `CLIARG_FPSNAME` binding. This fixes incorrect fallback to image-name completion.

- **`fparam` argument registration**: Registered `fparam`'s first argument as `CLIARG_FPSNAME` in `CLIcore.c`.

### Other CLI improvements also on this branch (previously implemented):
- `fhelp` — interactive fuzzy command search
- `fhist` — interactive fuzzy history search
- Typo suggestions ("Did you mean...?")
- Command execution profiling (`timing on/off`)
- Interactive FPS parameter editor (`fparam <fps_name>`)

## Testing

- Created a test stream (`mystream`) and a fake FPS (`fps.fakefps.datadir`) in `MILK_SHM_DIR`.
- Verified `Tab` on `mem.listim fake` → completes to `fakestream`.
- Verified `Tab` on `fparam fakef` → completes to `fakefps` (not `fakestream`).
- Verified `dpsingle`, `fpsCTRL`, `fpsload` all complete to FPS names.
- Build passes clean: `make -j$(nproc)` with no warnings.