### PR TITLE
docs: fix tags index page — use Material tags marker

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install MkDocs Material
-        run: pip install mkdocs-material
+        run: pip install "mkdocs-material[plugins]"
 
       - name: Build MkDocs site
         run: mkdocs build --strict -d _site

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -33,3 +33,11 @@ MD012: false
 
 # Disable table column style checking (produces ~470 false positives)
 MD060: false
+
+# Allow flexible list-marker spacing — Material card grids
+# use 3-space indent after "-   " which triggers this rule.
+MD030: false
+
+# Allow indented code blocks — Material content tabs
+# (=== "tab") require 4-space-indented code fences.
+MD046: false

--- a/docs/cli/CLIcore.md
+++ b/docs/cli/CLIcore.md
@@ -29,23 +29,31 @@ available:
 |--------|-------------|
 | `-h`, `--help` | Print help and exit |
 | `-i`, `--info` | Print version, settings, info and exit |
-| `-j`, `--journal` | Write all commands to `milk_cmdlog.txt` |
 | `--verbose` | Be verbose |
 | `-d`, `--debug=LEVEL` | Set debug level at startup |
 | `-o`, `--overwrite` | Auto-overwrite FITS files (**use with caution**) |
-| `-l` | Write image list to `imlist.txt` |
+| `-e`, `--errorexit` | Exit on command error |
+| `-l`, `--listimf` | Write image list to `imlist.txt` |
 | `-m`, `--mmon=TTY` | Open memory monitor on tty device |
 | `-n`, `--pname=NAME` | Rename process |
 | `-p`, `--priority=PR` | Set RT priority (0–99, higher = higher) |
-| `-f`, `--fifo=FIFO` | Specify fifo name |
-| `-s`, `--startup=FILE` | Execute script on startup (requires `-f`) |
+| `-f`, `--fifoflag` | Enable fifo input; auto-generate fifo path |
+| `-F`, `--fifoname=PATH` | Enable fifo input; use custom fifo path |
+| `-s`, `--startup=FILE` | Feed startup file into fifo (requires `-f` or `-F`) |
+| `-A`, `--autocomplete` | Enable autocomplete preview |
+| `--no-autocomplete` | Disable autocomplete |
+| `--no-history-suggest` | Disable ghost history suggestions |
+| `--no-arg-hints` | Disable argument hint bar |
+| `--no-fuzzy` | Disable fuzzy matching in completions |
 
 **Examples:**
 
 ```bash
-$ milk-cli -m /dev/tty2       # memory monitor
-$ milk-cli -p 90              # high priority
-$ milk-cli -f /tmp/fifo24     # custom fifo
+$ milk-cli -m /dev/tty2            # memory monitor on tty2
+$ milk-cli -p 90                   # high RT priority
+$ milk-cli -f                      # enable fifo (auto-named)
+$ milk-cli -F /tmp/myfifo          # enable fifo, custom path
+$ milk-cli -F /tmp/myfifo -s init.milk  # fifo + startup script
 ```
 
 ## 2. Syntax Rules and Parser
@@ -101,7 +109,62 @@ The CLI also reads commands from `cmdfile.txt` if it exists,
 executing them top-to-bottom and removing each line as it
 is read.
 
