### PR TITLE
ci: fix docs deployment — install missing MkDocs plugins

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,7 @@ on:
       - main
       - master
       - dev
+      - framework-dev
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
@@ -36,21 +37,28 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
-      - name: Install MkDocs Material
-        run: pip install "mkdocs-material[plugins]"
+      - name: Install MkDocs Material and plugins
+        run: |
+          pip install "mkdocs-material[plugins]" \
+            mkdocs-glightbox \
+            mkdocs-git-revision-date-localized-plugin \
+            mkdocs-minify-plugin
 
       - name: Build MkDocs site
+        id: build_strict
         run: mkdocs build --strict -d _site
         continue-on-error: true
 
       - name: Build MkDocs site (lenient)
-        if: failure()
+        if: steps.build_strict.outcome == 'failure'
         run: mkdocs build -d _site
 
       - name: Install Doxygen


### PR DESCRIPTION
## Problem

Tags are not appearing on https://milk-org.github.io/milk/tags/ — the page shows raw `[TAGS]` text instead of the tag index.

## Root Cause

The docs deployment workflow (`docs.yml`) was failing silently because:

1. **Missing plugin installs**: `mkdocs.yml` references `glightbox`, `git-revision-date-localized`, and `minify` plugins (added in PR #95), but the workflow only installed `mkdocs-material[plugins]`. The build would fail because these packages were missing.

2. **Broken fallback logic**: The strict→lenient fallback didn't work. `continue-on-error: true` sets the step outcome to "success" even on failure, so `if: failure()` (which checks the *job* status) never triggered the lenient build.

3. **Shallow checkout**: The `git-revision-date-localized` plugin needs full git history to show "last updated" timestamps, but the checkout used the default depth of 1.

Even though PR #96 correctly fixed the `tags.md` marker to `<!-- material/tags -->`, the deployment couldn't run because the build kept failing.

## Fix

- **Install missing plugins**: `mkdocs-glightbox`, `mkdocs-git-revision-date-localized-plugin`, `mkdocs-minify-plugin`
- **Full clone**: `fetch-depth: 0` for git history access
- **Fix fallback**: Use `steps.build_strict.outcome == 'failure'` instead of `failure()`
- **Add `framework-dev`** to `pull_request` trigger branches for CI validation