### PR TITLE
feat(cli): add dynamic FIFO handling

### DIFF
--- a/docs/cli/fifo.md
+++ b/docs/cli/fifo.md
@@ -1,0 +1,168 @@
+---
+tags:
+  - CLI
+  - FIFO
+  - Scripting
+---
+
+# FIFO Command Input
+
+milk-cli supports **command FIFO** (named pipe) input,
+allowing external processes to inject commands into a
+running CLI session. This enables powerful automation
+workflows where shell pipelines feed commands into
+milk-cli in real time.
+
+## Quick Start
+
+```
+milk> fifo create
+[fifo] opened: /milk/shm/.milk.fifo.12345 (fd=4)
+
+milk> echo $MCLIFIFO
+/milk/shm/.milk.fifo.12345
+```
+
+From another terminal:
+
+```bash
+echo "mem.listim" > /milk/shm/.milk.fifo.12345
+```
+
+The milk-cli session shows ingestion feedback:
+
+```
+[fifo] ← "mem.listim"
+... (command output) ...
+[fifo] ✓ (0.003s)
+```
+
+## The `fifo` Command
+
+| Sub-command | Description |
+|---|---|
+| `fifo create [path]` | Create and open a new FIFO. Auto-generates path if omitted. |
+| `fifo open <path>` | Connect to an existing FIFO at the given path. |
+| `fifo close` | Close and remove the current FIFO. |
+| `fifo on` | Re-enable FIFO input (after `fifo off`). |
+| `fifo off` | Temporarily disable FIFO input without destroying the pipe. |
+| `fifo status` | Print current FIFO state, path, and file descriptor. |
+| `fifo` | Same as `fifo status`. |
+
+## The `$MCLIFIFO` Variable
+
+The special variable `$MCLIFIFO` expands to the
+current FIFO path when a FIFO is active, or an empty
+string when no FIFO is open. This makes it easy to
+reference the FIFO in shell commands:
+
+```
+milk> fifo create
+milk> !echo "echo hello" > $MCLIFIFO
+```
+
+## Startup Flags
+
+FIFOs can also be enabled at startup:
+
+| Flag | Description |
+|---|---|
+| `-f` | Auto-create a FIFO (path based on process name and PID) |
+| `-F <path>` | Create a FIFO at the specified path |
+
+These are equivalent to running `fifo create` or
+`fifo create <path>` immediately after startup.
+
+## Examples
+
+### Batch Command Injection
+
+Feed a list of commands from a file into a running
+milk-cli session:
+
+```bash
+# Terminal 1: start milk-cli with FIFO
+milk-cli -f
+
+# Terminal 2: send commands
+cat commands.milk > $(cat /milk/shm/.milk.fifo.*)
+```
+
+### Dynamic Processing with awk
+
+Process a list of images and save specific ones based
+on metadata:
+
+```
+milk> fifo create
+milk> !awk '{if ($4>200) print "iofits.saveFITS " $2 " " $2 "_save.fits"}' imlist.txt > $MCLIFIFO
+```
+
+Each generated command appears with ingestion feedback:
+
+```
+[fifo] ← "iofits.saveFITS im003 im003_save.fits"
+[fifo] ✓ (0.012s)
+[fifo] ← "iofits.saveFITS im007 im007_save.fits"
+[fifo] ✓ (0.015s)
+```
+
+### Pausing and Resuming FIFO Input
+
+Temporarily disable FIFO input while doing interactive
+work, then re-enable it:
+
+```
+milk> fifo create
+milk> fifo off
+[fifo] input disabled
+
+milk> # ... do interactive work ...
+
+milk> fifo on
+[fifo] input enabled
+```
+
+### Connecting to Another Session's FIFO
+
+If another milk-cli session has a FIFO open, you can
+connect to it:
+
+```
+milk> fifo open /milk/shm/.othersession.fifo.54321
+[fifo] opened: /milk/shm/.othersession.fifo.54321 (fd=4)
+```
+
+### Using with xargs
+
+Combine `find`, `xargs`, and FIFO to batch-process
+files:
+
+```
+milk> fifo create
+milk> !find /data/frames -name "*.fits" | xargs -I {} echo "iofits.loadfits {} frame" > $MCLIFIFO
+```
+
+### Scripted FIFO Workflow
+
+Create a shell script that starts milk-cli and feeds
+commands through the FIFO:
+
+```bash
+#!/bin/bash
+# Start milk-cli with FIFO in the background
+milk-cli -f &
+MILKPID=$!
+sleep 1
+
+# Find the FIFO path
+FIFO=$(ls /milk/shm/.milk.fifo.${MILKPID})
+
+# Send commands
+echo "mem.mk2Dim im1 128 128" > "$FIFO"
+echo "mem.mk2Dim im2 256 256" > "$FIFO"
+echo "mem.listim" > "$FIFO"
+echo "exit" > "$FIFO"
+
+wait $MILKPID
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
     - Process Info: procinfo.md
     - CLI Syntax: cli/CLIcore.md
     - Scripting: cli/scripting.md
+    - FIFO Command Input: cli/fifo.md
     - Readline Keys: cli/helpreadline.md
     - Scripts: scripts.md
     - Python API: python.md

--- a/src/cli/CLIcore/CLIcore.c
+++ b/src/cli/CLIcore/CLIcore.c
@@ -104,7 +104,6 @@ static int single_command_flag = 0;
 static char single_command_string[STRINGMAXLEN_CLICMDLINE];
 
 // fifo input
-static int    fifofd;
 static fd_set cli_fdin_set;
 
 /*-----------------------------------------
@@ -122,6 +121,11 @@ static int command_line_process_options(int argc, char **argv);
 /// CLI commands
 static int exitCLI();
 
+/* Forward declarations for FIFO helpers */
+void cli_fifo_close(void);
+int  cli_fifo_open(const char *path);
+errno_t cli_fifo(void);
+
 /* =============================================================================================== */
 /* =============================================================================================== */
 /*                                    FUNCTIONS SOURCE CODE                                        */
@@ -138,9 +142,10 @@ errno_t exitCLI()
      * scroll region and desync row positions. */
     CLI_cleanup_scroll_region();
 
-    if(data.fifoON == 1)
+    if(data.fifoON == 1
+       || data.fifofd >= 0)
     {
-        EXECUTE_SYSTEM_COMMAND("rm %s", data.fifoname);
+        cli_fifo_close();
     }
 
     if(Listimfile == 1)
@@ -287,21 +292,97 @@ errno_t streamCTRL_CTRLscreen__cli()
 
 void fnExit_fifoclose()
 {
-    //	printf("Running atexit function fnExit_fifoclose\n");
-    //	if ( data.fifoON == 1)
-    //	{
-    //		if (fifofd != -1) {
-    //			close(fifofd);
-    //		}
-    //	}
+}
 
-    //	FD_ZERO(&cli_fdin_set);  // Initializes the file descriptor set cli_fdin_set to have zero bits for all file descriptors.
-    //       if(data.fifoON==1)
-    //           FD_SET(fifofd, &cli_fdin_set);  // Sets the bit for the file descriptor fifofd in the file descriptor set cli_fdin_set.
-    //    FD_SET(fileno(stdin), &cli_fdin_set);  // Sets the bit for the file descriptor fifofd in the file descriptor set cli_fdin_set.
+/**
+ * @brief Open (or create) a command FIFO
+ *
+ * If path is NULL, auto-generates a default path
+ * based on process name and PID.
+ *
+ * @param path  FIFO path, or NULL for auto
+ * @return 0 on success, -1 on error
+ */
+int cli_fifo_open(const char *path)
+{
+    /* Close any existing FIFO first */
+    if(data.fifoON == 1)
+    {
+        cli_fifo_close();
+    }
 
-    // reset terminal properties
-    //	system("tset");
+    /* Set the path */
+    if(path != NULL && path[0] != '\0')
+    {
+        snprintf(data.fifoname,
+                 STRINGMAXLEN_FULLFILENAME,
+                 "%s", path);
+    }
+    else
+    {
+        WRITE_FULLFILENAME(
+            data.fifoname,
+            "%s/.%s.fifo.%07d",
+            dcshmdir,
+            data.processname,
+            getpid());
+    }
+
+    /* Create the FIFO if it doesn't exist */
+    struct stat sb;
+    if(stat(data.fifoname, &sb) != 0)
+    {
+        if(mkfifo(data.fifoname, 0666) != 0)
+        {
+            printf(
+                "\033[31mfifo: cannot create"
+                " '%s': %s\033[0m\n",
+                data.fifoname,
+                strerror(errno));
+            return -1;
+        }
+    }
+
+    data.fifofd = open(
+        data.fifoname,
+        O_RDWR | O_NONBLOCK);
+    if(data.fifofd == -1)
+    {
+        perror("open");
+        printf("File name : %s\n",
+               data.fifoname);
+        return -1;
+    }
+
+    data.fifoON = 1;
+
+    if(dcquiet == 0)
+    {
+        printf(
+            "\033[36m[fifo]\033[0m "
+            "opened: %s (fd=%d)\n",
+            data.fifoname, data.fifofd);
+    }
+    return 0;
+}
+
+/**
+ * @brief Close the current command FIFO
+ */
+void cli_fifo_close(void)
+{
+    if(data.fifofd >= 0)
+    {
+        close(data.fifofd);
+        data.fifofd = -1;
+    }
+    if(data.fifoON == 1
+       && data.fifoname[0] != '\0')
+    {
+        unlink(data.fifoname);
+    }
+    data.fifoON = 0;
+    data.fifoname[0] = '\0';
 }
 
 errno_t CLI_startup()
@@ -420,6 +501,7 @@ errno_t CLI_startup()
 
     data.CLIlogON          = 0; // log every command
     data.fifoON            = 0;
+    data.fifofd            = -1;
     dcprocinfo       = 1; // process info for intensive processes
     dcprocinfoact = 0; // toggles to 1 when process is logged
     data.autocomplete      = 1; // autocomplete preview ON by default
@@ -620,22 +702,14 @@ errno_t runCLI(int argc, char *argv[], char *promptstring)
     fdmax = fileno(stdin);
     if(data.fifoON == 1)
     {
-        if(dcquiet == 0)
+        if(cli_fifo_open(data.fifoname) != 0)
         {
-            printf("Creating fifo %s\n", data.fifoname);
-        }
-        mkfifo(data.fifoname, 0666);
-        fifofd = open(data.fifoname, O_RDWR | O_NONBLOCK);
-        if(fifofd == -1)
-        {
-            perror("open");
-            printf("File name : %s\n", data.fifoname);
             DEBUG_TRACE_FEXIT();
             return EXIT_FAILURE;
         }
-        if(fifofd > fdmax)
+        if(data.fifofd > fdmax)
         {
-            fdmax = fifofd;
+            fdmax = data.fifofd;
         }
     }
 
@@ -756,11 +830,12 @@ errno_t runCLI(int argc, char *argv[], char *promptstring)
 
         FD_ZERO(
             &cli_fdin_set); // Initializes the file descriptor set cli_fdin_set to have zero bits for all file descriptors.
-        if(data.fifoON == 1)
+        if(data.fifoON == 1
+           && data.fifofd >= 0)
         {
             FD_SET(
-                fifofd,
-                &cli_fdin_set); // Sets the bit for the file descriptor fifofd in the file descriptor set cli_fdin_set.
+                data.fifofd,
+                &cli_fdin_set);
         }
 
         FD_SET(
@@ -825,6 +900,14 @@ errno_t runCLI(int argc, char *argv[], char *promptstring)
 #endif
             }
 
+            /* Recompute fdmax in case fifo
+             * was opened dynamically */
+            fdmax = fileno(stdin);
+            if(data.fifoON == 1
+               && data.fifofd > fdmax)
+            {
+                fdmax = data.fifofd;
+            }
             n = select(fdmax + 1, &cli_fdin_set, NULL, NULL, &tv);
 
             if(n ==
@@ -833,17 +916,17 @@ errno_t runCLI(int argc, char *argv[], char *promptstring)
                 tv.tv_sec  = 0;
                 tv.tv_usec = cliwaitus;
 
-                FD_ZERO(
-                    &cli_fdin_set); // Initializes the file descriptor set cli_fdin_set to have zero bits for all file descriptors.
-                if(data.fifoON == 1)
+                FD_ZERO(&cli_fdin_set);
+                if(data.fifoON == 1
+                   && data.fifofd >= 0)
                 {
                     FD_SET(
-                        fifofd,
-                        &cli_fdin_set); // Sets the bit for the file descriptor fifofd in the file descriptor set cli_fdin_set.
+                        data.fifofd,
+                        &cli_fdin_set);
                 }
                 FD_SET(
                     fileno(stdin),
-                    &cli_fdin_set); // Sets the bit for the file descriptor fifofd in the file descriptor set cli_fdin_set.
+                    &cli_fdin_set);
                 continue;
             }
             if(n == -1)
@@ -863,23 +946,31 @@ errno_t runCLI(int argc, char *argv[], char *promptstring)
 
             blockCLIinput = 0;
 
-            if(data.fifoON == 1)
+            if(data.fifoON == 1
+               && data.fifofd >= 0)
             {
                 DEBUG_TRACEPOINT("fifo ON");
-                if(FD_ISSET(fifofd, &cli_fdin_set))
+                if(FD_ISSET(
+                    data.fifofd,
+                    &cli_fdin_set))
                 {
                     total_bytes = 0;
                     for(;;)
                     {
-                        bytes = read(fifofd, buf0, 1);
+                        bytes = read(
+                            data.fifofd,
+                            buf0, 1);
                         if(bytes > 0)
                         {
-                            buf1[total_bytes] = buf0[0];
-                            total_bytes += (size_t) bytes;
+                            buf1[total_bytes] =
+                                buf0[0];
+                            total_bytes +=
+                                (size_t) bytes;
                         }
                         else
                         {
-                            if(errno == EWOULDBLOCK)
+                            if(errno
+                               == EWOULDBLOCK)
                             {
                                 break;
                             }
@@ -887,34 +978,69 @@ errno_t runCLI(int argc, char *argv[], char *promptstring)
                             {
                                 perror("read");
                                 DEBUG_TRACE_FEXIT();
-                                return EXIT_FAILURE;
+                                return
+                                    EXIT_FAILURE;
                             }
                         }
                         if(buf0[0] == '\n')
                         {
-                            buf1[total_bytes - 1] = '\0';
-                            strncpy(data.CLIcmdline,
+                            buf1[
+                                total_bytes - 1]
+                                = '\0';
+                            strncpy(
+                                data.CLIcmdline,
                                 buf1,
-                                STRINGMAXLEN_CLICMDLINE - 1);
+                                STRINGMAXLEN_CLICMDLINE
+                                - 1);
 
-                            DEBUG_TRACEPOINT(
-                                "CLI executing line: "
-                                "%s",
+                            /* FIFO ingestion
+                             * feedback */
+                            printf(
+                                "\033[36m"
+                                "[fifo]\033[0m"
+                                " \u2190 \"%s\""
+                                "\n",
                                 data.CLIcmdline);
-                            if(dcdebug > 0)
-                            {
-                                printf("DEBUG: %s: execute line, fifo mode\n", __func__);
-                            }
-                            CLI_execute_line();
-                            DEBUG_TRACEPOINT("CLI line executed");
 
-                            printf("%s", prompt);
+                            struct timespec
+                                ft0;
+                            struct timespec
+                                ft1;
+                            clock_gettime(
+                                CLOCK_MONOTONIC,
+                                &ft0);
+
+                            CLI_execute_line();
+
+                            clock_gettime(
+                                CLOCK_MONOTONIC,
+                                &ft1);
+                            {
+                                double fe =
+                                    (double)
+                                    (ft1.tv_sec
+                                     - ft0.tv_sec)
+                                    + 1.0e-9
+                                    * (double)
+                                    (ft1.tv_nsec
+                                     - ft0.tv_nsec);
+                                printf(
+                                    "\033[36m"
+                                    "[fifo]"
+                                    "\033[0m"
+                                    " \u2713 "
+                                    "(%.3fs)"
+                                    "\n",
+                                    fe);
+                            }
+
+                            printf("%s",
+                                   prompt);
                             fflush(stdout);
                             break;
                         }
                     }
-                    blockCLIinput =
-                        1; // keep blocking input while fifo is not empty
+                    blockCLIinput = 1;
                 }
             }
 
@@ -1319,6 +1445,16 @@ void runCLI_cmd_init()
                        "no argument",
                        "pwd",
                        "cli_pwd()");
+
+    RegisterCLIcommand(
+        "fifo",
+        __FILE__,
+        cli_fifo,
+        "manage command FIFO input",
+        "[create|open|close|on|off"
+        "|status] [path]",
+        "fifo create /tmp/myfifo",
+        "cli_fifo()");
 
     RegisterCLIcommand("alias",
                        __FILE__,

--- a/src/cli/CLIcore/CLIcore.h
+++ b/src/cli/CLIcore/CLIcore.h
@@ -353,6 +353,7 @@ typedef struct
     // =================================================
 
     int      fifoON;
+    int      fifofd;
     char     processname[STRINGMAXLEN_PROCESSNAME];
     char     processname0[STRINGMAXLEN_PROCESSNAME];
     int      processnameflag;

--- a/src/cli/CLIcore/CLIcore/CLIcore_UI_builtins.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI_builtins.c
@@ -679,3 +679,176 @@ errno_t cli_pwd(void)
         return RETURN_FAILURE;
     }
 }
+
+/* Forward declarations for FIFO helpers
+ * defined in CLIcore.c */
+extern int  cli_fifo_open(const char *path);
+extern void cli_fifo_close(void);
+
+/**
+ * @brief Dynamic FIFO management command
+ *
+ * Sub-commands:
+ *   fifo create [path] — create+open FIFO
+ *   fifo open <path>   — connect to FIFO
+ *   fifo close         — close+remove FIFO
+ *   fifo on            — enable FIFO input
+ *   fifo off           — disable FIFO input
+ *   fifo status        — print FIFO state
+ *   fifo (no args)     — same as status
+ *
+ * @return RETURN_SUCCESS or RETURN_FAILURE
+ */
+errno_t cli_fifo(void)
+{
+    const char *sub = NULL;
+
+    if(data.cmdNBarg >= 2)
+    {
+        sub = data.cmdargtoken[1]
+              .val.string;
+    }
+
+    /* No sub-command → status */
+    if(sub == NULL
+       || strcmp(sub, "status") == 0)
+    {
+        printf("FIFO status:\n");
+        if(data.fifoON == 1)
+        {
+            printf(
+                "  state : \033[32m"
+                "ON\033[0m\n");
+            printf(
+                "  path  : %s\n",
+                data.fifoname);
+            printf(
+                "  fd    : %d\n",
+                data.fifofd);
+        }
+        else if(data.fifofd >= 0)
+        {
+            printf(
+                "  state : \033[33m"
+                "PAUSED\033[0m "
+                "(fifo open, input off)\n");
+            printf(
+                "  path  : %s\n",
+                data.fifoname);
+            printf(
+                "  fd    : %d\n",
+                data.fifofd);
+        }
+        else
+        {
+            printf(
+                "  state : \033[2m"
+                "OFF\033[0m "
+                "(no fifo)\n");
+        }
+        return RETURN_SUCCESS;
+    }
+
+    /* fifo create [path] */
+    if(strcmp(sub, "create") == 0)
+    {
+        const char *path = NULL;
+        if(data.cmdNBarg >= 3)
+        {
+            path = data.cmdargtoken[2]
+                   .val.string;
+        }
+        if(cli_fifo_open(path) != 0)
+        {
+            return RETURN_FAILURE;
+        }
+        return RETURN_SUCCESS;
+    }
+
+    /* fifo open <path> */
+    if(strcmp(sub, "open") == 0)
+    {
+        if(data.cmdNBarg < 3)
+        {
+            printf(
+                "Usage: fifo open "
+                "<path>\n");
+            return RETURN_FAILURE;
+        }
+        /* Check that the FIFO exists */
+        const char *path =
+            data.cmdargtoken[2]
+            .val.string;
+        struct stat sb;
+        if(stat(path, &sb) != 0
+           || !S_ISFIFO(sb.st_mode))
+        {
+            printf(
+                "\033[31mfifo open:"
+                " '%s' is not a "
+                "FIFO\033[0m\n",
+                path);
+            return RETURN_FAILURE;
+        }
+        if(cli_fifo_open(path) != 0)
+        {
+            return RETURN_FAILURE;
+        }
+        return RETURN_SUCCESS;
+    }
+
+    /* fifo close */
+    if(strcmp(sub, "close") == 0)
+    {
+        if(data.fifofd < 0)
+        {
+            printf(
+                "fifo: no fifo open\n");
+            return RETURN_SUCCESS;
+        }
+        printf(
+            "\033[36m[fifo]\033[0m "
+            "closing: %s\n",
+            data.fifoname);
+        cli_fifo_close();
+        return RETURN_SUCCESS;
+    }
+
+    /* fifo on */
+    if(strcmp(sub, "on") == 0)
+    {
+        if(data.fifofd < 0)
+        {
+            printf(
+                "fifo: no fifo open "
+                "(use 'fifo create' "
+                "first)\n");
+            return RETURN_FAILURE;
+        }
+        data.fifoON = 1;
+        printf(
+            "\033[36m[fifo]\033[0m "
+            "input enabled\n");
+        return RETURN_SUCCESS;
+    }
+
+    /* fifo off */
+    if(strcmp(sub, "off") == 0)
+    {
+        data.fifoON = 0;
+        printf(
+            "\033[36m[fifo]\033[0m "
+            "input disabled\n");
+        return RETURN_SUCCESS;
+    }
+
+    /* Unknown sub-command */
+    printf(
+        "fifo: unknown sub-command "
+        "'%s'\n"
+        "Usage: fifo "
+        "[create|open|close|on|off"
+        "|status]\n",
+        sub);
+    return RETURN_FAILURE;
+}

--- a/src/cli/CLIcore/CLIcore/CLIcore_script.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_script.c
@@ -143,6 +143,16 @@ const char *cli_var_lookup(const char *name)
         return retbuf;
     }
 
+    /* $MCLIFIFO — current command FIFO path */
+    if(strcmp(name, "MCLIFIFO") == 0)
+    {
+        if(data.fifoON == 1)
+        {
+            return data.fifoname;
+        }
+        return "";
+    }
+
     /* CLI variable */
     const char *v = cli_var_get(name);
     if(v != NULL)

--- a/src/cli/CLIcore/CLIcore_standalone.h
+++ b/src/cli/CLIcore/CLIcore_standalone.h
@@ -303,6 +303,7 @@ typedef struct
     char CLIlogname[STRINGMAXLEN_FULLFILENAME];
 
     int      fifoON;
+    int      fifofd;
     char     processname[STRINGMAXLEN_PROCESSNAME];
     char     processname0[STRINGMAXLEN_PROCESSNAME];
     int      processnameflag;


### PR DESCRIPTION
## Summary

Add dynamic FIFO handling to milk-cli, allowing users to create, connect to, enable/disable, and reference command FIFOs from within a running session — no longer requiring `-f`/`-F` startup flags.

### New features
- **`fifo` builtin command** with sub-commands: `create`, `open`, `close`, `on`, `off`, `status`
- **`$MCLIFIFO` special variable** — expands to the current FIFO path
- **Ingestion feedback** — shows each FIFO command with timing: `[fifo] ← "cmd"` / `[fifo] ✓ (0.003s)`
- **Dynamic select loop** — FIFOs opened mid-session are immediately active (fdmax recomputed)
- **`cli_fifo_open()`/`cli_fifo_close()` helpers** — reusable FIFO lifecycle management
- **MkDocs documentation** at `docs/cli/fifo.md` with examples (awk, xargs, batch injection, scripted workflows)

### Testing
- Build: ✅ clean compilation
- CLI robustness tests: 133/133 pass, 0 fail, 0 crash, 0 hang
- Smoke tests: fifo create/close/on/off/status, $MCLIFIFO expansion all verified

### Prompt Summary
User requested dynamic FIFO handling capabilities within the CLI, including creating/connecting to FIFOs, a special `$MCLIFIFO` variable, dynamic on/off toggling, and ingestion feedback.

### AI Authorship
- **Model**: Antigravity
- **User edits**: None