### PR TITLE
feat(cli): add bitwise ops, string funcs, processinfo integration

### DIFF
--- a/src/cli/CLIcore/CLIcore/CLIcore_script.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_script.c
@@ -21,6 +21,7 @@
 #include <sys/stat.h>
 #include <signal.h>
 #include <sys/wait.h>
+#include <time.h>
 
 #include "CLIcore.h"
 #include "CLIcore_script.h"
@@ -72,6 +73,10 @@ int cli_trap_signum(const char *name)
     if(strcasecmp(name, "USR2") == 0)
     {
         return SIGUSR2;
+    }
+    if(strcasecmp(name, "ERR") == 0)
+    {
+        return -1; /* pseudo-signal */
     }
     return (int) strtol(name, NULL, 0);
 }
@@ -923,6 +928,173 @@ int cli_script_intercept(const char *line)
                 cli_var_unset(dst);
             }
         }
+        return 1;
+    }
+
+    /* time <command> — measure duration */
+    if(starts_with(p, "time ")
+       || starts_with(p, "time\t"))
+    {
+        const char *cmd = p + 4;
+        while(*cmd == ' ' || *cmd == '\t')
+        {
+            cmd++;
+        }
+        struct timespec t0, t1;
+        clock_gettime(
+            CLOCK_MONOTONIC, &t0);
+        CLI_execute_string(cmd);
+        clock_gettime(
+            CLOCK_MONOTONIC, &t1);
+        double elapsed =
+            (double)(t1.tv_sec - t0.tv_sec)
+            + (double)(t1.tv_nsec
+                       - t0.tv_nsec)
+              / 1.0e9;
+        printf(
+            "\nreal\t%.3fs\n",
+            elapsed);
+        return 1;
+    }
+
+    /* assert [ cond ] "message" */
+    if(starts_with(p, "assert ")
+       || starts_with(p, "assert\t"))
+    {
+        const char *ap = p + 6;
+        while(*ap == ' ' || *ap == '\t')
+        {
+            ap++;
+        }
+        if(*ap == '[')
+        {
+            ap++;
+            const char *end =
+                strrchr(ap, ']');
+            if(end != NULL)
+            {
+                char cs[512];
+                int clen =
+                    (int)(end - ap);
+                if(clen
+                   >= (int) sizeof(cs))
+                {
+                    clen =
+                        (int) sizeof(cs)
+                        - 1;
+                }
+                memcpy(cs, ap,
+                       (size_t) clen);
+                cs[clen] = '\0';
+                int result =
+                    cli_eval_test(cs);
+                if(!result)
+                {
+                    const char *msg =
+                        end + 1;
+                    while(*msg == ' '
+                          || *msg == '\t')
+                    {
+                        msg++;
+                    }
+                    /* strip quotes */
+                    if(*msg == '"'
+                       || *msg == '\'')
+                    {
+                        msg++;
+                    }
+                    int mlen =
+                        (int) strlen(msg);
+                    if(mlen > 0
+                       && (msg[mlen - 1]
+                           == '"'
+                           || msg[mlen - 1]
+                              == '\''))
+                    {
+                        char mb[512];
+                        strncpy(
+                            mb, msg,
+                            sizeof(mb) - 1);
+                        mb[sizeof(mb) - 1]
+                            = '\0';
+                        if(mlen - 1
+                           < (int)
+                             sizeof(mb))
+                        {
+                            mb[mlen - 1]
+                                = '\0';
+                        }
+                        printf(
+                            "ASSERT "
+                            "FAILED: "
+                            "%s\n", mb);
+                    }
+                    else
+                    {
+                        printf(
+                            "ASSERT "
+                            "FAILED: "
+                            "%s\n", msg);
+                    }
+                    cli_last_retval = 1;
+                    if(cli_flag_errexit)
+                    {
+                        cli_trap_run(-1);
+                    }
+                }
+            }
+        }
+        return 1;
+    }
+
+    /* watch -n <sec> <command> */
+    if(starts_with(p, "watch ")
+       || starts_with(p, "watch\t"))
+    {
+        const char *wp = p + 5;
+        while(*wp == ' ' || *wp == '\t')
+        {
+            wp++;
+        }
+        double interval = 2.0;
+        if(*wp == '-' && *(wp + 1) == 'n')
+        {
+            wp += 2;
+            while(*wp == ' '
+                  || *wp == '\t')
+            {
+                wp++;
+            }
+            interval = strtod(wp, NULL);
+            while(*wp != ' '
+                  && *wp != '\t'
+                  && *wp != '\0')
+            {
+                wp++;
+            }
+            while(*wp == ' '
+                  || *wp == '\t')
+            {
+                wp++;
+            }
+        }
+        struct timespec ts;
+        ts.tv_sec =
+            (time_t) interval;
+        ts.tv_nsec =
+            (long)((interval
+                    - (double) ts.tv_sec)
+                   * 1.0e9);
+        while(!cli_break_flag)
+        {
+            printf(
+                "\033[2J\033[H"
+                "Every %.1fs: %s\n\n",
+                interval, wp);
+            CLI_execute_string(wp);
+            nanosleep(&ts, NULL);
+        }
+        cli_break_flag = 0;
         return 1;
     }
 

--- a/src/cli/CLIcore/CLIcore/CLIcore_script.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_script.c
@@ -27,6 +27,14 @@
 #include "CLIcore_script.h"
 #include "CLIcore_UI.h"
 
