### PR TITLE
fix(cli): Enforce string stringency for unquoted flow symbols

### DIFF
--- a/src/cli/CLIcore/CLIcore/CLIcore_UI.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI.c
@@ -876,6 +876,93 @@ errno_t CLI_execute_string(const char *cmd)
     return ret;
 }
 
+
+static int cli_check_unquoted_restricted_symbols(const char *cmdline) {
+    int in_squote = 0;
+    int in_dquote = 0;
+    int esc = 0;
+    
+    const char *restricted = ";<>|[]()&*?$";
+    
+    int word_start = 1;
+    int valid_assign_prefix = 0; 
+    
+    for (int i = 0; cmdline[i] != '\0'; i++) {
+        char c = cmdline[i];
+        
+        if (esc) {
+            esc = 0;
+            word_start = 0;
+            valid_assign_prefix = 0;
+            continue;
+        }
+        
+        if (c == '\\') {
+            esc = 1;
+            word_start = 0;
+            valid_assign_prefix = 0;
+            continue;
+        }
+        
+        if (in_squote) {
+            if (c == '\'') in_squote = 0;
+            continue;
+        }
+        
+        if (in_dquote) {
+            if (c == '"') in_dquote = 0;
+            continue;
+        }
+        
+        if (c == '\'') {
+            in_squote = 1;
+            word_start = 0;
+            valid_assign_prefix = 0;
+            continue;
+        }
+        
+        if (c == '"') {
+            in_dquote = 1;
+            word_start = 0;
+            valid_assign_prefix = 0;
+            continue;
+        }
+        
+        if (isspace(c)) {
+            word_start = 1;
+            valid_assign_prefix = 0;
+            continue;
+        }
+        
+        if (strchr(restricted, c) != NULL) {
+            return 1;
+        }
+        
+        if (c == '=') {
+            if (!valid_assign_prefix) {
+                return 1;
+            }
+            valid_assign_prefix = 0;
+            continue;
+        }
+        
+        if (word_start) {
+            if (isalpha(c) || c == '_') {
+                valid_assign_prefix = 1;
+            } else {
+                valid_assign_prefix = 0;
+            }
+            word_start = 0;
+        } else {
+            if (!isalnum(c) && c != '_') {
+                valid_assign_prefix = 0;
+            }
+        }
+    }
+    
+    return 0;
+}
+
 errno_t CLI_execute_line()
 {
     DEBUG_TRACE_FSTART();
@@ -3019,6 +3106,16 @@ pipe_fallthrough:
         
         cli_export_vars_to_env(); // export variables prior to wordexp evaluation
         
+        if (cli_check_unquoted_restricted_symbols(data.CLIcmdline) != 0)
+        {
+            printf(
+                "\n%c[%d;%dm ERROR %c[%d;m Syntax error: flow process symbols must be quoted\n",
+                (char) 27, 1, 31, (char) 27, 0);
+            data.CMDexecuted = 1; // Prevent fallback to shell
+            data.parseerror = 1;
+            return RETURN_FAILURE;
+        }
+
         wordexp_t p;
         int we_ret = wordexp(data.CLIcmdline, &p, WRDE_SHOWERR | WRDE_UNDEF);
         if(we_ret == 0)
@@ -3049,6 +3146,13 @@ pipe_fallthrough:
                 }
                 else
                 {
+                    strncpy(
+                        data.cmdargtoken[data.cmdNBarg].val.string,
+                        cmdargstring,
+                        STRINGMAXLEN_CMDARGTOKEN_VAL - 1);
+                    data.cmdargtoken[data.cmdNBarg]
+                        .val.string[STRINGMAXLEN_CMDARGTOKEN_VAL - 1] = '\0';
+
                     snprintf(str, strmaxlen,
                              "%s\n", cmdargstring);
                     cli_parse(str);

--- a/tests/cli/cli_test_stringency.milk
+++ b/tests/cli/cli_test_stringency.milk
@@ -1,0 +1,21 @@
+# Test string stringency in CLI
+
+# 1. Unquoted restricted symbols should be rejected
+echo "Running unquoted restricted symbol test..."
+!test "$(milk-cli -c 'echo a;b' 2>&1 | grep -c 'Syntax error: flow process symbols must be quoted')" -eq 1
+!test "$(milk-cli -c 'echo a>b' 2>&1 | grep -c 'Syntax error: flow process symbols must be quoted')" -eq 1
+!test "$(milk-cli -c 'echo a|b' 2>&1 | grep -c 'Syntax error: flow process symbols must be quoted')" -eq 1
+
+# 2. Quoted restricted symbols should be accepted
+echo "Running quoted restricted symbol test..."
+a="a;b"
+!test "$a" = "a;b"
+
+# 3. Dynamic variable assignment with unquoted = should be accepted
+echo "Running dynamic variable assignment test..."
+wer=4
+!test "$wer" = "4"
+b=1.5
+!test "$b" = "1.5"
+
+echo "CLI_STRINGENCY_TESTS_COMPLETE"


### PR DESCRIPTION
### Prompt Summary
The user requested that flow process symbols (e.g., `;`, `<`, `>`, `|`, `[`, `]`, `(`, `)`, `&`, `*`, `?`, `$`) not be allowed within `milk-cli` strings unless the string is enclosed in quotes. This ensures more predictable string parsing and prevents accidental shell injections or parser breaks. The user also brought up a crash when executing `mem.mk2Dim wer=4 10 20`, hypothesizing it was related.

### Changes Made
1. **Added `cli_check_unquoted_restricted_symbols`**: A pre-scan loop in `CLIcore_UI.c` that checks for restricted symbols before `wordexp()` is called. If an unquoted restricted symbol is found, it aborts execution with a clear syntax error message.
2. **Fixed Token String Preservation**: Fixed a critical bug where `cli_parse` evaluation (e.g., detecting `=`) would overwrite the `CMDARGTOKEN` type but leave its `.val.string` field empty. This was the true root cause of the `mk2Dim wer=4 10 20` crash, as `ImageStreamIO_sizing` received an empty name. Now, `.val.string` is strictly preserved for the original raw string.
3. **Tests Added**: Added `cli_test_stringency.milk` to the test suite to verify the rejection of unquoted flow symbols and the correct handling of valid strings.

### AI Authorship
- **Model(s) used**: Antigravity
- **User edits**: None