### PR TITLE
feat(cli): enhance script interpretation with native expansions and evaluation

### DIFF
--- a/docs/cli/scripting.md
+++ b/docs/cli/scripting.md
@@ -10,8 +10,8 @@ The `milk-cli` interpreter is designed to provide a seamless scripting experienc
 
 This means **all standard Bash scripting features are fully supported** inside `milk-cli`, including:
 
-- Variables (`$var`), Arithmetic (`$(( ))`), and String Manipulation
-- Flow Control (`if`, `for`, `while`, `case`)
+- Variables (`$var`), Arithmetic (`$(( ))`), array indexing, and bash-style parameter expansions
+- Flow Control (`if`, `for`, `while`, `case`), including C-style `for ((i=0; i<N; i++))` loops
 - Built-ins (`sleep`, `read`, `printf`, `trap`, `shift`)
 - I/O Redirection (`>`. `<`. `|`), Heredocs, and Background Jobs (`&`)
 
@@ -85,6 +85,14 @@ This is extremely useful for event-driven processing and synchronous scripts:
 on_update wfs_cam { echo "New WFS frame received!" }
 ```
 
+### Enhanced Conditional Tests (`[ ]`)
+
+The native interpreter supports a robust set of file and logic tests inside `[ ]` that run instantly without invoking `test` subprocesses:
+- **Filesystem**: `-f` (file), `-d` (directory), `-e` (exists), `-s` (non-empty), `-r` (readable), `-w` (writable), `-x` (executable), `-L` (symlink).
+- **Strings**: `-n` (not empty), `-z` (empty), `==`, `!=`.
+- **Numbers**: `-eq`, `-ne`, `-lt`, `-le`, `-gt`, `-ge`.
+- **Logic**: `-a` (AND), `-o` (OR), `!` (NOT).
+
 ### Wait for Resources (`waitfor_*`)
 
 You can tell your script to pause and wait for shared memory streams or FPS parameter blocks to be initialized by other compute units before proceeding:
@@ -125,6 +133,21 @@ To write FPS parameters programmatically, natively use the `fpsset` command:
 # Note: Do not use the '@' prefix when writing
 fpsset myloop loopgain 0.5
 ```
+
+### Advanced Variable Expansion and Arrays
+
+`milk-cli`'s native interpreter includes powerful bash-like variable expansions:
+- **Default values**: `${var:-default}` returns `default` if `var` is empty/unset.
+- **Assign default**: `${var:=default}` sets `var` to `default` if it was empty/unset.
+- **Error if empty**: `${var:?message}` prints an error if `var` is empty/unset.
+- **Substring**: `${var:offset:length}` returns a slice of the string. Negative offsets count from the end.
+- **String length**: `${#var}` returns the number of characters in the variable.
+- **Array indexing**: `${myarray[idx]}` or `${myassoc[key]}` returns the value at the given element of the respective array.
+
+For mathematical expressions, the `$(( ... ))` expansion natively supports standard arithmetic and bitwise logic:
+- Basic operators: `+  -  *  /  %`
+- Bitwise operators: `&  |  ^  <<  >>  ~`
+- Comparisons: `==  !=  <  >  <=  >=`
 
 ### Stream & FPS Metadata Expansion
 

--- a/docs/cli/scripting.md
+++ b/docs/cli/scripting.md
@@ -88,6 +88,7 @@ on_update wfs_cam { echo "New WFS frame received!" }
 ### Enhanced Conditional Tests (`[ ]`)
 
 The native interpreter supports a robust set of file and logic tests inside `[ ]` that run instantly without invoking `test` subprocesses:
+
 - **Filesystem**: `-f` (file), `-d` (directory), `-e` (exists), `-s` (non-empty), `-r` (readable), `-w` (writable), `-x` (executable), `-L` (symlink).
 - **Strings**: `-n` (not empty), `-z` (empty), `==`, `!=`.
 - **Numbers**: `-eq`, `-ne`, `-lt`, `-le`, `-gt`, `-ge`.
@@ -137,6 +138,7 @@ fpsset myloop loopgain 0.5
 ### Advanced Variable Expansion and Arrays
 
 `milk-cli`'s native interpreter includes powerful bash-like variable expansions:
+
 - **Default values**: `${var:-default}` returns `default` if `var` is empty/unset.
 - **Assign default**: `${var:=default}` sets `var` to `default` if it was empty/unset.
 - **Error if empty**: `${var:?message}` prints an error if `var` is empty/unset.
