### PR TITLE
fix: CLI error reporting for `cmd?` and `cd` with absolute paths

### DIFF
--- a/.agents/workflows/cli-robustness-test.md
+++ b/.agents/workflows/cli-robustness-test.md
@@ -1,0 +1,57 @@
+---
+description: Run the CLI robustness test suite
+---
+
+# CLI Robustness Test Suite
+
+Run this workflow to verify that `milk-cli` correctly
+handles valid commands, invalid commands, missing arguments,
+and scripting constructs — without crashing, hanging, or
+silently failing.
+
+## Steps
+
+// turbo-all
+
+1. Run the test suite from the repository root:
+
+```bash
+cd /home/oguyon/src/milk && bash tests/cli/run_cli_robustness_tests.sh --verbose
+```
+
+2. Review the summary output. Categorized results:
+   - **PASS** — command worked as expected
+   - **FAIL** — expected success but got error exit
+   - **MISSING_ERROR** — expected error message but
+     none was printed
+   - **CRASH** — process killed by signal (segfault etc.)
+   - **HANG** — command timed out
+
+3. If any failures, examine the detailed report at:
+   `tests/cli/cli_test_report.txt`
+
+4. Fix issues in the CLI code, then re-run step 1.
+
+5. When adding new CLI features or changing syntax,
+   update `tests/cli/cli_robustness_tests.milk` with
+   matching test cases.
+
+## Test File Format
+
+Each test block in `cli_robustness_tests.milk` has:
+
+```
+#DESC: Short description
+#EXPECT:OK       (or #EXPECT:ERR)
+command_line_1
+command_line_2   (for multi-line constructs)
+```
+
+## Adding New Tests
+
+1. Add a `#DESC:` + `#EXPECT:` annotation pair
+2. Follow with the command(s) to test
+3. Use `#EXPECT:ERR` for commands that should print
+   an error message
+4. For multi-line constructs (if/while/for/function),
+   include all lines in the block

