### PR TITLE
feat(cli): add savescript, savehistory, dot-sourcing & scripting docs

### DIFF
--- a/docs/cli/CLIcore.md
+++ b/docs/cli/CLIcore.md
@@ -268,28 +268,32 @@ synhl on
 
 ```text
 milk-cli > source myscript.milk  # run commands from file
+milk-cli > . myscript.milk       # same thing (dot-source)
 ```
 
 Blank lines and `#` comments are skipped. On error, the
 filename and line number are printed in red.
 
+The CLI supports bash-like scripting constructs including
+variables, arithmetic, flow control (`if`/`while`/`for`),
+and user-defined functions. See the
+[Scripting](scripting.md) page for full documentation.
+
+| Command | Description |
+|---------|-------------|
+| `source <file>` | Execute a script file |
+| `. <file>` | Same as `source` (dot-source) |
+| `savescript <file>` | Save variables and functions to file |
+| `savehistory <file>` | Save command history to file |
+
 **Example `myscript.milk`:**
 
 ```bash
 # This is a sample milk script
-!echo "Starting image processing..."
-
-# Create a 100x100 image named 'myimg'
-mem.mk2Dim myimg 100 100
-
-# Perform some basic arithmetic
-im1=myimg+5.0
-
-# Save to FITS using an environment variable
-iofits.saveFITS im1 ${HOME}/im1_test.fits
-
-# Print current images in memory
-mem.listim
+x=10
+if [ $x -gt 5 ]; then
+    echo x is big
+fi
 ```
 
 ## 16. Command Timing

--- a/docs/cli/scripting.md
+++ b/docs/cli/scripting.md
@@ -1,0 +1,271 @@
+---
+tags:
+  - cli
+  - scripting
+---
+
+# Scripting
+
+The `milk-cli` shell supports bash-like scripting
+constructs: variables, arithmetic, flow control,
+user-defined functions, and script files. This page
+documents the full scripting system.
+
+See also: [CLI Syntax](CLIcore.md) ·
+[FPS](../fps.md) · [Streams](../streams.md)
+
+## Variables
+
+### Setting and Reading
+
+```bash
+milk-cli > x=42
+milk-cli > name=hello
+milk-cli > echo $x          # prints: 42
+milk-cli > echo ${name}     # prints: hello
+```
+
+Variable names are case-sensitive and may contain
+letters, digits, and underscores. No spaces around `=`.
+
+### Listing and Removing
+
+```bash
+milk-cli > vars              # list all variables
+milk-cli > unset x           # remove variable x
+```
+
+### Special Variables
+
+| Variable | Description |
+|----------|-------------|
+| `$?` | Exit status of last command (0=success) |
+| `$HOME`, `$PATH`, … | Environment variables |
+
+### FPS Parameter Access
+
+Read FPS parameters using `@fpsname.param` syntax:
+
+```bash
+milk-cli > echo @myloop.loopgain      # read FPS param
+milk-cli > g=@myloop.loopgain         # store in variable
+```
+
+Write FPS parameters with `fpsset`:
+
+```bash
+milk-cli > fpsset myloop loopgain 0.5
+```
+
+## Arithmetic
+
+`$(( expr ))` evaluates integer arithmetic with
+`+`, `-`, `*`, `/`, `%` operators. Variables and FPS
+parameters are expanded inside the expression:
+
+```bash
+milk-cli > x=10
+milk-cli > y=$(( x + 5 ))        # y = 15
+milk-cli > z=$(( y * 2 - x ))    # z = 20
+milk-cli > echo $y $z            # prints: 15 20
+```
+
+## Flow Control
+
+### if / then / else / fi
+
+```bash
+milk-cli > x=10
+milk-cli > if [ $x -gt 5 ]; then
+milk-cli >     echo x is big
+milk-cli > else
+milk-cli >     echo x is small
+milk-cli > fi
+```
+
+The `[ ... ]` syntax supports these test operators:
+
+| Operator | Meaning |
+|----------|---------|
+| `-eq` | equal |
+| `-ne` | not equal |
+| `-gt` | greater than |
+| `-ge` | greater or equal |
+| `-lt` | less than |
+| `-le` | less or equal |
+| `=` | string equal |
+| `!=` | string not equal |
+
+### while / do / done
+
+```bash
+milk-cli > n=1
+milk-cli > while [ $n -le 5 ]; do
+milk-cli >     echo iteration $n
+milk-cli >     n=$(( n + 1 ))
+milk-cli > done
+```
+
+Use `break` to exit early:
+
+```bash
+milk-cli > n=0
+milk-cli > while [ $n -lt 100 ]; do
+milk-cli >     n=$(( n + 1 ))
+milk-cli >     if [ $n -eq 5 ]; then
+milk-cli >         break
+milk-cli >     fi
+milk-cli > done
+milk-cli > echo stopped at $n    # prints: stopped at 5
+```
+
+### for / do / done
+
+```bash
+milk-cli > for item in alpha beta gamma; do
+milk-cli >     echo processing $item
+milk-cli > done
+```
+
+For loops with arithmetic:
+
+```bash
+milk-cli > sum=0
+milk-cli > for val in 10 20 30; do
+milk-cli >     sum=$(( sum + val ))
+milk-cli > done
+milk-cli > echo total=$sum       # prints: total=60
+```
+
+### Nesting
+
+All flow control constructs can be nested:
+
+```bash
+milk-cli > n=0
+milk-cli > while [ $n -lt 3 ]; do
+milk-cli >     n=$(( n + 1 ))
+milk-cli >     if [ $n -eq 2 ]; then
+milk-cli >         echo found two
+milk-cli >     fi
+milk-cli >     echo n=$n
+milk-cli > done
+```
+
+## Functions
+
+Define reusable functions with `function name { ... }`.
+Inside the body, `$1` through `$9` are the call
+arguments:
+
+```bash
+milk-cli > function greet {
+milk-cli >     echo Hello $1
+milk-cli > }
+milk-cli > greet world           # prints: Hello world
+milk-cli > greet milk            # prints: Hello milk
+```
+
+Functions can contain flow control:
+
+```bash
+milk-cli > function classify {
+milk-cli >     if [ $1 -gt 100 ]; then
+milk-cli >         echo big
+milk-cli >     else
+milk-cli >         echo small
+milk-cli >     fi
+milk-cli > }
+milk-cli > classify 200          # prints: big
+milk-cli > classify 5            # prints: small
+```
+
+## Script Files
+
+### Running Scripts
+
+Use `source` (or the shorthand `.`) to execute a
+script file:
+
+```bash
+milk-cli > source myscript.milk
+milk-cli > . myscript.milk        # same thing
+```
+
+Blank lines and `#` comments are skipped. On error,
+the filename and line number are printed.
+
+### Saving State
+
+Export all current variables and function definitions
+to a file:
+
+```bash
+milk-cli > savescript state.milk
+```
+
+The saved file can be loaded later with `source`.
+
+### Saving History
+
+Write the readline command history to a file:
+
+```bash
+milk-cli > savehistory replay.milk
+```
+
+This creates a script that replays your interactive
+session.
+
+### Example Script
+
+```bash
+#!/usr/bin/env milk-cli -s
+# setup.milk — initialize processing pipeline
+
+# Configuration
+nframes=100
+gain=0.5
+
+# Create shared memory images
+mem.mk2Dim wfs 128 128
+mem.mk2Dim dm 32 32
+
+# Define a helper function
+function run_loop {
+    n=0
+    while [ $n -lt $nframes ]; do
+        n=$(( n + 1 ))
+        echo frame $n
+    done
+}
+
+# Execute
+run_loop
+echo "Processing complete"
+```
+
+### Script File Convention
+
+| Feature | Detail |
+|---------|--------|
+| Extension | `.milk` (by convention) |
+| Comments | Lines starting with `#` |
+| Shebang | `#!/usr/bin/env milk-cli -s` |
+| Startup | `-s FILE` flag on command line |
+
+## Command Reference
+
+| Command | Description |
+|---------|-------------|
+| `source <file>` | Execute a script file |
+| `. <file>` | Same as `source` |
+| `savescript <file>` | Save variables and functions |
+| `savehistory <file>` | Save command history |
+| `echo <args>` | Print arguments |
+| `vars` | List all variables |
+| `unset <var>` | Remove a variable |
+| `fpsset <fps> <param> <val>` | Write FPS parameter |
+
+---
+← [CLI Syntax](CLIcore.md) · [Documentation Index](../index.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
     - FPS: fps.md
     - Process Info: procinfo.md
     - CLI Syntax: cli/CLIcore.md
+    - Scripting: cli/scripting.md
     - Readline Keys: cli/helpreadline.md
     - Scripts: scripts.md
     - Python API: python.md

--- a/src/cli/CLIcore/CLIcore.c
+++ b/src/cli/CLIcore/CLIcore.c
@@ -1252,6 +1252,25 @@ void runCLI_cmd_init()
                        "cli_source()");
 
     RegisterCLIcommand(
+        "savescript",
+        __FILE__,
+        cli_savescript,
+        "save variables and functions "
+        "to a script file",
+        "<filename>",
+        "savescript state.milk",
+        "cli_savescript()");
+
+    RegisterCLIcommand(
+        "savehistory",
+        __FILE__,
+        cli_savehistory,
+        "save command history to a file",
+        "<filename>",
+        "savehistory cmds.milk",
+        "cli_savehistory()");
+
+    RegisterCLIcommand(
         "setprompt",
         __FILE__,
         cli_setprompt,
@@ -1340,6 +1359,15 @@ void runCLI_cmd_init()
         "",
         "vars",
         "cli_cmd_vars()");
+
+    RegisterCLIcommand(
+        "fpsset",
+        __FILE__,
+        cli_cmd_fpsset,
+        "set FPS parameter value",
+        "<fpsname.param> <value>",
+        "fpsset loopctrl.gain 0.3",
+        "cli_cmd_fpsset()");
 
     //  init_modules();
 

--- a/src/cli/CLIcore/CLIcore.c
+++ b/src/cli/CLIcore/CLIcore.c
@@ -62,6 +62,7 @@
 
 
 #include "CLIcore.h"
+#include "CLIcore_script.h"
 #include "streamCTRL/streamCTRL_TUI.h"
 
 //#include "initmodules.h"
@@ -1312,6 +1313,33 @@ void runCLI_cmd_init()
         "<fpsname>",
         "fparam cnt2push",
         "cli_fparam()");
+
+    RegisterCLIcommand(
+        "echo",
+        __FILE__,
+        cli_cmd_echo,
+        "print arguments",
+        "[-n] <args...>",
+        "echo hello world",
+        "cli_cmd_echo()");
+
+    RegisterCLIcommand(
+        "unset",
+        __FILE__,
+        cli_cmd_unset,
+        "remove a CLI variable",
+        "<varname>",
+        "unset myvar",
+        "cli_cmd_unset()");
+
+    RegisterCLIcommand(
+        "vars",
+        __FILE__,
+        cli_cmd_vars,
+        "list all CLI variables",
+        "",
+        "vars",
+        "cli_cmd_vars()");
 
     //  init_modules();
 

--- a/src/cli/CLIcore/CLIcore/CLIcore_UI.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI.c
@@ -20,6 +20,7 @@
 
 #include "CLIcore.h"
 #include "CLIcore/cli_calc_parser.h"
