### PR TITLE
fix: install mkdocs-material[plugins] to enable tags on docs site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install MkDocs Material
-        run: pip install mkdocs-material
+        run: pip install "mkdocs-material[plugins]"
 
       - name: Build MkDocs site
         run: mkdocs build --strict -d _site


### PR DESCRIPTION
## Problem

The `tags` plugin is enabled in `mkdocs.yml` but was not rendering on the live site at https://milk-org.github.io/milk/tags/ because the CI workflow only installed the base `mkdocs-material` package.

The built-in plugins (including `tags`) shipped with `mkdocs-material` require the `[plugins]` extras group to be installed, which pulls in the necessary dependencies (e.g. `mkdocs-material-extensions`, `pillow`, etc.).

## Fix

Change:
```yaml
run: pip install mkdocs-material
```
to:
```yaml
run: pip install "mkdocs-material[plugins]"
```

This ensures the `tags` plugin is properly loaded by MkDocs at build time, populating the `[TAGS]` placeholder in `docs/tags.md`.