+#include <sys/mman.h>
+
+/* processinfo functions — linked via milkprocessinfo */
+extern PROCESSINFO *processinfo_shm_link(
+    const char *pname, int *fd);
+extern errno_t processinfo_procdirname(
+    char *procdname);
+
 /* ============================================================
  *  CLI Variable Storage
  * ============================================================
@@ -183,6 +191,37 @@ const char *cli_var_lookup(const char *name)
             return data.fifoname;
         }
         return "";
+    }
+
+    /* $PROCINFO_NCPU — online CPUs */
+    if(strcmp(name, "PROCINFO_NCPU") == 0)
+    {
+        long ncpu = sysconf(
+            _SC_NPROCESSORS_ONLN);
+        snprintf(retbuf, sizeof(retbuf),
+                 "%ld", ncpu);
+        return retbuf;
+    }
+
+    /* $PROCINFO_NPROC — active procs */
+    if(strcmp(name, "PROCINFO_NPROC") == 0)
+    {
+        int cnt = 0;
+        if(pinfolist != NULL)
+        {
+            for(int pi = 0;
+                pi < PROCESSINFOLISTSIZE;
+                pi++)
+            {
+                if(pinfolist->active[pi])
+                {
+                    cnt++;
+                }
+            }
+        }
+        snprintf(retbuf, sizeof(retbuf),
+                 "%d", cnt);
+        return retbuf;
     }
 
     /* CLI variable */
