### PR TITLE
test: expand CLI robustness suite with 46 new tests and runner improvements

### DIFF
--- a/tests/cli/cli_robustness_tests.milk
+++ b/tests/cli/cli_robustness_tests.milk
@@ -968,3 +968,249 @@ mem.rm _sliceout
 mem.rm _sliceout2
 mem.rm _sliceout3
 mem.rm _sliceout4
+
+# ============================================
+# SECTION 33: Alias System
+# ============================================
+
+#DESC: Define an alias
+#EXPECT:OK
+alias _testalias "echo alias_works"
+
+#DESC: Run an alias
+#EXPECT:OK
+_testalias
+
+#DESC: Overwrite an alias
+#EXPECT:OK
+alias _testalias "echo overwritten"
+_testalias
+
+#DESC: Remove an alias
+#EXPECT:OK
+unalias _testalias
+
+#DESC: Unalias nonexistent name (no crash)
+#EXPECT:OK
+unalias _no_such_alias_xyz
+
+#DESC: Alias list (bare alias)
+#EXPECT:OK
+alias
+
+# ============================================
+# SECTION 34: Bookmark System
+# ============================================
+
+#DESC: Bookmark list (initially empty or existing)
+#EXPECT:OK
+bookmark list
+
+#DESC: Bookmark save and run
+#EXPECT:OK
+bookmark save _tbm "echo bookmark_ok"
+bookmark run _tbm
+
+#DESC: Bookmark remove
+#EXPECT:OK
+bookmark rm _tbm
+
+#DESC: Bookmark unknown action
+#EXPECT:ERR
+bookmark frobnicate
+
+#DESC: Bookmark run nonexistent
+#EXPECT:ERR
+bookmark run _no_such_bm_xyz
+
+# ============================================
+# SECTION 35: printf Command
+# ============================================
+
+#DESC: printf with format string
+#EXPECT:OK
+printf "%s=%d\n" hello 42
+
+#DESC: printf with float format
+#EXPECT:OK
+printf "%.3f\n" 3.14159
+
+#DESC: printf with escape sequences
+#EXPECT:OK
+printf "a\tb\n"
+
+#DESC: printf with no arguments (just format)
+#EXPECT:OK
+printf "literal\n"
+
+# ============================================
+# SECTION 36: sleep Command
+# ============================================
+
+#DESC: Sleep with fractional seconds
+#EXPECT:OK
+sleep 0.01
+
+#DESC: Sleep with no argument (usage)
+#EXPECT:ERR
+sleep
+
+# ============================================
+# SECTION 37: trap Command
+# ============================================
+
+#DESC: Set EXIT trap (parse only)
+#EXPECT:OK
+trap "echo trap_set" EXIT
+
+#DESC: List traps
+#EXPECT:OK
+trap -l
+
+# ============================================
+# SECTION 38: savehistory Command
+# ============================================
+
+#DESC: savehistory to file
+#EXPECT:OK
+savehistory /tmp/_clitest_hist.txt
+
+#DESC: savehistory no argument (usage)
+#EXPECT:ERR
+savehistory
+
+#DESC: Clean up savehistory temp
+#EXPECT:OK
+!rm -f /tmp/_clitest_hist.txt
+
+# ============================================
+# SECTION 39: History Commands
+# ============================================
+
+#DESC: Local history display
+#EXPECT:OK
+lhistory
+
+#DESC: Global history display
+#EXPECT:OK
+ghistory
+
+#DESC: ghistory with count
+#EXPECT:OK
+ghistory 5
+
+#DESC: lhistory with type filter
+#EXPECT:OK
+lhistory -t cmd
+
+# ============================================
+# SECTION 40: fpsset Error Paths
+# ============================================
+
+#DESC: fpsset with no arguments (usage)
+#EXPECT:ERR
+fpsset
+
+#DESC: fpsset with missing dot notation
+#EXPECT:ERR
+fpsset nodotparam 42
+
+#DESC: fpsset nonexistent FPS
+#EXPECT:ERR
+fpsset nosuchfps_xyz.param 42
+
+# ============================================
+# SECTION 41: on_update Error Paths
+# ============================================
+
+#DESC: on_update with nonexistent stream
+#EXPECT:ERR
+on_update _no_such_stream_xyz { echo x }
+
+#DESC: on_update with no arguments (usage)
+#EXPECT:ERR
+on_update
+
+# ============================================
+# SECTION 42: Shell Bypass
+# ============================================
+
+#DESC: Shell bypass with valid command
+#EXPECT:OK
+!echo shell_bypass_test
+
+#DESC: Shell bypass with nonexistent command
+#EXPECT:ERR
+!nonexistent_cmd_xyz_456
+
+# ============================================
+# SECTION 43: include_once Idempotency
+# ============================================
+
+#DESC: include_once same file twice (no error)
+#EXPECT:OK
+!echo "echo sourced_once" > /tmp/_clitest_inc.milk
+include_once /tmp/_clitest_inc.milk
+include_once /tmp/_clitest_inc.milk
+!rm -f /tmp/_clitest_inc.milk
+
+# ============================================
+# SECTION 44: Edge Cases
+# ============================================
+
+#DESC: Variable name with digits
+#EXPECT:OK
+_var123abc=test_digits
+echo $_var123abc
+unset _var123abc
+
+#DESC: Deeply nested arithmetic
+#EXPECT:OK
+_deep=$(( ((1 + 2) * (3 + 4)) + ((5 - 6) * 7) ))
+echo $_deep
+unset _deep
+
+#DESC: While false (never enters body)
+#EXPECT:OK
+while [ 0 -eq 1 ]; do
+    echo never
+done
+
+#DESC: Nested function calls
+#EXPECT:OK
+function _outer { echo outer_$1; }
+function _inner { _outer inner; }
+_inner
+
+#DESC: OR chain first fails
+#EXPECT:OK
+xyzzy_nonexistent_12345 || echo fallback_ok
+
+#DESC: AND chain first fails
+#EXPECT:OK
+xyzzy_nonexistent_12345 && echo skipped
+echo and_chain_done
+
+#DESC: Semicolon with trailing spaces
+#EXPECT:OK
+echo first_sc ;   echo second_sc
+
+#DESC: Empty variable expansion in argument
+#EXPECT:OK
+_ev=
+echo prefix${_ev}suffix
+unset _ev
+
+#DESC: Calculator with negative literal
+#EXPECT:OK
+_neg = -5 + 3
+echo $_neg
+unset _neg
+
+#DESC: Image math type promotion (double)
+#EXPECT:OK
+dpdouble
+mem.mk2Dim _dbl_test 4 4
+_dbl_test = _dbl_test * 0.0 + 1.5
+mem.rm _dbl_test
+dpsingle