@@ -145,6 +147,7 @@ fpsset myloop loopgain 0.5
 - **Array indexing**: `${myarray[idx]}` or `${myassoc[key]}` returns the value at the given element of the respective array.
 
 For mathematical expressions, the `$(( ... ))` expansion natively supports standard arithmetic and bitwise logic:
+
 - Basic operators: `+  -  *  /  %`
 - Bitwise operators: `&  |  ^  <<  >>  ~`
 - Comparisons: `==  !=  <  >  <=  >=`

--- a/src/cli/CLIcore/CLIcore/CLIcore_script_expand.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_script_expand.c
@@ -47,6 +47,13 @@ double arith_atom(ArithParser *p)
         return -arith_atom(p);
     }
 
+    /* Bitwise NOT */
+    if(p->s[p->pos] == '~')
+    {
+        p->pos++;
+        return (double)(~(long)arith_atom(p));
+    }
+
     /* Parenthesized sub-expression */
     if(p->s[p->pos] == '(')
     {
@@ -156,57 +163,126 @@ double arith_term(ArithParser *p)
     return left;
 }
 
-double arith_compare(ArithParser *p)
+double arith_shift(ArithParser *p)
 {
     double left = arith_term(p);
+    arith_skip_ws(p);
+
+    while((p->s[p->pos] == '<' && p->s[p->pos + 1] == '<')
+            || (p->s[p->pos] == '>' && p->s[p->pos + 1] == '>'))
+    {
+        char op = p->s[p->pos];
+        p->pos += 2;
+        double right = arith_term(p);
+        arith_skip_ws(p);
+        if(op == '<')
+        {
+            left = (double)((long)left << (long)right);
+        }
+        else
+        {
+            left = (double)((long)left >> (long)right);
+        }
+    }
+    return left;
+}
+
+double arith_compare(ArithParser *p)
+{
+    double left = arith_shift(p);
     arith_skip_ws(p);
 
     if(p->s[p->pos] == '<'
             && p->s[p->pos + 1] == '=')
     {
         p->pos += 2;
-        double right = arith_term(p);
+        double right = arith_shift(p);
         return (left <= right) ? 1.0 : 0.0;
     }
     if(p->s[p->pos] == '>'
             && p->s[p->pos + 1] == '=')
     {
         p->pos += 2;
-        double right = arith_term(p);
+        double right = arith_shift(p);
         return (left >= right) ? 1.0 : 0.0;
     }
     if(p->s[p->pos] == '<')
     {
         p->pos++;
-        double right = arith_term(p);
+        double right = arith_shift(p);
         return (left < right) ? 1.0 : 0.0;
     }
     if(p->s[p->pos] == '>')
     {
         p->pos++;
-        double right = arith_term(p);
+        double right = arith_shift(p);
         return (left > right) ? 1.0 : 0.0;
     }
     if(p->s[p->pos] == '='
             && p->s[p->pos + 1] == '=')
     {
         p->pos += 2;
-        double right = arith_term(p);
+        double right = arith_shift(p);
         return (left == right) ? 1.0 : 0.0;
     }
     if(p->s[p->pos] == '!'
             && p->s[p->pos + 1] == '=')
     {
         p->pos += 2;
-        double right = arith_term(p);
+        double right = arith_shift(p);
         return (left != right) ? 1.0 : 0.0;
+    }
+    return left;
+}
+
+double arith_bitwise_and(ArithParser *p)
+{
+    double left = arith_compare(p);
+    arith_skip_ws(p);
+
+    while(p->s[p->pos] == '&')
+    {
+        p->pos++;
+        double right = arith_compare(p);
+        arith_skip_ws(p);
+        left = (double)((long)left & (long)right);
+    }
+    return left;
+}
+
+double arith_bitwise_xor(ArithParser *p)
+{
+    double left = arith_bitwise_and(p);
+    arith_skip_ws(p);
+
+    while(p->s[p->pos] == '^')
+    {
+        p->pos++;
+        double right = arith_bitwise_and(p);
+        arith_skip_ws(p);
+        left = (double)((long)left ^ (long)right);
+    }
+    return left;
+}
+
+double arith_bitwise_or(ArithParser *p)
+{
+    double left = arith_bitwise_xor(p);
+    arith_skip_ws(p);
+
+    while(p->s[p->pos] == '|')
+    {
+        p->pos++;
+        double right = arith_bitwise_xor(p);
+        arith_skip_ws(p);
+        left = (double)((long)left | (long)right);
     }
     return left;
 }
 
 double arith_expr(ArithParser *p)
 {
-    return arith_compare(p);
+    return arith_bitwise_or(p);
 }
 
 