-## 7. Help Commands
+## 7. FIFO Input Mode
+
+The CLI can receive commands from a named pipe (FIFO) in
+addition to interactive keyboard input. This allows
+external processes to send commands to a running
+`milk-cli` session.
+
+### Enabling FIFO mode
+
+| Flag | Effect |
+|------|--------|
+| `-f` / `--fifoflag` | Enable fifo; path auto-generated |
+| `-F PATH` / `--fifoname=PATH` | Enable fifo; use `PATH` as fifo file |
+
+The auto-generated path follows the template:
+
+```text
+$SHMDIR/.<processname>.fifo.<PID>
+```
+
+For example, with default settings and PID 12345:
+
+```text
+/dev/shm/.1740801234p12345.fifo.0012345
+```
+
+Use `-n NAME` together with `-f` to produce a friendlier
+path:
+
+```bash
+$ milk-cli -n myctl -f   # /dev/shm/.myctl.fifo.<PID>
+```
+
+### Sending commands to a running session
+
+From a separate shell, write newline-terminated commands
+to the fifo:
+
+```bash
+$ echo "mem.listim" > /dev/shm/.myctl.fifo.0012345
+```
+
+The CLI processes one line per select iteration and
+returns to interactive input once the pipe is drained.
+
+### Startup script via fifo
+
+Use `-s FILE` together with `-f` or `-F` to pre-load a
+startup script. The file content is piped into the fifo
+before accepting interactive input:
+
+```bash
+$ milk-cli -n myctl -F /tmp/myfifo -s setup.milk
+```
+
+## 8. Help Commands
 
 ```text
 milk-cli > ?                       # print help
@@ -119,7 +182,7 @@ Command names and descriptions are color-coded: cyan for
 command names, green for descriptions, yellow for examples,
 dim for source file paths.
 
-## 8. Important Commands
+## 9. Important Commands
 
 ```text
 milk-cli > ci                      # compilation info & memory usage
@@ -135,7 +198,7 @@ milk-cli > cd <dir>                # change current working directory
 milk-cli > pwd                     # print current working directory
 ```
 
-## 9. FITS File I/O
+## 10. FITS File I/O
 
 FITSIO is used for FITS file I/O. Requires `USE_CFITSIO=ON`.
 See [Build Tiers](../install/build_tiers.md).
@@ -148,7 +211,7 @@ milk-cli > iofits.save_fl im1 imf1.fits        # save as float
 milk-cli > iofits.save_fl im1 "!im1.fits"      # overwrite existing file
 ```
 
-## 10. Persistent History
+## 11. Persistent History
 
 Command history is saved to `~/.milk_history` and loaded
 at startup. Up to 1000 entries are retained between
@@ -162,7 +225,7 @@ milk-cli > history 50           # show last 50 commands
 Use `Ctrl+R` for interactive reverse search through
 history.
 
-## 11. History Expansion
+## 12. History Expansion
 
 | Shortcut | Description |
 |----------|-------------|
@@ -180,7 +243,7 @@ milk-cli > !!                   # re-runs: iofits.loadfits im1.fits im1
 milk-cli > iofits.save_fl !$    # expands to: iofits.save_fl im1
 ```
 
-## 12. Fuzzy History Search
+## 13. Fuzzy History Search
 
 ```text
 milk-cli > searchhist mem.listim
@@ -190,7 +253,7 @@ Finds all history entries containing "mem.listim" (case-
 insensitive) and highlights the matching substring in
 yellow. Shows match count at the end.
 
-## 13. Startup Script
+## 14. Startup Script
 
 Commands in `~/.milkrc` are executed line-by-line on
 startup. Blank lines and `#` comments are skipped.
@@ -201,7 +264,7 @@ alias li mem.listim
 synhl on
 ```
 
-## 14. Script Execution
+## 15. Script Execution
 
 ```text
 milk-cli > source myscript.milk  # run commands from file
@@ -229,7 +292,7 @@ iofits.saveFITS im1 ${HOME}/im1_test.fits
 mem.listim
 ```
 
-## 15. Command Timing
+## 16. Command Timing
 
 ```text
 milk-cli > time mem.listim      # measure execution time
@@ -238,7 +301,7 @@ milk-cli > time mem.listim      # measure execution time
 Prints the elapsed wall-clock time after the command
 completes.
 
-## 16. Command Chaining
+## 17. Command Chaining
 
 Sequential, conditional, and unconditional chaining:
 
@@ -251,7 +314,7 @@ milk-cli > cmd1 || cmd2        # run cmd2 only if cmd1 fails
 Operators inside double-quoted strings are not treated as
 chain separators.
 
-## 17. Pipe to Shell
+## 18. Pipe to Shell
 
 Pipe a CLI command's output to a standard shell command:
 
@@ -260,7 +323,7 @@ milk-cli > mem.listim | grep wfs     # filter image list
 milk-cli > cmd? | head -5            # show first 5 help lines
 ```
 
-## 18. Output Redirect
+## 19. Output Redirect
 
 Redirect command output to a file:
 
@@ -268,7 +331,7 @@ Redirect command output to a file:
 milk-cli > mem.listim > imlist.txt  # write image list to file
 ```
 
