### PR TITLE
fix(cli): fix arrow key navigation in Interactive Fuzzy Help prompts

### DIFF
--- a/src/cli/CLIcore/CLIcore/CLIcore_help.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_help.c
@@ -2015,7 +2015,7 @@ int cli_fhelp(void)
     // Setup raw terminal mode
     tcgetattr(STDIN_FILENO, &oldt);
     newt = oldt;
-    newt.c_lflag &= ~(ICANON | ECHO);
+    newt.c_lflag &= ~(ICANON | ECHO | ISIG);
     tcsetattr(STDIN_FILENO, TCSANOW, &newt);
 
     while (1) {
@@ -2062,14 +2062,21 @@ int cli_fhelp(void)
         // Input loop
         char c = getchar();
         if (c == 27) { // Escape seq
-            char seq[2];
-            seq[0] = getchar();
-            seq[1] = getchar();
-            if (seq[0] == '[') {
-                if (seq[1] == 'A') selected--; // Up
-                else if (seq[1] == 'B') selected++; // Down
-                else if (seq[1] == '5') { selected -= 10; getchar(); } // PgUp
-                else if (seq[1] == '6') { selected += 10; getchar(); } // PgDn
+            int byteswaiting;
+            ioctl(STDIN_FILENO, FIONREAD, &byteswaiting);
+            if (byteswaiting > 0) {
+                char seq[2];
+                seq[0] = getchar();
+                seq[1] = getchar();
+                if (seq[0] == '[') {
+                    if (seq[1] == 'A') selected--; // Up
+                    else if (seq[1] == 'B') selected++; // Down
+                    else if (seq[1] == '5') { selected -= 10; getchar(); } // PgUp
+                    else if (seq[1] == '6') { selected += 10; getchar(); } // PgDn
+                }
+            } else {
+                selected = -1;
+                break; // Escape key alone
             }
         } else if (c == 10 || c == 13) { // Enter
             break; // Select
@@ -2139,7 +2146,7 @@ int cli_fhist(void)
     // Setup raw terminal mode
     tcgetattr(STDIN_FILENO, &oldt);
     newt = oldt;
-    newt.c_lflag &= ~(ICANON | ECHO);
+    newt.c_lflag &= ~(ICANON | ECHO | ISIG);
     tcsetattr(STDIN_FILENO, TCSANOW, &newt);
 
     while (1) {
@@ -2292,7 +2299,7 @@ int cli_fparam(void)
 
     tcgetattr(STDIN_FILENO, &oldt);
     newt = oldt;
-    newt.c_lflag &= ~(ICANON | ECHO);
+    newt.c_lflag &= ~(ICANON | ECHO | ISIG);
     tcsetattr(STDIN_FILENO, TCSANOW, &newt);
 
     char error_msg[200] = {0};

--- a/src/cli/CLIcore/CLIcore/CLIcore_help.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_help.c
@@ -1968,6 +1968,28 @@ errno_t help_module()
 #include <readline/history.h>
 #endif
 
+#include <sys/select.h>
+
+/**
+ * @brief Wait up to ms milliseconds for stdin to have data.
+ *
+ * Returns 1 if data is ready, 0 on timeout.
+ * Used to disambiguate a bare ESC from ESC-sequence prefixes
+ * (arrow keys, PgUp/PgDn) inside raw-mode TUI prompts.
+ */
+static int tui_stdin_wait_ms(int ms)
+{
+    fd_set fds;
+    struct timeval tv;
+
+    FD_ZERO(&fds);
+    FD_SET(STDIN_FILENO, &fds);
+    tv.tv_sec  = 0;
+    tv.tv_usec = ms * 1000;
+    return select(STDIN_FILENO + 1,
+                  &fds, NULL, NULL, &tv) > 0;
+}
+
 // Simple Levenshtein distance for fuzzy matching
 static int fuzzy_match_score(const char *query, const char *target)
 {
@@ -2062,9 +2084,7 @@ int cli_fhelp(void)
         // Input loop
         char c = getchar();
         if (c == 27) { // Escape seq
-            int byteswaiting;
-            ioctl(STDIN_FILENO, FIONREAD, &byteswaiting);
-            if (byteswaiting > 0) {
+            if (tui_stdin_wait_ms(50)) {
                 char seq[2];
                 seq[0] = getchar();
                 seq[1] = getchar();
@@ -2207,10 +2227,7 @@ int cli_fhist(void)
         // Input loop
         char c = getchar();
         if (c == 27) { // Escape seq
-            // check if there is an escape sequence waiting
-            int byteswaiting;
-            ioctl(STDIN_FILENO, FIONREAD, &byteswaiting);
-            if (byteswaiting > 0) {
+            if (tui_stdin_wait_ms(50)) {
                 char seq[2];
                 seq[0] = getchar();
                 seq[1] = getchar();
@@ -2350,10 +2367,7 @@ int cli_fparam(void)
         // Input loop
         char c = getchar();
         if (c == 27) { // Escape seq
-            // check if there is an escape sequence waiting
-            int byteswaiting;
-            ioctl(STDIN_FILENO, FIONREAD, &byteswaiting);
-            if (byteswaiting > 0) {
+            if (tui_stdin_wait_ms(50)) {
                 char seq[2];
                 seq[0] = getchar();
                 seq[1] = getchar();


### PR DESCRIPTION
### Prompt Summary
The user reported that pressing the Down arrow key inside the `>> Interactive Fuzzy Help <<` prompt caused the prompt to exit instead of moving the selection down.

### Root Cause
After the previous fix (PR #118), a `select()`/`FIONREAD` check was used to detect whether the ESC byte was a standalone keypress or the start of an escape sequence (e.g. `ESC [ B` for Down arrow). The `FIONREAD` approach had a race condition: immediately after reading the `ESC` byte, the remaining `[ B` bytes may not yet be in the kernel buffer, causing `FIONREAD` to return 0 and incorrectly treating it as a standalone ESC — which then cancelled the prompt.

### Fix
Replaced all three raw `ioctl(FIONREAD)` checks in `cli_fhelp`, `cli_fhist`, and `cli_fparam` with a new shared helper `tui_stdin_wait_ms(50)` that uses `select()` with a 50 ms timeout. This gives the terminal time to deliver the rest of the escape sequence before deciding whether it is a bare ESC. 50 ms is imperceptible to the user but long enough for any terminal emulator to deliver `[ B` after `ESC`.

### AI Authorship
- **Model used:** Gemini 3.1 Pro (Google DeepMind)
- **User edits:** No direct edits to the source code were manually executed by the user.