--- a/src/cli/CLIcore/CLIcore/CLIcore_UI.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI.c
@@ -2944,16 +2944,21 @@ pipe_fallthrough:
 
                     /* When a CLI command has already been
                      * identified and the current argument
-                     * starts with '-', treat it as a raw
-                     * string rather than running it through
-                     * the arithmetic expression parser.
-                     * This prevents flags like -n, -g, --since
-                     * from triggering a parse error that would
-                     * block the command from being called. */
+                     * starts with '-' or '/', treat it as
+                     * a raw string rather than running it
+                     * through the arithmetic expression
+                     * parser.
+                     * '-' prevents flags like -n, -g,
+                     * --since from triggering a parse
+                     * error.
+                     * '/' prevents absolute paths from
+                     * being misinterpreted as division
+                     * (e.g. cd /tmp). */
                     if(data.cmdNBarg > 0
                        && data.cmdargtoken[0].type
                           == CMDARGTOKEN_TYPE_COMMAND
-                       && cmdargstring[0] == '-')
+                       && (cmdargstring[0] == '-'
+                           || cmdargstring[0] == '/'))
                     {
                         strncpy(
                             data.cmdargtoken[data.cmdNBarg]

--- a/src/cli/CLIcore/CLIcore/CLIcore_help.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_help.c
@@ -1100,9 +1100,13 @@ errno_t help_command(
         {
             if(foundregexmatch == 0)
             {
-                printf("\tNo substring or regex match to \"%s\"\n", cmdkey);
+                printf(
+                    "\tNo substring or regex "
+                    "match to \"%s\"\n",
+                    cmdkey);
             }
         }
+        return RETURN_FAILURE;
     }
 
     return RETURN_SUCCESS;

--- a/tests/cli/cli_robustness_tests.milk
+++ b/tests/cli/cli_robustness_tests.milk
@@ -146,8 +146,8 @@ mem.rm _clitest_im1
 # SECTION 4: Missing / Wrong Arguments
 # ============================================
 
-#DESC: mem.mk2Dim with no arguments
-#EXPECT:ERR
+#DESC: mem.mk2Dim with no arguments (FPS default)
+#EXPECT:OK
 mem.mk2Dim
 
 #DESC: mem.mk2Dim with only 1 argument
@@ -158,8 +158,8 @@ mem.mk2Dim _clitest_partial
 #EXPECT:ERR
 mem.mk2Dim _clitest_partial 32
 
-#DESC: mem.rm with no arguments
-#EXPECT:ERR
+#DESC: mem.rm with no arguments (FPS default)
+#EXPECT:OK
 mem.rm
 
 #DESC: source with no arguments

--- a/tests/cli/cli_robustness_tests.milk
+++ b/tests/cli/cli_robustness_tests.milk
@@ -1,0 +1,630 @@
+#!/usr/bin/env milk-cli -s
+#
+# CLI Robustness Test Suite
+# =========================
+#
+# Comprehensive test cases for milk-cli command
+# parsing, scripting, and error handling.
+#
+# Each test line is annotated with:
+#   #EXPECT:OK   — command should succeed
+#   #EXPECT:ERR  — command should fail with a
+#                  clear error message
+#   #DESC: ...   — short description
+#
+# This file is sourced by the test runner
+# (run_cli_robustness_tests.sh) which feeds
+# commands one-by-one and checks outcomes.
+#
+# When CLI syntax changes, update this file
+# to match. Keep tests grouped by section.
+#
+# ============================================
+# SECTION 1: Basic Parsing
+# ============================================
+
+#DESC: Empty line (should be ignored)
+#EXPECT:OK
+
+#DESC: Comment-only line
+#EXPECT:OK
+# This is a comment
+
+#DESC: Multiple spaces before command
+#EXPECT:OK
+   echo hello
+
+#DESC: Echo with no arguments
+#EXPECT:OK
+echo
+
+#DESC: Echo with arguments
+#EXPECT:OK
+echo hello world
+
+#DESC: Echo with -n flag (no newline)
+#EXPECT:OK
+echo -n test
+
+#DESC: Echo with quoted string
+#EXPECT:OK
+echo "hello world"
+
+#DESC: Echo with single-quoted string
+#EXPECT:OK
+echo 'hello world'
+
+#DESC: Inline comment after command
+#EXPECT:OK
+echo test_value # this is a comment
+
+# ============================================
+# SECTION 2: Help and Discovery
+# ============================================
+
+#DESC: Question mark help
+#EXPECT:OK
+?
+
+#DESC: help command
+#EXPECT:OK
+help
+
+#DESC: List loaded modules
+#EXPECT:OK
+lm?
+
+#DESC: List all commands
+#EXPECT:OK
+m?
+
+#DESC: Compilation info
+#EXPECT:OK
+ci
+
+#DESC: Command help with cmd?
+#EXPECT:OK
+cmd? echo
+
+#DESC: Command help for mem.listim
+#EXPECT:OK
+cmd? mem.listim
+
+#DESC: Command help for unknown command
+#EXPECT:ERR
+cmd? nonexistent_command_xyz
+
+# ============================================
+# SECTION 3: Built-in Commands
+# ============================================
+
+#DESC: List images in memory
+#EXPECT:OK
+mem.listim
+
+#DESC: Print working directory
+#EXPECT:OK
+pwd
+
+#DESC: Change directory to /tmp
+#EXPECT:OK
+cd /tmp
+
+#DESC: Change directory back to home
+#EXPECT:OK
+cd
+
+#DESC: Change to non-existent directory
+#EXPECT:ERR
+cd /nonexistent_directory_xyz_123
+
+#DESC: Usleep command
+#EXPECT:OK
+usleep 1000
+
+#DESC: Set default precision to float
+#EXPECT:OK
+dpsingle
+
+#DESC: Set default precision to double
+#EXPECT:OK
+dpdouble
+
+#DESC: Create 2D image
+#EXPECT:OK
+mem.mk2Dim _clitest_im1 32 32
+
+#DESC: List images - should show _clitest_im1
+#EXPECT:OK
+mem.listim
+
+#DESC: Delete test image
+#EXPECT:OK
+mem.rm _clitest_im1
+
+# ============================================
+# SECTION 4: Missing / Wrong Arguments
+# ============================================
+
+#DESC: mem.mk2Dim with no arguments
+#EXPECT:ERR
+mem.mk2Dim
+
+#DESC: mem.mk2Dim with only 1 argument
+#EXPECT:ERR
+mem.mk2Dim _clitest_partial
+
+#DESC: mem.mk2Dim with only 2 arguments
+#EXPECT:ERR
+mem.mk2Dim _clitest_partial 32
+
+#DESC: mem.rm with no arguments
+#EXPECT:ERR
+mem.rm
+
+#DESC: source with no arguments
+#EXPECT:ERR
+source
+
+#DESC: source with nonexistent file
+#EXPECT:ERR
+source /tmp/nonexistent_file_xyz_456.milk
+
+#DESC: savescript with no arguments
+#EXPECT:ERR
+savescript
+
+#DESC: time with no arguments
+#EXPECT:ERR
+time
+
+#DESC: watch with no arguments
+#EXPECT:ERR
+watch
+
+#DESC: watch with only interval
+#EXPECT:ERR
+watch 1000
+
+# ============================================
+# SECTION 5: Variables
+# ============================================
+
+#DESC: Set a simple variable
+#EXPECT:OK
+_testvar1=hello
+
+#DESC: Echo a variable
+#EXPECT:OK
+echo $_testvar1
+
+#DESC: Set numeric variable
+#EXPECT:OK
+_testvar2=42
+
+#DESC: Echo numeric variable
+#EXPECT:OK
+echo $_testvar2
+
+#DESC: Variable with braces
+#EXPECT:OK
+echo ${_testvar1}
+
+#DESC: Unset a variable
+#EXPECT:OK
+unset _testvar1
+
+#DESC: Echo unset variable (should be empty)
+#EXPECT:OK
+echo $_testvar1
+
+#DESC: Last return value ($?)
+#EXPECT:OK
+echo $?
+
+#DESC: List variables
+#EXPECT:OK
+vars
+
+#DESC: String length ${#var}
+#EXPECT:OK
+_teststr=hello
+echo ${#_teststr}
+
+#DESC: Substring extraction ${var:0:3}
+#EXPECT:OK
+echo ${_teststr:0:3}
+
+#DESC: Uppercase ${var^^}
+#EXPECT:OK
+echo ${_teststr^^}
+
+#DESC: Lowercase ${var,,}
+#EXPECT:OK
+_TESTUP=HELLO
+echo ${_TESTUP,,}
+
+#DESC: Default value ${var:-default}
+#EXPECT:OK
+echo ${_unsetvar:-fallback}
+
+#DESC: Assign default ${var:=default}
+#EXPECT:OK
+echo ${_defvar:=assigned}
+
+#DESC: Clean up test variables
+#EXPECT:OK
+unset _testvar2
+unset _teststr
+unset _TESTUP
+unset _defvar
+
+# ============================================
+# SECTION 6: Arithmetic
+# ============================================
+
+#DESC: Simple addition
+#EXPECT:OK
+_arith_a=10
+_arith_b=$(( _arith_a + 5 ))
+echo $_arith_b
+
+#DESC: Multiplication and subtraction
+#EXPECT:OK
+_arith_c=$(( _arith_b * 2 - 3 ))
+echo $_arith_c
+
+#DESC: Modulo
+#EXPECT:OK
+_arith_d=$(( 17 % 3 ))
+echo $_arith_d
+
+#DESC: Nested arithmetic
+#EXPECT:OK
+_arith_e=$(( (_arith_a + 5) * 2 ))
+echo $_arith_e
+
+#DESC: Arithmetic in echo
+#EXPECT:OK
+echo $(( 100 + 200 ))
+
+#DESC: Clean up arithmetic vars
+#EXPECT:OK
+unset _arith_a
+unset _arith_b
+unset _arith_c
+unset _arith_d
+unset _arith_e
+
+# ============================================
+# SECTION 7: Flow Control
+# ============================================
+
+#DESC: Simple if/then/fi (true branch)
+#EXPECT:OK
+_fc_x=10
+if [ $_fc_x -gt 5 ]; then
+    echo big
+fi
+
+#DESC: Simple if/else (false branch)
+#EXPECT:OK
+if [ $_fc_x -lt 5 ]; then
+    echo small
+else
+    echo not_small
+fi
+
+#DESC: If/elif/else chain
+#EXPECT:OK
+if [ $_fc_x -gt 100 ]; then
+    echo huge
+elif [ $_fc_x -gt 5 ]; then
+    echo medium
+else
+    echo small
+fi
+
+#DESC: While loop
+#EXPECT:OK
+_fc_n=0
+while [ $_fc_n -lt 3 ]; do
+    _fc_n=$(( _fc_n + 1 ))
+done
+echo $_fc_n
+
+#DESC: For loop with word list
+#EXPECT:OK
+for _fc_item in alpha beta gamma; do
+    echo $_fc_item
+done
+
+#DESC: For loop with brace expansion
+#EXPECT:OK
+for _fc_i in {1..3}; do
+    echo iter_$_fc_i
+done
+
+#DESC: Nested if inside while
+#EXPECT:OK
+_fc_m=0
+while [ $_fc_m -lt 3 ]; do
+    _fc_m=$(( _fc_m + 1 ))
+    if [ $_fc_m -eq 2 ]; then
+        echo found_two
+    fi
+done
+
+#DESC: Break in while loop
+#EXPECT:OK
+_fc_k=0
+while [ $_fc_k -lt 100 ]; do
+    _fc_k=$(( _fc_k + 1 ))
+    if [ $_fc_k -eq 3 ]; then
+        break
+    fi
+done
+echo $_fc_k
+
+#DESC: Continue in while loop
+#EXPECT:OK
+_fc_sum=0
+_fc_j=0
+while [ $_fc_j -lt 5 ]; do
+    _fc_j=$(( _fc_j + 1 ))
+    if [ $_fc_j -eq 3 ]; then
+        continue
+    fi
+    _fc_sum=$(( _fc_sum + _fc_j ))
+done
+echo $_fc_sum
+
+#DESC: Case/esac statement
+#EXPECT:OK
+_fc_mode=fast
+case $_fc_mode in
+    fast) echo speed ;;
+    safe) echo caution ;;
+    *) echo unknown ;;
+esac
+
+#DESC: String comparison in test
+#EXPECT:OK
+_fc_s=hello
+if [ $_fc_s = hello ]; then
+    echo match
+fi
+
+#DESC: String inequality
+#EXPECT:OK
+if [ $_fc_s != world ]; then
+    echo differ
+fi
+
+#DESC: Test -n (non-empty string)
+#EXPECT:OK
+if [ -n $_fc_s ]; then
+    echo nonempty
+fi
+
+#DESC: Test -z (empty string)
+#EXPECT:OK
+_fc_empty=
+if [ -z $_fc_empty ]; then
+    echo empty
+fi
+
+#DESC: Test -d (directory exists)
+#EXPECT:OK
+if [ -d /tmp ]; then
+    echo dir_exists
+fi
+
+#DESC: Test -f (file exists)
+#EXPECT:OK
+if [ -f /etc/hostname ]; then
+    echo file_exists
+fi
+
+#DESC: Negation with !
+#EXPECT:OK
+if [ ! -f /tmp/no_such_file_xyz ]; then
+    echo not_found
+fi
+
+#DESC: Clean up flow control vars
+#EXPECT:OK
+unset _fc_x
+unset _fc_n
+unset _fc_m
+unset _fc_k
+unset _fc_sum
+unset _fc_j
+unset _fc_mode
+unset _fc_s
+unset _fc_empty
+
+# ============================================
+# SECTION 8: User Functions
+# ============================================
+
+#DESC: Define a simple function
+#EXPECT:OK
+function _testfunc_greet {
+    echo greeting_$1
+}
+
+#DESC: Call user function
+#EXPECT:OK
+_testfunc_greet world
+
+#DESC: Function with return value
+#EXPECT:OK
+function _testfunc_check {
+    if [ $1 -gt 10 ]; then
+        return 0
+    fi
+    return 1
+}
+_testfunc_check 20
+echo $?
+
+#DESC: Function with local variable
+#EXPECT:OK
+_gvar=global
+function _testfunc_local {
+    local _gvar=localized
+    echo $_gvar
+}
+_testfunc_local
+echo $_gvar
+
+#DESC: Function with multiple arguments
+#EXPECT:OK
+function _testfunc_add {
+    _result=$(( $1 + $2 ))
+    echo $_result
+}
+_testfunc_add 3 7
+
+#DESC: Call undefined function
+#EXPECT:ERR
+_nonexistent_function_xyz
+
+#DESC: Clean up function vars
+#EXPECT:OK
+unset _gvar
+unset _result
+
+# ============================================
+# SECTION 9: Command Chaining
+# ============================================
+
+#DESC: Semicolon chaining
+#EXPECT:OK
+echo first ; echo second
+
+#DESC: AND chaining (first succeeds)
+#EXPECT:OK
+echo ok_cmd && echo and_ran
+
+#DESC: OR chaining (first succeeds)
+#EXPECT:OK
+echo ok_cmd || echo or_skipped
+
+# ============================================
+# SECTION 10: Shell Features
+# ============================================
+
+#DESC: Output redirect to file
+#EXPECT:OK
+echo redirect_test > /tmp/_clitest_redir.txt
+
+#DESC: Append redirect
+#EXPECT:OK
+echo append_line >> /tmp/_clitest_redir.txt
+
+#DESC: Command substitution
+#EXPECT:OK
+_subst_val=$(echo hello_sub)
+echo $_subst_val
+
+#DESC: Environment variable expansion
+#EXPECT:OK
+echo $HOME
+
+#DESC: Tilde expansion
+#EXPECT:OK
+echo ~
+
+#DESC: Brace expansion
+#EXPECT:OK
+echo {1..5}
+
+#DESC: Brace expansion with step
+#EXPECT:OK
+echo {0..10..2}
+
+#DESC: Here-string
+#EXPECT:OK
+read _hs_val <<< "here_string_test"
+echo $_hs_val
+
+#DESC: Pipe to shell grep
+#EXPECT:OK
+echo searchable_text | grep searchable
+
+#DESC: Clean up shell feature vars
+#EXPECT:OK
+unset _subst_val
+unset _hs_val
+
+# ============================================
+# SECTION 11: Error Conditions
+# ============================================
+
+#DESC: Unknown command (should suggest)
+#EXPECT:ERR
+mem.lisim
+
+#DESC: Completely unknown command
+#EXPECT:ERR
+xyzzy_nonexistent_command
+
+#DESC: Syntax highlighting toggle
+#EXPECT:OK
+synhl off
+synhl on
+
+#DESC: Nonexistent file in source
+#EXPECT:ERR
+source /tmp/_clitest_no_such_file.milk
+
+#DESC: Include_once nonexistent file
+#EXPECT:ERR
+include_once /tmp/_clitest_no_such_f2.milk
+
+# ============================================
+# SECTION 12: Set Flags
+# ============================================
+
+#DESC: set -x (trace on)
+#EXPECT:OK
+set -x
+
+#DESC: set +x (trace off)
+#EXPECT:OK
+set +x
+
+# ============================================
+# SECTION 13: Readonly and Declare
+# ============================================
+
+#DESC: Readonly variable
+#EXPECT:OK
+readonly _RO_PI=3
+
+#DESC: Declare integer
+#EXPECT:OK
+declare -i _decl_count=0
+
+#DESC: Let arithmetic
+#EXPECT:OK
+let "_decl_count=5+3"
+echo $_decl_count
+
+#DESC: Clean up
+#EXPECT:OK
+unset _decl_count
+
+# ============================================
+# SECTION 14: Cleanup
+# ============================================
+
+#DESC: Remove temp redirect file
+#EXPECT:OK
+!rm -f /tmp/_clitest_redir.txt
+
+#DESC: Final echo
+#EXPECT:OK
+echo CLI_ROBUSTNESS_TESTS_COMPLETE

