### PR TITLE
fix(cli): clean up help topic listing and unknown-topic error

### DIFF
--- a/src/cli/CLIcore/CLIcore/CLIcore_help.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_help.c
@@ -1851,19 +1851,19 @@ void print_milk_cli_help(void)
            "========================================\n" C_RST);
     printf("\n");
     printf(C_HDR "Available help topics:\n" C_RST);
-    printf("  " C_CMD "help-cmdopts     " C_RST
+    printf("  " C_CMD "cmdopts     " C_RST
            "Command-line flags (-h, -s, -n…)\n");
-    printf("  " C_CMD "help-syntax      " C_RST
+    printf("  " C_CMD "syntax      " C_RST
            "Syntax, tab completion, piping\n");
-    printf("  " C_CMD "help-commands    " C_RST
+    printf("  " C_CMD "commands    " C_RST
            "Built-in CLI commands (?, cmd?…)\n");
-    printf("  " C_CMD "help-variables   " C_RST
+    printf("  " C_CMD "variables   " C_RST
            "Variables, arrays, arithmetic\n");
-    printf("  " C_CMD "help-flowcontrol " C_RST
+    printf("  " C_CMD "flowcontrol " C_RST
            "if/while/for/case/function\n");
-    printf("  " C_CMD "help-scripting   " C_RST
+    printf("  " C_CMD "scripting   " C_RST
            "Script files, I/O, builtins\n");
-    printf("  " C_CMD "help-milk        " C_RST
+    printf("  " C_CMD "milk        " C_RST
            "Streams, FPS, milk-specific\n");
     printf("\n");
     printf(C_NOTE "From the shell:\n" C_RST);
@@ -1892,9 +1892,9 @@ errno_t help()
         const char *topic = data.cmdargtoken[1].val.string;
         if (help_topic_dispatch(topic) != 0)
         {
-            printf("Unknown help topic: \"%s\"\n", topic);
-            printf("Run " C_CMD "help" C_RST
-                   " for the list of available topics.\n");
+            printf("Unknown help topic: \"%s\"\n\n",
+                   topic);
+            print_milk_cli_help();
         }
     }
     else

--- a/src/cli/CLIcore/CLIcore/CLIcore_help.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_help.c
@@ -30,6 +30,7 @@
 #define C_CMD    "\033[32m"
 #define C_BOLD   "\033[1m"
 #define C_NOTE   "\033[33m"
+#define C_ERR    "\033[1;31m"
 
 // Compatibility aliases
 #ifndef COLORRESET
@@ -1840,23 +1841,21 @@ int help_topic_dispatch(const char *topic)
  * The full content for each topic is obtained via help-<topic> CLI
  * commands or  milk-cli-help <topic>  from the shell.
  */
-void print_milk_cli_help(void)
+/**
+ * @brief Print only the available-topics list.
+ *
+ * Shown both in the full help index and as a concise
+ * hint when an unknown topic is supplied.
+ */
+void print_help_topic_list(void)
 {
-    printf("\n");
-    printf(C_TITLE
-           "========================================\n" C_RST);
-    printf(C_TITLE
-           "           milk-cli — HELP INDEX\n" C_RST);
-    printf(C_TITLE
-           "========================================\n" C_RST);
-    printf("\n");
     printf(C_HDR "Available help topics:\n" C_RST);
     printf("  " C_CMD "cmdopts     " C_RST
-           "Command-line flags (-h, -s, -n…)\n");
+           "Command-line flags (-h, -s, -n\xe2\x80\xa6)\n");
     printf("  " C_CMD "syntax      " C_RST
            "Syntax, tab completion, piping\n");
     printf("  " C_CMD "commands    " C_RST
-           "Built-in CLI commands (?, cmd?…)\n");
+           "Built-in CLI commands (?, cmd?\xe2\x80\xa6)\n");
     printf("  " C_CMD "variables   " C_RST
            "Variables, arrays, arithmetic\n");
     printf("  " C_CMD "flowcontrol " C_RST
@@ -1866,6 +1865,19 @@ void print_milk_cli_help(void)
     printf("  " C_CMD "milk        " C_RST
            "Streams, FPS, milk-specific\n");
     printf("\n");
+}
+
+void print_milk_cli_help(void)
+{
+    printf("\n");
+    printf(C_TITLE
+           "========================================\n" C_RST);
+    printf(C_TITLE
+           "           milk-cli \xe2\x80\x94 HELP INDEX\n" C_RST);
+    printf(C_TITLE
+           "========================================\n" C_RST);
+    printf("\n");
+    print_help_topic_list();
     printf(C_NOTE "From the shell:\n" C_RST);
     printf("  $ " C_CMD "milk-cli-help <topic>\n" C_RST);
     printf("\n");
@@ -1892,9 +1904,9 @@ errno_t help()
         const char *topic = data.cmdargtoken[1].val.string;
         if (help_topic_dispatch(topic) != 0)
         {
-            printf("Unknown help topic: \"%s\"\n\n",
+            printf(C_ERR "Unknown help topic: \"%s\"" C_RST "\n\n",
                    topic);
-            print_milk_cli_help();
+            print_help_topic_list();
         }
     }
     else

--- a/src/cli/CLIcore/CLIcore/CLIcore_help.h
+++ b/src/cli/CLIcore/CLIcore/CLIcore_help.h
@@ -41,6 +41,9 @@ void print_milk_framework_help(void);
 /** @brief Print milk CLI-specific help */
 void print_milk_cli_help(void);
 
+/** @brief Print only the available-topics list */
+void print_help_topic_list(void);
+
 /* Per-topic help functions */
 void help_topic_cmdopts(void);
 void help_topic_syntax(void);

--- a/src/cli/CLIcore/milk-cli-help.c
+++ b/src/cli/CLIcore/milk-cli-help.c
@@ -26,10 +26,9 @@ int main(int argc, char *argv[])
         if (ret != 0)
         {
             fprintf(stderr,
-                    "milk-cli-help: unknown topic \"%s\"\n"
-                    "Available topics: cmdopts  syntax  commands"
-                    "  variables  flowcontrol  scripting  milk\n",
+                    "milk-cli-help: unknown topic \"%s\"\n\n",
                     topic);
+            print_milk_cli_help();
             return 1;
         }
     }

--- a/src/cli/CLIcore/milk-cli-help.c
+++ b/src/cli/CLIcore/milk-cli-help.c
@@ -26,9 +26,10 @@ int main(int argc, char *argv[])
         if (ret != 0)
         {
             fprintf(stderr,
-                    "milk-cli-help: unknown topic \"%s\"\n\n",
+                    "\033[1;31mmilk-cli-help: unknown topic"
+                    " \"%s\"\033[0m\n\n",
                     topic);
-            print_milk_cli_help();
+            print_help_topic_list();
             return 1;
         }
     }


### PR DESCRIPTION
### Prompt Summary
`milk-cli-help` was displaying `help-cmdopts`, `help-syntax`, etc. (with spurious `help-` prefix) in the topic list. Additionally, entering an unknown topic showed a plain one-liner error instead of the topic list, making it hard to know what to type next.

### Changes
**`CLIcore_help.c`:**
- Extracted a new `print_help_topic_list()` helper that prints just the 7 topics with their descriptions and nothing else.
- `print_milk_cli_help()` (the full index shown with no argument) now calls `print_help_topic_list()` internally instead of duplicating the list.
- Topic names no longer carry the `help-` prefix in either function.
- On unknown topic inside `milk-cli`, the error is printed in **red** (`C_ERR`) followed by only the compact topic list.

**`CLIcore_help.h`:**
- Added declaration for `print_help_topic_list()`.

**`milk-cli-help.c`:**
- On unknown topic, the error line is printed in **red** (inline ANSI) followed by `print_help_topic_list()`.

### Testing
Verified with the installed binary:
- ✅ `milk-cli-help` with no args → full index (unchanged)
- ✅ `milk-cli-help badtopic` → red error + clean 7-topic list only
- ✅ Confirmed working by user on interactive terminal

### AI Authorship
- **Model used:** Claude Sonnet 4.6 (Anthropic)
- **User edits:** No direct source edits by the user.