### PR TITLE
fix(cli,docs): remove ? from restricted symbols, fix markdownlint

### DIFF
--- a/docs/cli/CLIcore.md
+++ b/docs/cli/CLIcore.md
@@ -411,10 +411,11 @@ milk-cli > iofits.imgs2cube *.fits cube.fits
 ### Arithmetic & Logic Operations
 
 Expressions that do not match any known command are passed to
-the internal CLI calculator (`cli_calc_parser`). The calculator 
+the internal CLI calculator (`cli_calc_parser`). The calculator
 supports images, scalars, and logical operations.
 
 **Assignments & Math:**
+
 ```text
 milk-cli > a = 5.0                 # scalar assignment
 milk-cli > b = a * 10              # scalar arithmetic
@@ -422,9 +423,10 @@ milk-cli > im1 = sqrt(im + 2.0)    # image arithmetic
 ```
 
 **Functions:**
-Standard math functions are supported on both scalars and 
-images (per-pixel): `abs`, `fabs`, `round`, `fmod`, `min`, `max`, 
+Standard math functions are supported on both scalars and
+images (per-pixel): `abs`, `fabs`, `round`, `fmod`, `min`, `max`,
 `sqrt`, `exp`, `cos`, `sin`, `tan`, `acos`, `asin`, `atan`.
+
 ```text
 milk-cli > m = max(im1, 5)         # clip image below 5
 ```
@@ -433,6 +435,7 @@ milk-cli > m = max(im1, 5)         # clip image below 5
 Supported operators: `<`, `<=`, `>`, `>=`, `==`, `!=`, `&&`, `||`, `!`.
 When applied to images, these return a binary mask (1.0 or 0.0)
 for each pixel.
+
 ```text
 milk-cli > mask = (im1 > 100) && (im2 != 0)
 ```
@@ -441,11 +444,13 @@ milk-cli > mask = (im1 > 100) && (im2 != 0)
 The `where(cond, true_val, false_val)` function works like a
 ternary operator. If `cond` is an image mask, it blends
 the `true_val` and `false_val` images/scalars based on the mask.
+
 ```text
 milk-cli > im_clean = where(im > 100, 100, im)  # cap at 100
 ```
 
 **Vector Reductions:**
+
 ```text
 milk-cli > d = dot(im1, im2)       # sum(im1 * im2)
 milk-cli > n = norm(im1)           # sqrt(dot(im1, im1))

--- a/docs/cli/fifo.md
+++ b/docs/cli/fifo.md
@@ -15,7 +15,7 @@ milk-cli in real time.
 
 ## Quick Start
 
-```
+```text
 milk> fifo create
 [fifo] opened: /milk/shm/.milk.fifo.12345 (fd=4)
 
@@ -31,7 +31,7 @@ echo "mem.listim" > /milk/shm/.milk.fifo.12345
 
 The milk-cli session shows ingestion feedback:
 
-```
+```text
 [fifo] ← "mem.listim"
 ... (command output) ...
 [fifo] ✓ (0.003s)
@@ -56,7 +56,7 @@ current FIFO path when a FIFO is active, or an empty
 string when no FIFO is open. This makes it easy to
 reference the FIFO in shell commands:
 
-```
+```text
 milk> fifo create
 milk> !echo "echo hello" > $MCLIFIFO
 ```
@@ -93,14 +93,14 @@ cat commands.milk > $(cat /milk/shm/.milk.fifo.*)
 Process a list of images and save specific ones based
 on metadata:
 
-```
+```text
 milk> fifo create
 milk> !awk '{if ($4>200) print "iofits.saveFITS " $2 " " $2 "_save.fits"}' imlist.txt > $MCLIFIFO
 ```
 
 Each generated command appears with ingestion feedback:
 
-```
+```text
 [fifo] ← "iofits.saveFITS im003 im003_save.fits"
 [fifo] ✓ (0.012s)
 [fifo] ← "iofits.saveFITS im007 im007_save.fits"
@@ -112,7 +112,7 @@ Each generated command appears with ingestion feedback:
 Temporarily disable FIFO input while doing interactive
 work, then re-enable it:
 
-```
+```text
 milk> fifo create
 milk> fifo off
 [fifo] input disabled
@@ -128,7 +128,7 @@ milk> fifo on
 If another milk-cli session has a FIFO open, you can
 connect to it:
 
-```
+```text
 milk> fifo open /milk/shm/.othersession.fifo.54321
 [fifo] opened: /milk/shm/.othersession.fifo.54321 (fd=4)
 ```
@@ -138,7 +138,7 @@ milk> fifo open /milk/shm/.othersession.fifo.54321
 Combine `find`, `xargs`, and FIFO to batch-process
 files:
 
-```
+```text
 milk> fifo create
 milk> !find /data/frames -name "*.fits" | xargs -I {} echo "iofits.loadfits {} frame" > $MCLIFIFO
 ```

--- a/src/cli/CLIcore/CLIcore/CLIcore_UI.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI.c
@@ -882,7 +882,7 @@ static int cli_check_unquoted_restricted_symbols(const char *cmdline) {
     int in_dquote = 0;
     int esc = 0;
     
-    const char *restricted = ";<>|[]()&*?$";
+    const char *restricted = ";<>|[]()&*$";
     
     int word_start = 1;
     int valid_assign_prefix = 0; 


### PR DESCRIPTION
## Summary

Fix two CI failures introduced by PR #144 (dynamic FIFO handling).

### CLI test fix

Remove `?` from the restricted-symbol check in `cli_check_unquoted_restricted_symbols()`. The `?` character is used in built-in commands (`cmd?`, `m?`, `lm?`, `cmdinfo?`) and was causing all 31 CLI tests to fail with: `Syntax error: flow process symbols must be quoted`.

### Markdownlint fix

- `docs/cli/fifo.md`: add `text` language specifier to 8 code blocks (MD040)
- `docs/cli/CLIcore.md`: remove trailing spaces (MD009) and add blank lines before code blocks (MD031)

### Prompt Summary

User identified failing CI tests and asked for a fix. Root-caused both failures and applied minimal targeted changes.

### AI Authorship

- **Model**: Antigravity
- **User edits**: None