### PR TITLE
Fix segmentation fault in stream_sem commands due to missing CLI bindings

### DIFF
--- a/src/coremods/COREMOD_memory/stream_sem.c
+++ b/src/coremods/COREMOD_memory/stream_sem.c
@@ -62,6 +62,43 @@ static long long p_semindex = 0;
       FPFLAG_DEFAULT_INPUT, \
       "semaphore index")
 
+#define FPS_PARAMS_IMSEM_INFO(X) \
+    X(".imname", p_imname, \
+      FPTYPE_STREAMNAME, 1, \
+      FPFLAG_DEFAULT_INPUT, \
+      "image name")
+
+#if !defined(FPS_STANDALONE) && !defined(MILK_NO_CLI)
+static FPS_CLI_BINDING bindings_imsem_info[] = {
+    FPS_PARAMS_IMSEM_INFO(FPS_X_BINDING)
+};
+static const int nb_bindings_imsem_info =
+    sizeof(bindings_imsem_info) /
+    sizeof(FPS_CLI_BINDING);
+static CLICMDARGDEF farg_imsem_info[] = {
+    FPS_PARAMS_IMSEM_INFO(FPS_X_FARG)
+};
+#define CLICMD_FIELDS_IMSEM_INFO \
+    __FILE__, sizeof(farg_imsem_info) / sizeof(CLICMDARGDEF), farg_imsem_info, CLICMDFLAG_FPS, NULL, NULL, NULL
+
+static FPS_CLI_BINDING bindings_imsem[] = {
+    FPS_PARAMS_IMSEM(FPS_X_BINDING)
+};
+static const int nb_bindings_imsem =
+    sizeof(bindings_imsem) /
+    sizeof(FPS_CLI_BINDING);
+static CLICMDARGDEF farg_imsem[] = {
+    FPS_PARAMS_IMSEM(FPS_X_FARG)
+};
+#define CLICMD_FIELDS_IMSEM \
+    __FILE__, sizeof(farg_imsem) / sizeof(CLICMDARGDEF), farg_imsem, CLICMDFLAG_FPS, NULL, NULL, NULL
+#else
+#define CLICMD_FIELDS_IMSEM_INFO \
+    __FILE__, 0, NULL, 0, NULL, NULL, NULL
+#define CLICMD_FIELDS_IMSEM \
+    __FILE__, 0, NULL, 0, NULL, NULL, NULL
+#endif
+
 
 /* ================================================================
  *  CMD 1: imseminfo (1 arg)
@@ -75,7 +112,7 @@ static FPS_APP_INFO FPS_app_info_seminfo = {
 };
 
 static CLICMDDATA CLIcmddata_seminfo = {
-    "", "", CLICMD_FIELDS_NOPARAM
+    "", "", CLICMD_FIELDS_IMSEM_INFO
 };
 static CMDSETTINGS cms1 = {0};
 
@@ -118,7 +155,7 @@ static FPS_APP_INFO FPS_app_info_sempost = {
 };
 
 static CLICMDDATA CLIcmddata_sempost = {
-    "", "", CLICMD_FIELDS_NOPARAM
+    "", "", CLICMD_FIELDS_IMSEM
 };
 static CMDSETTINGS cms2 = {0};
 
@@ -227,7 +264,7 @@ static FPS_APP_INFO FPS_app_info_semwait = {
 };
 
 static CLICMDDATA CLIcmddata_semwait = {
-    "", "", CLICMD_FIELDS_NOPARAM
+    "", "", CLICMD_FIELDS_IMSEM
 };
 static CMDSETTINGS cms4 = {0};
 
@@ -271,7 +308,7 @@ static FPS_APP_INFO FPS_app_info_semflush = {
 };
 
 static CLICMDDATA CLIcmddata_semflush = {
-    "", "", CLICMD_FIELDS_NOPARAM
+    "", "", CLICMD_FIELDS_IMSEM
 };
 static CMDSETTINGS cms5 = {0};
 
@@ -309,23 +346,12 @@ static errno_t __attribute__((unused)) compute_semflush()
 
 #if !defined(FPS_STANDALONE) && !defined(MILK_NO_CLI)
 
-/* bindings for 2-arg commands */
-static FPS_CLI_BINDING bindings_imsem[] = {
-    FPS_PARAMS_IMSEM(FPS_X_BINDING)
-};
-static const int nb_bindings_imsem =
-    sizeof(bindings_imsem) /
-    sizeof(FPS_CLI_BINDING);
-static CLICMDARGDEF farg_imsem[] = {
-    FPS_PARAMS_IMSEM(FPS_X_FARG)
-};
-
 static errno_t CLIfunction_seminfo(void)
 {
     return safe_fps_generic_CLIfunction(
         &FPS_app_info_seminfo,
-        farg_imsem, &CLIcmddata_seminfo,
-        bindings_imsem, nb_bindings_imsem,
+        farg_imsem_info, &CLIcmddata_seminfo,
+        bindings_imsem_info, nb_bindings_imsem_info,
         compute_seminfo);
 }
 


### PR DESCRIPTION
This PR fixes a critical segmentation fault occurring dynamically when calling `imsetsempost`, `imsetsemwait`, or `imsetsemflush` with CLI arguments inside `milk-cli` (e.g. `mem.imsetsempost imA -1`).

These commands were mistakenly registered to the CLI parser with `CLICMD_FIELDS_NOPARAM` meaning their parameter count `nbarg` evaluated to 0. Subsequently, passing arguments to these commands inside `milk-cli` bypassed the argument count boundary checks and dereferenced an unallocated `argdata` array.

To resolve this, I standardized `stream_sem.c` to use `FPS_PARAMS_IMSEM` and `FPS_PARAMS_IMSEM_INFO` bindings. This properly propagates `farg` arrays and correctly increments argument requirements on command registration, fixing the null pointer crash while retaining full compatibility with script automation tasks like `milksemloopspeed`.

**AI Authorship**:
- Models used: Antigravity