### PR TITLE
feat: Implement machine-readable JSON and TSV output for CLI

### DIFF
--- a/docs/cli/CLIcore.md
+++ b/docs/cli/CLIcore.md
@@ -205,6 +205,8 @@ and modules.
 ```text
 milk-cli > ?                       # print help
 milk-cli > help                    # same as ?
+milk-cli > help --json             # print help index in JSON format
+milk-cli > help --porcelain        # print help index in TSV format
 milk-cli > helprl                  # readline quick reference
 milk-cli > lm?                     # list all loaded modules
 milk-cli > m? <module>             # list commands for a module
@@ -223,6 +225,8 @@ dim for source file paths.
 ```text
 milk-cli > ci                      # compilation info & memory usage
 milk-cli > mem.listim              # list all images in memory
+milk-cli > mem.listim --json       # list all images in JSON format
+milk-cli > mem.listim --porcelain  # list all images in TSV format
 milk-cli > listimf <file>          # list images, write to file
 milk-cli > !<syscmd>               # execute system command
 milk-cli > quit                    # exit (or: exit, exitCLI)

--- a/docs/cli/help.txt
+++ b/docs/cli/help.txt
@@ -72,6 +72,10 @@ HELP COMMANDS
 > ?
 > help
 	# print this help file
+> help --json
+	# print help index in JSON format
+> help --porcelain
+	# print help index in TSV format
 > helprl
 	# print readline quick help
 > m? <module>
@@ -92,6 +96,10 @@ IMPORTANT COMMANDS
 	# compilation time and memory usage
 > mem.listim
 	# list all images in memory
+> mem.listim --json
+	# list all images in JSON format
+> mem.listim --porcelain
+	# list all images in TSV format
 > listimf <filename>
 	# list all images in memory and write output to file <filename>
 > !<syscommand>

--- a/src/cli/CLIcore/CLIcore/CLIcore_help.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_help.c
@@ -54,6 +54,8 @@
 #endif
 
 
+int help_format_mode = 0;
+
 errno_t printInfo()
 {
     float f1;
@@ -1871,8 +1873,55 @@ void print_help_topic_list(void)
     printf("\n");
 }
 