@@ -926,6 +965,385 @@ int cli_script_intercept(const char *line)
             else
             {
                 cli_var_unset(dst);
+            }
+        }
+        return 1;
+    }
+
+    /* procctl <name> run|pause|step|stop */
+    if(starts_with(p, "procctl ")
+       || starts_with(p, "procctl\t"))
+    {
+        const char *ap = p + 7;
+        while(*ap == ' ' || *ap == '\t')
+        {
+            ap++;
+        }
+        char pname[256];
+        int nlen = 0;
+        while(*ap && *ap != ' '
+              && *ap != '\t'
+              && nlen < 255)
+        {
+            pname[nlen++] = *ap++;
+        }
+        pname[nlen] = '\0';
+        while(*ap == ' ' || *ap == '\t')
+        {
+            ap++;
+        }
+        int ctrlval = -1;
+        if(strncmp(ap, "run", 3) == 0)
+        {
+            ctrlval = PROCESSINFO_CTRLVAL_RUN;
+        }
+        else if(strncmp(ap, "pause", 5) == 0)
+        {
+            ctrlval = PROCESSINFO_CTRLVAL_PAUSE;
+        }
+        else if(strncmp(ap, "step", 4) == 0)
+        {
+            ctrlval = PROCESSINFO_CTRLVAL_INCR;
+        }
+        else if(strncmp(ap, "stop", 4) == 0
+                || strncmp(ap, "exit", 4)
+                   == 0)
+        {
+            ctrlval = PROCESSINFO_CTRLVAL_EXIT;
+        }
+        if(ctrlval < 0)
+        {
+            printf(
+                "procctl: unknown action "
+                "'%s' (use run|pause|"
+                "step|stop)\n", ap);
+            return 1;
+        }
+        if(pinfolist != NULL)
+        {
+            pid_t fpid = 0;
+            for(int pi = 0;
+                pi < PROCESSINFOLISTSIZE;
+                pi++)
+            {
+                if(pinfolist->active[pi]
+                   && strcmp(
+                       pinfolist
+                           ->pnamearray[pi],
+                       pname) == 0)
+                {
+                    fpid = pinfolist
+                        ->PIDarray[pi];
+                    break;
+                }
+            }
+            if(fpid > 0)
+            {
+                char pfn[512];
+                char pdname[256];
+                processinfo_procdirname(
+                    pdname);
+                snprintf(pfn, sizeof(pfn),
+                         "%s/proc.%d.shm",
+                         pdname,
+                         (int) fpid);
+                int pfd = -1;
+                PROCESSINFO *pi =
+                    processinfo_shm_link(
+                        pfn, &pfd);
+                if(pi != MAP_FAILED
+                   && pi != NULL)
+                {
+                    pi->CTRLval = ctrlval;
+                    munmap(pi,
+                        sizeof(PROCESSINFO));
+                    close(pfd);
+                }
+                else if(pfd >= 0)
+                {
+                    close(pfd);
+                }
+            }
+            else
+            {
+                printf(
+                    "procctl: process "
+                    "'%s' not found\n",
+                    pname);
+            }
+        }
+        return 1;
+    }
+
+    /* procwait <name> <state> [timeout] */
+    if(starts_with(p, "procwait ")
+       || starts_with(p, "procwait\t"))
+    {
+        const char *ap = p + 8;
+        while(*ap == ' ' || *ap == '\t')
+        {
+            ap++;
+        }
+        char pname[256];
+        int nlen = 0;
+        while(*ap && *ap != ' '
+              && *ap != '\t'
+              && nlen < 255)
+        {
+            pname[nlen++] = *ap++;
+        }
+        pname[nlen] = '\0';
+        while(*ap == ' ' || *ap == '\t')
+        {
+            ap++;
+        }
+        int tgt = -1;
+        if(strncasecmp(ap, "INIT", 4) == 0)
+        {
+            tgt = PROCESSINFO_LOOPSTAT_INIT;
+        }
+        else if(strncasecmp(ap, "ACTIVE",
+                6) == 0)
+        {
+            tgt = PROCESSINFO_LOOPSTAT_ACTIVE;
+        }
+        else if(strncasecmp(ap, "PAUSE",
+                5) == 0)
+        {
+            tgt = PROCESSINFO_LOOPSTAT_PAUSE;
+        }
+        else if(strncasecmp(ap, "STOP",
+                4) == 0)
+        {
+            tgt = PROCESSINFO_LOOPSTAT_STOP;
+        }
+        else if(strncasecmp(ap, "ERROR",
+                5) == 0)
+        {
+            tgt = PROCESSINFO_LOOPSTAT_ERROR;
+        }
+        else
+        {
+            tgt = (int) strtol(ap, NULL, 0);
+        }
+        /* Skip state word */
+        while(*ap && *ap != ' '
+              && *ap != '\t')
+        {
+            ap++;
+        }
+        while(*ap == ' ' || *ap == '\t')
+        {
+            ap++;
+        }
+        double timeout = 30.0;
+        if(*ap != '\0')
+        {
+            timeout = strtod(ap, NULL);
+        }
+        struct timespec slp;
+        slp.tv_sec = 0;
+        slp.tv_nsec = 100000000; /* 100ms */
+        double elapsed = 0.0;
+        cli_last_retval = 1;
+        while(elapsed < timeout)
+        {
+            if(pinfolist != NULL)
+            {
+                for(int pi = 0;
+                    pi < PROCESSINFOLISTSIZE;
+                    pi++)
+                {
+                    if(pinfolist->active[pi]
+                       && strcmp(
+                           pinfolist
+                               ->pnamearray[
+                                   pi],
+                           pname) == 0)
+                    {
+                        pid_t fpid =
+                            pinfolist
+                                ->PIDarray[
+                                    pi];
+                        char pfn[512];
+                        char pdname[256];
+                        processinfo_procdirname(
+                            pdname);
+                        snprintf(
+                            pfn,
+                            sizeof(pfn),
+                            "%s/proc."
+                            "%d.shm",
+                            pdname,
+                            (int) fpid);
+                        int pfd = -1;
+                        PROCESSINFO *pii =
+                            processinfo_shm_link(
+                                pfn, &pfd);
+                        if(pii
+                           != MAP_FAILED
+                           && pii != NULL)
+                        {
+                            if(pii
+                               ->loopstat
+                               == tgt)
+                            {
+                                cli_last_retval
+                                    = 0;
+                            }
+                            munmap(pii,
+                                sizeof(
+                                PROCESSINFO));
+                            close(pfd);
+                        }
+                        else if(pfd >= 0)
+                        {
+                            close(pfd);
+                        }
+                        break;
+                    }
+                }
+            }
+            if(cli_last_retval == 0)
+            {
+                break;
+            }
+            nanosleep(&slp, NULL);
+            elapsed += 0.1;
+        }
+        return 1;
+    }
+
+    /* procstat [name] */
+    if(strcmp(p, "procstat") == 0
+       || starts_with(p, "procstat ")
+       || starts_with(p, "procstat\t"))
+    {
+        const char *ap = p + 8;
+        while(*ap == ' ' || *ap == '\t')
+        {
+            ap++;
+        }
+        char filter[256];
+        filter[0] = '\0';
+        if(*ap != '\0')
+        {
+            strncpy(filter, ap,
+                    sizeof(filter) - 1);
+            filter[sizeof(filter) - 1]
+                = '\0';
+        }
+        if(pinfolist != NULL)
+        {
+            char pdname[256];
+            processinfo_procdirname(pdname);
+            for(int pi = 0;
+                pi < PROCESSINFOLISTSIZE;
+                pi++)
+            {
+                if(!pinfolist->active[pi])
+                {
+                    continue;
+                }
+                if(filter[0] != '\0'
+                   && strcmp(
+                       pinfolist
+                           ->pnamearray[pi],
+                       filter) != 0)
+                {
+                    continue;
+                }
+                pid_t fpid =
+                    pinfolist
+                        ->PIDarray[pi];
+                char pfn[512];
+                snprintf(pfn,
+                         sizeof(pfn),
+                         "%s/proc.%d.shm",
+                         pdname,
+                         (int) fpid);
+                int pfd = -1;
+                PROCESSINFO *pii =
+                    processinfo_shm_link(
+                        pfn, &pfd);
+                if(pii == MAP_FAILED
+                   || pii == NULL)
+                {
+                    if(pfd >= 0)
+                    {
+                        close(pfd);
+                    }
+                    continue;
+                }
+                const char *stname =
+                    "UNKNOWN";
+                switch(pii->loopstat)
+                {
+                    case 0:
+                        stname = "INIT";
+                        break;
+                    case 1:
+                        stname = "ACTIVE";
+                        break;
+                    case 2:
+                        stname = "PAUSED";
+                        break;
+                    case 3:
+                        stname = "STOPPED";
+                        break;
+                    case 4:
+                        stname = "ERROR";
+                        break;
+                    case 5:
+                        stname = "SPINNING";
+                        break;
+                    case 6:
+                        stname = "CRASHED";
+                        break;
+                }
+                double hz = 0.0;
+                if(pii->dtmedian_iter_ns
+                   > 0)
+                {
+                    hz = 1.0e9
+                        / (double)
+                          pii
+                          ->dtmedian_iter_ns;
+                }
+                double us =
+                    (double)
+                    pii->dtmedian_exec_ns
+                    / 1000.0;
+                printf(
+                    "name=%s\n"
+                    "pid=%d\n"
+                    "loopstat=%s\n"
+                    "loopcnt=%ld\n"
+                    "loopfreq_hz=%.1f\n"
+                    "exectime_us=%.1f\n"
+                    "rtprio=%d\n"
+                    "ctrlval=%d\n"
+                    "missedframes=%lu\n"
+                    "tmux=%s\n",
+                    pii->name,
+                    (int) pii->PID,
+                    stname,
+                    pii->loopcnt,
+                    hz, us,
+                    pii->RT_priority,
+                    pii->CTRLval,
+                    (unsigned long)
+                    pii
+                    ->triggermissedframe_cumul,
+                    pii->tmuxname);
+                munmap(pii,
+                    sizeof(PROCESSINFO));
+                close(pfd);
+                if(filter[0] != '\0')
+                {
+                    break;
+                }
+                printf("---\n");
             }
         }
         return 1;

--- a/src/cli/CLIcore/CLIcore/CLIcore_script_expand.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_script_expand.c
@@ -14,6 +14,13 @@
 #include <sys/stat.h>
 #include <ctype.h>
 #include <regex.h>
+#include <sys/mman.h>
+
+/* processinfo functions — linked via milkprocessinfo */
+extern PROCESSINFO *processinfo_shm_link(
+    const char *pname, int *fd);
+extern errno_t processinfo_procdirname(
+    char *procdname);
 
 /* ============================================================
  *  Arithmetic Expansion Helper Functions
@@ -373,6 +380,202 @@ void cli_expand_fpsvar(
             if(fpsconn == -1
                     || fps.parray == NULL)
             {
+                /* FPS not found — try procinfo */
+                if(pinfolist != NULL)
+                {
+                    pid_t found_pid = 0;
+                    for(int pi = 0;
+                        pi < PROCESSINFOLISTSIZE;
+                        pi++)
+                    {
+                        if(pinfolist->active[pi]
+                           && strcmp(
+                               pinfolist
+                                   ->pnamearray[pi],
+                               fpsname) == 0)
+                        {
+                            found_pid =
+                                pinfolist
+                                    ->PIDarray[pi];
+                            break;
+                        }
+                    }
+                    if(found_pid > 0)
+                    {
+                        char pfname[512];
+                        char procdname[256];
+                        processinfo_procdirname(
+                            procdname);
+                        snprintf(
+                            pfname,
+                            sizeof(pfname),
+                            "%s/proc.%d.shm",
+                            procdname,
+                            (int) found_pid);
+                        int pfd = -1;
+                        PROCESSINFO *pi =
+                            processinfo_shm_link(
+                                pfname, &pfd);
+                        if(pi != MAP_FAILED
+                           && pi != NULL)
+                        {
+                            char vstr[512];
+                            vstr[0] = '\0';
+                            if(strcmp(pname,
+                                "pid") == 0)
+                            {
+                                snprintf(
+                                    vstr,
+                                    sizeof(vstr),
+                                    "%d",
+                                    (int) pi->PID);
+                            }
+                            else if(strcmp(pname,
+                                "loopstat") == 0)
+                            {
+                                snprintf(
+                                    vstr,
+                                    sizeof(vstr),
+                                    "%d",
+                                    pi->loopstat);
+                            }
+                            else if(strcmp(pname,
+                                "loopcnt") == 0)
+                            {
+                                snprintf(
+                                    vstr,
+                                    sizeof(vstr),
+                                    "%ld",
+                                    pi->loopcnt);
+                            }
+                            else if(strcmp(pname,
+                                "loopfreq") == 0)
+                            {
+                                double hz = 0.0;
+                                if(pi
+                                    ->dtmedian_iter_ns
+                                   > 0)
+                                {
+                                    hz = 1.0e9
+                                        / (double)
+                                          pi
+                                          ->dtmedian_iter_ns;
+                                }
+                                snprintf(
+                                    vstr,
+                                    sizeof(vstr),
+                                    "%.1f", hz);
+                            }
+                            else if(strcmp(pname,
+                                "exectime") == 0)
+                            {
+                                double us =
+                                    (double)
+                                    pi
+                                    ->dtmedian_exec_ns
+                                    / 1000.0;
+                                snprintf(
+                                    vstr,
+                                    sizeof(vstr),
+                                    "%.1f", us);
+                            }
+                            else if(strcmp(pname,
+                                "rtprio") == 0)
+                            {
+                                snprintf(
+                                    vstr,
+                                    sizeof(vstr),
+                                    "%d",
+                                    pi
+                                    ->RT_priority);
+                            }
+                            else if(strcmp(pname,
+                                "ctrlval") == 0)
+                            {
+                                snprintf(
+                                    vstr,
+                                    sizeof(vstr),
+                                    "%d",
+                                    pi->CTRLval);
+                            }
+                            else if(strcmp(pname,
+                                "trigmode") == 0)
+                            {
+                                snprintf(
+                                    vstr,
+                                    sizeof(vstr),
+                                    "%d",
+                                    pi
+                                    ->triggermode);
+                            }
+                            else if(strcmp(pname,
+                                "statusmsg") == 0)
+                            {
+                                strncpy(
+                                    vstr,
+                                    pi->statusmsg,
+                                    sizeof(vstr)
+                                    - 1);
+                                vstr[sizeof(vstr)
+                                     - 1] = '\0';
+                            }
+                            else if(strcmp(pname,
+                                "tmux") == 0)
+                            {
+                                strncpy(
+                                    vstr,
+                                    pi->tmuxname,
+                                    sizeof(vstr)
+                                    - 1);
+                                vstr[sizeof(vstr)
+                                     - 1] = '\0';
+                            }
+                            else if(strcmp(pname,
+                                "description")
+                                == 0)
+                            {
+                                strncpy(
+                                    vstr,
+                                    pi
+                                    ->description,
+                                    sizeof(vstr)
+                                    - 1);
+                                vstr[sizeof(vstr)
+                                     - 1] = '\0';
+                            }
+                            else if(strcmp(pname,
+                                "missedframes")
+                                == 0)
+                            {
+                                snprintf(
+                                    vstr,
+                                    sizeof(vstr),
+                                    "%lu",
+                                    (unsigned long)
+                                    pi
+                                    ->triggermissedframe_cumul);
+                            }
+                            int vlen =
+                                (int) strlen(vstr);
+                            int avail =
+                                maxlen - 1 - opos;
+                            int clen =
+                                vlen < avail
+                                ? vlen : avail;
+                            memcpy(out + opos,
+                                   vstr,
+                                   (size_t) clen);
+                            opos += clen;
+                            munmap(pi,
+                                sizeof(PROCESSINFO));
+                            close(pfd);
+                        }
+                        else if(pfd >= 0)
+                        {
+                            close(pfd);
+                        }
+                    }
+                }
                 continue;
             }
 

