### PR TITLE
fix(cmake): link _compute variant for imggen standalones

### DIFF
--- a/plugins/milk-extra-src/image_gen/CMakeLists.txt
+++ b/plugins/milk-extra-src/image_gen/CMakeLists.txt
@@ -110,10 +110,10 @@ endif()
 add_milk_standalone(imggen-voronoi voronoi.c)
 add_milk_standalone(imggen-mkdisk mkdisk.c)
 target_link_libraries(milk-fpsexec-imggen-mkdisk PUBLIC
-    ${LIBNAME})
+    ${LIBNAME_COMPUTE})
 add_milk_standalone(imggen-mkspdisk mkspdisk.c)
 target_link_libraries(milk-fpsexec-imggen-mkspdisk PUBLIC
-    ${LIBNAME})
+    ${LIBNAME_COMPUTE})
 add_milk_standalone(imggen-mkpolygon mkpolygon.c)
 target_link_libraries(milk-fpsexec-imggen-mkpolygon PUBLIC
-    ${LIBNAME})
+    ${LIBNAME_COMPUTE})


### PR DESCRIPTION
Three image_gen standalone executables (`mkdisk`, `mkspdisk`, `mkpolygon`) were linking `milkimagegen` which depends on CLIcore. Changed to link `milkimagegen_compute` instead, fixing the `standalone-dep-check` CI test failure.

### Prompt Summary
Fix CI `standalone-dep-check` test failure on `framework-dev` introduced by the new imggen standalone executables.

### AI Authorship
- **Model:** Claude Opus 4 (`claude-opus-4-20250514`, Anthropic)
- **User edits:** None