-## 19. Environment Variable Expansion
+## 20. Environment Variable Expansion
 
 `$VAR` and `${VAR}` are expanded before execution:
 
@@ -277,7 +340,7 @@ milk-cli > iofits.loadfits ${HOME}/data/im.fits im1
 milk-cli > iofits.saveFITS im1 $OUTDIR/result.fits
 ```
 
-## 20. Command Substitution
+## 21. Command Substitution
 
 Replace `$(cmd)` or `` `cmd` `` in the command line with the standard
 output of the command execution.
@@ -287,7 +350,7 @@ milk-cli > cd $(echo /tmp)
 milk-cli > iofits.loadfits `findim.sh` result
 ```
 
-## 21. Wildcard Expansion (Globbing)
+## 22. Wildcard Expansion (Globbing)
 
 File path wildcards like `*`, `?`, and `[]` are automatically
 expanded into matching files if placed unquoted in arguments.
@@ -296,7 +359,7 @@ expanded into matching files if placed unquoted in arguments.
 milk-cli > iofits.imgs2cube *.fits cube.fits
 ```
 
-## 22. Backslash Line Continuation
+## 23. Backslash Line Continuation
 
 End a line with `\` to continue on the next line. The
 prompt changes to `>` for continuation lines:
@@ -306,7 +369,7 @@ milk-cli > arith.imfunc \
 >   im1 im2 outim
 ```
 
-## 21. Syntax Highlighting
+## 24. Syntax Highlighting
 
 The first word is colored **green** (valid command) or
 **red** (unknown). Toggle with:
@@ -320,7 +383,7 @@ milk-cli > synhl on              # enable (default)
 > If you encounter rendering issues with syntax
 > highlighting, disable it with `synhl off`.
 
-## 22. Auto-Correction
+## 25. Auto-Correction
 
 When a command is not found, the CLI suggests the closest
 match using Levenshtein distance:
@@ -330,7 +393,7 @@ milk-cli > mem.lisim
 Command 'mem.lisim' not found. Did you mean 'mem.listim'?
 ```
 
-## 23. Command Statistics
+## 26. Command Statistics
 
 ```text
 milk-cli > cmdstats              # top 20 most-used commands
@@ -338,7 +401,7 @@ milk-cli > cmdstats              # top 20 most-used commands
 
 Shows command name and call count for the current session.
 
-## 24. Configurable Prompt
+## 27. Configurable Prompt
 
 Customize the prompt format using `setprompt`:
 
@@ -355,7 +418,7 @@ user@host src >
 | `%t` | HH:MM:SS |
 | `%n` | process name |
 
-## 25. Command Aliases
+## 28. Command Aliases
 
 ```text
 milk-cli > alias li mem.listim   # create alias
@@ -365,7 +428,7 @@ milk-cli > aliases               # list all aliases
 
 Aliases persist in `~/.milk_aliases`.
 
-## 26. Command Bookmarks
+## 29. Command Bookmarks
 
 Save and recall multi-command sequences:
 
@@ -378,7 +441,7 @@ milk-cli > bookmark rm setup
 
 Bookmarks persist in `~/.milk_bookmarks`.
 
-## 27. Session Logging
+## 30. Session Logging
 
 Log all executed commands with timestamps:
 
@@ -391,7 +454,7 @@ milk-cli > sessionlog off         # stop logging
 Each entry includes a timestamp and elapsed time since
 the session started.
 
-## 28. Watch Command
+## 31. Watch Command
 
 ```text
 milk-cli > watch 1000 mem.listim   # repeat every 1000ms
@@ -399,7 +462,7 @@ milk-cli > watch 1000 mem.listim   # repeat every 1000ms
 
 Press any key to stop the repeating execution.
 
-## 29. Arithmetic Operations
+## 32. Arithmetic Operations
 
 Expressions not matching any command are evaluated as
 image arithmetic:
@@ -408,7 +471,7 @@ image arithmetic:
 milk-cli > im1=sqrt(im+2.0)       # arithmetic on images
 ```
 
-## 30. Module Loading
+## 33. Module Loading
 
 Load shared library modules at runtime:
 
@@ -417,7 +480,7 @@ milk-cli > soload mylib.so         # load shared object
 milk-cli > mload COREMOD_arith     # load module by name
 ```
 
-## 31. Integration with Standard Linux Tools
+## 34. Integration with Standard Linux Tools
 
 ### Using `cmdfile.txt` to drive milk-cli
 

--- a/docs/fps.md
+++ b/docs/fps.md
@@ -103,37 +103,45 @@ Then run `milk-fpsmkcmd` to automatically generate startup scripts for initializ
 
 The primary TUI control tool is `milk-fpsCTRL`. For example, `milk-fpsCTRL -m _ALL` scans and manages all FPS instances defined in `fpslist.txt`.
 
-## 4. Parameter Data Types
+## 4. Parameter Data Types and Flags
 
-FPS natively supports multiple parameter forms and configurations:
+=== "Data Types"
 
-- `ONOFF`: Booleans (0/1)
-- `INT`: Integer values
-- `FLOAT`: Floating-point measurements
-- `STRING`: Texts and paths
-- `TIMESPEC`: Specific timestamp mapping structures
-- `STREAMNAME`: Name of a shared memory stream
-- `FILENAME`: File path on disk
+    FPS natively supports the following parameter types:
 
-### 4.1. Common Parameter Flags
+    | Type | Description |
+    |------|-------------|
+    | `ONOFF` | Boolean (0/1) |
+    | `INT` | Integer value |
+    | `FLOAT` | Floating-point measurement |
+    | `STRING` | Text or path string |
+    | `TIMESPEC` | Timestamp structure |
+    | `STREAMNAME` | Name of a SHM stream |
+    | `FILENAME` | File path on disk |
 
-When creating parameters, you can apply flags to configure their behavior and GUI visibility:
+=== "Flags"
 
-- `FPFLAG_DEFAULT_INPUT`: Standard interactive input
-  parameter (combines `FPFLAG_ACTIVE`,
-  `FPFLAG_USED`, `FPFLAG_VISIBLE`, `FPFLAG_WRITE`,
-  `FPFLAG_WRITECONF`, `FPFLAG_SAVEONCHANGE`,
-  `FPFLAG_FEEDBACK`, `FPFLAG_WRITESTATUS`).
-- `FPFLAG_CLI_INPUT`: Typically combined with default
-  input.
-- `FPFLAG_MINLIMIT` / `FPFLAG_MAXLIMIT`: Enforces
-  min/max boundaries on the parameter.
+    Flags control parameter behavior and TUI visibility:
 
-For a module developer, integrating with FPS generally
-entails filling out `FPS_APP_INFO` to register an
-identity, defining `FPS_PARAMS` with an X-macro to bind
-shared memory to local C references, and wrapping the
-core math inside `fpsexec()`.
+    | Flag | Effect |
+    |------|--------|
+    | `FPFLAG_DEFAULT_INPUT` | Standard interactive input (combines ACTIVE, USED, VISIBLE, WRITE, WRITECONF, SAVEONCHANGE, FEEDBACK, WRITESTATUS) |
+    | `FPFLAG_CLI_INPUT` | Typically combined with default input |
+    | `FPFLAG_MINLIMIT` | Enforce minimum boundary |
+    | `FPFLAG_MAXLIMIT` | Enforce maximum boundary |
+
+=== "Developer Integration"
+
+    Integrating with FPS entails three steps:
+
+    1. Fill out `FPS_APP_INFO` to register an identity
+       (SHM name, CLI keyword, description).
+    2. Define `FPS_PARAMS` with an X-macro to bind shared
+       memory to local C variables.
+    3. Wrap the core computation inside `fpsexec()`.
+
+    See the [Developer Tutorial](developer/tutorial.md) for
+    a step-by-step walkthrough.
 
 
 ---