--- a/src/cli/CLIcore/cli_calc_parser.c
+++ b/src/cli/CLIcore/cli_calc_parser.c
@@ -15,6 +15,7 @@
  * as per-pixel masking. Populates data.cmdargtoken[data.cmdNBarg].
  */
 
+#include <ctype.h>
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
@@ -153,23 +154,32 @@ static inline int get_prec(cli_token_type t)
             return 1;
         case TOK_OP_AND:
             return 2;
+        case TOK_OP_BOR:
+            return 3;
+        case TOK_OP_BXOR:
+            return 4;
+        case TOK_OP_BAND:
+            return 5;
         case TOK_OP_EQ:
         case TOK_OP_NEQ:
-            return 3;
+            return 6;
         case TOK_OP_LT:
         case TOK_OP_LE:
         case TOK_OP_GT:
         case TOK_OP_GE:
-            return 4;
+            return 7;
+        case TOK_OP_LSHIFT:
+        case TOK_OP_RSHIFT:
+            return 8;
         case TOK_OP_PLUS:
         case TOK_OP_MINUS:
-            return 5;
+            return 9;
         case TOK_OP_STAR:
         case TOK_OP_SLASH:
         case TOK_OP_MOD:
-            return 6;
+            return 10;
         case TOK_OP_CARET:
