### PR TITLE
fix: skip empty-key commands in RegisterCLIcmd

### DIFF
--- a/src/cli/CLIcore/CLIcore/CLIcore_modules.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_modules.c
@@ -564,6 +564,16 @@ uint32_t RegisterCLIcmd(
     // Command registration logic
     DEBUG_TRACE_FSTART();
 
+    /* Guard against constructor ordering race:
+     * per-command __attribute__((constructor))
+     * may not have run yet, leaving key empty.
+     */
+    if (CLIcmddata.key[0] == '\0')
+    {
+        DEBUG_TRACE_FEXIT();
+        return data.NBcmd;
+    }
+
     data.cmd[data.NBcmd].moduleindex = data.moduleindex;
     if(data.cmd[data.NBcmd].moduleindex == -1)
     {


### PR DESCRIPTION
### Problem
`m? statistic` and `m? psf` show ghost entries (`stat.`, `psf.`) with no command name or description.

### Root Cause
`__attribute__((constructor))` ordering race: `INIT_MODULE_LIB`'s constructor calls `RegisterCLIcmd()` before per-command constructors have filled in `CLIcmddata.key`, registering commands with empty keys.

### Fix
Added a 3-line early guard in `RegisterCLIcmd()` to return immediately when key is empty.

### Testing
- Build: clean ✅
- ctest: 37/37 pass ✅

### Prompt Summary
User reported empty command entries in `m? statistic` and `m? psf` output. Investigated and found a constructor ordering race, fixed with a guard in `RegisterCLIcmd`.

### AI Authorship
- **Model**: Antigravity
- **User edits**: None