--- a/tests/cli/run_cli_robustness_tests.sh
+++ b/tests/cli/run_cli_robustness_tests.sh
@@ -9,7 +9,13 @@
 # messages.
 #
 # Usage:
-#   bash run_cli_robustness_tests.sh [--verbose]
+#   bash run_cli_robustness_tests.sh [OPTIONS]
+#
+# Options:
+#   --verbose         Show details for failures
+#   --filter PATTERN  Run only test descriptions
+#                     matching glob PATTERN
+#   --stop-on-fail    Stop after first failure
 #
 # Exit codes:
 #   0 — all tests passed
@@ -30,9 +36,17 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TEST_FILE="${SCRIPT_DIR}/cli_robustness_tests.milk"
 TIMEOUT_SEC=10
 VERBOSE=0
-if [[ "${1:-}" == "--verbose" ]]; then
-    VERBOSE=1
-fi
+FILTER=""
+STOP_ON_FAIL=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --verbose)     VERBOSE=1 ;;
+        --filter)      FILTER="${2:-}"; shift ;;
+        --stop-on-fail) STOP_ON_FAIL=1 ;;
+    esac
+    shift
+done
 
 # ---- Color codes ----
 RED='\033[0;31m'
@@ -56,6 +70,9 @@ FAIL=0
 ERRFAIL=0    # Expected error but no message
 CRASH=0
 HANG=0
+TOTAL_TIME_MS=0
+SLOWEST_MS=0
+SLOWEST_DESC=""
 
 echo -e "${CYN}═══════════════════════════════════════════${RST}"
 echo -e "${CYN} milk-cli Robustness Test Suite${RST}"
@@ -146,6 +163,14 @@ run_one_test() {
     local expect="${TEST_EXPECT[$idx]}"
     local cmd="${TEST_CMD[$idx]}"
 
+    # Skip if filter is set and doesn't match
+    if [[ -n "$FILTER" ]]; then
+        case "$desc" in
+            *${FILTER}*) ;;
+            *) return 0 ;;
+        esac
+    fi
+
     local cmd_file="${TMPDIR}/cmd_${idx}.milk"
     local out_file="${TMPDIR}/out_${idx}.txt"
     local err_file="${TMPDIR}/err_${idx}.txt"
