### PR TITLE
fix: ghistory/lhistory — do not log themselves to history

### DIFF
--- a/src/cli/CLIcore/CLIcore/CLIcore_UI_history.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI_history.c
@@ -15,11 +15,8 @@
 #endif
 #include "CLIcore.h"
 #include "CLIcore_UI.h"
-#include "CLIcore_script.h"
-#include "CLIcore/cli_calc_parser.h"
 #include <glob.h>
 #include <sys/wait.h>
-#include "COREMOD_memory/COREMOD_memory.h"
 #include "timeutils.h"
 
 
@@ -163,6 +160,28 @@ void cli_history_log_cmd(
     if(cmd == NULL || cmd[0] == '\0')
     {
         return;
+    }
+
+    /* Do not log history-display commands —
+     * they would pollute the log they read. */
+    {
+        static const char *const skip[] =
+        {
+            "ghistory",
+            "lhistory",
+            NULL
+        };
+        for(int k = 0; skip[k] != NULL; k++)
+        {
+            size_t n = strlen(skip[k]);
+            if(strncmp(cmd, skip[k], n) == 0
+               && (cmd[n] == '\0'
+                   || cmd[n] == ' '
+                   || cmd[n] == '\t'))
+            {
+                return;
+            }
+        }
     }
 
     FILE *fp = fopen(CLI_history_log_file(), "a");


### PR DESCRIPTION
### Prompt Summary

User requested that `ghistory` and `lhistory` commands do not appear in the history log they display.

### Changes

Adds a skip-list inside `cli_history_log_cmd()`: if the first word of the command is `ghistory` or `lhistory`, the function returns early without writing to the log. The check is word-boundary exact (`ghistory2` would still be logged normally).

Also removes three unused includes (`CLIcore_script.h`, `cli_calc_parser.h`, `COREMOD_memory.h`) left over from an earlier refactor.

### AI Authorship

- **Model used**: Antigravity (Google DeepMind)
- **User edits**: None