+#include "CLIcore_script.h"
 
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "timeutils.h"
@@ -2226,7 +2227,10 @@ static void cli_expand_cmdsub(
 
     while(line[i] != '\0' && opos < maxlen - 1)
     {
-        int is_dollar_paren = (line[i] == '$' && line[i + 1] == '(');
+        int is_dollar_paren =
+            (line[i] == '$'
+             && line[i + 1] == '('
+             && line[i + 2] != '(');
         int is_backtick = (line[i] == '`');
 
         if(is_dollar_paren || is_backtick)
@@ -2317,6 +2321,14 @@ static void cli_expand_env(
     {
         if(line[i] == '$')
         {
+            /* Skip $(( — arithmetic token,
+             * handled by cli_expand_arith */
+            if(line[i + 1] == '('
+               && line[i + 2] == '(')
+            {
+                out[opos++] = line[i++];
+                continue;
+            }
             i++;
             int  braced = 0;
             if(line[i] == '{')
@@ -2349,7 +2361,8 @@ static void cli_expand_env(
                 varname[vlen++] = line[i++];
             }
             varname[vlen] = '\0';
-            const char *val = getenv(varname);
+            const char *val =
+                cli_var_lookup(varname);
             if(val != NULL)
             {
                 int vallen = (int) strlen(val);
@@ -2554,12 +2567,31 @@ errno_t CLI_execute_line()
     /* Expand command substitution */
     cli_expand_cmdsub(data.CLIcmdline, STRINGMAXLEN_CLICMDLINE);
 
-    /* Expand environment variables ($VAR) */
+    /* Expand @fpsname.param tokens */
+    cli_expand_fpsvar(data.CLIcmdline,
+                      STRINGMAXLEN_CLICMDLINE);
+
+    /* Expand environment variables ($VAR).
+     * Runs before arith so $(( $n + 1 )) works.
+     * cli_expand_env skips $(( tokens. */
     cli_expand_env(data.CLIcmdline,
                    STRINGMAXLEN_CLICMDLINE);
 
+    /* Expand arithmetic $(( expr )) */
+    cli_expand_arith(data.CLIcmdline,
+                     STRINGMAXLEN_CLICMDLINE);
+
     /* Log command to session log if active */
     cli_session_log_cmd(data.CLIcmdline);
+
+    /* Check for variable assignment (VAR=val) */
+    if(cli_try_var_assign(data.CLIcmdline))
+    {
+        data.CMDexecuted = 1;
+        free(thetime);
+        DEBUG_TRACE_FEXIT();
+        return RETURN_SUCCESS;
+    }
 
     /*
      * ---- Command chaining: ; && || ----
@@ -2784,6 +2816,36 @@ errno_t CLI_execute_line()
     else if(data.CLIcmdline[0] == '#')
     {
         // do nothing... this is a comment
+        data.CMDexecuted = 1;
+    }
+    else if(strncmp(data.CLIcmdline,
+                    "echo ", 5) == 0
+            || strcmp(data.CLIcmdline,
+                      "echo") == 0)
+    {
+        /* Handle echo before tokenization
+         * to avoid image name resolution */
+        const char *args =
+            data.CLIcmdline + 4;
+        while(*args == ' ')
+        {
+            args++;
+        }
+        int nl = 1;
+        if(strncmp(args, "-n ", 3) == 0)
+        {
+            nl = 0;
+            args += 3;
+            while(*args == ' ')
+            {
+                args++;
+            }
+        }
+        printf("%s", args);
+        if(nl)
+        {
+            printf("\n");
+        }
         data.CMDexecuted = 1;
     }
     else

--- a/src/cli/CLIcore/CLIcore/CLIcore_UI.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI.c
@@ -1725,6 +1725,122 @@ errno_t cli_source(void)
 
 /*
  * ============================================================
+ *  Save Script — export variables and functions
+ * ============================================================
+ */
+
+/**
+ * @brief Write all CLI variables and user functions
+ *        to a file that can be sourced later.
+ *
+ * Usage: savescript <filename>
+ */
+errno_t cli_savescript(void)
+{
+    if(data.cmdNBarg < 2)
+    {
+        printf("Usage: savescript <filename>\n");
+        return RETURN_FAILURE;
+    }
+    const char *fname =
+        data.cmdargtoken[1].val.string;
+    FILE *fp = fopen(fname, "w");
+    if(fp == NULL)
+    {
+        printf("savescript: cannot open "
+               "'%s' for writing\n", fname);
+        return RETURN_FAILURE;
+    }
+
+    fprintf(fp, "# milk-cli script\n");
+    fprintf(fp,
+            "# saved by savescript command\n\n");
+
+    /* Export variables */
+    int nv = 0;
+    for(int i = 0; i < CLI_MAX_VARS; i++)
+    {
+        if(cli_vars[i].used)
+        {
+            fprintf(fp, "%s=%s\n",
+                    cli_vars[i].name,
+                    cli_vars[i].val);
+            nv++;
+        }
+    }
+    if(nv > 0)
+    {
+        fprintf(fp, "\n");
+    }
+
+    /* Export user-defined functions */
+    int nf = 0;
+    for(int i = 0; i < CLI_MAX_FUNCS; i++)
+    {
+        if(cli_funcs[i].used)
+        {
+            fprintf(fp, "function %s {\n",
+                    cli_funcs[i].name);
+            for(int j = 0;
+                j < cli_funcs[i].nbody; j++)
+            {
+                fprintf(fp, "%s\n",
+                        cli_funcs[i].body[j]);
+            }
+            fprintf(fp, "}\n\n");
+            nf++;
+        }
+    }
+
+    fclose(fp);
+    printf("Saved %d variables, %d functions "
+           "to '%s'\n", nv, nf, fname);
+    return RETURN_SUCCESS;
+}
+
+
+/*
+ * ============================================================
+ *  Save History — export readline history
+ * ============================================================
+ */
+
+/**
+ * @brief Write readline command history to a file.
+ *
+ * Usage: savehistory <filename>
+ */
+errno_t cli_savehistory(void)
+{
+    if(data.cmdNBarg < 2)
+    {
+        printf("Usage: savehistory "
+               "<filename>\n");
+        return RETURN_FAILURE;
+    }
+    const char *fname =
+        data.cmdargtoken[1].val.string;
+
+#ifdef USE_READLINE
+    if(write_history(fname) != 0)
+    {
+        printf("savehistory: failed to write "
+               "'%s'\n", fname);
+        return RETURN_FAILURE;
+    }
+    printf("History saved to '%s'\n", fname);
+    return RETURN_SUCCESS;
+#else
+    printf("savehistory: readline not "
+           "available\n");
+    (void) fname;
+    return RETURN_FAILURE;
+#endif
+}
+
+
+/*
+ * ============================================================
  *  Configurable Prompt — setprompt command
  * ============================================================
  *
@@ -2307,7 +2423,7 @@ static void cli_expand_cmdsub(
 /**
  * @brief Expand $VAR and ${VAR} in place
  */
-static void cli_expand_env(
+void cli_expand_env(
     char *line,
     int   maxlen
 )
@@ -2563,6 +2679,42 @@ errno_t CLI_execute_line()
 
     /* Expand aliases before anything else */
     cli_alias_expand();
+
+    /* Dot-sourcing: ". file" → "source file"
+     * Must check before script intercept */
+    {
+        const char *p = data.CLIcmdline;
+        while(*p == ' ' || *p == '\t')
+        {
+            p++;
+        }
+        if(p[0] == '.' && p[1] == ' ')
+        {
+            char tmp[STRINGMAXLEN_CLICMDLINE];
+            snprintf(tmp,
+                     STRINGMAXLEN_CLICMDLINE,
+                     "source %s", p + 2);
+            strncpy(data.CLIcmdline, tmp,
+                    STRINGMAXLEN_CLICMDLINE
+                    - 1);
+            data.CLIcmdline[
+                STRINGMAXLEN_CLICMDLINE
+                - 1] = '\0';
+        }
+    }
+
+    /* Flow control: if/while/for/function
+     * and user-defined function calls.
+     * Must run BEFORE expansion so block
+     * accumulator stores raw lines with
+     * $VAR unexpanded. */
+    if(cli_script_intercept(data.CLIcmdline))
+    {
+        data.CMDexecuted = 1;
+        free(thetime);
+        DEBUG_TRACE_FEXIT();
+        return RETURN_SUCCESS;
+    }
 
     /* Expand command substitution */
     cli_expand_cmdsub(data.CLIcmdline, STRINGMAXLEN_CLICMDLINE);
@@ -2845,6 +2997,98 @@ errno_t CLI_execute_line()
         if(nl)
         {
             printf("\n");
+        }
+        data.CMDexecuted = 1;
+    }
+    else if(strncmp(data.CLIcmdline,
+                    "source ", 7) == 0)
+    {
+        /* Handle before tokenization so
+         * file paths with dots are not
+         * misinterpreted by the parser */
+        const char *arg =
+            data.CLIcmdline + 7;
+        while(*arg == ' ' || *arg == '\t')
+        {
+            arg++;
+        }
+        if(*arg == '\0')
+        {
+            printf("Usage: source "
+                   "<filename>\n");
+        }
+        else
+        {
+            data.cmdNBarg = 2;
+            strncpy(
+                data.cmdargtoken[1]
+                .val.string,
+                arg,
+                sizeof(
+                    data.cmdargtoken[1]
+                    .val.string) - 1);
+            cli_source();
+        }
+        data.CMDexecuted = 1;
+    }
+    else if(strncmp(data.CLIcmdline,
+                    "savescript ", 11) == 0)
+    {
+        /* Handle before tokenization so
+         * file paths with dots etc. are
+         * not misinterpreted */
+        const char *arg =
+            data.CLIcmdline + 11;
+        while(*arg == ' ' || *arg == '\t')
+        {
+            arg++;
+        }
+        if(*arg == '\0')
+        {
+            printf("Usage: savescript "
+                   "<filename>\n");
+        }
+        else
+        {
+            /* Temporarily set cmdNBarg and
+             * token for cli_savescript() */
+            data.cmdNBarg = 2;
+            strncpy(
+                data.cmdargtoken[1]
+                .val.string,
+                arg,
+                sizeof(
+                    data.cmdargtoken[1]
+                    .val.string) - 1);
+            cli_savescript();
+        }
+        data.CMDexecuted = 1;
+    }
+    else if(strncmp(data.CLIcmdline,
+                    "savehistory ", 12) == 0)
+    {
+        const char *arg =
+            data.CLIcmdline + 12;
+        while(*arg == ' ' || *arg == '\t')
+        {
+            arg++;
+        }
+        if(*arg == '\0')
+        {
+            printf("Usage: savehistory "
+                   "<filename>\n");
+        }
+        else
+        {
+            data.cmdNBarg = 2;
+            strncpy(
+                data.cmdargtoken[1]
+                .val.string,
+                arg,
+                sizeof(
+                    data.cmdargtoken[1]
+                    .val.string) - 1);
+            cli_savehistory();
         }
         data.CMDexecuted = 1;
     }

--- a/src/cli/CLIcore/CLIcore/CLIcore_UI.h
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI.h
@@ -61,6 +61,12 @@ void cli_history_save(void);
 /* Script execution */
 errno_t cli_source(void);
 
+/* Script save */
+errno_t cli_savescript(void);
+
+/* History save */
+errno_t cli_savehistory(void);
+
 /* Configurable prompt */
 errno_t cli_setprompt(void);
 void cli_build_prompt(

--- a/src/cli/CLIcore/CLIcore/CLIcore_script.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_script.c
@@ -1,0 +1,731 @@
+/**
+ * @file CLIcore_script.c
+ * @brief CLI scripting engine — variables, FPS access,
+ *        arithmetic evaluation, flow control
+ *
+ * This module implements bash-style scripting constructs
+ * for the milk CLI: variable assignment (VAR=val),
+ * variable expansion ($VAR, ${VAR}, $?), FPS parameter
+ * read (@fpsname.param), and arithmetic $(( expr )).
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <math.h>
+
+#include "CLIcore.h"
+#include "CLIcore_script.h"
+
+/* ============================================================
+ *  CLI Variable Storage
+ * ============================================================
+ */
+
+CLI_VAR cli_vars[CLI_MAX_VARS];
+int     cli_last_retval = 0;
+
+/**
+ * @brief Look up a CLI variable by name
+ *
+ * @param name  Variable name
+ * @return pointer to value string, or NULL
+ */
+const char *cli_var_get(const char *name)
+{
+    for(int i = 0; i < CLI_MAX_VARS; i++)
+    {
+        if(cli_vars[i].used
+                && strcmp(cli_vars[i].name, name)
+                == 0)
+        {
+            return cli_vars[i].val;
+        }
+    }
+    return NULL;
+}
+
+/**
+ * @brief Set a CLI variable (create or update)
+ *
+ * @param name  Variable name
+ * @param val   Value string
+ */
+void cli_var_set(
+    const char *name,
+    const char *val
+)
+{
+    /* Update existing */
+    for(int i = 0; i < CLI_MAX_VARS; i++)
+    {
+        if(cli_vars[i].used
+                && strcmp(cli_vars[i].name, name)
+                == 0)
+        {
+            strncpy(cli_vars[i].val, val,
+                    CLI_VAR_VALLEN - 1);
+            cli_vars[i].val[
+                CLI_VAR_VALLEN - 1] = '\0';
+            return;
+        }
+    }
+    /* Find empty slot */
+    for(int i = 0; i < CLI_MAX_VARS; i++)
+    {
+        if(!cli_vars[i].used)
+        {
+            strncpy(cli_vars[i].name, name,
+                    CLI_VAR_NAMELEN - 1);
+            cli_vars[i].name[
+                CLI_VAR_NAMELEN - 1] = '\0';
+            strncpy(cli_vars[i].val, val,
+                    CLI_VAR_VALLEN - 1);
+            cli_vars[i].val[
+                CLI_VAR_VALLEN - 1] = '\0';
+            cli_vars[i].used = 1;
+            return;
+        }
+    }
+    printf("Error: variable table full "
+           "(max %d)\n", CLI_MAX_VARS);
+}
+
+/**
+ * @brief Remove a CLI variable
+ *
+ * @param name  Variable name
+ */
+void cli_var_unset(const char *name)
+{
+    for(int i = 0; i < CLI_MAX_VARS; i++)
+    {
+        if(cli_vars[i].used
+                && strcmp(cli_vars[i].name, name)
+                == 0)
+        {
+            cli_vars[i].used = 0;
+            cli_vars[i].name[0] = '\0';
+            cli_vars[i].val[0] = '\0';
+            return;
+        }
+    }
+}
+
+/**
+ * @brief Unified variable lookup: CLI vars, then
+ *        special vars ($?), then env vars
+ *
+ * @param name  Variable name
+ * @return pointer to value string, or NULL
+ */
+const char *cli_var_lookup(const char *name)
+{
+    static char retbuf[32];
+
+    /* $? — last return value */
+    if(strcmp(name, "?") == 0)
+    {
+        snprintf(retbuf, sizeof(retbuf),
+                 "%d", cli_last_retval);
+        return retbuf;
+    }
+
+    /* CLI variable */
+    const char *v = cli_var_get(name);
+    if(v != NULL)
+    {
+        return v;
+    }
+
+    /* Fall through to environment */
+    return getenv(name);
+}
+
+
+/* ============================================================
+ *  Variable Assignment Detection
+ * ============================================================
+ *
+ * Detect bash-style VAR=val on the command line.
+ * Rules: first token must match [A-Za-z_][A-Za-z0-9_]*=
+ * with no spaces before '='.
+ */
+
+/**
+ * @brief Check if line is VAR=val assignment
+ *
+ * @param line  Command line string
+ * @return 1 if handled as assignment, 0 otherwise
+ */
+int cli_try_var_assign(const char *line)
+{
+    const char *p = line;
+
+    /* Skip leading whitespace */
+    while(*p == ' ' || *p == '\t')
+    {
+        p++;
+    }
+
+    /* Must start with alpha or underscore */
+    if(!isalpha((unsigned char) *p)
+            && *p != '_')
+    {
+        return 0;
+    }
+
+    /* Scan variable name */
+    const char *name_start = p;
+    while(isalnum((unsigned char) *p)
+            || *p == '_')
+    {
+        p++;
+    }
+
+    /* Must hit '=' immediately */
+    if(*p != '=')
+    {
+        return 0;
+    }
+
+    /* Check it's not a command (e.g. "cmd=")
+     * by verifying name is not a registered cmd */
+    {
+        int namelen = (int)(p - name_start);
+        char tmpname[CLI_VAR_NAMELEN];
+        if(namelen >= CLI_VAR_NAMELEN)
+        {
+            namelen = CLI_VAR_NAMELEN - 1;
+        }
+        memcpy(tmpname, name_start,
+               (size_t) namelen);
+        tmpname[namelen] = '\0';
+
+        /* Extract value (everything after '=') */
+        const char *val = p + 1;
+
+        /* Strip trailing whitespace/newline */
+        char valbuf[CLI_VAR_VALLEN];
+        strncpy(valbuf, val,
+                CLI_VAR_VALLEN - 1);
+        valbuf[CLI_VAR_VALLEN - 1] = '\0';
+        {
+            size_t vl = strlen(valbuf);
+            while(vl > 0
+                    && (valbuf[vl - 1] == ' '
+                        || valbuf[vl - 1] == '\t'
+                        || valbuf[vl - 1] == '\n'))
+            {
+                valbuf[--vl] = '\0';
+            }
+        }
+
+        cli_var_set(tmpname, valbuf);
+        return 1;
+    }
+}
+
+
+/* ============================================================
+ *  CLI Commands: unset, vars, echo
+ * ============================================================
+ */
+
+/**
+ * @brief unset command — remove a variable
+ */
+errno_t cli_cmd_unset(void)
+{
+    if(data.cmdNBarg < 2)
+    {
+        printf("Usage: unset <varname>\n");
+        return RETURN_FAILURE;
+    }
+    cli_var_unset(
+        data.cmdargtoken[1].val.string);
+    return RETURN_SUCCESS;
+}
+
+/**
+ * @brief vars command — list all CLI variables
+ */
+errno_t cli_cmd_vars(void)
+{
+    int count = 0;
+    printf("\n  CLI Variables:\n");
+    printf("  %-20s  %s\n",
+           "NAME", "VALUE");
+    printf("  %-20s  %s\n",
+           "----", "-----");
+    for(int i = 0; i < CLI_MAX_VARS; i++)
+    {
+        if(cli_vars[i].used)
+        {
+            printf("  %-20s  %s\n",
+                   cli_vars[i].name,
+                   cli_vars[i].val);
+            count++;
+        }
+    }
+    if(count == 0)
+    {
+        printf("  (none)\n");
+    }
+    printf("  $? = %d\n\n", cli_last_retval);
+    return RETURN_SUCCESS;
+}
+
+/**
+ * @brief echo command — print arguments
+ *
+ * Prints all arguments separated by spaces,
+ * followed by a newline. Supports -n flag.
+ */
+errno_t cli_cmd_echo(void)
+{
+    int start = 1;
+    int newline = 1;
+
+    if(data.cmdNBarg >= 2
+            && strcmp(
+                data.cmdargtoken[1].val.string,
+                "-n") == 0)
+    {
+        newline = 0;
+        start = 2;
+    }
+
+    for(int i = start; i < data.cmdNBarg; i++)
+    {
+        if(i > start)
+        {
+            printf(" ");
+        }
+        printf("%s",
+               data.cmdargtoken[i].val.string);
+    }
+    if(newline)
+    {
+        printf("\n");
+    }
+    return RETURN_SUCCESS;
+}
+
+
+/* ============================================================
+ *  FPS Variable Expansion — @fpsname.param
+ * ============================================================
+ *
+ * Scan for @fpsname.paramname tokens and replace
+ * with the live FPS parameter value.
+ */
+
+#include "fps.h"
+#include "fps_GetParamIndex.h"
+#include "fps_printparameter_valuestring.h"
+#include "fps_connect.h"
+
+/**
+ * @brief Expand @fpsname.param tokens in place
+ *
+ * @param line   Command line buffer
+ * @param maxlen Buffer size
+ */
+void cli_expand_fpsvar(
+    char *line,
+    int   maxlen
+)
+{
+    char out[STRINGMAXLEN_CLICMDLINE];
+    int  opos = 0;
+    int  i = 0;
+
+    while(line[i] != '\0'
+            && opos < maxlen - 1)
+    {
+        if(line[i] == '@')
+        {
+            i++; /* skip @ */
+            /* Collect fpsname.paramname */
+            char token[512];
+            int  tlen = 0;
+            while(line[i] != '\0'
+                    && tlen < 511
+                    && (isalnum(
+                            (unsigned char)
+                            line[i])
+                        || line[i] == '_'
+                        || line[i] == '.'
+                        || line[i] == '-'))
+            {
+                token[tlen++] = line[i++];
+            }
+            token[tlen] = '\0';
+
+            /* Split at first '.' into
+             * fpsname and paramname */
+            char *dot = strchr(token, '.');
+            if(dot == NULL)
+            {
+                /* No param — just copy
+                 * @token literally */
+                if(opos < maxlen - 1)
+                {
+                    out[opos++] = '@';
+                }
+                int clen = tlen;
+                if(opos + clen > maxlen - 1)
+                {
+                    clen = maxlen - 1 - opos;
+                }
+                memcpy(out + opos, token,
+                       (size_t) clen);
+                opos += clen;
+                continue;
+            }
+
+            *dot = '\0';
+            const char *fpsname = token;
+            const char *pname = dot + 1;
+
+            /* Connect to FPS */
+            FUNCTION_PARAMETER_STRUCT fps;
+            int fpsconn =
+                function_parameter_struct_connect(
+                    fpsname, &fps, FPSCONNECT_SIMPLE);
+
+            if(fpsconn == -1
+                    || fps.parray == NULL)
+            {
+                /* Connection failed —
+                 * output empty string */
+                continue;
+            }
+
+            /* Look up parameter */
+            int pindex =
+                functionparameter_GetParamIndex(
+                    &fps, pname);
+
+            if(pindex < 0)
+            {
+                /* Try with leading dot */
+                char dotname[512];
+                snprintf(dotname,
+                         sizeof(dotname),
+                         ".%s", pname);
+                pindex =
+                    functionparameter_GetParamIndex(
+                        &fps, dotname);
+            }
+
+            if(pindex >= 0)
+            {
+                char vstr[512];
+                functionparameter_GetParamValueString(
+                    &fps.parray[pindex],
+                    vstr,
+                    (int) sizeof(vstr));
+
+                int vlen = (int) strlen(vstr);
+                int avail = maxlen - 1 - opos;
+                int clen = vlen < avail
+                           ? vlen : avail;
+                memcpy(out + opos, vstr,
+                       (size_t) clen);
+                opos += clen;
+            }
+
+            function_parameter_struct_disconnect(
+                &fps);
+        }
+        else
+        {
+            out[opos++] = line[i++];
+        }
+    }
+    out[opos] = '\0';
+    strncpy(line, out, (size_t) maxlen);
+    line[maxlen - 1] = '\0';
+}
+
+
+/* ============================================================
+ *  Arithmetic Expansion — $(( expr ))
+ * ============================================================
+ *
+ * Evaluate simple arithmetic expressions with
+ * integer and float support. Operators: + - * / %
+ * Parentheses supported.
+ */
+
+/* ---- Recursive descent expression parser ---- */
+
+/** Parser state */
+typedef struct
+{
+    const char *s;
+    int         pos;
+} ArithParser;
+
+static double arith_expr(ArithParser *p);
+
+static void arith_skip_ws(ArithParser *p)
+{
+    while(p->s[p->pos] == ' '
+            || p->s[p->pos] == '\t')
+    {
+        p->pos++;
+    }
+}
+
+static double arith_atom(ArithParser *p)
+{
+    arith_skip_ws(p);
+
+    /* Unary minus */
+    if(p->s[p->pos] == '-')
+    {
+        p->pos++;
+        return -arith_atom(p);
+    }
+
+    /* Parenthesized sub-expression */
+    if(p->s[p->pos] == '(')
+    {
+        p->pos++;
+        double v = arith_expr(p);
+        arith_skip_ws(p);
+        if(p->s[p->pos] == ')')
+        {
+            p->pos++;
+        }
+        return v;
+    }
+
+    /* Number */
+    arith_skip_ws(p);
+    const char *start = p->s + p->pos;
+    char *end = NULL;
+    double v = strtod(start, &end);
+    if(end > start)
+    {
+        p->pos += (int)(end - start);
+        return v;
+    }
+
+    /* Unknown — return 0 */
+    return 0.0;
+}
+
+static double arith_factor(ArithParser *p)
+{
+    double left = arith_atom(p);
+    arith_skip_ws(p);
+
+    while(p->s[p->pos] == '*'
+            || p->s[p->pos] == '/'
+            || p->s[p->pos] == '%')
+    {
+        char op = p->s[p->pos];
+        p->pos++;
+        double right = arith_atom(p);
+        arith_skip_ws(p);
+        if(op == '*')
+        {
+            left *= right;
+        }
+        else if(op == '/')
+        {
+            if(right != 0.0)
+            {
+                left /= right;
+            }
+        }
+        else if(op == '%')
+        {
+            if(right != 0.0)
+            {
+                left = fmod(left, right);
+            }
+        }
+    }
+    return left;
+}
+
+static double arith_term(ArithParser *p)
+{
+    double left = arith_factor(p);
+    arith_skip_ws(p);
+
+    while(p->s[p->pos] == '+'
+            || p->s[p->pos] == '-')
+    {
+        char op = p->s[p->pos];
+        p->pos++;
+        double right = arith_factor(p);
+        arith_skip_ws(p);
+        if(op == '+')
+        {
+            left += right;
+        }
+        else
+        {
+            left -= right;
+        }
+    }
+    return left;
+}
+
+/** Comparison operators for use in conditions */
+static double arith_compare(ArithParser *p)
+{
+    double left = arith_term(p);
+    arith_skip_ws(p);
+
+    if(p->s[p->pos] == '<'
+            && p->s[p->pos + 1] == '=')
+    {
+        p->pos += 2;
+        double right = arith_term(p);
+        return (left <= right) ? 1.0 : 0.0;
+    }
+    if(p->s[p->pos] == '>'
+            && p->s[p->pos + 1] == '=')
+    {
+        p->pos += 2;
+        double right = arith_term(p);
+        return (left >= right) ? 1.0 : 0.0;
+    }
+    if(p->s[p->pos] == '<')
+    {
+        p->pos++;
+        double right = arith_term(p);
+        return (left < right) ? 1.0 : 0.0;
+    }
+    if(p->s[p->pos] == '>')
+    {
+        p->pos++;
+        double right = arith_term(p);
+        return (left > right) ? 1.0 : 0.0;
+    }
+    if(p->s[p->pos] == '='
+            && p->s[p->pos + 1] == '=')
+    {
+        p->pos += 2;
+        double right = arith_term(p);
+        return (left == right) ? 1.0 : 0.0;
+    }
+    if(p->s[p->pos] == '!'
+            && p->s[p->pos + 1] == '=')
+    {
+        p->pos += 2;
+        double right = arith_term(p);
+        return (left != right) ? 1.0 : 0.0;
+    }
+    return left;
+}
+
+static double arith_expr(ArithParser *p)
+{
+    return arith_compare(p);
+}
+
+
+/**
+ * @brief Expand $(( expr )) in place
+ *
+ * @param line   Command line buffer
+ * @param maxlen Buffer size
+ */
+void cli_expand_arith(
+    char *line,
+    int   maxlen
+)
+{
+    char out[STRINGMAXLEN_CLICMDLINE];
+    int  opos = 0;
+    int  i = 0;
+
+    while(line[i] != '\0'
+            && opos < maxlen - 1)
+    {
+        /* Detect $(( */
+        if(line[i] == '$'
+                && line[i + 1] == '('
+                && line[i + 2] == '(')
+        {
+            i += 3; /* skip $(( */
+
+            /* Extract expression until )) */
+            char expr[512];
+            int  elen = 0;
+            int  depth = 1;
+            while(line[i] != '\0'
+                    && elen < 511)
+            {
+                if(line[i] == '('
+                        && line[i + 1] == '(')
+                {
+                    depth++;
+                    expr[elen++] = line[i++];
+                    expr[elen++] = line[i++];
+                    continue;
+                }
+                if(line[i] == ')'
+                        && line[i + 1] == ')')
+                {
+                    depth--;
+                    if(depth == 0)
+                    {
+                        i += 2; /* skip )) */
+                        break;
+                    }
+                    expr[elen++] = line[i++];
+                    expr[elen++] = line[i++];
+                    continue;
+                }
+                expr[elen++] = line[i++];
+            }
+            expr[elen] = '\0';
+
+            /* Evaluate */
+            ArithParser parser;
+            parser.s = expr;
+            parser.pos = 0;
+            double result = arith_expr(&parser);
+
+            /* Format result: integer if whole,
+             * else float */
+            char rbuf[64];
+            if(result == floor(result)
+                    && fabs(result) < 1e15)
+            {
+                snprintf(rbuf, sizeof(rbuf),
+                         "%ld", (long) result);
+            }
+            else
+            {
+                snprintf(rbuf, sizeof(rbuf),
+                         "%g", result);
+            }
+
+            int rlen = (int) strlen(rbuf);
+            int avail = maxlen - 1 - opos;
+            int clen = rlen < avail
+                       ? rlen : avail;
+            memcpy(out + opos, rbuf,
+                   (size_t) clen);
+            opos += clen;
+        }
+        else
+        {
+            out[opos++] = line[i++];
+        }
+    }
+    out[opos] = '\0';
+    strncpy(line, out, (size_t) maxlen);
+    line[maxlen - 1] = '\0';
+}

--- a/src/cli/CLIcore/CLIcore/CLIcore_script.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_script.c
@@ -1,12 +1,18 @@
 /**
  * @file CLIcore_script.c
  * @brief CLI scripting engine — variables, FPS access,
- *        arithmetic evaluation, flow control
+ *        arithmetic, flow control, user functions
  *
- * This module implements bash-style scripting constructs
- * for the milk CLI: variable assignment (VAR=val),
- * variable expansion ($VAR, ${VAR}, $?), FPS parameter
- * read (@fpsname.param), and arithmetic $(( expr )).
+ * Implements bash-style scripting constructs for the
+ * milk CLI:
+ * - Variable assignment (VAR=val), expansion ($VAR)
+ * - FPS parameter read (@fpsname.param)
+ * - FPS parameter write (fpsset)
+ * - Arithmetic $(( expr ))
+ * - Flow control: if/then/else/fi,
+ *   while/do/done, for/do/done
+ * - User-defined functions:
+ *   function name { body }
  */
 
 #include <stdio.h>
@@ -114,8 +120,8 @@ void cli_var_unset(const char *name)
 }
 
 /**
- * @brief Unified variable lookup: CLI vars, then
- *        special vars ($?), then env vars
+ * @brief Unified variable lookup: CLI vars,
+ *        then special vars ($?), then env vars
  *
  * @param name  Variable name
  * @return pointer to value string, or NULL
@@ -147,10 +153,6 @@ const char *cli_var_lookup(const char *name)
 /* ============================================================
  *  Variable Assignment Detection
  * ============================================================
- *
- * Detect bash-style VAR=val on the command line.
- * Rules: first token must match [A-Za-z_][A-Za-z0-9_]*=
- * with no spaces before '='.
  */
 
 /**
@@ -190,8 +192,6 @@ int cli_try_var_assign(const char *line)
         return 0;
     }
 
-    /* Check it's not a command (e.g. "cmd=")
-     * by verifying name is not a registered cmd */
     {
         int namelen = (int)(p - name_start);
         char tmpname[CLI_VAR_NAMELEN];
@@ -229,7 +229,7 @@ int cli_try_var_assign(const char *line)
 
 
 /* ============================================================
- *  CLI Commands: unset, vars, echo
+ *  CLI Commands: unset, vars, echo, fpsset
  * ============================================================
  */
 
@@ -280,8 +280,9 @@ errno_t cli_cmd_vars(void)
 /**
  * @brief echo command — print arguments
  *
- * Prints all arguments separated by spaces,
- * followed by a newline. Supports -n flag.
+ * Note: echo is intercepted before tokenization
+ * in CLIcore_UI.c. This registered version is a
+ * fallback that should rarely be called.
  */
 errno_t cli_cmd_echo(void)
 {
@@ -315,17 +316,150 @@ errno_t cli_cmd_echo(void)
 
 
 /* ============================================================
- *  FPS Variable Expansion — @fpsname.param
+ *  FPS Write — fpsset command
  * ============================================================
- *
- * Scan for @fpsname.paramname tokens and replace
- * with the live FPS parameter value.
  */
 
 #include "fps.h"
 #include "fps_GetParamIndex.h"
 #include "fps_printparameter_valuestring.h"
 #include "fps_connect.h"
+
+/**
+ * @brief fpsset command — write FPS parameter
+ *
+ * Usage: fpsset fpsname.param value
+ */
+errno_t cli_cmd_fpsset(void)
+{
+    if(data.cmdNBarg < 3)
+    {
+        printf("Usage: fpsset "
+               "<fpsname.param> <value>\n");
+        return RETURN_FAILURE;
+    }
+
+    const char *fullname =
+        data.cmdargtoken[1].val.string;
+    const char *valstr =
+        data.cmdargtoken[2].val.string;
+
+    /* Split fpsname.param at first dot */
+    char fpsname[256];
+    strncpy(fpsname, fullname,
+            sizeof(fpsname) - 1);
+    fpsname[sizeof(fpsname) - 1] = '\0';
+
+    char *dot = strchr(fpsname, '.');
+    if(dot == NULL)
+    {
+        printf("Error: fpsset requires "
+               "fpsname.paramname\n");
+        return RETURN_FAILURE;
+    }
+    *dot = '\0';
+    const char *pname = dot + 1;
+
+    /* Connect to FPS */
+    FUNCTION_PARAMETER_STRUCT fps;
+    int fpsconn =
+        function_parameter_struct_connect(
+            fpsname, &fps, FPSCONNECT_SIMPLE);
+
+    if(fpsconn == -1 || fps.parray == NULL)
+    {
+        printf("Error: cannot connect to "
+               "FPS '%s'\n", fpsname);
+        return RETURN_FAILURE;
+    }
+
+    /* Find parameter index */
+    int pindex =
+        functionparameter_GetParamIndex(
+            &fps, pname);
+
+    if(pindex < 0)
+    {
+        char dotname[512];
+        snprintf(dotname, sizeof(dotname),
+                 ".%s", pname);
+        pindex =
+            functionparameter_GetParamIndex(
+                &fps, dotname);
+    }
+
+    if(pindex < 0)
+    {
+        printf("Error: parameter '%s' not "
+               "found in FPS '%s'\n",
+               pname, fpsname);
+        function_parameter_struct_disconnect(
+            &fps);
+        return RETURN_FAILURE;
+    }
+
+    /* Set value based on parameter type */
+    uint32_t ptype =
+        fps.parray[pindex].type;
+
+    if(ptype & FPTYPE_INT64)
+    {
+        fps.parray[pindex].val.i64[0] =
+            (int64_t) strtol(valstr, NULL, 0);
+        fps.parray[pindex].cnt0++;
+    }
+    else if(ptype & FPTYPE_FLOAT64)
+    {
+        fps.parray[pindex].val.f64[0] =
+            strtod(valstr, NULL);
+        fps.parray[pindex].cnt0++;
+    }
+    else if(ptype & FPTYPE_FLOAT32)
+    {
+        fps.parray[pindex].val.f32[0] =
+            (float) strtod(valstr, NULL);
+        fps.parray[pindex].cnt0++;
+    }
+    else if(ptype & FPTYPE_ONOFF)
+    {
+        if(strcmp(valstr, "ON") == 0
+           || strcmp(valstr, "on") == 0
+           || strcmp(valstr, "1") == 0)
+        {
+            fps.parray[pindex].val.i64[0] = 1;
+        }
+        else
+        {
+            fps.parray[pindex].val.i64[0] = 0;
+        }
+        fps.parray[pindex].cnt0++;
+    }
+    else if(ptype & FPTYPE_STRING)
+    {
+        strncpy(
+            fps.parray[pindex].val.string[0],
+            valstr,
+            FUNCTION_PARAMETER_STRMAXLEN - 1);
+        fps.parray[pindex].val.string[0][
+            FUNCTION_PARAMETER_STRMAXLEN - 1]
+            = '\0';
+        fps.parray[pindex].cnt0++;
+    }
+    else
+    {
+        printf("Warning: unsupported param "
+               "type 0x%x\n", ptype);
+    }
+
+    function_parameter_struct_disconnect(&fps);
+    return RETURN_SUCCESS;
+}
+
+
+/* ============================================================
+ *  FPS Variable Expansion — @fpsname.param
+ * ============================================================
+ */
 
 /**
  * @brief Expand @fpsname.param tokens in place
@@ -348,7 +482,6 @@ void cli_expand_fpsvar(
         if(line[i] == '@')
         {
             i++; /* skip @ */
-            /* Collect fpsname.paramname */
             char token[512];
             int  tlen = 0;
             while(line[i] != '\0'
@@ -364,13 +497,9 @@ void cli_expand_fpsvar(
             }
             token[tlen] = '\0';
 
-            /* Split at first '.' into
-             * fpsname and paramname */
             char *dot = strchr(token, '.');
             if(dot == NULL)
             {
-                /* No param — just copy
-                 * @token literally */
                 if(opos < maxlen - 1)
                 {
                     out[opos++] = '@';
@@ -390,28 +519,24 @@ void cli_expand_fpsvar(
             const char *fpsname = token;
             const char *pname = dot + 1;
 
-            /* Connect to FPS */
             FUNCTION_PARAMETER_STRUCT fps;
             int fpsconn =
                 function_parameter_struct_connect(
-                    fpsname, &fps, FPSCONNECT_SIMPLE);
+                    fpsname, &fps,
+                    FPSCONNECT_SIMPLE);
 
             if(fpsconn == -1
                     || fps.parray == NULL)
             {
-                /* Connection failed —
-                 * output empty string */
                 continue;
             }
 
-            /* Look up parameter */
             int pindex =
                 functionparameter_GetParamIndex(
                     &fps, pname);
 
             if(pindex < 0)
             {
-                /* Try with leading dot */
                 char dotname[512];
                 snprintf(dotname,
                          sizeof(dotname),
@@ -455,15 +580,8 @@ void cli_expand_fpsvar(
 /* ============================================================
  *  Arithmetic Expansion — $(( expr ))
  * ============================================================
- *
- * Evaluate simple arithmetic expressions with
- * integer and float support. Operators: + - * / %
- * Parentheses supported.
  */
 
-/* ---- Recursive descent expression parser ---- */
-
-/** Parser state */
 typedef struct
 {
     const char *s;
@@ -505,6 +623,29 @@ static double arith_atom(ArithParser *p)
         return v;
     }
 
+    /* Variable name (bare identifier) */
+    if(isalpha((unsigned char) p->s[p->pos])
+       || p->s[p->pos] == '_')
+    {
+        char vname[256];
+        int vn = 0;
+        while(vn < 255
+              && (isalnum(
+                      (unsigned char)
+                      p->s[p->pos])
+                  || p->s[p->pos] == '_'))
+        {
+            vname[vn++] = p->s[p->pos++];
+        }
+        vname[vn] = '\0';
+        const char *vv = cli_var_lookup(vname);
+        if(vv != NULL)
+        {
+            return strtod(vv, NULL);
+        }
+        return 0.0;
+    }
+
     /* Number */
     arith_skip_ws(p);
     const char *start = p->s + p->pos;
@@ -516,7 +657,6 @@ static double arith_atom(ArithParser *p)
         return v;
     }
 
-    /* Unknown — return 0 */
     return 0.0;
 }
 
@@ -579,7 +719,6 @@ static double arith_term(ArithParser *p)
     return left;
 }
 
-/** Comparison operators for use in conditions */
 static double arith_compare(ArithParser *p)
 {
     double left = arith_term(p);
@@ -636,9 +775,6 @@ static double arith_expr(ArithParser *p)
 
 /**
  * @brief Expand $(( expr )) in place
- *
- * @param line   Command line buffer
- * @param maxlen Buffer size
  */
 void cli_expand_arith(
     char *line,
@@ -652,14 +788,12 @@ void cli_expand_arith(
     while(line[i] != '\0'
             && opos < maxlen - 1)
     {
-        /* Detect $(( */
         if(line[i] == '$'
                 && line[i + 1] == '('
                 && line[i + 2] == '(')
         {
-            i += 3; /* skip $(( */
+            i += 3;
 
-            /* Extract expression until )) */
             char expr[512];
             int  elen = 0;
             int  depth = 1;
@@ -680,7 +814,7 @@ void cli_expand_arith(
                     depth--;
                     if(depth == 0)
                     {
-                        i += 2; /* skip )) */
+                        i += 2;
                         break;
                     }
                     expr[elen++] = line[i++];
@@ -691,14 +825,11 @@ void cli_expand_arith(
             }
             expr[elen] = '\0';
 
-            /* Evaluate */
             ArithParser parser;
             parser.s = expr;
             parser.pos = 0;
             double result = arith_expr(&parser);
 
-            /* Format result: integer if whole,
-             * else float */
             char rbuf[64];
             if(result == floor(result)
                     && fabs(result) < 1e15)
@@ -728,4 +859,1080 @@ void cli_expand_arith(
     out[opos] = '\0';
     strncpy(line, out, (size_t) maxlen);
     line[maxlen - 1] = '\0';
+}
+
+
+/* ============================================================
+ *  Test Condition Evaluator — [ expr ]
+ * ============================================================
+ *
+ * Evaluates bash-style test expressions:
+ *   [ val1 -eq val2 ]   numeric equal
+ *   [ val1 -ne val2 ]   numeric not equal
+ *   [ val1 -lt val2 ]   numeric less than
+ *   [ val1 -gt val2 ]   numeric greater than
+ *   [ val1 -le val2 ]   numeric less or equal
+ *   [ val1 -ge val2 ]   numeric greater or equal
+ *   [ str1 == str2 ]    string equal
+ *   [ str1 != str2 ]    string not equal
+ *   [ -n str ]          string not empty
+ *   [ -z str ]          string empty
+ */
+
+/**
+ * @brief Evaluate [ ... ] test expression
+ *
+ * @param expr   The content between [ and ]
+ * @return 1 = true, 0 = false
+ */
+int cli_eval_test(const char *expr)
+{
+    /* Tokenize expression */
+    char buf[512];
+    strncpy(buf, expr, sizeof(buf) - 1);
+    buf[sizeof(buf) - 1] = '\0';
+
+    /* Strip leading/trailing whitespace */
+    char *p = buf;
+    while(*p == ' ' || *p == '\t')
+    {
+        p++;
+    }
+    {
+        size_t len = strlen(p);
+        while(len > 0
+              && (p[len - 1] == ' '
+                  || p[len - 1] == '\t'))
+        {
+            p[--len] = '\0';
+        }
+    }
+
+    /* Tokenize into words */
+    char *tokens[16];
+    int ntok = 0;
+    {
+        char *saveptr = NULL;
+        char *tok = strtok_r(p, " \t", &saveptr);
+        while(tok != NULL && ntok < 16)
+        {
+            tokens[ntok++] = tok;
+            tok = strtok_r(NULL, " \t", &saveptr);
+        }
+    }
+
+    if(ntok == 0)
+    {
+        return 0;
+    }
+
+    /* Unary: -n str, -z str */
+    if(ntok == 2
+       && strcmp(tokens[0], "-n") == 0)
+    {
+        return strlen(tokens[1]) > 0 ? 1 : 0;
+    }
+    if(ntok == 2
+       && strcmp(tokens[0], "-z") == 0)
+    {
+        return strlen(tokens[1]) == 0 ? 1 : 0;
+    }
+
+    /* Single value: true if non-empty */
+    if(ntok == 1)
+    {
+        return strlen(tokens[0]) > 0 ? 1 : 0;
+    }
+
+    /* Binary: val1 op val2 */
+    if(ntok >= 3)
+    {
+        const char *lhs = tokens[0];
+        const char *op = tokens[1];
+        const char *rhs = tokens[2];
+
+        double lv = strtod(lhs, NULL);
+        double rv = strtod(rhs, NULL);
+
+        if(strcmp(op, "-eq") == 0)
+        {
+            return (lv == rv) ? 1 : 0;
+        }
+        if(strcmp(op, "-ne") == 0)
+        {
+            return (lv != rv) ? 1 : 0;
+        }
+        if(strcmp(op, "-lt") == 0)
+        {
+            return (lv < rv) ? 1 : 0;
+        }
+        if(strcmp(op, "-gt") == 0)
+        {
+            return (lv > rv) ? 1 : 0;
+        }
+        if(strcmp(op, "-le") == 0)
+        {
+            return (lv <= rv) ? 1 : 0;
+        }
+        if(strcmp(op, "-ge") == 0)
+        {
+            return (lv >= rv) ? 1 : 0;
+        }
+        if(strcmp(op, "==") == 0)
+        {
+            return strcmp(lhs, rhs) == 0
+                   ? 1 : 0;
+        }
+        if(strcmp(op, "!=") == 0)
+        {
+            return strcmp(lhs, rhs) != 0
+                   ? 1 : 0;
+        }
+    }
+
+    printf("Error: invalid test expression\n");
+    return 0;
+}
+
+
+/* ============================================================
+ *  Block Accumulator — flow control engine
+ * ============================================================
+ *
+ * Multi-line constructs (if/while/for/function)
+ * are accumulated in a block buffer until the
+ * closing keyword is seen, then the complete
+ * block is evaluated.
+ */
+
+CLI_BLOCK cli_block_stack[CLI_BLOCK_MAXDEPTH];
+int       cli_block_level = 0;
+
+/* Break/continue flags for while/for loops */
+static int cli_break_flag = 0;
+static int cli_continue_flag = 0;
+
+/* Forward declaration */
+static void cli_exec_block_if(
+    char lines[][STRINGMAXLEN_CLICMDLINE],
+    int nlines
+);
+static void cli_exec_block_while(
+    char lines[][STRINGMAXLEN_CLICMDLINE],
+    int nlines
+);
+static void cli_exec_block_for(
+    char lines[][STRINGMAXLEN_CLICMDLINE],
+    int nlines
+);
+
+
+/* ---- Helper: strip whitespace ---- */
+
+static const char *strip_ws(const char *s)
+{
+    while(*s == ' ' || *s == '\t')
+    {
+        s++;
+    }
+    return s;
+}
+
+static int starts_with(
+    const char *line,
+    const char *prefix
+)
+{
+    return strncmp(line, prefix,
+                   strlen(prefix)) == 0;
+}
+
+/**
+ * @brief Execute lines through CLI_execute_line
+ */
+void cli_exec_lines(
+    char lines[][STRINGMAXLEN_CLICMDLINE],
+    int  nlines
+)
+{
+    for(int i = 0; i < nlines; i++)
+    {
+        if(cli_break_flag
+           || cli_continue_flag)
+        {
+            break;
+        }
+
+        /* Copy to cmdline and execute */
+        strncpy(data.CLIcmdline, lines[i],
+                STRINGMAXLEN_CLICMDLINE - 1);
+        data.CLIcmdline[
+            STRINGMAXLEN_CLICMDLINE - 1] = '\0';
+        CLI_execute_line();
+    }
+}
+
+
+/* ---- Parse if/then/else/fi block ---- */
+
+/**
+ * @brief Execute an if/then/else/fi block
+ *
+ * Expected format in lines[]:
+ *   lines[0]: "if [ condition ]; then"
+ *              or "if [ condition ]"
+ *   ...then-body...
+ *   "else"
+ *   ...else-body...
+ *   "fi"
+ */
+static void cli_exec_block_if(
+    char lines[][STRINGMAXLEN_CLICMDLINE],
+    int nlines
+)
+{
+    if(nlines < 2)
+    {
+        return;
+    }
+
+    /* Expand variables in condition */
+    char condline[STRINGMAXLEN_CLICMDLINE];
+    strncpy(condline, lines[0],
+            STRINGMAXLEN_CLICMDLINE - 1);
+    condline[
+        STRINGMAXLEN_CLICMDLINE - 1] = '\0';
+    cli_expand_fpsvar(
+        condline, STRINGMAXLEN_CLICMDLINE);
+    cli_expand_env(
+        condline, STRINGMAXLEN_CLICMDLINE);
+    cli_expand_arith(
+        condline, STRINGMAXLEN_CLICMDLINE);
+
+    /* Parse condition from first line */
+    const char *first = strip_ws(condline);
+
+    /* Skip "if" */
+    first += 2;
+    first = strip_ws(first);
+
+    /* Find [ ... ] or just evaluate */
+    int cond_result = 0;
+    if(*first == '[')
+    {
+        first++;
+        /* Find matching ] */
+        const char *end = strrchr(first, ']');
+        if(end != NULL)
+        {
+            char condstr[512];
+            int clen = (int)(end - first);
+            if(clen >= (int) sizeof(condstr))
+            {
+                clen = (int) sizeof(condstr) - 1;
+            }
+            memcpy(condstr, first,
+                   (size_t) clen);
+            condstr[clen] = '\0';
+            cond_result =
+                cli_eval_test(condstr);
+        }
+    }
+    else
+    {
+        /* Arithmetic condition:
+         * treat non-zero as true */
+        cond_result =
+            (strtod(first, NULL) != 0.0)
+            ? 1 : 0;
+    }
+
+    /* Split body at 'else' */
+    int then_start = 1;
+
+    /* Skip standalone 'then' line from
+     * semicolon-split (e.g. "; then") */
+    if(then_start < nlines - 1)
+    {
+        const char *ts =
+            strip_ws(lines[then_start]);
+        if(strcmp(ts, "then") == 0)
+        {
+            then_start++;
+        }
+    }
+    int else_start = -1;
+
+    for(int i = 1; i < nlines; i++)
+    {
+        const char *ln = strip_ws(lines[i]);
+        if(strcmp(ln, "else") == 0)
+        {
+            else_start = i + 1;
+            break;
+        }
+    }
+
+    if(cond_result)
+    {
+        int end = (else_start > 0)
+                  ? else_start - 1
+                  : nlines;
+        if(end > then_start)
+        {
+            cli_exec_lines(
+                lines + then_start,
+                end - then_start);
+        }
+    }
+    else if(else_start > 0)
+    {
+        int end = nlines;
+        if(end > else_start)
+        {
+            cli_exec_lines(
+                lines + else_start,
+                end - else_start);
+        }
+    }
+}
+
+
+/* ---- Parse while/do/done block ---- */
+
+/**
+ * @brief Execute a while/do/done block
+ *
+ * Expected format:
+ *   lines[0]: "while [ condition ]; do"
+ *   ...body...
+ *   "done"
+ */
+static void cli_exec_block_while(
+    char lines[][STRINGMAXLEN_CLICMDLINE],
+    int nlines
+)
+{
+    if(nlines < 2)
+    {
+        return;
+    }
+
+    /* Find body start (after "do") */
+    int body_start = 1;
+    int body_end = nlines;
+    int max_iter = 100000;
+
+    /* Skip standalone 'do' line from
+     * semicolon-split */
+    if(body_start < body_end)
+    {
+        const char *ds =
+            strip_ws(lines[body_start]);
+        if(strcmp(ds, "do") == 0)
+        {
+            body_start++;
+        }
+    }
+
+    for(int iter = 0; iter < max_iter; iter++)
+    {
+        /* Re-expand condition each iteration */
+        char condline[STRINGMAXLEN_CLICMDLINE];
+        strncpy(condline, lines[0],
+                STRINGMAXLEN_CLICMDLINE - 1);
+        condline[
+            STRINGMAXLEN_CLICMDLINE - 1] = '\0';
+
+        /* Run expansion on condition */
+        cli_expand_fpsvar(
+            condline,
+            STRINGMAXLEN_CLICMDLINE);
+        cli_expand_env(
+            condline,
+            STRINGMAXLEN_CLICMDLINE);
+        cli_expand_arith(
+            condline,
+            STRINGMAXLEN_CLICMDLINE);
+
+        /* Parse condition */
+        const char *cl = strip_ws(condline);
+        cl += 5; /* skip "while" */
+        cl = strip_ws(cl);
+
+        int cond_result = 0;
+        if(*cl == '[')
+        {
+            cl++;
+            const char *end = strrchr(cl, ']');
+            if(end != NULL)
+            {
+                char cs[512];
+                int clen = (int)(end - cl);
+                if(clen >= (int) sizeof(cs))
+                {
+                    clen =
+                        (int) sizeof(cs) - 1;
+                }
+                memcpy(cs, cl, (size_t) clen);
+                cs[clen] = '\0';
+                cond_result =
+                    cli_eval_test(cs);
+            }
+        }
+
+        if(!cond_result)
+        {
+            break;
+        }
+
+        /* Execute body */
+        cli_continue_flag = 0;
+        cli_exec_lines(
+            lines + body_start,
+            body_end - body_start);
+
+        if(cli_break_flag)
+        {
+            cli_break_flag = 0;
+            break;
+        }
+    }
+}
+
+
+/* ---- Parse for/do/done block ---- */
+
+/**
+ * @brief Execute a for/do/done block
+ *
+ * Expected format:
+ *   lines[0]: "for VAR in val1 val2 ...; do"
+ *   ...body...
+ *   "done"
+ */
+static void cli_exec_block_for(
+    char lines[][STRINGMAXLEN_CLICMDLINE],
+    int nlines
+)
+{
+    if(nlines < 2)
+    {
+        return;
+    }
+
+    /* Parse: for VAR in val1 val2 ... */
+    const char *fl = strip_ws(lines[0]);
+    fl += 3; /* skip "for" */
+    fl = strip_ws(fl);
+
+    /* Get variable name */
+    char varname[CLI_VAR_NAMELEN];
+    {
+        int vn = 0;
+        while(*fl != '\0' && *fl != ' '
+              && *fl != '\t'
+              && vn < CLI_VAR_NAMELEN - 1)
+        {
+            varname[vn++] = *fl++;
+        }
+        varname[vn] = '\0';
+    }
+    fl = strip_ws(fl);
+
+    /* Skip "in" */
+    if(strncmp(fl, "in ", 3) == 0
+       || strncmp(fl, "in\t", 3) == 0)
+    {
+        fl += 2;
+        fl = strip_ws(fl);
+    }
+
+    /* Collect values (strip trailing ;do) */
+    char vallist[STRINGMAXLEN_CLICMDLINE];
+    strncpy(vallist, fl,
+            STRINGMAXLEN_CLICMDLINE - 1);
+    vallist[
+        STRINGMAXLEN_CLICMDLINE - 1] = '\0';
+
+    /* Remove trailing "; do" or ";do" */
+    {
+        char *semi = strstr(vallist, ";");
+        if(semi != NULL)
+        {
+            *semi = '\0';
+        }
+    }
+
+    /* Strip trailing whitespace */
+    {
+        size_t vl = strlen(vallist);
+        while(vl > 0
+              && (vallist[vl - 1] == ' '
+                  || vallist[vl - 1] == '\t'
+                  || vallist[vl - 1] == '\n'))
+        {
+            vallist[--vl] = '\0';
+        }
+    }
+
+    int body_start = 1;
+    int body_end = nlines;
+
+    /* Skip standalone 'do' line */
+    if(body_start < body_end)
+    {
+        const char *ds =
+            strip_ws(lines[body_start]);
+        if(strcmp(ds, "do") == 0)
+        {
+            body_start++;
+        }
+    }
+
+    /* Iterate over values */
+    char *saveptr = NULL;
+    char *val = strtok_r(vallist, " \t",
+                         &saveptr);
+    while(val != NULL)
+    {
+        cli_var_set(varname, val);
+
+        cli_continue_flag = 0;
+        cli_exec_lines(
+            lines + body_start,
+            body_end - body_start);
+
+        if(cli_break_flag)
+        {
+            cli_break_flag = 0;
+            break;
+        }
+
+        val = strtok_r(NULL, " \t", &saveptr);
+    }
+}
+
+
+/* ============================================================
+ *  User-Defined Functions
+ * ============================================================
+ */
+
+CLI_FUNC cli_funcs[CLI_MAX_FUNCS];
+
+/**
+ * @brief Find a user-defined function by name
+ */
+CLI_FUNC *cli_func_find(const char *name)
+{
+    for(int i = 0; i < CLI_MAX_FUNCS; i++)
+    {
+        if(cli_funcs[i].used
+           && strcmp(cli_funcs[i].name, name)
+              == 0)
+        {
+            return &cli_funcs[i];
+        }
+    }
+    return NULL;
+}
+
+/**
+ * @brief Register a new user function
+ */
+static void cli_func_define(
+    const char *name,
+    char body[][STRINGMAXLEN_CLICMDLINE],
+    int nbody
+)
+{
+    /* Update existing */
+    for(int i = 0; i < CLI_MAX_FUNCS; i++)
+    {
+        if(cli_funcs[i].used
+           && strcmp(cli_funcs[i].name, name)
+              == 0)
+        {
+            cli_funcs[i].nbody = nbody;
+            for(int j = 0; j < nbody; j++)
+            {
+                strncpy(
+                    cli_funcs[i].body[j],
+                    body[j],
+                    STRINGMAXLEN_CLICMDLINE - 1
+                );
+            }
+            return;
+        }
+    }
+    /* Find empty slot */
+    for(int i = 0; i < CLI_MAX_FUNCS; i++)
+    {
+        if(!cli_funcs[i].used)
+        {
+            strncpy(cli_funcs[i].name, name,
+                    CLI_FUNC_NAMELEN - 1);
+            cli_funcs[i].name[
+                CLI_FUNC_NAMELEN - 1] = '\0';
+            cli_funcs[i].nbody = nbody;
+            cli_funcs[i].used = 1;
+            for(int j = 0; j < nbody; j++)
+            {
+                strncpy(
+                    cli_funcs[i].body[j],
+                    body[j],
+                    STRINGMAXLEN_CLICMDLINE - 1
+                );
+            }
+            return;
+        }
+    }
+    printf("Error: function table full "
+           "(max %d)\n", CLI_MAX_FUNCS);
+}
+
+
+/**
+ * @brief Try to call a user-defined function
+ *
+ * Syntax: funcname arg1 arg2 ...
+ * Inside the function body, $1..$9 are args.
+ *
+ * @return 1 if matched, 0 if not
+ */
+int cli_try_func_call(const char *line)
+{
+    const char *p = strip_ws(line);
+
+    /* Extract first word (function name) */
+    char fname[CLI_FUNC_NAMELEN];
+    {
+        int fn = 0;
+        while(*p != '\0' && *p != ' '
+              && *p != '\t'
+              && fn < CLI_FUNC_NAMELEN - 1)
+        {
+            fname[fn++] = *p++;
+        }
+        fname[fn] = '\0';
+    }
+
+    CLI_FUNC *func = cli_func_find(fname);
+    if(func == NULL)
+    {
+        return 0;
+    }
+
+    /* Parse arguments */
+    p = strip_ws(p);
+    char *args[CLI_FUNC_MAXARGS];
+    char argbuf[CLI_FUNC_MAXARGS][
+        CLI_VAR_VALLEN];
+    int nargs = 0;
+
+    while(*p != '\0'
+          && nargs < CLI_FUNC_MAXARGS)
+    {
+        int ai = 0;
+        while(*p != '\0' && *p != ' '
+              && *p != '\t'
+              && ai < CLI_VAR_VALLEN - 1)
+        {
+            argbuf[nargs][ai++] = *p++;
+        }
+        argbuf[nargs][ai] = '\0';
+        args[nargs] = argbuf[nargs];
+        nargs++;
+        p = strip_ws(p);
+    }
+
+    /* Save old $1..$9, set new ones */
+    char old_args[CLI_FUNC_MAXARGS][
+        CLI_VAR_VALLEN];
+    int old_used[CLI_FUNC_MAXARGS];
+    for(int i = 0; i < CLI_FUNC_MAXARGS; i++)
+    {
+        char aname[4];
+        snprintf(aname, sizeof(aname),
+                 "%d", i + 1);
+        const char *ov = cli_var_get(aname);
+        old_used[i] = (ov != NULL) ? 1 : 0;
+        if(ov != NULL)
+        {
+            strncpy(old_args[i], ov,
+                    CLI_VAR_VALLEN - 1);
+            old_args[i][
+                CLI_VAR_VALLEN - 1] = '\0';
+        }
+        if(i < nargs)
+        {
+            cli_var_set(aname, args[i]);
+        }
+        else
+        {
+            cli_var_unset(aname);
+        }
+    }
+
+    /* Execute body lines */
+    cli_exec_lines(func->body, func->nbody);
+
+    /* Restore old $1..$9 */
+    for(int i = 0; i < CLI_FUNC_MAXARGS; i++)
+    {
+        char aname[4];
+        snprintf(aname, sizeof(aname),
+                 "%d", i + 1);
+        if(old_used[i])
+        {
+            cli_var_set(aname, old_args[i]);
+        }
+        else
+        {
+            cli_var_unset(aname);
+        }
+    }
+
+    return 1;
+}
+
+
+/* ============================================================
+ *  Block Intercept — main entry point
+ * ============================================================
+ *
+ * Called from CLI_execute_line() before any other
+ * processing. Returns 1 if the line was consumed
+ * (buffered or block completed).
+ */
+
+/**
+ * @brief Intercept line for flow control
+ *
+ * @param line  The raw command line
+ * @return 1 if consumed, 0 if not
+ */
+int cli_script_intercept(const char *line)
+{
+    const char *p = strip_ws(line);
+
+    /* If we're already accumulating a block,
+     * buffer the line */
+    if(cli_block_level > 0)
+    {
+        CLI_BLOCK *blk =
+            &cli_block_stack[
+                cli_block_level - 1];
+
+        /* Check for nested openers */
+        if(starts_with(p, "if ")
+           || starts_with(p, "if\t")
+           || starts_with(p, "while ")
+           || starts_with(p, "while\t")
+           || starts_with(p, "for ")
+           || starts_with(p, "for\t")
+           || starts_with(p, "function ")
+           || starts_with(p, "function\t"))
+        {
+            blk->depth++;
+        }
+
+        /* Check for closers.
+         * When depth > 0 (nested block),
+         * ANY closer keyword decrements
+         * the depth. Only at depth 0 does
+         * the closer need to match the
+         * outer block type. */
+        int is_close = 0;
+        int is_any_close =
+            (strcmp(p, "fi") == 0
+             || strcmp(p, "done") == 0
+             || strcmp(p, "}") == 0);
+
+        if(is_any_close && blk->depth > 0)
+        {
+            /* Nested closer — decrement
+             * depth and buffer */
+            blk->depth--;
+            if(blk->nlines
+               < CLI_BLOCK_MAXLINES)
+            {
+                strncpy(
+                    blk->lines[
+                        blk->nlines],
+                    p,
+                    STRINGMAXLEN_CLICMDLINE
+                    - 1);
+                blk->nlines++;
+            }
+            return 1;
+        }
+
+        /* Check outer block closer */
+        if(blk->type == CLI_BLOCK_IF
+           && strcmp(p, "fi") == 0)
+        {
+            is_close = 1;
+        }
+        if((blk->type == CLI_BLOCK_WHILE
+            || blk->type == CLI_BLOCK_FOR)
+           && strcmp(p, "done") == 0)
+        {
+            is_close = 1;
+        }
+        if(blk->type == CLI_BLOCK_FUNC
+           && strcmp(p, "}") == 0)
+        {
+            is_close = 1;
+        }
+
+        if(is_close)
+        {
+            /* Outer block complete — save
+             * data locally because the stack
+             * slot may be reused by nested
+             * blocks during execution.
+             * Use malloc to avoid stack
+             * overflow on deep nesting. */
+            int saved_type = blk->type;
+            int saved_nlines = blk->nlines;
+            char (*saved_lines)[
+                STRINGMAXLEN_CLICMDLINE] =
+                malloc(
+                    (size_t) saved_nlines
+                    * STRINGMAXLEN_CLICMDLINE);
+            if(saved_lines == NULL)
+            {
+                printf("Error: malloc failed "
+                       "for block lines\n");
+                cli_block_level--;
+                return 1;
+            }
+            for(int si = 0;
+                si < saved_nlines; si++)
+            {
+                strncpy(
+                    saved_lines[si],
+                    blk->lines[si],
+                    STRINGMAXLEN_CLICMDLINE
+                    - 1);
+                saved_lines[si][
+                    STRINGMAXLEN_CLICMDLINE
+                    - 1] = '\0';
+            }
+            cli_block_level--;
+
+            if(saved_type == CLI_BLOCK_IF)
+            {
+                cli_exec_block_if(
+                    saved_lines,
+                    saved_nlines);
+            }
+            else if(
+                saved_type == CLI_BLOCK_WHILE)
+            {
+                cli_exec_block_while(
+                    saved_lines,
+                    saved_nlines);
+            }
+            else if(
+                saved_type == CLI_BLOCK_FOR)
+            {
+                cli_exec_block_for(
+                    saved_lines,
+                    saved_nlines);
+            }
+            else if(
+                saved_type == CLI_BLOCK_FUNC)
+            {
+                /* Define function from
+                 * buffered lines */
+                const char *fl =
+                    strip_ws(
+                        saved_lines[0]);
+                fl += 8; /* "function" */
+                fl = strip_ws(fl);
+                char fname[CLI_FUNC_NAMELEN];
+                {
+                    int fn = 0;
+                    while(*fl != '\0'
+                          && *fl != ' '
+                          && *fl != '\t'
+                          && *fl != '{'
+                          && fn
+                             < CLI_FUNC_NAMELEN
+                               - 1)
+                    {
+                        fname[fn++] = *fl++;
+                    }
+                    fname[fn] = '\0';
+                }
+                /* Body starts at line 1
+                 * (skip function header) */
+                cli_func_define(
+                    fname,
+                    saved_lines + 1,
+                    saved_nlines - 1);
+            }
+
+            free(saved_lines);
+            return 1;
+        }
+
+        /* Buffer normal line */
+        if(blk->nlines < CLI_BLOCK_MAXLINES)
+        {
+            strncpy(
+                blk->lines[blk->nlines],
+                p,
+                STRINGMAXLEN_CLICMDLINE - 1);
+            blk->nlines++;
+        }
+        return 1;
+    }
+
+    /* ---- Not in a block: check openers ---- */
+
+    /* break / continue */
+    if(strcmp(p, "break") == 0)
+    {
+        cli_break_flag = 1;
+        return 1;
+    }
+    if(strcmp(p, "continue") == 0)
+    {
+        cli_continue_flag = 1;
+        return 1;
+    }
+
+    /* local VAR=val — set variable (only
+     * meaningful inside function, but works
+     * anywhere) */
+    if(starts_with(p, "local ")
+       || starts_with(p, "local\t"))
+    {
+        p += 5;
+        p = strip_ws(p);
+        cli_try_var_assign(p);
+        return 1;
+    }
+
+    /* if ... */
+    if(starts_with(p, "if ")
+       || starts_with(p, "if\t"))
+    {
+        if(cli_block_level
+           >= CLI_BLOCK_MAXDEPTH)
+        {
+            printf("Error: max block "
+                   "nesting exceeded\n");
+            return 1;
+        }
+        CLI_BLOCK *blk =
+            &cli_block_stack[
+                cli_block_level];
+        memset(blk, 0, sizeof(*blk));
+        blk->type = CLI_BLOCK_IF;
+        blk->active = 1;
+        strncpy(blk->lines[0], p,
+                STRINGMAXLEN_CLICMDLINE - 1);
+        blk->nlines = 1;
+        cli_block_level++;
+        return 1;
+    }
+
+    /* while ... */
+    if(starts_with(p, "while ")
+       || starts_with(p, "while\t"))
+    {
+        if(cli_block_level
+           >= CLI_BLOCK_MAXDEPTH)
+        {
+            printf("Error: max block "
+                   "nesting exceeded\n");
+            return 1;
+        }
+        CLI_BLOCK *blk =
+            &cli_block_stack[
+                cli_block_level];
+        memset(blk, 0, sizeof(*blk));
+        blk->type = CLI_BLOCK_WHILE;
+        blk->active = 1;
+        strncpy(blk->lines[0], p,
+                STRINGMAXLEN_CLICMDLINE - 1);
+        blk->nlines = 1;
+        cli_block_level++;
+        return 1;
+    }
+
+    /* for ... */
+    if(starts_with(p, "for ")
+       || starts_with(p, "for\t"))
+    {
+        if(cli_block_level
+           >= CLI_BLOCK_MAXDEPTH)
+        {
+            printf("Error: max block "
+                   "nesting exceeded\n");
+            return 1;
+        }
+        CLI_BLOCK *blk =
+            &cli_block_stack[
+                cli_block_level];
+        memset(blk, 0, sizeof(*blk));
+        blk->type = CLI_BLOCK_FOR;
+        blk->active = 1;
+        strncpy(blk->lines[0], p,
+                STRINGMAXLEN_CLICMDLINE - 1);
+        blk->nlines = 1;
+        cli_block_level++;
+        return 1;
+    }
+
+    /* function name { ... } */
+    if(starts_with(p, "function ")
+       || starts_with(p, "function\t"))
+    {
+        if(cli_block_level
+           >= CLI_BLOCK_MAXDEPTH)
+        {
+            printf("Error: max block "
+                   "nesting exceeded\n");
+            return 1;
+        }
+        CLI_BLOCK *blk =
+            &cli_block_stack[
+                cli_block_level];
+        memset(blk, 0, sizeof(*blk));
+        blk->type = CLI_BLOCK_FUNC;
+        blk->active = 1;
+        strncpy(blk->lines[0], p,
+                STRINGMAXLEN_CLICMDLINE - 1);
+        blk->nlines = 1;
+        cli_block_level++;
+        return 1;
+    }
+
+    /* Try user-defined function call */
+    {
+        char firstword[CLI_FUNC_NAMELEN];
+        int fw = 0;
+        while(*p != '\0' && *p != ' '
+              && *p != '\t'
+              && fw < CLI_FUNC_NAMELEN - 1)
+        {
+            firstword[fw++] = *p++;
+        }
+        firstword[fw] = '\0';
+
+        if(cli_func_find(firstword) != NULL)
+        {
+            p = strip_ws(line);
+            cli_try_func_call(p);
+            return 1;
+        }
+    }
+
+    return 0;
 }

--- a/src/cli/CLIcore/CLIcore/CLIcore_script.h
+++ b/src/cli/CLIcore/CLIcore/CLIcore_script.h
@@ -1,0 +1,78 @@
+/**
+ * @file CLIcore_script.h
+ * @brief CLI scripting engine — variables, FPS access,
+ *        flow control, functions
+ */
+
+#ifndef CLICORE_SCRIPT_H
+#define CLICORE_SCRIPT_H
+
+#include "CLIcore.h"
+
+/* ---- CLI Variable Storage ---- */
+
+#define CLI_VAR_NAMELEN   64
+#define CLI_VAR_VALLEN   512
+#define CLI_MAX_VARS     256
+
+typedef struct
+{
+    char name[CLI_VAR_NAMELEN];
+    char val[CLI_VAR_VALLEN];
+    int  used;
+} CLI_VAR;
+
+/* Global variable table */
+extern CLI_VAR cli_vars[CLI_MAX_VARS];
+extern int     cli_last_retval;
+
+/* ---- Variable Functions ---- */
+
+/** Look up a CLI variable by name.
+ *  Returns pointer to value string, or NULL. */
+const char *cli_var_get(const char *name);
+
+/** Set a CLI variable. Creates if new. */
+void cli_var_set(
+    const char *name,
+    const char *val
+);
+
+/** Remove a CLI variable. */
+void cli_var_unset(const char *name);
+
+/* ---- CLI Commands ---- */
+
+/** unset VAR — remove a variable */
+errno_t cli_cmd_unset(void);
+
+/** vars — list all variables */
+errno_t cli_cmd_vars(void);
+
+/** echo — print arguments */
+errno_t cli_cmd_echo(void);
+
+/* ---- Expansion Functions ---- */
+
+/** Expand CLI variables ($VAR, ${VAR}, $?)
+ *  before falling through to env vars.
+ *  Called from cli_expand_env(). */
+const char *cli_var_lookup(const char *name);
+
+/** Expand @fpsname.param tokens in place. */
+void cli_expand_fpsvar(
+    char *line,
+    int   maxlen
+);
+
+/** Expand $(( expr )) arithmetic in place. */
+void cli_expand_arith(
+    char *line,
+    int   maxlen
+);
+
+/** Check if line is a variable assignment
+ *  (VAR=val). Returns 1 if handled. */
+int cli_try_var_assign(const char *line);
+
+#endif /* CLICORE_SCRIPT_H */

--- a/src/cli/CLIcore/CLIcore/CLIcore_script.h
+++ b/src/cli/CLIcore/CLIcore/CLIcore_script.h
@@ -28,8 +28,7 @@ extern int     cli_last_retval;
 
 /* ---- Variable Functions ---- */
 
-/** Look up a CLI variable by name.
- *  Returns pointer to value string, or NULL. */
+/** Look up a CLI variable by name. */
 const char *cli_var_get(const char *name);
 
 /** Set a CLI variable. Creates if new. */
@@ -52,11 +51,12 @@ errno_t cli_cmd_vars(void);
 /** echo — print arguments */
 errno_t cli_cmd_echo(void);
 
+/** fpsset — write FPS parameter */
+errno_t cli_cmd_fpsset(void);
+
 /* ---- Expansion Functions ---- */
 
-/** Expand CLI variables ($VAR, ${VAR}, $?)
- *  before falling through to env vars.
- *  Called from cli_expand_env(). */
+/** Unified variable lookup: CLI > special > env */
 const char *cli_var_lookup(const char *name);
 
 /** Expand @fpsname.param tokens in place. */
@@ -71,8 +71,82 @@ void cli_expand_arith(
     int   maxlen
 );
 
+/** Expand $VAR and ${VAR} in place.
+ *  Defined in CLIcore_UI.c. */
+void cli_expand_env(
+    char *line,
+    int   maxlen
+);
+
 /** Check if line is a variable assignment
  *  (VAR=val). Returns 1 if handled. */
 int cli_try_var_assign(const char *line);
+
+/* ---- Block Accumulator (flow control) ---- */
+
+#define CLI_BLOCK_MAXLINES  1024
+#define CLI_BLOCK_MAXDEPTH    16
+
+/** Block types */
+enum
+{
+    CLI_BLOCK_NONE = 0,
+    CLI_BLOCK_IF,
+    CLI_BLOCK_WHILE,
+    CLI_BLOCK_FOR,
+    CLI_BLOCK_FUNC
+};
+
+/** Block accumulator state */
+typedef struct
+{
+    int  type;
+    int  depth;
+    char lines[CLI_BLOCK_MAXLINES][
+        STRINGMAXLEN_CLICMDLINE];
+    int  nlines;
+    int  active;
+} CLI_BLOCK;
+
+extern CLI_BLOCK cli_block_stack[CLI_BLOCK_MAXDEPTH];
+extern int       cli_block_level;
+
+/** Intercept a line for block accumulation.
+ *  Returns 1 if consumed, 0 if not. */
+int cli_script_intercept(const char *line);
+
+/** Evaluate a test expression [ ... ].
+ *  Returns 1 if true, 0 if false. */
+int cli_eval_test(const char *expr);
+
+/** Execute a list of lines as a block. */
+void cli_exec_lines(
+    char lines[][STRINGMAXLEN_CLICMDLINE],
+    int  nlines
+);
+
+/* ---- User-Defined Functions ---- */
+
+#define CLI_FUNC_MAXARGS  10
+#define CLI_MAX_FUNCS     64
+#define CLI_FUNC_NAMELEN  64
+
+typedef struct
+{
+    char name[CLI_FUNC_NAMELEN];
+    char body[CLI_BLOCK_MAXLINES][
+        STRINGMAXLEN_CLICMDLINE];
+    int  nbody;
+    int  used;
+} CLI_FUNC;
+
+extern CLI_FUNC cli_funcs[CLI_MAX_FUNCS];
+
+/** Look up user function by name. */
+CLI_FUNC *cli_func_find(const char *name);
+
+/** Try to call a user-defined function.
+ *  Returns 1 if matched and called. */
+int cli_try_func_call(const char *line);
 
 #endif /* CLICORE_SCRIPT_H */

--- a/src/cli/CLIcore/CMakeLists.txt
+++ b/src/cli/CLIcore/CMakeLists.txt
@@ -35,6 +35,7 @@ set(CORE_FILES
     CLIcore/CLIcore_memory.c
     CLIcore/CLIcore_modules.c
     CLIcore/CLIcore_setSHMdir.c
+    CLIcore/CLIcore_script.c
     CLIcore/CLIcore_signals.c
     cli_calc_tokenizer.c
     cli_calc_parser.c)
@@ -148,6 +149,7 @@ install(FILES CLIcore/CLIcore_UI.h
               CLIcore/CLIcore_memory.h
               CLIcore/CLIcore_modules.h
               CLIcore/CLIcore_setSHMdir.h
+              CLIcore/CLIcore_script.h
               CLIcore/CLIcore_signals.h
               CLIcore/CLIcore_utils.h
               DESTINATION include/${SRCNAME}/CLIcore)


### PR DESCRIPTION
## Summary

Adds filesystem script save/load capabilities and comprehensive scripting documentation to the milk CLI.

## New Commands

| Command | Description |
|---------|-------------|
| `savescript <file>` | Export all CLI variables and user-defined functions to a `.milk` script file |
| `savehistory <file>` | Write readline command history to a file |
| `. <file>` | Dot-sourcing shorthand for `source` (bash syntax) |

## Bug Fix

**Fixed `source` command failing for file paths containing dots** (e.g., `test.milk`). The CLI tokenizer was misinterpreting the `.milk` extension. Moved `source` to pre-tokenization keyword handling (same approach as `echo`), alongside the new `savescript` and `savehistory` commands.

## Documentation

- **New**: `docs/cli/scripting.md` — comprehensive MkDocs page covering variables, arithmetic, FPS parameter access, flow control (`if`/`while`/`for`), user-defined functions, and script file management
- **Updated**: `mkdocs.yml` — added Scripting page to navigation
- **Updated**: `docs/cli/CLIcore.md` — section 15 now references the scripting page and lists new commands

## Files Changed

| File | Change |
|------|--------|
| `CLIcore_UI.c` | `cli_savescript()`, `cli_savehistory()`, dot-sourcing, pre-tokenization keyword handlers for `source`/`savescript`/`savehistory` |
| `CLIcore_UI.h` | Declarations for new functions |
| `CLIcore.c` | Command registration for `savescript` and `savehistory` |
| `CLIcore_script.c` | Flow control bug fixes (nested closers, body_end calculation) |
| `CLIcore_script.h` | Updated declarations |
| `docs/cli/scripting.md` | **[NEW]** Comprehensive scripting documentation |
| `mkdocs.yml` | Added Scripting nav entry |
| `docs/cli/CLIcore.md` | Updated section 15 |

## Testing

| Test | Result |
|------|--------|
| `savescript` exports vars+functions | ✅ |
| `source` restores vars+functions | ✅ |
| `. file` dot-sourcing | ✅ |
| `savehistory` writes history | ✅ |
| Flow control in sourced scripts | ✅ |

Build: clean (no warnings, no errors)