@@ -159,6 +184,8 @@ run_one_test() {
     # Run milk-cli with the test script, capturing
     # stdout and stderr, with timeout
     local exit_code=0
+    local t_start t_end elapsed_ms
+    t_start=$(date +%s%N)
     timeout "${TIMEOUT_SEC}" milk-cli \
         --no-autocomplete \
         --no-history-suggest \
@@ -167,6 +194,13 @@ run_one_test() {
         -f \
         > "$out_file" 2>"$err_file" < /dev/null \
         || exit_code=$?
+    t_end=$(date +%s%N)
+    elapsed_ms=$(( (t_end - t_start) / 1000000 ))
+    TOTAL_TIME_MS=$((TOTAL_TIME_MS + elapsed_ms))
+    if [[ $elapsed_ms -gt $SLOWEST_MS ]]; then
+        SLOWEST_MS=$elapsed_ms
+        SLOWEST_DESC="$desc"
+    fi
 
     local result="PASS"
     local detail=""
@@ -231,6 +265,7 @@ run_one_test() {
     if [[ -n "$detail" ]]; then
         printf "  ${DIM}(%s)${RST}" "$detail"
     fi
+    printf "  ${DIM}[%dms]${RST}" "$elapsed_ms"
     echo ""
 
     if [[ $VERBOSE -eq 1 && "$result" != "PASS" ]]; then
@@ -262,6 +297,14 @@ run_one_test() {
 
 for i in $(seq 0 $((NUM_TESTS - 1))); do
     run_one_test "$i"
+    if [[ $STOP_ON_FAIL -eq 1 ]]; then
+        PROBLEMS=$((FAIL + ERRFAIL + CRASH + HANG))
+        if [[ $PROBLEMS -gt 0 ]]; then
+            echo ""
+            echo -e "${RED}Stopping on first failure (--stop-on-fail)${RST}"
+            break
+        fi
+    fi
 done
 
 # ============================================================
@@ -293,6 +336,14 @@ printf "  ${RED}Fail:          %d${RST}\n" "$FAIL"
 printf "  ${YLW}Missing Error: %d${RST}\n" "$ERRFAIL"
 printf "  ${RED}Crash:         %d${RST}\n" "$CRASH"
 printf "  ${RED}Hang:          %d${RST}\n" "$HANG"
+echo ""
+printf "  Total time:    %d.%03ds\n" \
+    "$((TOTAL_TIME_MS / 1000))" \
+    "$((TOTAL_TIME_MS % 1000))"
+if [[ -n "$SLOWEST_DESC" ]]; then
+    printf "  Slowest test:  %dms (%s)\n" \
+        "$SLOWEST_MS" "$SLOWEST_DESC"
+fi
 echo ""
 
 # Copy report to working directory


### PR DESCRIPTION
## Summary

Expands the CLI robustness test suite from ~162 to 208 test cases and adds usability improvements to the test runner.

### New test sections (33–44)

| Section | Feature | Tests |
|---------|---------|-------|
| 33 | Alias system (define, run, overwrite, remove) | 6 |
| 34 | Bookmark system (list, save, run, remove) | 5 |
| 35 | `printf` command (format strings, floats, escapes) | 4 |
| 36 | `sleep` command (fractional seconds, usage error) | 2 |
| 37 | `trap` command (EXIT trap, list) | 2 |
| 38 | `savehistory` (file output, usage error) | 3 |
| 39 | `lhistory`/`ghistory` (display, count, filter) | 4 |
| 40 | `fpsset` error paths (no args, missing dot, bad FPS) | 3 |
| 41 | `on_update` error paths (bad stream, no args) | 2 |
| 42 | Shell bypass `!` (valid and invalid commands) | 2 |
| 43 | `include_once` idempotency | 1 |
| 44 | Edge cases (digit vars, deep arithmetic, nested functions, OR/AND chains, negative literals, double precision) | 10 |

### Runner improvements

- `--filter PATTERN` — run only tests matching a description glob
- `--stop-on-fail` — halt after first failure
- Per-test wall-clock timing `[Nms]` in output
- Total time + slowest test in summary

### Verification

All 208/208 tests pass. No crashes, hangs, or missing errors.

### Prompt Summary

User requested a review of CLI test suite coverage. A gap analysis identified ~46 untested features (alias, bookmark, printf, sleep, trap, history commands, fpsset/on_update error paths, shell bypass, include_once, and edge cases). User approved all recommendations, tests were added and verified.

### AI Authorship

- **Model:** Antigravity
- **User edits:** None