@@ -489,6 +565,78 @@ int cli_eval_test(const char *expr)
         return 0;
     }
 
+    /* Logical OR */
+    for(int i = 0; i < ntok; i++)
+    {
+        if(strcmp(tokens[i], "-o") == 0)
+        {
+            char left[512]  = "";
+            char right[512] = "";
+            for(int j = 0; j < i; j++)
+            {
+                if(j > 0)
+                {
+                    strncat(left, " ",
+                            sizeof(left) - strlen(left) - 1);
+                }
+                strncat(left, tokens[j],
+                        sizeof(left) - strlen(left) - 1);
+            }
+            if(cli_eval_test(left))
+            {
+                return 1;
+            }
+
+            for(int j = i + 1; j < ntok; j++)
+            {
+                if(j > i + 1)
+                {
+                    strncat(right, " ",
+                            sizeof(right) - strlen(right) - 1);
+                }
+                strncat(right, tokens[j],
+                        sizeof(right) - strlen(right) - 1);
+            }
+            return cli_eval_test(right);
+        }
+    }
+
+    /* Logical AND */
+    for(int i = 0; i < ntok; i++)
+    {
+        if(strcmp(tokens[i], "-a") == 0)
+        {
+            char left[512]  = "";
+            char right[512] = "";
+            for(int j = 0; j < i; j++)
+            {
+                if(j > 0)
+                {
+                    strncat(left, " ",
+                            sizeof(left) - strlen(left) - 1);
+                }
+                strncat(left, tokens[j],
+                        sizeof(left) - strlen(left) - 1);
+            }
+            if(!cli_eval_test(left))
+            {
+                return 0;
+            }
+
+            for(int j = i + 1; j < ntok; j++)
+            {
+                if(j > i + 1)
+                {
+                    strncat(right, " ",
+                            sizeof(right) - strlen(right) - 1);
+                }
+                strncat(right, tokens[j],
+                        sizeof(right) - strlen(right) - 1);
+            }
+            return cli_eval_test(right);
+        }
+    }
+
     /* Unary: -n str, -z str */
     if(ntok == 2
        && strcmp(tokens[0], "-n") == 0)
@@ -501,7 +649,30 @@ int cli_eval_test(const char *expr)
         return strlen(tokens[1]) == 0 ? 1 : 0;
     }
 
-    /* File tests: -f, -d, -e, -s */
+    /* File tests: -f, -d, -e, -s, -r, -w, -x, -L */
+    if(ntok == 2
+       && strcmp(tokens[0], "-r") == 0)
+    {
+        return access(tokens[1], R_OK) == 0 ? 1 : 0;
+    }
+    if(ntok == 2
+       && strcmp(tokens[0], "-w") == 0)
+    {
+        return access(tokens[1], W_OK) == 0 ? 1 : 0;
+    }
+    if(ntok == 2
+       && strcmp(tokens[0], "-x") == 0)
+    {
+        return access(tokens[1], X_OK) == 0 ? 1 : 0;
+    }
+    if(ntok == 2
+       && strcmp(tokens[0], "-L") == 0)
+    {
+        struct stat sb;
+        return (lstat(tokens[1], &sb) == 0
+                && S_ISLNK(sb.st_mode))
+               ? 1 : 0;
+    }
     if(ntok == 2
        && strcmp(tokens[0], "-f") == 0)
     {
@@ -684,6 +855,13 @@ void cli_expand_env(
                 i++;
             }
 
+            int is_length = 0;
+            if(has_brace && line[i] == '#')
+            {
+                is_length = 1;
+                i++;
+            }
+
             char varname[256];
             int  vlen = 0;
 
@@ -706,6 +884,43 @@ void cli_expand_env(
                 }
             }
             varname[vlen] = '\0';
+            
+            char index_str[256];
+            int  has_index = 0;
+            if(has_brace && line[i] == '[')
+            {
+                i++;
+                int ilen = 0;
+                while(line[i] != '\0' && line[i] != ']' && ilen < 255)
+                {
+                    index_str[ilen++] = line[i++];
+                }
+                if(line[i] == ']') i++;
+                index_str[ilen] = '\0';
+                has_index = 1;
+            }
+
+            char mod_op[3] = {0};
+            char mod_arg[256] = {0};
+            if(has_brace && line[i] == ':')
+            {
+                i++;
+                if(line[i] == '-' || line[i] == '=' || line[i] == '?' || line[i] == '+')
+                {
+                    mod_op[0] = ':';
+                    mod_op[1] = line[i++];
+                }
+                else
+                {
+                    mod_op[0] = ':';
+                }
+                int mlen = 0;
+                while(line[i] != '\0' && line[i] != '}' && mlen < 255)
+                {
+                    mod_arg[mlen++] = line[i++];
+                }
+                mod_arg[mlen] = '\0';
+            }
 
             /* Check if this is a supported $VAR string, else just copy literal.
              * E.g. ${#foo} is not supported here, handled elsewhere. */
