### PR TITLE
refactor: remove redundant s> stream modifier, consolidate to @S:

### DIFF
--- a/docs/streams.md
+++ b/docs/streams.md
@@ -78,11 +78,39 @@ module.
   to be visible externally.
 - `@F:` (File / FITS): Bypasses shared memory to directly
   read a physical file on disk.
+- `@E:` (Exists): The stream must already exist.
+  Returns an error if not found.
+- `@N:` (New): The stream must **not** exist.
+  Returns an error if it already exists.
+
+Modifiers are composable: `@LE:name` means "local
+memory, must exist".
 
 *When writing modules using `fpsexec` patterns, passing
 a non-existent or disallowed modifier automatically alerts
 the user and aborts the module spin-up to prevent silent
 failures.*
+
+### Legacy `>` Prefixes
+
+Older code may use `>` as a separator for inline
+creation hints embedded in the stream name string:
+
+| Prefix | Example | Effect |
+|--------|---------|--------|
+| `t...>` | `tf32>im1` | Set data type (float32) |
+| `k...>` | `k10>im1` | Set keyword count |
+| `c...>` | `c20>im1` | Set circular buffer size |
+
+These are parsed by `imgid_make_from_name()` and
+remain supported.
+
+> [!NOTE]
+> The `s>` prefix (shared memory) has been **removed**.
+> It was redundant with the default behavior
+> (shared memory is always the default). Use `@S:` for
+> explicit shared-memory annotation if needed.
+
 
 ## 4. Introspection
 
@@ -142,9 +170,9 @@ arguments.
     }
     ```
 
-    Special name syntax like `s>tf32>im1` can also be
-    used to automatically set type and location
-    properties.
+    Name prefixes like `tf32>im1` set the data type
+    automatically. Use `@S:` / `@L:` modifiers for
+    location control (see section 3 above).
 
 === "Format-checked"
 

--- a/src/engine/libfps/IMGID.h
+++ b/src/engine/libfps/IMGID.h
@@ -159,14 +159,22 @@ static inline void imgid_free(
 
 /** make IMGID from name
  *
- * Some settings can be embedded in the image name string for convenience :
+ * Settings can be embedded in the image name
+ * string for convenience.
  *
- * Examples:
- * "im1" no optional setting, image name = im1
- * "s>im1" : set shared memory flag
- * "k10>im1" : number of keyword = 10
- * "c20>im1" : 20-sized circular buffer
- * "tf64>im1" : datatype is double (64 bit floating point)
+ * @X: prefix modifiers (parsed first):
+ *   @S:im1  shared memory (default)
+ *   @L:im1  local memory only
+ *   @E:im1  must already exist
+ *   @N:im1  must not exist
+ *
+ * Legacy > prefixes (still supported):
+ *   "tf64>im1"  datatype double
+ *   "k10>im1"   number of keywords = 10
+ *   "c20>im1"   20-sized circular buffer
+ *
+ * The legacy "s>" prefix has been removed.
+ * Use @S: instead (or omit — shared is default).
 */
 static inline IMGID imgid_make_from_name(CONST_WORD name)
 {
@@ -217,11 +225,9 @@ static inline IMGID imgid_make_from_name(CONST_WORD name)
             pch1 = pch;
             //printf("[%2d] %s\n", nbword, pch);
 
-            if(strcmp(pch, "s") == 0)
-            {
-                printf("    shared memory\n");
-                img.mdt->shared = 1;
-            }
+            /* "s>" prefix removed — use @S:
+             * instead (shared is default).
+             */
 
             if(strcmp(pch, "tui8") == 0)
             {


### PR DESCRIPTION
## Summary

The `s>` prefix in `imgid_make_from_name()` was redundant with `@S:` (shared memory is the default). This removes the `s>` handler and updates documentation.

## Changes

- **`IMGID.h`**: removed `s>` handler (4 lines), updated doc comment to document `@X:` modifiers
- **`streams.md`**: added `@E:`, `@N:` modifier docs, composability note, legacy `>` prefix table, `s>` deprecation note, replaced `s>tf32>im1` example

The `t>`, `k>`, `c>` legacy prefixes are preserved.

## Prompt Summary

User asked whether `@S:` and `s>` are redundant and should be consolidated. Analysis confirmed they are identical (both set `mdt->shared = 1`, which is already the default). Agreed to remove `s>` and consolidate to `@S:`.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None — no direct user edits to source code.