### PR TITLE
fix(cli): clean ESC and CTRL+C exit from Interactive Fuzzy Help

### DIFF
--- a/src/cli/CLIcore/CLIcore/CLIcore_help.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_help.c
@@ -2015,7 +2015,7 @@ int cli_fhelp(void)
     // Setup raw terminal mode
     tcgetattr(STDIN_FILENO, &oldt);
     newt = oldt;
-    newt.c_lflag &= ~(ICANON | ECHO);
+    newt.c_lflag &= ~(ICANON | ECHO | ISIG);
     tcsetattr(STDIN_FILENO, TCSANOW, &newt);
 
     while (1) {
@@ -2062,14 +2062,21 @@ int cli_fhelp(void)
         // Input loop
         char c = getchar();
         if (c == 27) { // Escape seq
-            char seq[2];
-            seq[0] = getchar();
-            seq[1] = getchar();
-            if (seq[0] == '[') {
-                if (seq[1] == 'A') selected--; // Up
-                else if (seq[1] == 'B') selected++; // Down
-                else if (seq[1] == '5') { selected -= 10; getchar(); } // PgUp
-                else if (seq[1] == '6') { selected += 10; getchar(); } // PgDn
+            int byteswaiting;
+            ioctl(STDIN_FILENO, FIONREAD, &byteswaiting);
+            if (byteswaiting > 0) {
+                char seq[2];
+                seq[0] = getchar();
+                seq[1] = getchar();
+                if (seq[0] == '[') {
+                    if (seq[1] == 'A') selected--; // Up
+                    else if (seq[1] == 'B') selected++; // Down
+                    else if (seq[1] == '5') { selected -= 10; getchar(); } // PgUp
+                    else if (seq[1] == '6') { selected += 10; getchar(); } // PgDn
+                }
+            } else {
+                selected = -1;
+                break; // Escape key alone
             }
         } else if (c == 10 || c == 13) { // Enter
             break; // Select
@@ -2139,7 +2146,7 @@ int cli_fhist(void)
     // Setup raw terminal mode
     tcgetattr(STDIN_FILENO, &oldt);
     newt = oldt;
-    newt.c_lflag &= ~(ICANON | ECHO);
+    newt.c_lflag &= ~(ICANON | ECHO | ISIG);
     tcsetattr(STDIN_FILENO, TCSANOW, &newt);
 
     while (1) {
@@ -2292,7 +2299,7 @@ int cli_fparam(void)
 
     tcgetattr(STDIN_FILENO, &oldt);
     newt = oldt;
-    newt.c_lflag &= ~(ICANON | ECHO);
+    newt.c_lflag &= ~(ICANON | ECHO | ISIG);
     tcsetattr(STDIN_FILENO, TCSANOW, &newt);
 
     char error_msg[200] = {0};


### PR DESCRIPTION
### Prompt Summary
The user reported that pressing `ESC` in the `>> Interactive Fuzzy Help <<` prompt did nothing, and pressing `CTRL+C` exited `milk-cli` entirely with a `SIGINT` instead of just cancelling the prompt.

### Details of Changes
Fixed `CLIcore_help.c` for the `cli_fhelp`, `cli_fhist`, and `cli_fparam` interactive TUI prompts:

- **CTRL+C killing `milk-cli`:** The raw terminal mode was set without disabling `ISIG`, so `CTRL+C` generated a real `SIGINT` that escaped the prompt and hit `milk-cli`'s main signal handler. Added `ISIG` to the `c_lflag` mask (`~(ICANON | ECHO | ISIG)`) so signals are suppressed while inside the prompt. CTRL+C (ASCII `3`) is now handled locally as a cancel action.
- **ESC blocking:** The `cli_fhelp` dialog was blindly calling `getchar()` twice after a `0x1B` byte, which would block waiting for arrow-key sequences when ESC was pressed alone. Added an `ioctl(FIONREAD)` check — if no further bytes are waiting in the buffer, the escape is a standalone keypress and the prompt exits cleanly. This same pattern was already present in `cli_fhist` and `cli_fparam`; `cli_fhelp` was the odd one out.

### AI Authorship
- **Model used:** Gemini 3.1 Pro (Google DeepMind)
- **User edits:** No direct edits to the source code were manually executed by the user.