@@ -717,10 +932,10 @@ void cli_expand_env(
                 }
                 else
                 {
-                    /* Something complex like ${var:-def}, let wordexp handle it.
-                     * We output ${varname back into out and continue. */
+                    /* Something complex ... */
                     out[opos++] = '$';
                     out[opos++] = '{';
+                    if (is_length) out[opos++] = '#';
                     for(int k=0; k<vlen; k++) {
                         if(opos < maxlen - 1) out[opos++] = varname[k];
                     }
@@ -728,21 +943,137 @@ void cli_expand_env(
                 }
             }
 
-            const char *val = cli_var_lookup(varname);
-            if(val != NULL)
+            const char *val = NULL;
+            if(has_index)
+            {
+                const char *idx_val = cli_var_lookup(index_str);
+                if(idx_val == NULL) idx_val = index_str;
+                
+                int is_found = 0;
+                for(int a = 0; a < CLI_MAX_ASSOC; a++)
+                {
+                    if(cli_assoc[a].used && strcmp(cli_assoc[a].name, varname) == 0)
+                    {
+                        for(int e = 0; e < cli_assoc[a].nelem; e++)
+                        {
+                            if(strcmp(cli_assoc[a].keys[e], idx_val) == 0)
+                            {
+                                val = cli_assoc[a].vals[e];
+                                is_found = 1;
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                }
+                if(!is_found)
+                {
+                    int num_idx = atoi(idx_val);
+                    for(int a = 0; a < CLI_MAX_ARRAYS; a++)
+                    {
+                        if(cli_arrays[a].used && strcmp(cli_arrays[a].name, varname) == 0)
+                        {
+                            if(num_idx >= 0 && num_idx < cli_arrays[a].nelem)
+                            {
+                                val = cli_arrays[a].elem[num_idx];
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                val = cli_var_lookup(varname);
+            }
+
+            char val_buf[256];
+            val_buf[0] = '\0';
+
+            if(mod_op[0] != '\0')
+            {
+                if(mod_op[1] == '-')
+                {
+                    if(val == NULL || val[0] == '\0') val = mod_arg;
+                }
+                else if(mod_op[1] == '=')
+                {
+                    if(val == NULL || val[0] == '\0')
+                    {
+                        val = mod_arg;
+                        cli_var_set(varname, val);
+                    }
+                }
+                else if(mod_op[1] == '?')
+                {
+                    if(val == NULL || val[0] == '\0')
+                    {
+                        printf("CLI expand error: %s: %s\n", varname, mod_arg);
+                        val = "";
+                    }
+                }
+                else if(mod_op[1] == '+')
+                {
+                    if(val != NULL && val[0] != '\0') val = mod_arg;
+                    else val = "";
+                }
+                else if(mod_op[0] == ':')
+                {
+                    int offset = 0;
+                    int length = 255;
+                    char *colon = strchr(mod_arg, ':');
+                    if(colon != NULL)
+                    {
+                        *colon = '\0';
+                        const char *lval = cli_var_lookup(mod_arg);
+                        offset = atoi(lval ? lval : mod_arg);
+                        const char *rval = cli_var_lookup(colon + 1);
+                        length = atoi(rval ? rval : colon + 1);
+                    }
+                    else
+                    {
+                        const char *lval = cli_var_lookup(mod_arg);
+                        offset = atoi(lval ? lval : mod_arg);
+                    }
+
+                    if(val != NULL)
+                    {
+                        int v1 = (int) strlen(val);
+                        if(offset < 0) offset = v1 + offset;
+                        if(offset < 0) offset = 0;
+                        if(offset > v1) offset = v1;
+                        
+                        if(length < 0) length = v1 - offset + length;
+                        if(length < 0) length = 0;
+                        if(offset + length > v1) length = v1 - offset;
+
+                        strncpy(val_buf, val + offset, (size_t) length);
+                        val_buf[length] = '\0';
+                        val = val_buf;
+                    }
+                }
+            }
+
+            if(is_length)
+            {
+                int len = val ? (int) strlen(val) : 0;
+                char numstr[32];
+                snprintf(numstr, sizeof(numstr), "%d", len);
+                emit_str_local(out, &opos, maxlen, numstr);
+            }
+            else if(val != NULL)
             {
                 emit_str_local(out, &opos, maxlen, val);
             }
             else
             {
-                /* Variable not found or milk doesn't know it. We let wordexp
-                 * try to expand it later from environment! Just emit original string */
+                /* E.g. var not found */
                 out[opos++] = '$';
-                if (has_brace) out[opos++] = '{';
+                if(has_brace) out[opos++] = '{';
                 for(int k=0; k<vlen; k++) {
                     if(opos < maxlen - 1) out[opos++] = varname[k];
                 }
-                if (has_brace && opos < maxlen - 1) out[opos++] = '}';
+                if(has_brace && opos < maxlen - 1) out[opos++] = '}';
             }
         }
         else if (line[i] == '\\' && line[i+1] == '$')

--- a/tests/cli/cli_robustness_tests.milk
+++ b/tests/cli/cli_robustness_tests.milk
@@ -781,3 +781,69 @@ BDIR_SYNC_VAR="hello_frommilk"
 test_subshell_var=$(echo "success_from_subshell")
 !test "$test_subshell_var" = "success_from_subshell"
 
+# ============================================
+# SECTION 22: Advanced Variable Expansions
+# ============================================
+
+#DESC: Default values ${var:-default}
+#EXPECT:OK
+echo ${_unset_adv:-fallback_adv}
+
+#DESC: Assign default values ${var:=default}
+#EXPECT:OK
+echo ${_unset_adv2:=assigned_adv}
+echo ${_unset_adv2}
+
+#DESC: Substring extraction
+#EXPECT:OK
+_sub_str="hello_world"
+echo ${_sub_str:0:5}
+
+#DESC: Substring with negative offset
+#EXPECT:OK
+echo ${_sub_str:-5:5}
+
+#DESC: Error if empty
+#EXPECT:ERR
+echo ${_empty_err:?variable_is_missing}
+
+# ============================================
+# SECTION 23: Advanced Test Evaluator
+# ============================================
+
+#DESC: Logical AND test
+#EXPECT:OK
+if [ 5 -gt 3 -a 10 -lt 20 ]; then echo both_true; fi
+
+#DESC: Logical OR test
+#EXPECT:OK
+if [ 5 -lt 3 -o 10 -gt 5 ]; then echo one_true; fi
+
+#DESC: File permissions test -r
+#EXPECT:OK
+if [ -r /etc/passwd ]; then echo readable; fi
+
+# ============================================
+# SECTION 24: Bitwise Operators & Native Math
+# ============================================
+
+#DESC: Bitwise logic AND / OR
+#EXPECT:OK
+_bit_val=$(( 5 & 3 | 8 ))
+echo $_bit_val
+
+#DESC: Bitwise shifts
+#EXPECT:OK
+_bit_shift=$(( 1 << 4 ))
+if [ $_bit_shift -eq 16 ]; then echo shifted; fi
+
+# ============================================
+# SECTION 25: C-style loop native support
+# ============================================
+
+#DESC: Native C-style for loop
+#EXPECT:OK
+_c_loop_sum=0
+for (( i=0; i<3; i++ )); do _c_loop_sum=$(( _c_loop_sum + i )); done
+echo $_c_loop_sum
+


### PR DESCRIPTION
### Prompt Summary
The user requested several enhancements to the CLI capabilities to improve the custom script parsing and variable expansion inside `milk-cli` without needing to invoke the underlying OS `bash` shell via `wordexp()`.

### Changes Made
- Added bitwise operators (`&, |, ^, <<, >>, ~`) to the `$(( ))` arithmetic expander.
- Enhanced the `[ ]` test evaluator with missing features from standard shell:
  - File tests: `-r, -w, -x, -L`
  - Logical tests: `-a` (AND) and `-o` (OR)
- Implemented robust bash-style parameter expansions for variables:
  - `${var:-default}`, `${var:=default}`
  - `${var:?msg}`, `${var:offset:length}`
  - `${#var}`
- Added native array reading capabilities for positional arrays (`${arr[idx]}`) and associative arrays (`${assoc[key]}`).
- Documented all features explicitly in `docs/cli/scripting.md` and added them alongside existing flow controls like the already-implemented C-style `for` loop logic.

### AI Authorship
- **Model(s) used**: Antigravity
- **User edits**: None