### PR TITLE
docs: replace outdated cmdfile.txt references with FIFO usage

### DIFF
--- a/docs/cli/CLIcore.md
+++ b/docs/cli/CLIcore.md
@@ -105,9 +105,9 @@ Key bindings include `Ctrl+A` (start of line), `Ctrl+E`
 (end of line), `Ctrl+R` (reverse history search), and
 arrow keys for navigation.
 
-The CLI also reads commands from `cmdfile.txt` if it exists,
-executing them top-to-bottom and removing each line as it
-is read.
+The CLI can also receive commands from external processes
+via a named pipe (FIFO). See [FIFO Input Mode](#7-fifo-input-mode)
+below.
 
 ## 7. FIFO Input Mode
 
@@ -486,32 +486,35 @@ milk-cli > mload COREMOD_arith     # load module by name
 
 ## 34. Integration with Standard Linux Tools
 
-### Using `cmdfile.txt` to drive milk-cli
+### Driving milk-cli via FIFO
 
-`milk-cli` executes commands from `cmdfile.txt` if the file
-exists. This enables scripting from both inside and outside
-the CLI.
+Start `milk-cli` with the `-f` flag to enable FIFO input
+(see [FIFO Input Mode](#7-fifo-input-mode)). External
+processes can then send commands through the named pipe.
 
-**From inside `milk-cli`:**
+**From inside `milk-cli`** (assuming FIFO is at
+`/dev/shm/.myctl.fifo.<PID>`):
 
 ```text
-milk-cli > !ls im*.fits | xargs -I {} echo iofits.loadfits {} > cmdfile.txt
+milk-cli > !ls im*.fits | xargs -I {} echo iofits.loadfits {} > /dev/shm/.myctl.fifo.0012345
 ```
 
-**From a separate shell (while `milk-cli` is running):**
+**From a separate shell** (while `milk-cli -n myctl -f`
+is running):
 
 ```bash
-$ ls im*.fits | xargs -I {} echo iofits.loadfits {} > cmdfile.txt
+$ ls im*.fits | xargs -I {} echo iofits.loadfits {} > /dev/shm/.myctl.fifo.0012345
 ```
 
-### Using `imlist.txt` and `cmdfile.txt`
+### Using `imlist.txt` and the FIFO
 
-Start `milk-cli` with `-l` to maintain `imlist.txt`. Then
-filter and act on the list:
+Start `milk-cli` with `-l -f` (or `-l -n myctl -f`) to
+maintain `imlist.txt` and enable FIFO input. Then filter
+and act on the list:
 
 ```text
 milk-cli > !awk '{if ($4>200) print $2}' imlist.txt \
-        | xargs -I {} echo iofits.save_fl {} {}_tmp.fits > cmdfile.txt
+        | xargs -I {} echo iofits.save_fl {} {}_tmp.fits > /dev/shm/.myctl.fifo.0012345
 ```
 
 ---

--- a/docs/cli/help.txt
+++ b/docs/cli/help.txt
@@ -64,7 +64,7 @@ INPUT
 GNU readline used to read input. See GNU readline documentation on http://tiswww.case.edu/php/chet/readline/rltop.html. For a quick help on readline input, type:
 > helprl
 
-The command line interpreter (CLI) will take input from file cmdfile.txt if it exists. If file cmdfile.txt exists commands will be read one by one from top to bottom, and will be removed from the file as they are read, until the file is empty
+The CLI can also receive commands from external processes via a named pipe (FIFO). Start milk-cli with the -f flag to enable FIFO input. See FIFO INPUT section below for details.
 
 -----------------------------------------------------------------------------------
 HELP COMMANDS
@@ -139,27 +139,33 @@ INTEGRATION WITH STANDARD LINUX TOOLS AND COMMANDS
 
 FIFO INPUT TO EXECUTABLE:
 
-You can control the executable through a named pipe (fifo), which is created by default when the executable is started, and removed when it is cleanly stopped. Note that starting the program will erase the content of the fifo upon startup even if it was previously created.
+You can control the executable through a named pipe (FIFO). To enable FIFO input, start milk-cli with the -f flag (auto-generated path) or -F <path> (custom path). The FIFO is removed when the process cleanly exits.
 
-By default, the fifo is created in the local directory, with the name "clififo", to pipe commands into the command line interface. You can opt out of the fifo feature by adding the option --nofifo to the command line executable, or rename the fifo with the -F option :
-<executable> -F "/tmp/fifo145.txt"
-This will create a fifo named /tmp/fifo145.txt.
+The auto-generated FIFO path follows the template:
+$SHMDIR/.<processname>.fifo.<PID>
 
-Other programs can write to the fifo to issue commands to the executable, such as:
-cat myscript.txt > clififo
-More complex commands can be issued within the executable using the fifo.
-For example, to load all im*.fits files in memory, you can type within the executable:
+Use -n to give the process a friendlier name:
+  milk-cli -n myctl -f    # creates /dev/shm/.myctl.fifo.<PID>
 
-> !ls im*.fits | xargs -I {} echo iofits.loadfits {} >> clififo
+Or specify a custom FIFO path:
+  milk-cli -F /tmp/myfifo
+
+Other programs can write to the FIFO to issue commands to the running session:
+  echo "mem.listim" > /dev/shm/.myctl.fifo.0012345
+
+More complex commands can be issued within the executable using the FIFO.
+For example, to load all im*.fits files in memory, you can type within the executable (replace the fifo path with the actual path for your session):
+
+> !ls im*.fits | xargs -I {} echo iofits.loadfits {} >> /dev/shm/.myctl.fifo.0012345
 
 
-USING "imlist.txt" AND fifo
+USING "imlist.txt" AND FIFO
 
-If you start the executable with the "--listimf" option,  the file "imlist.txt" contains the list of images currently in memory in a ASCII table. You can use standard unix tools to process this list and issue commands. For example, if you want to save all images with x size > 200 onto disk as single precision FITS files :
+If you start the executable with the "--listimf" option, the file "imlist.txt" contains the list of images currently in memory in an ASCII table. You can use standard unix tools to process this list and issue commands. For example, if you want to save all images with x size > 200 onto disk as single precision FITS files:
 
-> !awk '{if ($4>200) print $2}' imlist.txt| xargs -I {} echo iofits.saveFITS {} {}_tmp.fits >> clififo
+> !awk '{if ($4>200) print $2}' imlist.txt| xargs -I {} echo iofits.saveFITS {} {}_tmp.fits >> /dev/shm/.myctl.fifo.0012345
 
-Note that if you launch several instances of the executable in the same directory, they will share the same fifo - this is generally a bad idea, as there is no easy way to control wich of the programs will read and execute the fifo commands.
+Note: each milk-cli session has its own unique FIFO path. Use -n to give sessions distinct names and avoid ambiguity.
 
 -----------------------------------------------------------------------------------
 ARITHMETIC OPERATIONS

--- a/src/cli/CLIcore/doc/help.txt
+++ b/src/cli/CLIcore/doc/help.txt
@@ -68,7 +68,7 @@ INPUT
 GNU readline used to read input. See GNU readline documentation on http://tiswww.case.edu/php/chet/readline/rltop.html. For a quick help on readline input, type:
 > helprl
 
-The command line interpreter (CLI) will take input from file cmdfile.txt if it exists. If file cmdfile.txt exists commands will be read one by one from top to bottom, and will be removed from the file as they are read, until the file is empty
+The CLI can also receive commands from external processes via a named pipe (FIFO). Start milk-cli with the -f flag to enable FIFO input. See FIFO INPUT section below for details.
 
 -----------------------------------------------------------------------------------
 HELP COMMANDS
@@ -145,27 +145,33 @@ INTEGRATION WITH STANDARD LINUX TOOLS AND COMMANDS
 
 FIFO INPUT TO EXECUTABLE:
 
-You can control the executable through a named pipe (fifo), which is created by default when the executable is started, and removed when it is cleanly stopped. Note that starting the program will erase the content of the fifo upon startup even if it was previously created.
+You can control the executable through a named pipe (FIFO). To enable FIFO input, start milk-cli with the -f flag (auto-generated path) or -F <path> (custom path). The FIFO is removed when the process cleanly exits.
 
-By default, the fifo is created in the local directory, with the name "clififo", to pipe commands into the command line interface. You can opt out of the fifo feature by adding the option --nofifo to the command line executable, or rename the fifo with the -f option :
-<executable> -f "/tmp/fifo145.txt"
-This will create a fifo named /tmp/fifo145.txt.
+The auto-generated FIFO path follows the template:
+$SHMDIR/.<processname>.fifo.<PID>
 
-Other programs can write to the fifo to issue commands to the executable, such as:
-cat myscript.txt > clififo
-More complex commands can be issued within the executable using the fifo.
-For example, to load all im*.fits files in memory, you can type within the executable:
+Use -n to give the process a friendlier name:
+  milk-cli -n myctl -f    # creates /dev/shm/.myctl.fifo.<PID>
 
-> !ls im*.fits | xargs -I {} echo loadfits {} >> clififo
+Or specify a custom FIFO path:
+  milk-cli -F /tmp/myfifo
+
+Other programs can write to the FIFO to issue commands to the running session:
+  echo "mem.listim" > /dev/shm/.myctl.fifo.0012345
+
+More complex commands can be issued within the executable using the FIFO.
+For example, to load all im*.fits files in memory, you can type within the executable (replace the fifo path with the actual path for your session):
+
+> !ls im*.fits | xargs -I {} echo loadfits {} >> /dev/shm/.myctl.fifo.0012345
 
 
-USING "imlist.txt" AND fifo
+USING "imlist.txt" AND FIFO
 
-If you start the executable with the "-l" option,  the file "imlist.txt" contains the list of images currently in memory in a ASCII table. You can use standard unix tools to process this list and issue commands. For example, if you want to save all images with x size > 200 onto disk as single precision FITS files :
+If you start the executable with the "-l" option, the file "imlist.txt" contains the list of images currently in memory in an ASCII table. You can use standard unix tools to process this list and issue commands. For example, if you want to save all images with x size > 200 onto disk as single precision FITS files:
 
-> !awk '{if ($4>200) print $2}' imlist.txt| xargs -I {} echo saveflfits {} {}_tmp.fits >> clififo
+> !awk '{if ($4>200) print $2}' imlist.txt| xargs -I {} echo saveflfits {} {}_tmp.fits >> /dev/shm/.myctl.fifo.0012345
 
-Note that if you launch several instances of the executable in the same directory, they will share the same fifo - this is generally a bad idea, as there is no easy way to control wich of the programs will read and execute the fifo commands.
+Note: each milk-cli session has its own unique FIFO path. Use -n to give sessions distinct names and avoid ambiguity.
 
 -----------------------------------------------------------------------------------
 SCRIPTING — VARIABLES & ARITHMETIC


### PR DESCRIPTION
### Summary

Replace all references to the defunct `cmdfile.txt` mechanism with the current FIFO-based approach for driving `milk-cli` from external processes. The `cmdfile.txt` feature no longer exists in the C source code — the FIFO (`-f`/`-F` flags) is the only supported mechanism.

### Changes

Three documentation files updated:

- **`docs/cli/CLIcore.md`** — Section 6 (Readline Editing) now points to the FIFO section instead of mentioning `cmdfile.txt`. Section 34 ("Integration with Standard Linux Tools") rewritten to show FIFO usage with `-f`/`-F`/`-n` flags and `/dev/shm/` paths.
- **`docs/cli/help.txt`** — INPUT section and INTEGRATION section updated to match.
- **`src/cli/CLIcore/doc/help.txt`** — Same updates applied to the in-source help file.

### Prompt Summary

User identified that the "Using cmdfile.txt to drive milk-cli" documentation section was outdated, as the actual mechanism is now the FIFO named pipe. Requested replacing all `cmdfile.txt` references with FIFO documentation.

### AI Authorship

- **Model:** Claude Opus 4 (`claude-opus-4-20250514`, Anthropic)
- **User edits:** None — all changes made by the agent.