### PR TITLE
fix: pipe to shell commands (grep, sort, wc) now works

### DIFF
--- a/src/cli/CLIcore/CLIcore/CLIcore_UI.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI.c
@@ -1071,6 +1071,35 @@ errno_t CLI_execute_line()
             right[STRINGMAXLEN_CLICMDLINE
                   - 1] = '\0';
 
+            /* Check whether the right side is
+             * a registered milk command.  If
+             * not, fall through so the popen-
+             * based handler can pipe to a shell
+             * command (e.g. grep, sort, wc). */
+            {
+                char rword[200];
+                int  rw = 0;
+                const char *rr = right;
+                while(*rr == ' '
+                      || *rr == '\t')
+                {
+                    rr++;
+                }
+                while(*rr != '\0'
+                      && *rr != ' '
+                      && *rr != '\t'
+                      && rw < (int)
+                         sizeof(rword) - 1)
+                {
+                    rword[rw++] = *rr++;
+                }
+                rword[rw] = '\0';
+                if(!cli_is_command(rword))
+                {
+                    goto pipe_fallthrough;
+                }
+            }
+
             /* Capture left stdout */
             FILE *tmpfp = tmpfile();
             if(tmpfp != NULL)
@@ -1117,6 +1146,8 @@ errno_t CLI_execute_line()
             }
         }
     }
+pipe_fallthrough:
+    (void) 0;
 
     /* Dot-sourcing: ". file" → "source file"
      * Must check before script intercept */


### PR DESCRIPTION
### Prompt Summary

User reported that piping command output to shell commands doesn't work: `ghistory | grep "cho"` produces no output.

### Root Cause

The first pipe handler in `CLI_execute_line()` (line ~1009) intercepts **all** `|` pipes and tries to run both sides via recursive `CLI_execute_line()`. This works for piping between two milk commands, but fails silently when the right side is a shell command (`grep`, `sort`, `wc`) since it is not a registered milk CLI command — the right-side `CLI_execute_line()` call does nothing.

The second pipe handler (line ~1943) correctly uses `popen()` to pipe to shell commands, but it is never reached because the first handler returns early.

### Fix

Before applying the milk-to-milk pipe handler, check `cli_is_command()` on the right side's first word. If it is **not** a registered milk command, `goto pipe_fallthrough` to skip the handler and let the `popen()`-based handler deal with it.

### Testing

Verified working:
- `help | grep "help"` — filters help output through grep ✓
- `ghistory 3 | cat` — forwards all ghistory output ✓
- `ghistory --today` — still works standalone ✓

### AI Authorship

- **Model used**: Antigravity (Google DeepMind)
- **User edits**: None