### PR TITLE
docs: clarify imlist.txt is independent of FIFO mode

### DIFF
--- a/docs/cli/CLIcore.md
+++ b/docs/cli/CLIcore.md
@@ -506,11 +506,26 @@ is running):
 $ ls im*.fits | xargs -I {} echo iofits.loadfits {} > /dev/shm/.myctl.fifo.0012345
 ```
 
-### Using `imlist.txt` and the FIFO
+### Using `imlist.txt`
 
-Start `milk-cli` with `-l -f` (or `-l -n myctl -f`) to
-maintain `imlist.txt` and enable FIFO input. Then filter
-and act on the list:
+Start `milk-cli` with `-l` (or `--listimf`) to maintain
+`imlist.txt` — an ASCII table of all images currently in
+memory. Standard Unix tools can filter this list and
+generate commands.
+
+The `-l` flag works independently of FIFO mode. You can
+feed the generated commands back into the CLI via
+`cmdfile.txt` or via a FIFO:
+
+**Via `cmdfile.txt`** (no `-f` flag needed):
+
+```text
+milk-cli > !awk '{if ($4>200) print $2}' imlist.txt \
+        | xargs -I {} echo iofits.save_fl {} {}_tmp.fits > cmdfile.txt
+```
+
+**Via FIFO** (requires `-f` or `-F`; start with
+`milk-cli -l -n myctl -f`):
 
 ```text
 milk-cli > !awk '{if ($4>200) print $2}' imlist.txt \

--- a/docs/cli/help.txt
+++ b/docs/cli/help.txt
@@ -159,9 +159,17 @@ For example, to load all im*.fits files in memory, you can type within the execu
 > !ls im*.fits | xargs -I {} echo iofits.loadfits {} >> /dev/shm/.myctl.fifo.0012345
 
 
-USING "imlist.txt" AND FIFO
+USING "imlist.txt"
 
-If you start the executable with the "--listimf" option, the file "imlist.txt" contains the list of images currently in memory in an ASCII table. You can use standard unix tools to process this list and issue commands. For example, if you want to save all images with x size > 200 onto disk as single precision FITS files:
+Start milk-cli with -l (or --listimf) to maintain "imlist.txt" -- an ASCII table of all images currently in memory. Standard unix tools can filter this list and generate commands.
+
+The -l flag works independently of FIFO mode. You can feed the generated commands back into the CLI via cmdfile.txt or via a FIFO.
+
+Via cmdfile.txt (no -f flag needed):
+
+> !awk '{if ($4>200) print $2}' imlist.txt| xargs -I {} echo iofits.saveFITS {} {}_tmp.fits > cmdfile.txt
+
+Via FIFO (requires -f or -F; start with milk-cli -l -n myctl -f):
 
 > !awk '{if ($4>200) print $2}' imlist.txt| xargs -I {} echo iofits.saveFITS {} {}_tmp.fits >> /dev/shm/.myctl.fifo.0012345
 

--- a/src/cli/CLIcore/doc/help.txt
+++ b/src/cli/CLIcore/doc/help.txt
@@ -165,11 +165,19 @@ For example, to load all im*.fits files in memory, you can type within the execu
 > !ls im*.fits | xargs -I {} echo loadfits {} >> /dev/shm/.myctl.fifo.0012345
 
 
-USING "imlist.txt" AND FIFO
+USING "imlist.txt"
 
-If you start the executable with the "-l" option, the file "imlist.txt" contains the list of images currently in memory in an ASCII table. You can use standard unix tools to process this list and issue commands. For example, if you want to save all images with x size > 200 onto disk as single precision FITS files:
+Start milk-cli with -l (or --listimf) to maintain "imlist.txt" -- an ASCII table of all images currently in memory. Standard unix tools can filter this list and generate commands.
 
-> !awk '{if ($4>200) print $2}' imlist.txt| xargs -I {} echo saveflfits {} {}_tmp.fits >> /dev/shm/.myctl.fifo.0012345
+The -l flag works independently of FIFO mode. You can feed the generated commands back into the CLI via cmdfile.txt or via a FIFO.
+
+Via cmdfile.txt (no -f flag needed):
+
+> !awk '{if ($4>200) print $2}' imlist.txt| xargs -I {} echo iofits.save_fl {} {}_tmp.fits > cmdfile.txt
+
+Via FIFO (requires -f or -F; start with milk-cli -l -n myctl -f):
+
+> !awk '{if ($4>200) print $2}' imlist.txt| xargs -I {} echo iofits.save_fl {} {}_tmp.fits >> /dev/shm/.myctl.fifo.0012345
 
 Note: each milk-cli session has its own unique FIFO path. Use -n to give sessions distinct names and avoid ambiguity.
 


### PR DESCRIPTION
The `imlist.txt` section in CLIcore docs previously implied that `-f` (FIFO) was required to use `-l` (`--listimf`). This rewrites the section across all three doc files to:

- Clarify that `-l` works independently of FIFO mode
- Show both `cmdfile.txt` and FIFO as options for acting on the image list
- Keep examples consistent across `docs/cli/CLIcore.md`, `docs/cli/help.txt`, and `src/cli/CLIcore/doc/help.txt`

### Prompt Summary

User asked whether the docs claim "Start milk-cli with `-l -f` to maintain `imlist.txt` and enable FIFO input" was accurate. Analysis showed `-l` is independent of `-f`, and the section conflated the two features. User requested syncing to `framework-dev` and updating the docs.

### AI Authorship
- **Model:** Claude Opus 4 (`claude-opus-4-20250514`, Anthropic)
- **User edits:** None