### PR TITLE
perf: fix float-double promotion in stream_ave RMS output

### DIFF
--- a/src/coremods/COREMOD_memory/stream_ave.c
+++ b/src/coremods/COREMOD_memory/stream_ave.c
@@ -181,7 +181,7 @@ static MILK_HOT errno_t fpsexec(
                  i < xysize; i++)
             {
                 imgoutrms->array.F[i] =
-                    sqrt(imdataarrayPOW[i])
+                    sqrtf(imdataarrayPOW[i])
                     / (streamave_cntindex);
             }
             processinfo_update_output_stream(


### PR DESCRIPTION
Replace `sqrt()` with `sqrtf()` in `stream_ave.c` RMS output computation. The result is stored in a float array, so double promotion is unnecessary.

Identified via static LTO build + `objdump` inspection of `cvtss2sd`/`cvtsd2ss` patterns.

### Prompt Summary
User requested optimizing runtime performance of fpsexec binaries by inspecting machine code for missed optimizations after static LTO builds.

### AI Authorship
- **Model**: Antigravity
- **User edits**: None