### PR TITLE
fix: move command chaining before variable assignment

### DIFF
--- a/src/cli/CLIcore/CLIcore/CLIcore_UI.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI.c
@@ -1903,29 +1903,14 @@ pipe_fallthrough:
         }
     }
 
-    /* Check for array assignment: arr=(a b c) */
-    if(cli_try_array_assign(data.CLIcmdline))
-    {
-        data.CMDexecuted = 1;
-        free(thetime);
-        DEBUG_TRACE_FEXIT();
-        return RETURN_SUCCESS;
-    }
-
-    /* Check for variable assignment (VAR=val) */
-    if(cli_try_var_assign(data.CLIcmdline))
-    {
-        data.CMDexecuted = 1;
-        free(thetime);
-        DEBUG_TRACE_FEXIT();
-        return RETURN_SUCCESS;
-    }
-
     /*
      * ---- Command chaining: ; && || ----
      *
      * Scan for the first unquoted chaining
      * operator and split there.
+     * Must run BEFORE variable assignment so
+     * that "a=1;b=2" is split into two
+     * commands rather than assigned as one.
      */
     {
         char fullline[STRINGMAXLEN_CLICMDLINE];
@@ -2043,6 +2028,24 @@ pipe_fallthrough:
             DEBUG_TRACE_FEXIT();
             return RETURN_SUCCESS;
         }
+    }
+
+    /* Check for array assignment: arr=(a b c) */
+    if(cli_try_array_assign(data.CLIcmdline))
+    {
+        data.CMDexecuted = 1;
+        free(thetime);
+        DEBUG_TRACE_FEXIT();
+        return RETURN_SUCCESS;
+    }
+
+    /* Check for variable assignment (VAR=val) */
+    if(cli_try_var_assign(data.CLIcmdline))
+    {
+        data.CMDexecuted = 1;
+        free(thetime);
+        DEBUG_TRACE_FEXIT();
+        return RETURN_SUCCESS;
     }
     /* ---- Smart Shell Fallback Bypass ---- */
     /* If the command does not start with an internal milk command, alias, or script keyword,


### PR DESCRIPTION
## Summary

Fixes `;` not working as a command separator when combined with variable assignment (e.g., `a=1;b=2` was stored as `a="1;b=2"` instead of executing two commands).

## Changes

The `;`/`&&`/`||` chaining block in `CLI_execute_line()` ran **after** `cli_try_var_assign()`, so the assignment greedily consumed the entire line. Moved the chaining block above the assignment checks so unquoted operators always split first.

## Testing

- **Smoke test:** `milk-cli -c 'a=1;b=2;vars'` → `a=1` (INT), `b=2` (INT) ✓
- **Robustness suite:** 134 tests — 133 PASS, 0 FAIL, 0 CRASH, 0 HANG

### Prompt Summary

User reported that `a=1;b=2` was not splitting on `;`. Root cause identified as operator precedence in `CLI_execute_line()`.

### AI Authorship

- **Model:** Antigravity
- **User edits:** None