-            return 7;
+            return 11;
         case TOK_EQUAL:
         case TOK_OP_PLUS_EQ:
         case TOK_OP_MINUS_EQ:
@@ -569,6 +579,21 @@ static val_t eval_binop(
                 return mk_long((left.lval && right.lval) ? 1 : 0);
             case TOK_OP_OR:
                 return mk_long((left.lval || right.lval) ? 1 : 0);
+            case TOK_OP_BAND:
+                return mk_long(
+                    left.lval & right.lval);
+            case TOK_OP_BOR:
+                return mk_long(
+                    left.lval | right.lval);
+            case TOK_OP_BXOR:
+                return mk_long(
+                    left.lval ^ right.lval);
+            case TOK_OP_LSHIFT:
+                return mk_long(
+                    left.lval << right.lval);
+            case TOK_OP_RSHIFT:
+                return mk_long(
+                    left.lval >> right.lval);
             default:
                 break;
         }
@@ -617,6 +642,21 @@ static val_t eval_binop(
                 return mk_long((lv != 0 && rv != 0) ? 1 : 0);
             case TOK_OP_OR:
                 return mk_long((lv != 0 || rv != 0) ? 1 : 0);
+            case TOK_OP_BAND:
+                return mk_long(
+                    (long) lv & (long) rv);
+            case TOK_OP_BOR:
+                return mk_long(
+                    (long) lv | (long) rv);
+            case TOK_OP_BXOR:
+                return mk_long(
+                    (long) lv ^ (long) rv);
+            case TOK_OP_LSHIFT:
+                return mk_long(
+                    (long) lv << (long) rv);
+            case TOK_OP_RSHIFT:
+                return mk_long(
+                    (long) lv >> (long) rv);
             default:
                 break;
         }
@@ -1102,6 +1142,327 @@ static val_t parse_funccall(cli_token *ftok)
         );
     }
 