--- a/docs/includes/abbreviations.md
+++ b/docs/includes/abbreviations.md
@@ -1,0 +1,13 @@
+*[FPS]: Function Processing System — shared-memory parameter management
+*[SHM]: Shared Memory (/dev/shm)
+*[AO]: Adaptive Optics
+*[TUI]: Text User Interface (ncurses-based)
+*[CLI]: Command Line Interface
+*[IMGID]: Image ID — milk's stream reference structure
+*[LTO]: Link-Time Optimization
+*[PGO]: Profile-Guided Optimization
+*[RT]: Real-Time (scheduling)
+*[DM]: Deformable Mirror
+*[WFS]: Wavefront Sensor
+*[FITS]: Flexible Image Transport System
+*[IPC]: Inter-Process Communication

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,63 +1,191 @@
-# Milk Documentation
+# milk Documentation
 
-Welcome to the `milk` documentation!
+Welcome to the `milk` documentation — a high-performance
+real-time image processing framework for Adaptive Optics
+and scientific computing.
 
-`milk` provides a high-performance framework and tools for image processing and analysis, particularly suited for building real-time execution pipelines (such as Adaptive Optics loops) out of small modular units. The framework provides zero-copy tensor passing and instant parameter synchronization.
+`milk` orchestrates many small compute units that
+communicate through zero-copy shared memory tensors,
+enabling microsecond-latency data pipelines. The three
+pillars — **ImageStreamIO**, **FPS**, and
+**processinfo** — live entirely in `/dev/shm/`.
 
-## 🚀 Getting Started
+---
 
-If you are new to the `milk` environment, follow these steps:
+## :rocket: Getting Started
 
-1. [**Install milk**](install/compile.md) — clone, build, and configure.
-2. [**CLI Overview**](cli/CLI_Overview.md) — understand `milk-cli` and standalone executables.
-3. [**Shared Memory Streams**](streams.md) — core concept: zero-copy image passing.
-4. [**Function Processing System (FPS)**](fps.md) — core concept: process parameters and configuration.
-5. [**Developer Tutorial**](developer/tutorial.md) — write your first compute module.
+<div class="grid cards" markdown>
 
-## 🏛️ Core Architecture
+-   :material-download-circle:{ .lg .middle } **Install**
 
-For a deep dive into how `milk` components interact at a system level, these documents explain the underlying structures.
+    ---
 