--- a/tests/cli/run_cli_robustness_tests.sh
+++ b/tests/cli/run_cli_robustness_tests.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# ============================================================
+# CLI Robustness Test Runner
+# ============================================================
+#
+# Feeds test cases from cli_robustness_tests.milk
+# to milk-cli one block at a time, capturing output
+# and checking for crashes, hangs, and missing error
+# messages.
+#
+# Usage:
+#   bash run_cli_robustness_tests.sh [--verbose]
+#
+# Exit codes:
+#   0 — all tests passed
+#   1 — one or more tests failed
+#
+# Output:
+#   - Summary table on stdout
+#   - Detailed report in cli_test_report.txt
+#
+# Requirements:
+#   - milk-cli must be on PATH
+#   - timeout(1) (coreutils)
+# ============================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEST_FILE="${SCRIPT_DIR}/cli_robustness_tests.milk"
+TIMEOUT_SEC=10
+VERBOSE=0
+if [[ "${1:-}" == "--verbose" ]]; then
+    VERBOSE=1
+fi
+
+# ---- Color codes ----
+RED='\033[0;31m'
+GRN='\033[0;32m'
+YLW='\033[0;33m'
+CYN='\033[0;36m'
+DIM='\033[2m'
+RST='\033[0m'
+
+# ---- Temp directory ----
+TMPDIR="$(mktemp -d /tmp/clitest.XXXXXX)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+REPORT="${TMPDIR}/report.txt"
+> "$REPORT"
+
+# ---- Counters ----
+TOTAL=0
+PASS=0
+FAIL=0
+ERRFAIL=0    # Expected error but no message
+CRASH=0
+HANG=0
+
+echo -e "${CYN}═══════════════════════════════════════════${RST}"
+echo -e "${CYN} milk-cli Robustness Test Suite${RST}"
+echo -e "${CYN}═══════════════════════════════════════════${RST}"
+echo ""
+
+# ============================================================
+# Parse test file into blocks
+# ============================================================
+#
+# A "test block" is:
+#   #DESC: description
+#   #EXPECT:OK or #EXPECT:ERR
+#   one or more command lines (until next #DESC or EOF)
+#
+# Multi-line constructs (if/while/for/function/case)
+# are accumulated into a single block.
+
+declare -a TEST_DESC=()
+declare -a TEST_EXPECT=()
+declare -a TEST_CMD=()
+
+cur_desc=""
+cur_expect=""
+cur_cmd=""
+
+flush_test() {
+    if [[ -n "$cur_desc" && -n "$cur_cmd" ]]; then
+        TEST_DESC+=("$cur_desc")
+        TEST_EXPECT+=("$cur_expect")
+        TEST_CMD+=("$cur_cmd")
+    fi
+    cur_desc=""
+    cur_expect=""
+    cur_cmd=""
+}
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+    # Check for DESC annotation
+    if [[ "$line" =~ ^#DESC:\ *(.*) ]]; then
+        flush_test
+        cur_desc="${BASH_REMATCH[1]}"
+        continue
+    fi
+
+    # Check for EXPECT annotation
+    if [[ "$line" =~ ^#EXPECT:(OK|ERR) ]]; then
+        cur_expect="${BASH_REMATCH[1]}"
+        continue
+    fi
+
+    # Skip pure comment lines (not annotations)
+    stripped="${line#"${line%%[![:space:]]*}"}"
+    if [[ -z "$stripped" || "$stripped" == \#* ]]; then
+        # If we have an active test block with
+        # no commands yet, this is just spacing
+        if [[ -z "$cur_cmd" ]]; then
+            continue
+        fi
+        # Otherwise include blank/comment in
+        # multi-line blocks
+        continue
+    fi
+
+    # Accumulate command lines
+    if [[ -n "$cur_desc" ]]; then
+        if [[ -n "$cur_cmd" ]]; then
+            cur_cmd="${cur_cmd}
+${line}"
+        else
+            cur_cmd="$line"
+        fi
+    fi
+done < "$TEST_FILE"
+flush_test
+
+NUM_TESTS=${#TEST_DESC[@]}
+echo -e "Parsed ${CYN}${NUM_TESTS}${RST} test blocks"
+echo ""
+
+# ============================================================
+# Run tests
+# ============================================================
+
+run_one_test() {
+    local idx="$1"
+    local desc="${TEST_DESC[$idx]}"
+    local expect="${TEST_EXPECT[$idx]}"
+    local cmd="${TEST_CMD[$idx]}"
+
+    local cmd_file="${TMPDIR}/cmd_${idx}.milk"
+    local out_file="${TMPDIR}/out_${idx}.txt"
+    local err_file="${TMPDIR}/err_${idx}.txt"
+
+    # Write commands to a temp script
+    echo "$cmd" > "$cmd_file"
+    echo "exit" >> "$cmd_file"
+
+    TOTAL=$((TOTAL + 1))
+
+    # Run milk-cli with the test script, capturing
+    # stdout and stderr, with timeout
+    local exit_code=0
+    timeout "${TIMEOUT_SEC}" milk-cli \
+        --no-autocomplete \
+        --no-history-suggest \
+        --no-arg-hints \
+        -s "$cmd_file" \
+        -f \
+        > "$out_file" 2>"$err_file" < /dev/null \
+        || exit_code=$?
+
+    local result="PASS"
+    local detail=""
+
+    # Check for timeout (exit 124)
+    if [[ $exit_code -eq 124 ]]; then
+        result="HANG"
+        detail="Command timed out after ${TIMEOUT_SEC}s"
+        HANG=$((HANG + 1))
+    # Check for crash (signal exits: 128+signal)
+    elif [[ $exit_code -ge 128 ]]; then
+        local sig=$((exit_code - 128))
+        result="CRASH"
+        detail="Killed by signal $sig"
+        CRASH=$((CRASH + 1))
+    # Check expected outcome
+    elif [[ "$expect" == "OK" ]]; then
+        if [[ $exit_code -ne 0 ]]; then
+            # Check if it's a minor issue —
+            # some commands return non-zero
+            # but are still "working"
+            result="FAIL"
+            detail="Expected success, got exit=$exit_code"
+            FAIL=$((FAIL + 1))
+        else
+            PASS=$((PASS + 1))
+        fi
+    elif [[ "$expect" == "ERR" ]]; then
+        # We expect an error — check that an
+        # error message was printed
+        local combined
+        combined="$(cat "$out_file" "$err_file")"
+        if echo "$combined" | \
+            grep -qiE \
+            '(error|usage|missing|cannot|not found|wrong|invalid|did you mean|unknown|no such)'; then
+            PASS=$((PASS + 1))
+        else
+            if [[ $exit_code -eq 0 ]]; then
+                result="MISSING_ERROR"
+                detail="Expected error message but got none (exit=0)"
+                ERRFAIL=$((ERRFAIL + 1))
+            else
+                # Non-zero exit but no message
+                result="MISSING_ERROR"
+                detail="Exit=$exit_code but no error message found"
+                ERRFAIL=$((ERRFAIL + 1))
+            fi
+        fi
+    fi
+
+    # Print result
+    local color="$GRN"
+    case "$result" in
+        FAIL)          color="$RED" ;;
+        CRASH)         color="$RED" ;;
+        HANG)          color="$RED" ;;
+        MISSING_ERROR) color="$YLW" ;;
+    esac
+
+    printf "  [%3d/%3d] ${color}%-14s${RST} %s" \
+        "$TOTAL" "$NUM_TESTS" "$result" "$desc"
+    if [[ -n "$detail" ]]; then
+        printf "  ${DIM}(%s)${RST}" "$detail"
+    fi
+    echo ""
+
+    if [[ $VERBOSE -eq 1 && "$result" != "PASS" ]]; then
+        echo -e "    ${DIM}Command: $(head -1 "$cmd_file")${RST}"
+        echo -e "    ${DIM}Stdout:  $(head -3 "$out_file" | \
+            tr '\n' '|')${RST}"
+        echo -e "    ${DIM}Stderr:  $(head -3 "$err_file" | \
+            tr '\n' '|')${RST}"
+    fi
+
+    # Write to report
+    {
+        echo "--- Test $TOTAL: $desc ---"
+        echo "Expect: $expect"
+        echo "Result: $result"
+        echo "Exit:   $exit_code"
+        if [[ -n "$detail" ]]; then
+            echo "Detail: $detail"
+        fi
+        echo "Command:"
+        cat "$cmd_file"
+        echo "Stdout:"
+        cat "$out_file"
+        echo "Stderr:"
+        cat "$err_file"
+        echo ""
+    } >> "$REPORT"
+}
+
+for i in $(seq 0 $((NUM_TESTS - 1))); do
+    run_one_test "$i"
+done
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+echo -e "${CYN}═══════════════════════════════════════════${RST}"
+echo -e "${CYN} Summary${RST}"
+echo -e "${CYN}═══════════════════════════════════════════${RST}"
+echo ""
+printf "  Total:         %d\n" "$TOTAL"
+printf "  ${GRN}Pass:          %d${RST}\n" "$PASS"
+printf "  ${RED}Fail:          %d${RST}\n" "$FAIL"
+printf "  ${YLW}Missing Error: %d${RST}\n" "$ERRFAIL"
+printf "  ${RED}Crash:         %d${RST}\n" "$CRASH"
+printf "  ${RED}Hang:          %d${RST}\n" "$HANG"
+echo ""
+
+# Copy report to working directory
+FINAL_REPORT="${SCRIPT_DIR}/cli_test_report.txt"
+cp "$REPORT" "$FINAL_REPORT"
+echo -e "Detailed report: ${CYN}${FINAL_REPORT}${RST}"
+echo ""
+
+PROBLEMS=$((FAIL + ERRFAIL + CRASH + HANG))
+if [[ $PROBLEMS -eq 0 ]]; then
+    echo -e "${GRN}All tests passed!${RST}"
+    exit 0
+else
+    echo -e "${RED}${PROBLEMS} problem(s) found.${RST}"
+    exit 1
+fi

--- a/tests/cli/run_cli_robustness_tests.sh
+++ b/tests/cli/run_cli_robustness_tests.sh
@@ -201,7 +201,7 @@ run_one_test() {
         combined="$(cat "$out_file" "$err_file")"
         if echo "$combined" | \
             grep -qiE \
-            '(error|usage|missing|cannot|not found|wrong|invalid|did you mean|unknown|no such)'; then
+            '(error|usage|missing|cannot|not found|does not exist|wrong|invalid|did you mean|unknown|no such)'; then
             PASS=$((PASS + 1))
         else
             if [[ $exit_code -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Adds a comprehensive CLI robustness test suite and fixes two error reporting bugs discovered by it.

### CLI robustness test suite (new)

- **`tests/cli/cli_robustness_tests.milk`** — 109 annotated test cases covering parsing, built-in commands, variables, arithmetic, flow control, user functions, command chaining, shell features, and error conditions.
- **`tests/cli/run_cli_robustness_tests.sh`** — Bash test runner that feeds test blocks to `milk-cli` via FIFO mode, captures output, and categorizes results as PASS/FAIL/MISSING_ERROR/CRASH/HANG.
- **`.agents/workflows/cli-robustness-test.md`** — Workflow for running the test suite.

### Bug fixes

1. **`cmd?` with unknown command** — `help_command()` in `CLIcore_help.c` now returns `RETURN_FAILURE` when the queried command is not found. Previously it always returned `RETURN_SUCCESS` even after printing "does not exist".

2. **`cd /absolute/path` silent failure** — Extended the tokenizer raw-string bypass in `CLIcore_UI.c` to treat `/`-prefixed arguments as raw strings (same as `-` prefixed arguments). The `/` in absolute paths was being interpreted as division by `cli_parse()`, causing a silent parse error that skipped command execution entirely.

### Test expectation corrections

- `mem.mk2Dim` and `mem.rm` with no arguments correctly create a local FPS with default values — updated test expectations from `#EXPECT:ERR` to `#EXPECT:OK`.
- Added `does not exist` to the runner's error-detection grep pattern.

### Prompt Summary

User requested a comprehensive CLI test suite to identify bad behavior (crashes, missing error messages). The test suite was created and run, revealing 4 MISSING_ERROR cases. Two were real bugs (fixed here), two were false positives (test expectations corrected).

### AI Authorship

- **Model:** Claude Sonnet 4.6 (Anthropic) via Antigravity
- **User edits:** None — all changes authored by the agent.