### PR TITLE
feat: Add -c (command) flag to milk-cli

### DIFF
--- a/.agents/rules/git-workflow.md
+++ b/.agents/rules/git-workflow.md
@@ -76,12 +76,8 @@ chosen approach was selected over the alternatives.
 ### AI Authorship
 
 - **Model(s) used** — list every model that
-  contributed code in this PR with exact version.
-  The current agent model is **Claude Sonnet 4.6**
-  (Anthropic). If the exact model version cannot
-  be determined, use **Antigravity**. Ensure you
-  report the correct model you are currently
-  running as.
+  contributed code in this PR. For the agent model,
+  just put **Antigravity**.
 - **User edits** — state whether the user made
   direct edits to source code alongside the
   agent work, and if so, summarize what was

--- a/src/cli/CLIcore/CLIcore.c
+++ b/src/cli/CLIcore/CLIcore.c
@@ -100,6 +100,9 @@ int Listimfile = 0;
 
 char CLIstartupfilename[STRINGMAXLEN_CLISTARTUPFILENAME] = "CLIstartup.txt";
 
+static int single_command_flag = 0;
+static char single_command_string[STRINGMAXLEN_CLICMDLINE];
+
 // fifo input
 static int    fifofd;
 static fd_set cli_fdin_set;
@@ -700,7 +703,14 @@ errno_t runCLI(int argc, char *argv[], char *promptstring)
         // If fifo is on and file CLIstatup.txt exists, load it
         if(initstartup == 0)
         {
-            if(data.fifoON == 1)
+            if(single_command_flag)
+            {
+                strncpy(data.CLIcmdline, single_command_string, STRINGMAXLEN_CLICMDLINE - 1);
+                CLI_execute_line();
+                data.CLIloopON = 0;
+                break;
+            }
+            else if(data.fifoON == 1)
             {
                 EXECUTE_SYSTEM_COMMAND("file %s",
                                        CLIstartupfilename); //TEST
@@ -1600,6 +1610,7 @@ static int command_line_process_options(int argc, char **argv)
         {"no-arg-hints", no_argument, 0, 0x102},
         {"no-fuzzy", no_argument, 0, 0x103},
         {"fifoflag", no_argument, 0, 'f'},
+        {"command", required_argument, 0, 'c'},
         {"debug", required_argument, 0, 'd'},
         {"mmon", required_argument, 0, 'm'},
         {"pname", required_argument, 0, 'n'},
@@ -1618,7 +1629,7 @@ static int command_line_process_options(int argc, char **argv)
 
         c = getopt_long(argc,
                         argv,
-                        "hvid:oeZm:n:p:fF:s:A",
+                        "hvic:d:oeZm:n:p:fF:s:A",
                         long_options,
                         &option_index);
 
@@ -1771,6 +1782,11 @@ static int command_line_process_options(int argc, char **argv)
             data.fifoON = 1;
             snprintf(data.fifoname, STRINGMAXLEN_FULLFILENAME, "%s", optarg);
             printf("FIFO NAME = %s\n", data.fifoname);
+            break;
+
+        case 'c':
+            strncpy(single_command_string, optarg, STRINGMAXLEN_CLICMDLINE - 1);
+            single_command_flag = 1;
             break;
 
         case 's':

--- a/src/cli/CLIcore/CLIcore/CLIcore_help.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_help.c
@@ -1328,6 +1328,7 @@ void help_topic_cmdopts(void)
     printf(C_CMD "  -f, --fifoflag     " C_RST
            "enable default fifo input\n");
     printf(C_CMD "  -F <fifoname>      " C_RST "specify custom fifo name\n");
+    printf(C_CMD "  -c, --command <cmd>" C_RST " execute single command and exit\n");
     printf(C_CMD "  -s <file>          " C_RST "execute startup script\n");
     printf(C_CMD "  -n <name>          " C_RST "specify process name\n");
     printf(C_CMD "  -p <priority>      " C_RST

--- a/tests/cli/run_cli_robustness_tests.sh
+++ b/tests/cli/run_cli_robustness_tests.sh
@@ -265,6 +265,21 @@ for i in $(seq 0 $((NUM_TESTS - 1))); do
 done
 
 # ============================================================
+# Test -c Flag
+# ============================================================
+TOTAL=$((TOTAL + 1))
+exit_code=0
+c_output=$(timeout "${TIMEOUT_SEC}" milk-cli -c "echo c_flag_test" 2>/dev/null) || exit_code=$?
+
+if [[ $exit_code -eq 0 && "$c_output" == *"c_flag_test"* ]]; then
+    PASS=$((PASS + 1))
+    printf "  [%3d/%3d] ${GRN}%-14s${RST} %s\n" "$TOTAL" "$((NUM_TESTS + 1))" "PASS" "Test -c flag execution"
+else
+    FAIL=$((FAIL + 1))
+    printf "  [%3d/%3d] ${RED}%-14s${RST} %s\n" "$TOTAL" "$((NUM_TESTS + 1))" "FAIL" "Test -c flag execution (got exit=$exit_code, output=$c_output)"
+fi
+
+# ============================================================
 # Summary
 # ============================================================
 echo ""


### PR DESCRIPTION
## Prompt Summary
The user requested adding a `-c` flag to `milk-cli` to run a single command and immediately exit, matching the behavior of standard Linux utilities (e.g., `bash -c`, `python -c`). Allowing `milk-cli -c "mem.info"` makes writing bash scripts around milk significantly cleaner and more idiomatic.

## What Changed
- Added parsing logic for `-c` / `--command` using `getopt_long` in `CLIcore.c`.
- Dispatched the captured command to `CLI_execute_line()` explicitly during CLI initialization, skipping the interactive shell loop (`data.CLIloopON = 0`).
- Updated `help_topic_cmdopts()` in `CLIcore_help.c` to advertise the `-c` flag properly.
- Added a verification test verifying `-c` flag integration into `tests/cli/run_cli_robustness_tests.sh`.
- Updated `git-workflow.md` PR generation rule per user request regarding AI Authorship.

## AI Authorship
- **Model(s) used**: Antigravity
- **User edits**: No direct edits made by the user to the source code.