-- [**Software Architecture**](architecture.md): Top-level hierarchical overview of the system design, subsystems, and data flow.
-- [**Programmer's Guide**](programmers_guide.md): The best starting point to understand the overall architecture, C API, and CMake setup.
-- [**Dependency Graph**](dependency_graph.md): Visual map of module dependencies.
-- [**FPS Standalone and CMD Modes**](FPS_Standalone_CMD_Modes.md): Execution context details for `milk-fpsexec-*` binaries.
-- [**Process Info (`procinfo`)**](procinfo.md): Telemetry, heartbeat monitoring, and profiling.
-- [**Debugging**](debugging.md): GDB, procinfo diagnostics, tmux log inspection, common failure patterns.
-- [**Performance Tuning**](performance.md): CPU pinning, RT scheduling, shared memory, GPU acceleration.
-- [**PGO & LTO Optimization**](pgo.md): Profile-guided optimization + static LTO for 15–40% speedup.
+    Clone, build, and configure the milk framework.
 
-## 🛠️ Developer Guides
+    [:octicons-arrow-right-24: Installation](install/compile.md)
 
-Guidelines and tutorials for writing your own compute modules or extending the CLI framework.
+-   :material-layers-outline:{ .lg .middle } **Build Tiers**
 
-- [**Coding Standards**](developer/coding_standards.md): C coding conventions for `milk`.
-- [**Adding Plugins**](developer/plugins.md): How to build modules that compile alongside the core.
-- [**Template Source Code**](developer/TemplateSourceCode.md): Breakdown of the example C module.
-- [**Loading Custom Modules**](developer/LoadingModules.md): Linking `.so` modules at runtime.
-- [**Working With Git**](developer/WorkingWithGit.md): Branching and commit workflow.
-- [**Documenting Code**](developer/DocumentingCode.md): In-code documentation standards.
-- [**Developer Tutorial**](developer/tutorial.md): Step-by-step guide to writing your first module.
-- [**Module Files Layout**](developer/ModuleFiles.md): Directory structure conventions.
-- [**Python API**](python.md): Accessing streams from Python with `pyMilk` and numpy.
-- [**Valkey Integration**](valkey.md): Multi-host FPS parameter sync via Valkey.
-- [**Code Assist Tools**](code_assist.md): Agent rules and workflows for AI-assisted development.
+    ---
 
-## 📖 CLI & Tools Reference
+    Engine → Core → Full: compile only what you need.
 
-- [**CLI Core Syntax**](cli/CLIcore.md): Argument parsing and command invocation rules.
-- [**Readline Keys**](cli/helpreadline.md): Keyboard shortcuts inside the `milk` shell.
-- [**Scripts Reference**](scripts.md): All `milk-*` shell scripts and utilities.
-- [**Help Text**](cli/help.txt): Built-in help text reference.
-- [**FAQ & Troubleshooting**](faq.md): Common issues and solutions.
-- [**Automatically Generated Index**](Markdown_Index.md): Complete list of all Markdown files in the repository.
+    [:octicons-arrow-right-24: Build tiers](install/build_tiers.md)
 
-## 🔬 API Reference
+-   :material-console:{ .lg .middle } **CLI Overview**
 
-- [**Doxygen API Docs**](api/html/index.html): Auto-generated C API reference with call graphs and source browser.
+    ---
 
-***
-*Can't find what you're looking for? Check the [Automatically Generated Document Index](Markdown_Index.md) for all plugin READMEs.*
+    Interactive shell, standalone executables, and
+    scripting basics.
 
-***
-← [Documentation Index](index.md)
+    [:octicons-arrow-right-24: CLI overview](cli/CLI_Overview.md)
+
+-   :material-help-circle-outline:{ .lg .middle } **FAQ**
+
+    ---
+
+    Common issues with builds, SHM, FPS, and CLI.
+
+    [:octicons-arrow-right-24: FAQ & Troubleshooting](faq.md)
+
+</div>
+
+---
+
+## :classical_building: Core Concepts
+
+<div class="grid cards" markdown>
+
+-   :material-memory:{ .lg .middle } **Streams**
+
+    ---
+
+    Zero-copy shared memory tensors (`ImageStreamIO`).
+
+    [:octicons-arrow-right-24: Streams](streams.md)
+
+-   :material-tune-variant:{ .lg .middle } **FPS**
+
+    ---
+
+    Live parameter sync, state control, TUI dashboards.
+
+    [:octicons-arrow-right-24: FPS](fps.md)
+
+-   :material-heart-pulse:{ .lg .middle } **Process Info**
+
+    ---
+
+    Heartbeat telemetry, loop-rate profiling, health
+    monitoring.
+
+    [:octicons-arrow-right-24: Process Info](procinfo.md)
+
+-   :material-sitemap-outline:{ .lg .middle } **Architecture**
+
+    ---
+
+    System overview, layered design, data flow diagrams.
+
+    [:octicons-arrow-right-24: Architecture](architecture.md)
+
+</div>
+
+---
+
+## :hammer_and_wrench: Developer Guides
+
+<div class="grid cards" markdown>
+
+-   :material-school-outline:{ .lg .middle } **Tutorial**
+
+    ---
+
+    Write your first compute module step by step.
+
+    [:octicons-arrow-right-24: Tutorial](developer/tutorial.md)
+
+-   :material-code-braces:{ .lg .middle } **Coding Standards**
+
+    ---
+
+    C style, line length, includes, Kernel-Doc.
+
+    [:octicons-arrow-right-24: Coding standards](developer/coding_standards.md)
+
+-   :material-puzzle-outline:{ .lg .middle } **Adding Plugins**
+
+    ---
+
+    Build modules that compile alongside the core.
+
+    [:octicons-arrow-right-24: Plugins](developer/plugins.md)
+
+-   :material-file-tree-outline:{ .lg .middle } **Template Code**
+
+    ---
+
+    Breakdown of `milk_module_example`.
+
+    [:octicons-arrow-right-24: Template source](developer/TemplateSourceCode.md)
+
+</div>
+
+---
+
+## :bar_chart: Operations & Reference
+
+<div class="grid cards" markdown>
+
+-   :material-speedometer:{ .lg .middle } **Performance**
+
+    ---
+
+    CPU pinning, RT scheduling, SIMD, BLAS, GPU.
+
+    [:octicons-arrow-right-24: Performance](performance.md)
+
+-   :material-chart-line:{ .lg .middle } **PGO & LTO**
+
+    ---
+
+    Profile-guided optimization + static link-time
+    optimization for 15–40 % speedup.
+
+    [:octicons-arrow-right-24: PGO & LTO](pgo.md)
+
+-   :material-bug-outline:{ .lg .middle } **Debugging**
+
+    ---
+
+    GDB, tmux logs, procinfo diagnostics, common
+    failures.
+
+    [:octicons-arrow-right-24: Debugging](debugging.md)
+
+-   :material-api:{ .lg .middle } **API Reference**
+
+    ---
+
+    Auto-generated Doxygen C API docs with call graphs.
+
+    [:octicons-arrow-right-24: Doxygen API](api/html/index.html)
+
+</div>
+
+---
+
+## :link: More Resources
+
+- [CLI Syntax Reference](cli/CLIcore.md) ·
+  [Readline Keys](cli/helpreadline.md)
+- [Scripts Reference](scripts.md) ·
+  [Python API](python.md) ·
+  [Valkey Integration](valkey.md)
+- [Programmer's Guide](programmers_guide.md) ·
+  [Dependency Graph](dependency_graph.md)
+- [Working with Git](developer/WorkingWithGit.md) ·
+  [Code Assist Tools](code_assist.md)
+- [All Markdown Files](Markdown_Index.md) ·
+  [Tag Index](tags.md)

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -99,77 +99,83 @@ images and streams. This structure is one level above
 the preferred way to pass images and streams as function
 arguments.
 
-### 5.1. Creating an `IMGID`
+=== "Create"
 
-Creating a blank `IMGID` (this does not allocate memory yet):
+    Creating a blank `IMGID` (does not allocate memory yet):
 
-```c
-static inline IMGID imgid_make()
-```
+    ```c
+    static inline IMGID imgid_make()
+    ```
 
-Creating an `IMGID` with a name:
+    Creating an `IMGID` with a name:
 
-```c
-static inline IMGID imgid_make_from_name(CONST_WORD name)
-```
+    ```c
+    static inline IMGID imgid_make_from_name(
+        CONST_WORD name
+    )
+    ```
 
-*(Special characters like `s>tf32>im1` can also be used to automatically set type and location properties).*
+    Creating a new stream in shared memory:
 
-### 5.2. Connecting to a stream
+    ```c
+    IMGID img = imgid_make_from_name("im1");
+    img.naxis = 2;
+    img.size[0] = 128;
+    img.size[1] = 128;
+    img.shared = 1; // 1 = SHM, 0 = local
 
-If you expect the stream to already exist, you can connect to it:
+    imgid_mkimage(&img);
 
-```c
-IMGID img1 = imgid_make();
-// imgid_connect returns quickly. Check if img1.ID != -1
-imgid_connect("streamname1", &img1, 0);
-if(img1.ID == -1) {
-	// handle failure securely
-}
-```
+    // When done:
+    imgid_free(&img);
+    ```
 
-### 5.3. Creating an image in shared memory
+=== "Connect"
 
-To create a new stream:
+    Connect to an existing stream:
 
-```c
-IMGID img = imgid_make_from_name("im1");
-img.naxis = 2;
-img.size[0] = 128;
-img.size[1] = 128;
-img.shared = 1; // 1 for shared memory stream, 0 for local memory
+    ```c
+    IMGID img1 = imgid_make();
+    imgid_connect("streamname1", &img1, 0);
+    if (img1.ID == -1) {
+        // handle failure
+    }
+    ```
 
-// Allocate memory and initialize stream headers
-imgid_mkimage(&img);
+    Special name syntax like `s>tf32>im1` can also be
+    used to automatically set type and location
+    properties.
 
-// When done parsing or exiting
-imgid_free(&img);
-```
+=== "Format-checked"
 
-### 5.4. Creating or connecting with format checks
+    Ensure the stream has specific dimensions, or create it
+    if it doesn't match:
 
-Often, you want to ensure the stream has specific dimensions and types before using it, or create it if it doesn't match:
+    ```c
+    IMGID img1 = imgid_make();
+    img1.naxis = 2;
+    img1.size[0] = 128;
+    img1.size[1] = 128;
 
-```c
-IMGID img1 = imgid_make();
-img1.naxis = 2;
-img1.size[0] = 128;
-img1.size[1] = 128;
+    // Create if format is wrong or doesn't exist
+    imgid_connect("streamname1", &img1,
+        IMGID_CONNECT_CHECK_CREATE);
+    ```
 
-// IMGID_CONNECT_CHECK_CREATE will create it if the format is wrong or it doesn't exist
-// IMGID_CONNECT_CHECK_FAIL will fail the connection if the format is wrong
-imgid_connect("streamname1", &img1, IMGID_CONNECT_CHECK_CREATE);
-```
+    Typed convenience function:
 
-For convenience, specialized typed functions are available:
-
-```c
-// Force connection/creation of a 2D float32 array
-imgid_connect_create_2Df32("streamname1", &img1, xsize, ysize);
-```
+    ```c
+    // Force 2D float32 creation/connection
+    imgid_connect_create_2Df32(
+        "streamname1", &img1, xsize, ysize
+    );
+    ```
 
 > [!TIP]
-> Functions should prefer passing parameters using `IMGID` pointers and accessing pixels through `img.im->array.F` or similar data type unions based on `img.im->md[0].datatype`.
+> Functions should prefer passing parameters using
+> `IMGID` pointers and accessing pixels through
+> `img.im->array.F` or similar data type unions based
+> on `img.im->md[0].datatype`.
 
 ---
 ← [Documentation Index](index.md)

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -5,4 +5,4 @@ search:
 
 # Tags
 
-[TAGS]
+<!-- material/tags -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ site_description: >-
   for Adaptive Optics and scientific computing.
 repo_url: https://github.com/milk-org/milk
 repo_name: milk-org/milk
+edit_uri: edit/framework-dev/docs/
 
 theme:
   name: material
@@ -34,6 +35,8 @@ theme:
     - navigation.instant
     - navigation.instant.progress
     - navigation.path
+    - navigation.indexes
+    - navigation.footer
     # Search
     - search.suggest
     - search.highlight
@@ -42,14 +45,25 @@ theme:
     - content.code.copy
     - content.code.annotate
     - content.tabs.link
+    - content.tooltips
+    - content.action.edit
+    - content.action.view
     # TOC
     - toc.follow
   icon:
     repo: fontawesome/brands/github
+    edit: material/pencil
+    view: material/eye
 
 plugins:
   - search
   - tags
+  - glightbox
+  - git-revision-date-localized:
+      enable_creation_date: true
+      type: timeago
+  - minify:
+      minify_html: true
 
 docs_dir: docs
 
@@ -92,8 +106,12 @@ nav:
   - API Reference: api/html/index.html
 
 markdown_extensions:
+  - abbr
   - admonition
+  - attr_list
+  - def_list
   - md_in_html
+  - tables
   - pymdownx.details
   - pymdownx.superfences:
       custom_fences:
@@ -110,10 +128,12 @@ markdown_extensions:
       slugify: !!python/object/apply:pymdownx.slugs.slugify
         kwds:
           case: lower
-  - pymdownx.snippets
-  - attr_list
-  - def_list
-  - tables
+  - pymdownx.snippets:
+      auto_append:
+        - docs/includes/abbreviations.md
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - toc:
       permalink: true
       toc_depth: 3


### PR DESCRIPTION
## Summary

Fix the tags index page which was showing no tags.

### Root cause

`docs/tags.md` used the old `[TAGS]` syntax which is not recognized by MkDocs Material 9.x. The correct marker is `<!-- material/tags -->`.

### Changes

- **`docs/tags.md`**: Replace `[TAGS]` with `<!-- material/tags -->`

### Verification

- Local preview at `/milk/tags/` now shows all tags with their linked pages
- `mkdocs build` succeeds with no new warnings