+    /* toupper(s), tolower(s) -> string */
+    if (ftok->type == TOK_FUNC_S_S)
+    {
+        val_t arg = parse_expr(0);
+        if (parse_error || eval_error)
+        {
+            return mk_double(0);
+        }
+        if (cur_func()->type != TOK_RPAREN)
+        {
+            parse_errmsg("Expected ')'");
+            return mk_double(0);
+        }
+        advance_func();
+
+        /* Resolve string value */
+        const char *sv = NULL;
+        char numbuf[64];
+        if (arg.type == VAL_STRING)
+        {
+            const char *cv =
+                cli_var_get(arg.sval);
+            sv = cv ? cv : arg.sval;
+        }
+        else if (arg.type == VAL_LONG)
+        {
+            snprintf(numbuf, 64,
+                     "%ld", arg.lval);
+            sv = numbuf;
+        }
+        else
+        {
+            snprintf(numbuf, 64,
+                     "%g", arg.dval);
+            sv = numbuf;
+        }
+
+        char result[CLI_CALC_TOKEN_MAXLEN];
+        strncpy(result, sv,
+                sizeof(result) - 1);
+        result[sizeof(result) - 1] = '\0';
+
+        const char *fn = ftok->sval;
+        if (strncmp(fn, "toupper(", 8) == 0)
+        {
+            for (int i = 0;
+                 result[i]; i++)
+            {
+                result[i] = (char) toupper(
+                    (unsigned char) result[i]);
+            }
+        }
+        else /* tolower */
+        {
+            for (int i = 0;
+                 result[i]; i++)
+            {
+                result[i] = (char) tolower(
+                    (unsigned char) result[i]);
+            }
+        }
+
+        /* Store as temp CLI var */
+        const char *tmpn = alloc_tmpname();
+        cli_var_set(tmpn, result);
+        return mk_string(tmpn);
+    }
+
+    /* substr(s, off, len) -> string */
+    if (ftok->type == TOK_FUNC_SDD_S)
+    {
+        val_t arg1 = parse_expr(0);
+        if (parse_error || eval_error)
+        {
+            return mk_double(0);
+        }
+        if (cur_func()->type != TOK_COMMA)
+        {
+            parse_errmsg("substr: need 3 args");
+            return mk_double(0);
+        }
+        advance_func();
+        val_t arg2 = parse_expr(0);
+        if (parse_error || eval_error)
+        {
+            return mk_double(0);
+        }
+        if (cur_func()->type != TOK_COMMA)
+        {
+            parse_errmsg("substr: need 3 args");
+            return mk_double(0);
+        }
+        advance_func();
+        val_t arg3 = parse_expr(0);
+        if (parse_error || eval_error)
+        {
+            return mk_double(0);
+        }
+        if (cur_func()->type != TOK_RPAREN)
+        {
+            parse_errmsg("Expected ')'");
+            return mk_double(0);
+        }
+        advance_func();
+
+        const char *sv = NULL;
+        if (arg1.type == VAL_STRING)
+        {
+            const char *cv =
+                cli_var_get(arg1.sval);
+            sv = cv ? cv : arg1.sval;
+        }
+        else
+        {
+            parse_errmsg(
+                "substr: first arg "
+                "must be string");
+            return mk_double(0);
+        }
+
+        int slen = (int) strlen(sv);
+        int off = (int) to_double(arg2);
+        int len = (int) to_double(arg3);
+        if (off < 0) { off = 0; }
+        if (off > slen) { off = slen; }
+        if (len < 0) { len = 0; }
+        if (off + len > slen)
+        {
+            len = slen - off;
+        }
+
+        char result[CLI_CALC_TOKEN_MAXLEN];
+        memcpy(result, sv + off,
+               (size_t) len);
+        result[len] = '\0';
+
+        const char *tmpn = alloc_tmpname();
+        cli_var_set(tmpn, result);
+        return mk_string(tmpn);
+    }
+
+    /* replace(s, old, new) -> string */
+    if (ftok->type == TOK_FUNC_SSS_S)
+    {
+        val_t arg1 = parse_expr(0);
+        if (parse_error || eval_error)
+        {
+            return mk_double(0);
+        }
+        if (cur_func()->type != TOK_COMMA)
+        {
+            parse_errmsg(
+                "replace: need 3 args");
+            return mk_double(0);
+        }
+        advance_func();
+        val_t arg2 = parse_expr(0);
+        if (parse_error || eval_error)
+        {
+            return mk_double(0);
+        }
+        if (cur_func()->type != TOK_COMMA)
+        {
+            parse_errmsg(
+                "replace: need 3 args");
+            return mk_double(0);
+        }
+        advance_func();
+        val_t arg3 = parse_expr(0);
+        if (parse_error || eval_error)
+        {
+            return mk_double(0);
+        }
+        if (cur_func()->type != TOK_RPAREN)
+        {
+            parse_errmsg("Expected ')'");
+            return mk_double(0);
+        }
+        advance_func();
+
+        const char *s1 = NULL;
+        const char *s2 = NULL;
+        const char *s3 = NULL;
+        if (arg1.type == VAL_STRING)
+        {
+            const char *cv =
+                cli_var_get(arg1.sval);
+            s1 = cv ? cv : arg1.sval;
+        }
+        if (arg2.type == VAL_STRING)
+        {
+            const char *cv =
+                cli_var_get(arg2.sval);
+            s2 = cv ? cv : arg2.sval;
+        }
+        if (arg3.type == VAL_STRING)
+        {
+            const char *cv =
+                cli_var_get(arg3.sval);
+            s3 = cv ? cv : arg3.sval;
+        }
+        if (!s1 || !s2 || !s3)
+        {
+            parse_errmsg(
+                "replace: all args "
+                "must be strings");
+            return mk_double(0);
+        }
+
+        char result[CLI_CALC_TOKEN_MAXLEN];
+        result[0] = '\0';
+        int s2len = (int) strlen(s2);
+        if (s2len == 0)
+        {
+            strncpy(result, s1,
+                    sizeof(result) - 1);
+            result[sizeof(result) - 1]
+                = '\0';
+        }
+        else
+        {
+            const char *p = s1;
+            char *w = result;
+            char *end = result
+                + sizeof(result) - 1;
+            while (*p && w < end)
+            {
+                if (strncmp(p, s2,
+                    (size_t) s2len) == 0)
+                {
+                    int rlen =
+                        (int) strlen(s3);
+                    if (w + rlen < end)
+                    {
+                        memcpy(w, s3,
+                            (size_t) rlen);
+                        w += rlen;
+                    }
+                    p += s2len;
+                }
+                else
+                {
+                    *w++ = *p++;
+                }
+            }
+            *w = '\0';
+        }
+
+        const char *tmpn = alloc_tmpname();
+        cli_var_set(tmpn, result);
+        return mk_string(tmpn);
+    }
+
+    /* hex(n), oct(n), bin(n) -> string */
+    if (ftok->type == TOK_FUNC_D_S)
+    {
+        val_t arg = parse_expr(0);
+        if (parse_error || eval_error)
+        {
+            return mk_double(0);
+        }
+        if (cur_func()->type != TOK_RPAREN)
+        {
+            parse_errmsg("Expected ')'");
+            return mk_double(0);
+        }
+        advance_func();
+
+        long iv = (arg.type == VAL_LONG)
+            ? arg.lval
+            : (long) to_double(arg);
+
+        char result[CLI_CALC_TOKEN_MAXLEN];
+        const char *fn = ftok->sval;
+        if (strncmp(fn, "hex(", 4) == 0)
+        {
+            snprintf(result,
+                     sizeof(result),
+                     "0x%lx", iv);
+        }
+        else if (strncmp(fn, "oct(", 4)
+                 == 0)
+        {
+            snprintf(result,
+                     sizeof(result),
+                     "0o%lo", iv);
+        }
+        else /* bin */
+        {
+            char *w = result;
+            *w++ = '0';
+            *w++ = 'b';
+            if (iv == 0)
+            {
+                *w++ = '0';
+            }
+            else
+            {
+                long v = iv;
+                char bits[65];
+                int bi = 0;
+                while (v > 0 && bi < 64)
+                {
+                    bits[bi++] =
+                        (v & 1) ? '1' : '0';
+                    v >>= 1;
+                }
+                for (int i = bi - 1;
+                     i >= 0; i--)
+                {
+                    *w++ = bits[i];
+                }
+            }
+            *w = '\0';
+        }
+
+        const char *tmpn = alloc_tmpname();
+        cli_var_set(tmpn, result);
+        return mk_string(tmpn);
+    }
+
     parse_errmsg("Unknown function type");
     return mk_double(0);
 }
