### PR TITLE
docs(help): add scripting sections to CLI help

### DIFF
--- a/src/cli/CLIcore/CLIcore/CLIcore_help.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_help.c
@@ -1342,6 +1342,96 @@ void print_milk_cli_help(void)
     printf(C_CMD "  iofits.savefits " C_RST "Save FITS file " C_NOTE "(requires CFITS)\n" C_RST);
     printf(C_CMD "  quit / exit     " C_RST "Exit the milk shell\n");
     printf(C_CMD "  !<syscommand>   " C_RST "Execute shell command\n");
+
+    printf("\n");
+    printf(C_TITLE "========================================================\n" C_RST);
+    printf(C_TITLE "                 SCRIPTING                              \n" C_RST);
+    printf(C_TITLE "========================================================\n" C_RST);
+    printf("\n");
+    printf(C_HDR "Variables:\n" C_RST);
+    printf("  " C_CMD "x=42" C_RST
+           "              Set variable\n");
+    printf("  " C_CMD "echo $x" C_RST
+           "           Print variable\n");
+    printf("  " C_CMD "echo ${x}" C_RST
+           "         Braced form\n");
+    printf("  " C_CMD "unset x" C_RST
+           "           Remove variable\n");
+    printf("  " C_CMD "vars" C_RST
+           "              List all variables\n");
+    printf("\n");
+    printf(C_HDR "Arithmetic:\n" C_RST);
+    printf("  " C_CMD "y=$(( x + 5 ))" C_RST
+           "  Integer +, -, *, /, %%\n");
+    printf("\n");
+    printf(C_HDR "FPS Parameter Access:\n" C_RST);
+    printf("  " C_CMD "@fpsname.param" C_RST
+           "    Read FPS parameter\n");
+    printf("  " C_CMD "fpsset fps p v" C_RST
+           "    Write FPS parameter\n");
+
+    printf("\n");
+    printf(C_TITLE "========================================================\n" C_RST);
+    printf(C_TITLE "                 FLOW CONTROL                           \n" C_RST);
+    printf(C_TITLE "========================================================\n" C_RST);
+    printf("\n");
+    printf(C_HDR "Conditionals:\n" C_RST);
+    printf("  " C_CMD
+           "if [ $x -gt 5 ]; then"
+           C_RST "\n");
+    printf("  " C_CMD "    echo big"
+           C_RST "\n");
+    printf("  " C_CMD "else" C_RST "\n");
+    printf("  " C_CMD "    echo small"
+           C_RST "\n");
+    printf("  " C_CMD "fi" C_RST "\n");
+    printf("  Tests: "
+           C_NOTE "-eq -ne -gt -ge -lt -le"
+           C_RST " (numeric), "
+           C_NOTE "= !=" C_RST
+           " (string)\n");
+    printf("\n");
+    printf(C_HDR "Loops:\n" C_RST);
+    printf("  " C_CMD
+           "while [ $n -lt 10 ]; do"
+           C_RST " ... "
+           C_CMD "done" C_RST "\n");
+    printf("  " C_CMD
+           "for x in a b c; do"
+           C_RST " ... "
+           C_CMD "done" C_RST "\n");
+    printf("  " C_CMD "break" C_RST
+           " exits loop early\n");
+    printf("\n");
+    printf(C_HDR "Functions:\n" C_RST);
+    printf("  " C_CMD
+           "function myfunc {" C_RST
+           " ... "
+           C_CMD "}" C_RST "\n");
+    printf("  " C_CMD "myfunc arg1 arg2"
+           C_RST "  call with "
+           C_NOTE "$1..$9" C_RST
+           " inside body\n");
+
+    printf("\n");
+    printf(C_TITLE "========================================================\n" C_RST);
+    printf(C_TITLE "                 SCRIPT FILES                           \n" C_RST);
+    printf(C_TITLE "========================================================\n" C_RST);
+    printf("\n");
+    printf(C_CMD "  source <file>     " C_RST
+           "Execute a script file\n");
+    printf(C_CMD "  . <file>          " C_RST
+           "Same (dot-source)\n");
+    printf(C_CMD "  savescript <file>  " C_RST
+           "Save variables & functions\n");
+    printf(C_CMD "  savehistory <file> " C_RST
+           "Save command history\n");
+    printf("  Startup: "
+           C_CMD "milk-cli -s <file>" C_RST
+           "  run script on launch\n");
+    printf("  Shebang: "
+           C_NOTE "#!/usr/bin/env milk-cli -s"
+           C_RST "\n");
     printf("\n");
 
     return;

--- a/src/cli/CLIcore/doc/help.txt
+++ b/src/cli/CLIcore/doc/help.txt
@@ -168,6 +168,74 @@ If you start the executable with the "-l" option,  the file "imlist.txt" contain
 Note that if you launch several instances of the executable in the same directory, they will share the same fifo - this is generally a bad idea, as there is no easy way to control wich of the programs will read and execute the fifo commands.
 
 -----------------------------------------------------------------------------------
+SCRIPTING — VARIABLES & ARITHMETIC
+
+> x=42
+	# set variable x to 42
+> echo $x
+	# print variable value
+> echo ${x}
+	# braced variable form
+> unset x
+	# remove variable
+> vars
+	# list all defined variables
+> y=$(( x + 5 ))
+	# integer arithmetic: + - * / %
+> echo @fpsname.param
+	# read FPS parameter value
+> fpsset fpsname param value
+	# write FPS parameter
+
+-----------------------------------------------------------------------------------
+FLOW CONTROL
+
+> if [ $x -gt 5 ]; then
+>     echo big
+> else
+>     echo small
+> fi
+	# conditionals: -eq -ne -gt -ge -lt -le (numeric), = != (string)
+
+> while [ $n -lt 10 ]; do
+>     n=$(( n + 1 ))
+>     echo $n
+> done
+	# while loop
+
+> for item in a b c; do
+>     echo $item
+> done
+	# for loop
+
+> break
+	# exit loop early
+
+> function myfunc {
+>     echo Hello $1
+> }
+> myfunc world
+	# user-defined functions with $1..$9 arguments
+
+-----------------------------------------------------------------------------------
+SCRIPT FILES
+
+> source myscript.milk
+	# execute commands from a script file
+> . myscript.milk
+	# same as source (dot-sourcing)
+> savescript state.milk
+	# export variables and functions to file
+> savehistory replay.milk
+	# save command history to file
+
+Startup script:
+	milk-cli -s myscript.milk
+
+Shebang for executable scripts:
+	#!/usr/bin/env milk-cli -s
+
+-----------------------------------------------------------------------------------
 ARITHMETIC OPERATIONS
 
 > im1=sqrt(im+2.0)


### PR DESCRIPTION
Add three new sections to `milk-cli-help` output and `doc/help.txt`:
- **SCRIPTING** — variables, arithmetic (`$(( ))`), FPS parameter access (`@fps.param`)
- **FLOW CONTROL** — `if/then/else/fi`, `while/do/done`, `for/do/done`, `break`, user-defined functions
- **SCRIPT FILES** — `source`, `. file` (dot-sourcing), `savescript`, `savehistory`, startup scripts (`-s`), shebang lines

### Files Changed
| File | Change |
|------|--------|
| `CLIcore_help.c` | New sections in `print_milk_cli_help()` |
| `doc/help.txt` | Matching plain-text sections |

### Prompt Summary
User requested updating `milk-cli-help` to document the new CLI scripting capabilities added in feat/cli-scripting.

### AI Authorship
- **Model:** Claude Opus 4 (Antigravity)
- **User edits:** None