+void print_milk_cli_help_json(void)
+{
+    printf("{\n");
+    printf("  \"topics\": [\n");
+    printf("    {\"name\": \"cmdopts\", \"description\": \"Command-line flags (-h, -s, -n...)\"},\n");
+    printf("    {\"name\": \"syntax\", \"description\": \"Syntax, tab completion, piping\"},\n");
+    printf("    {\"name\": \"commands\", \"description\": \"Built-in CLI commands (?, cmd?...)\"},\n");
+    printf("    {\"name\": \"variables\", \"description\": \"Variables, arrays, arithmetic\"},\n");
+    printf("    {\"name\": \"flowcontrol\", \"description\": \"if/while/for/case/function\"},\n");
+    printf("    {\"name\": \"scripting\", \"description\": \"Script files, I/O, builtins\"},\n");
+    printf("    {\"name\": \"milk\", \"description\": \"Streams, FPS, milk-specific\"}\n");
+    printf("  ],\n");
+    printf("  \"quick_reference\": [\n");
+    printf("    {\"command\": \"cmd?\", \"args\": \"[name]\", \"description\": \"Help for a specific command\"},\n");
+    printf("    {\"command\": \"m?\", \"args\": \"[module]\", \"description\": \"List commands in a module\"},\n");
+    printf("    {\"command\": \"h?\", \"args\": \"[string]\", \"description\": \"Search command descriptions\"},\n");
+    printf("    {\"command\": \"fhelp\", \"args\": \"\", \"description\": \"Interactive fuzzy command search\"},\n");
+    printf("    {\"command\": \"quit / exit\", \"args\": \"\", \"description\": \"Exit the milk shell\"}\n");
+    printf("  ]\n");
+    printf("}\n");
+}
+
+void print_milk_cli_help_porcelain(void)
+{
+    printf("TYPE\tNAME\tARGS\tDESCRIPTION\n");
+    printf("TOPIC\tcmdopts\t\tCommand-line flags (-h, -s, -n...)\n");
+    printf("TOPIC\tsyntax\t\tSyntax, tab completion, piping\n");
+    printf("TOPIC\tcommands\t\tBuilt-in CLI commands (?, cmd?...)\n");
+    printf("TOPIC\tvariables\t\tVariables, arrays, arithmetic\n");
+    printf("TOPIC\tflowcontrol\t\tif/while/for/case/function\n");
+    printf("TOPIC\tscripting\t\tScript files, I/O, builtins\n");
+    printf("TOPIC\tmilk\t\tStreams, FPS, milk-specific\n");
+    printf("QUICKREF\tcmd?\t[name]\tHelp for a specific command\n");
+    printf("QUICKREF\tm?\t[module]\tList commands in a module\n");
+    printf("QUICKREF\th?\t[string]\tSearch command descriptions\n");
+    printf("QUICKREF\tfhelp\t\tInteractive fuzzy command search\n");
+    printf("QUICKREF\tquit / exit\t\tExit the milk shell\n");
+}
+
 void print_milk_cli_help(void)
 {
+    if (help_format_mode == 1) {
+        print_milk_cli_help_json();
+        return;
+    } else if (help_format_mode == 2) {
+        print_milk_cli_help_porcelain();
+        return;
+    }
+
     printf("\n");
     printf(C_TITLE
            "========================================\n" C_RST);
@@ -1902,15 +1951,39 @@ void print_milk_cli_help(void)
 
 errno_t help()
 {
-    if ((data.cmdargtoken[1].type == CMDARGTOKEN_TYPE_STRING) ||
-            (data.cmdargtoken[1].type == CMDARGTOKEN_TYPE_RAWSTRING))
+    int json_mode = 0;
+    int porcelain_mode = 0;
+    const char *topic = NULL;
+
+    for (int arg = 1; arg < data.cmdNBarg; arg++)
     {
-        const char *topic = data.cmdargtoken[1].val.string;
+        if (data.cmdargtoken[arg].type == CMDARGTOKEN_TYPE_STRING || data.cmdargtoken[arg].type == CMDARGTOKEN_TYPE_RAWSTRING)
+        {
+            if (strcmp(data.cmdargtoken[arg].val.string, "--json") == 0)
+            {
+                json_mode = 1;
+            }
+            else if (strcmp(data.cmdargtoken[arg].val.string, "--porcelain") == 0)
+            {
+                porcelain_mode = 1;
+            }
+            else
+            {
+                topic = data.cmdargtoken[arg].val.string;
+            }
+        }
+    }
+
+    help_format_mode = json_mode ? 1 : (porcelain_mode ? 2 : 0);
+
+    if (topic != NULL)
+    {
         if (help_topic_dispatch(topic) != 0)
         {
-            printf(C_ERR "Unknown help topic: \"%s\"" C_RST "\n\n",
-                   topic);
-            print_help_topic_list();
+            if (help_format_mode == 0) {
+                printf(C_ERR "Unknown help topic: \"%s\"" C_RST "\n\n", topic);
+                print_help_topic_list();
+            }
         }
     }
     else

--- a/src/cli/CLIcore/CLIcore/CLIcore_help.h
+++ b/src/cli/CLIcore/CLIcore/CLIcore_help.h
@@ -39,6 +39,7 @@ errno_t printInfo();
 void print_milk_framework_help(void);
 
 /** @brief Print milk CLI-specific help */
+extern int help_format_mode;
 void print_milk_cli_help(void);
 
 /** @brief Print only the available-topics list */

--- a/src/cli/CLIcore/CLIcore/CLIcore_modules.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_modules.c
@@ -327,7 +327,7 @@ errno_t RegisterModule(const char *__restrict FileName,
     if(dcprogstatus == 0)
     {
         OKmsg = 1;
-        if(!getenv("MILK_QUIET"))
+        if(!getenv("MILK_QUIET") && dcquiet == 0)
         {
             printf(".");
         }

--- a/src/cli/CLIcore/milk-cli-help.c
+++ b/src/cli/CLIcore/milk-cli-help.c
@@ -11,6 +11,7 @@
  *                   flowcontrol  scripting  milk
  */
 
+#include <string.h>
 #include <stdio.h>
 #include "CLIcore.h"
 
@@ -19,17 +20,36 @@ int main(int argc, char *argv[])
     dcquiet = 1;
     CLI_startup();
 
-    if (argc >= 2)
+    const char *topic = NULL;
+
+    for (int i = 1; i < argc; i++)
     {
-        const char *topic = argv[1];
+        if (strcmp(argv[i], "--json") == 0)
+        {
+            help_format_mode = 1;
+        }
+        else if (strcmp(argv[i], "--porcelain") == 0)
+        {
+            help_format_mode = 2;
+        }
+        else
+        {
+            topic = argv[i];
+        }
+    }
+
+    if (topic != NULL)
+    {
         int ret = help_topic_dispatch(topic);
         if (ret != 0)
         {
-            fprintf(stderr,
-                    "\033[1;31mmilk-cli-help: unknown topic"
-                    " \"%s\"\033[0m\n\n",
-                    topic);
-            print_help_topic_list();
+            if (help_format_mode == 0) {
+                fprintf(stderr,
+                        "\033[1;31mmilk-cli-help: unknown topic"
+                        " \"%s\"\033[0m\n\n",
+                        topic);
+                print_help_topic_list();
+            }
             return 1;
         }
     }

--- a/src/coremods/COREMOD_memory/list_image.c
+++ b/src/coremods/COREMOD_memory/list_image.c
@@ -48,6 +48,8 @@ void close_list_image_ID_ncurses();
 errno_t list_image_ID_ncurses();
 errno_t list_image_ID_ofp(FILE *fo);
 errno_t list_image_ID_ofp_simple(FILE *fo);
+errno_t list_image_ID_ofp_json(FILE *fo);
+errno_t list_image_ID_ofp_porcelain(FILE *fo);
 errno_t list_image_ID();
 errno_t list_image_ID_file(
     const char *fname);
@@ -160,7 +162,39 @@ void init_cms_listim(void)
 
 static errno_t compute_listim()
 {
-    list_image_ID();
+    int json_mode = 0;
+    int porcelain_mode = 0;
+
+#if !defined(FPS_STANDALONE) && !defined(MILK_NO_CLI)
+    long arg;
+    for(arg = 1; arg < data.cmdNBarg; arg++)
+    {
+        if(data.cmdargtoken[arg].type == CMDARGTOKEN_TYPE_STRING || data.cmdargtoken[arg].type == CMDARGTOKEN_TYPE_RAWSTRING)
+        {
+            if(strcmp(data.cmdargtoken[arg].val.string, "--json") == 0)
+            {
+                json_mode = 1;
+            }
+            if(strcmp(data.cmdargtoken[arg].val.string, "--porcelain") == 0)
+            {
+                porcelain_mode = 1;
+            }
+        }
+    }
+#endif
+
+    if(json_mode)
+    {
+        list_image_ID_ofp_json(stdout);
+    }
+    else if(porcelain_mode)
+    {
+        list_image_ID_ofp_porcelain(stdout);
+    }
+    else
+    {
+        list_image_ID();
+    }
     return RETURN_SUCCESS;
 }
 
@@ -618,6 +652,90 @@ errno_t list_image_ID()
 {
     list_image_ID_ofp(stdout);
     //malloc_stats();
+    return RETURN_SUCCESS;
+}
+
+errno_t list_image_ID_ofp_json(FILE *fo)
+{
+    long i, j;
+    long long   tmp_long;
+    uint8_t datatype;
+    unsigned long long sizeb = compute_image_memory();
+    struct timespec timenow;
+    clock_gettime(CLOCK_MILK, &timenow);
+
+    fprintf(fo, "{\n  \"images\": [\n");
+    int first = 1;
+    for(i = 0; i < dcnimg; i++)
+        if(dcimg[i].used == 1)
+        {
+            if (!first) {
+                fprintf(fo, ",\n");
+            }
+            first = 0;
+            datatype = dcimg[i].md[0].datatype;
+            tmp_long = ((long long) (dcimg[i].md[0].nelement)) * ImageStreamIO_typesize(datatype);
+
+            fprintf(fo, "    {\n");
+            fprintf(fo, "      \"index\": %ld,\n", i);
+            fprintf(fo, "      \"name\": \"%s\",\n", dcimg[i].name);
+            fprintf(fo, "      \"naxis\": %ld,\n", (long) dcimg[i].md[0].naxis);
+            fprintf(fo, "      \"size\": [");
+            for(j = 0; j < dcimg[i].md[0].naxis; j++)
+            {
+                fprintf(fo, "%ld%s", (long) dcimg[i].md[0].size[j], (j < dcimg[i].md[0].naxis - 1) ? ", " : "");
+            }
+            fprintf(fo, "],\n");
+            fprintf(fo, "      \"type\": \"%s\",\n", ImageStreamIO_typename_7(datatype));
+            fprintf(fo, "      \"shared\": %ld,\n", (long) dcimg[i].md[0].shared);
+            fprintf(fo, "      \"size_kb\": %ld,\n", (long)(tmp_long / 1024));
+
+            double timediff = (1.0 * timenow.tv_sec + 0.000000001 * timenow.tv_nsec) -
+                              (1.0 * dcimg[i].md[0].lastaccesstime.tv_sec +
+                               0.000000001 * dcimg[i].md[0].lastaccesstime.tv_nsec);
+            fprintf(fo, "      \"last_access_dt\": %.9f\n", timediff);
+            fprintf(fo, "    }");
+        }
+    fprintf(fo, "\n  ],\n");
+    fprintf(fo, "  \"summary\": {\n");
+    fprintf(fo, "    \"total_images\": %ld,\n", compute_nb_image());
+    fprintf(fo, "    \"total_size_b\": %llu\n", (unsigned long long)sizeb);
+    fprintf(fo, "  }\n}\n");
+
+    return RETURN_SUCCESS;
+}
+
+errno_t list_image_ID_ofp_porcelain(FILE *fo)
+{
+    long i, j;
+    long long   tmp_long;
+    uint8_t datatype;
+    struct timespec timenow;
+    clock_gettime(CLOCK_MILK, &timenow);
+
+    fprintf(fo, "INDEX\tNAME\tNAXIS\tSIZE\tTYPE\tSHARED\tSIZE_KB\tLAST_ACCESS_DT\n");
+
+    for(i = 0; i < dcnimg; i++)
+        if(dcimg[i].used == 1)
+        {
+            datatype = dcimg[i].md[0].datatype;
+            tmp_long = ((long long) (dcimg[i].md[0].nelement)) * ImageStreamIO_typesize(datatype);
+
+            fprintf(fo, "%ld\t%s\t%ld\t", i, dcimg[i].name, (long) dcimg[i].md[0].naxis);
+            for(j = 0; j < dcimg[i].md[0].naxis; j++)
+            {
+                fprintf(fo, "%ld%s", (long) dcimg[i].md[0].size[j], (j < dcimg[i].md[0].naxis - 1) ? "x" : "");
+            }
+            double timediff = (1.0 * timenow.tv_sec + 0.000000001 * timenow.tv_nsec) -
+                              (1.0 * dcimg[i].md[0].lastaccesstime.tv_sec +
+                               0.000000001 * dcimg[i].md[0].lastaccesstime.tv_nsec);
+            fprintf(fo, "\t%s\t%ld\t%ld\t%.9f\n",
+                    ImageStreamIO_typename_7(datatype),
+                    (long) dcimg[i].md[0].shared,
+                    (long)(tmp_long / 1024),
+                    timediff);
+        }
+
     return RETURN_SUCCESS;
 }
 


### PR DESCRIPTION
## Description

This PR introduces robust, machine-readable output formats for `milk-cli`, allowing users to pipe command output directly into `jq`, `awk`, or other downstream processing utilities without needing to parse out UI elements (borders, tables, colors).

Currently supported commands:
- `mem.listim --json` / `--porcelain`
- `help --json` / `--porcelain` (or `milk-cli-help --json` / `--porcelain`)

### Prompt Summary
The user requested adding flags to commands like `mem.listim` and `milk-cli-help` to strip ANSI colors, tables, and borders in favor of strict JSON or Tab-Separated Values (TSV). The goal was to make piping data out of milk significantly more robust. 

### What was changed
- Updated `compute_listim()` in `list_image.c` to parse `--json` and `--porcelain` flags, and added `list_image_ID_json()` and `list_image_ID_porcelain()`.
- Added formatting parsing to `milk-cli-help.c` and `CLIcore_help.c`.
- Fixed stray dot (`.`) printing during startup in `CLIcore_modules.c` to guarantee valid standard output streams when printing JSON/TSV.
- Updated documentation in `docs/cli/CLIcore.md` and `docs/cli/help.txt` with examples covering these new flags.

### Testing
Compiled fully and verified the output format matches valid JSON and TSV schemas via terminal queries:
- `milk-cli -c "mem.listim --json" | jq .`
- `milk-cli-help --porcelain`

### AI Authorship
- **Model(s) used:** Antigravity 
- **User edits:** None