@@ -1204,6 +1565,20 @@ static val_t parse_primary(void)
         return mk_double(0);
     }
 
+    /* unary bitwise NOT */
+    if (t->type == TOK_OP_BNOT)
+    {
+        advance_func();
+        val_t v = parse_primary();
+        if (parse_error || eval_error)
+        {
+            return mk_long(0);
+        }
+        long iv = (v.type == VAL_LONG)
+            ? v.lval : (long) v.dval;
+        return mk_long(~iv);
+    }
+
     /* parenthesized expression */
     if (t->type == TOK_LPAREN)
     {
@@ -1230,7 +1605,11 @@ static val_t parse_primary(void)
         || t->type == TOK_FUNC_IMD_D
         || t->type == TOK_FUNC_WHERE
         || t->type == TOK_FUNC_IMIM_D
-        || t->type == TOK_FUNC_S_D)
+        || t->type == TOK_FUNC_S_D
+        || t->type == TOK_FUNC_S_S
+        || t->type == TOK_FUNC_SDD_S
+        || t->type == TOK_FUNC_SSS_S
+        || t->type == TOK_FUNC_D_S)
     {
         advance_func();
         return parse_funccall(t);

--- a/src/cli/CLIcore/cli_calc_tokenizer.c
+++ b/src/cli/CLIcore/cli_calc_tokenizer.c
@@ -94,6 +94,21 @@ static const builtin_func builtins[] =
     /* string -> double */
     {"strlen(", NULL, TOK_FUNC_S_D},
 
+    /* string -> string */
+    {"toupper(", NULL, TOK_FUNC_S_S},
+    {"tolower(", NULL, TOK_FUNC_S_S},
+
+    /* string,int,int -> string */
+    {"substr(", NULL, TOK_FUNC_SDD_S},
+
+    /* string,string,string -> string */
+    {"replace(", NULL, TOK_FUNC_SSS_S},
+
+    /* double -> string (format) */
+    {"hex(", NULL, TOK_FUNC_D_S},
+    {"oct(", NULL, TOK_FUNC_D_S},
+    {"bin(", NULL, TOK_FUNC_D_S},
+
     {NULL, NULL, TOK_EOF}
 };
 
