### PR TITLE
fix(cli): display assigned value for variable assignments via cli_try_var_assign

### DIFF
--- a/src/cli/CLIcore/CLIcore/CLIcore_script_var.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_script_var.c
@@ -258,6 +258,34 @@ int cli_try_var_assign(const char *line)
         {
             cli_var_set(tmpname, valbuf);
         }
+
+        /* Print the assigned value so the user
+         * gets feedback, matching the output
+         * format of cli_calc_eval_line(). */
+        for (int i = 0; i < CLI_MAX_VARS; i++)
+        {
+            if (cli_vars[i].used
+                && strcmp(cli_vars[i].name,
+                          tmpname) == 0)
+            {
+                if (cli_vars[i].type == 1)
+                {
+                    printf("    long: %ld\n",
+                           cli_vars[i].num.l);
+                }
+                else if (cli_vars[i].type == 0)
+                {
+                    printf("    double: %g\n",
+                           cli_vars[i].num.f);
+                }
+                else
+                {
+                    printf("    string: %s\n",
+                           cli_vars[i].val);
+                }
+                break;
+            }
+        }
         return 1;
     }
 }


### PR DESCRIPTION
### Summary

Variable assignments handled by `cli_try_var_assign()` (plain assignments and command substitution, e.g. `e=$(ls|wc -l)`, `d=42`, `c=hello`) did not print the assigned value, unlike assignments evaluated through `cli_calc_eval_line()` (e.g. `a=sqrt(4)`).

Added a value lookup+print after `cli_var_set()` in `cli_try_var_assign()`, matching the existing output format (`long:`, `double:`, `string:`).

### Testing

- Build: clean compilation, no warnings
- CLI robustness tests: 164/164 pass
- Manual verification of all assignment types

### Prompt Summary

User reported that `e=$(ls|wc -l)` did not display the assigned value.

### AI Authorship

- **Model:** Antigravity
- **User edits:** None