@@ -181,6 +196,9 @@ int cli_tokenize(
             else if (*p == '-' && *(p+1) == '=') { optype = TOK_OP_MINUS_EQ; oplen = 2; }
             else if (*p == '*' && *(p+1) == '=') { optype = TOK_OP_STAR_EQ; oplen = 2; }
             else if (*p == '/' && *(p+1) == '=') { optype = TOK_OP_SLASH_EQ; oplen = 2; }
+            else if (*p == '<' && *(p+1) == '<') { optype = TOK_OP_LSHIFT; oplen = 2; }
+            else if (*p == '>' && *(p+1) == '>') { optype = TOK_OP_RSHIFT; oplen = 2; }
+            else if (*p == '^' && *(p+1) == '^') { optype = TOK_OP_BXOR; oplen = 2; }
             else
             {
                 switch (*p)
@@ -196,7 +214,9 @@ int cli_tokenize(
                     case '!': optype = TOK_OP_NOT; break;
                     case '(': optype = TOK_LPAREN; break;
                     case ')': optype = TOK_RPAREN; break;
-                    case '|': optype = TOK_OP_PIPE; break;
+                    case '|': optype = TOK_OP_BOR; break;
+                    case '&': optype = TOK_OP_BAND; break;
+                    case '~': optype = TOK_OP_BNOT; break;
                     case ',': optype = TOK_COMMA; break;
                     case '=': optype = TOK_EQUAL; break;
                     case '?': optype = TOK_OP_QUESTION; break;

--- a/src/cli/CLIcore/cli_calc_tokenizer.h
+++ b/src/cli/CLIcore/cli_calc_tokenizer.h
@@ -66,6 +66,19 @@ typedef enum
     TOK_OP_QUESTION, /**< ? (ternary) */
     TOK_OP_COLON,    /**< : (ternary) */
     TOK_FUNC_S_D,    /**< func(string)->double */
+    /* Bitwise operators */
+    TOK_OP_BAND,     /**< & (bitwise AND) */
+    TOK_OP_BOR,      /**< | (bitwise OR)  */
+    TOK_OP_BXOR,     /**< ^ (bitwise XOR) */
+    TOK_OP_BNOT,     /**< ~ (bitwise NOT) */
+    TOK_OP_LSHIFT,   /**< <<              */
+    TOK_OP_RSHIFT,   /**< >>              */
+    /* String functions */
+    TOK_FUNC_S_S,    /**< func(string)->string */
+    TOK_FUNC_SDD_S,  /**< func(s,d,d)->string  */
+    TOK_FUNC_SSS_S,  /**< func(s,s,s)->string  */
+    /* Format conversions */
+    TOK_FUNC_D_S,    /**< func(double)->string */
     TOK_NEWLINE
 } cli_token_type;
 

--- a/tests/cli/cli_robustness_tests.milk
+++ b/tests/cli/cli_robustness_tests.milk
@@ -1348,3 +1348,152 @@ shift
 echo $1
 }
 _test_shift alpha beta
+
+# ============================================
+# ---- Bitwise operators ----
+# ============================================
+
+#DESC: Bitwise AND
+#EXPECT:OK
+_ba = 0xff & 0x0f
+echo $_ba
+unset _ba
+
+#DESC: Bitwise OR
+#EXPECT:OK
+_bo = 0x0f | 0xf0
+echo $_bo
+unset _bo
+
+#DESC: Bitwise XOR
+#EXPECT:OK
+_bx = 0xff ^^ 0x0f
+echo $_bx
+unset _bx
+
+#DESC: Bitwise NOT
+#EXPECT:OK
+_bn = ~0
+echo $_bn
+unset _bn
+
+#DESC: Left shift
+#EXPECT:OK
+_ls = 1 << 4
+echo $_ls
+unset _ls
+
+#DESC: Right shift
+#EXPECT:OK
+_rs = 256 >> 4
+echo $_rs
+unset _rs
+
+# ============================================
+# ---- String functions ----
+# ============================================
+
+#DESC: toupper function
+#EXPECT:OK
+_su = "hello"
+_up = toupper(_su)
+echo $_up
+unset _su
+unset _up
+
+#DESC: tolower function
+#EXPECT:OK
+_sl = "HELLO"
+_lo = tolower(_sl)
+echo $_lo
+unset _sl
+unset _lo
+
+# ============================================
+# ---- Format conversions ----
+# ============================================
+
+#DESC: hex format conversion
+#EXPECT:OK
+_hf = hex(255)
+echo $_hf
+unset _hf
+
+#DESC: oct format conversion
+#EXPECT:OK
+_of = oct(255)
+echo $_of
+unset _of
+
+#DESC: bin format conversion
+#EXPECT:OK
+_bf = bin(10)
+echo $_bf
+unset _bf
+
+# ============================================
+# ---- Default parameter expansion ----
+# ============================================
+
+#DESC: Default value with :-
+#EXPECT:OK
+_unsetvar123=""
+_dv="${_unsetvar123:-fallback}"
+echo $_dv
+unset _unsetvar123
+unset _dv
+
+#DESC: Assign default with :=
+#EXPECT:OK
+_unsetvar456=""
+_iv="${_unsetvar456:=assigned}"
+echo $_unsetvar456
+unset _unsetvar456
+
+#DESC: Alternative with :+
+#EXPECT:OK
+_setvar="yes"
+_av="${_setvar:+alternate}"
+echo $_av
+unset _setvar
+unset _av
+
+# ============================================
+# ---- String slicing ----
+# ============================================
+
+#DESC: String slicing offset:length
+#EXPECT:OK
+_ss="helloworld"
+_sub="${_ss:5:5}"
+echo $_sub
+unset _ss
+unset _sub
+
+# ============================================
+# ---- time command ----
+# ============================================
+
+#DESC: Time command
+#EXPECT:OK
+time echo timed_output
+
+# ============================================
+# ---- assert statement ----
+# ============================================
+
+#DESC: Assert passing condition
+#EXPECT:OK
+assert [ 1 -eq 1 ] "should pass"
+
+#DESC: Assert failing condition
+#EXPECT:OK
+assert [ 1 -eq 2 ] "expected failure"
+
+# ============================================
+# ---- trap ERR ----
+# ============================================
+
+#DESC: Trap ERR registration
+#EXPECT:OK
+trap 'echo error_caught' ERR

--- a/tests/cli/cli_robustness_tests.milk
+++ b/tests/cli/cli_robustness_tests.milk
@@ -1497,3 +1497,23 @@ assert [ 1 -eq 2 ] "expected failure"
 #DESC: Trap ERR registration
 #EXPECT:OK
 trap 'echo error_caught' ERR
+
+# ============================================
+# ---- Processinfo CLI Integration ----
+# ============================================
+
+#DESC: PROCINFO_NCPU auto-variable
+#EXPECT:OK
+echo $PROCINFO_NCPU
+
+#DESC: PROCINFO_NPROC auto-variable
+#EXPECT:OK
+echo $PROCINFO_NPROC
+
+#DESC: procstat no processes
+#EXPECT:OK
+procstat
+
+#DESC: procctl unknown process
+#EXPECT:OK
+procctl _nonexistent_proc_ stop


### PR DESCRIPTION
## Summary

Adds three categories of CLI enhancements:

### 1. Bitwise Operators & Expression Functions
- **Bitwise operators**: `&` (AND), `|` (OR), `^^` (XOR), `~` (NOT), `<<` (left shift), `>>` (right shift) — C-standard precedence
- **String functions**: `toupper(s)`, `tolower(s)`, `substr(s, off, len)`, `replace(s, old, new)`
- **Format conversions**: `hex(n)`, `oct(n)`, `bin(n)`

### 2. Script Builtins
- `time <command>` — measure execution duration (nanosecond precision)
- `assert [ cond ] "message"` — fail-fast condition guard
- `watch -n <sec> <command>` — polling monitor with clear-screen
- `trap ERR` — error handler callback (pseudo-signal -1)

### 3. Processinfo CLI Integration
- **`@procname.field`** — extends @ variable syntax to query processinfo fields (pid, loopstat, loopcnt, loopfreq, exectime, rtprio, ctrlval, trigmode, statusmsg, tmux, description, missedframes)
- **`procctl <name> run|pause|step|stop`** — set process CTRLval in shared memory
- **`procwait <name> <state> [timeout]`** — block until process reaches target loopstat
- **`procstat [name]`** — print key=value telemetry for all or one process
- **\$PROCINFO_NCPU** — online CPU count auto-variable
- **\$PROCINFO_NPROC** — active processinfo entry count auto-variable

## Testing
**247/247** CLI robustness tests pass — 0 failures, 0 crashes, 0 hangs.

## Prompt Summary
User requested CLI syntax enhancements (bitwise ops, string functions, format conversions, scripting builtins) and processinfo integration for scriptable process telemetry and control.

## AI Authorship
- **Model**: Antigravity
- **User edits**: None