### PR TITLE
feat: add module dependency system with MODULE_DEPS macro

### DIFF
--- a/src/cli/CLIcore/CLIcore.h
+++ b/src/cli/CLIcore/CLIcore.h
@@ -146,7 +146,26 @@ static inline errno_t TUI_exit() { return 0; }
 //  ************ lib module init **********************************
 //
 
-/** @brief Initialize module
+/**
+ * @brief Declare module dependencies.
+ *
+ * Place this macro before INIT_MODULE_LIB() in the
+ * module's main .c file.  Arguments are loadnames
+ * (matching mload convention), e.g.:
+ *
+ *     MODULE_DEPS("milkfft", "milkimage_gen")
+ *
+ * If a module has no deps, omit this macro entirely.
+ */
+#define MODULE_DEPS(...)                              \
+    static const char *_module_deps[] =               \
+        { __VA_ARGS__ };                              \
+    static const int _module_ndeps =                  \
+        (int)(sizeof(_module_deps)                    \
+              / sizeof(_module_deps[0]));             \
+    static const int _module_deps_defined = 1
+
+/** @brief Initialize module (no dependencies)
  */
 #define INIT_MODULE_LIB(modname)                                               \
     static errno_t init_module_CLI(); /* forward declaration */                \
@@ -159,6 +178,73 @@ static inline errno_t TUI_exit() { return 0; }
             strncpy(data.moduledatestring, __DATE__, STRINGMAXLEN_MODULE_DATESTRING-1);                           \
             strncpy(data.moduletimestring, __TIME__, STRINGMAXLEN_MODULE_TIMESTRING-1);                           \
             strncpy(data.modulename, (#modname), STRINGMAXLEN_MODULE_NAME);                               \
+            data.module_nbdep = 0;                                             \
+            RegisterModule(__FILE__,                                           \
+                           PROJECT_NAME,                                       \
+                           MODULE_DESCRIPTION,                                 \
+                           VERSION_MAJOR,                                      \
+                           VERSION_MINOR,                                      \
+                           VERSION_PATCH);                                     \
+            init_module_CLI();                                                 \
+            INITSTATUS_##modname = 1;                                          \
+            strncpy(data.modulename, "", STRINGMAXLEN_MODULE_NAME-1);              /* reset after use */    \
+            strncpy(data.moduleshortname_default, "", STRINGMAXLEN_MODULE_SHORTNAME-1); /* reset after use */    \
+            strncpy(data.moduleshortname, "", STRINGMAXLEN_MODULE_SHORTNAME-1);         /* reset after use */    \
+        }                                                                      \
+    }                                                                          \
+    void __attribute__((destructor)) libclose_##modname()                      \
+    {                                                                          \
+        if (INITSTATUS_##modname == 1)                                         \
+        {                                                                      \
+        }                                                                      \
+    }
+
+/**
+ * @brief Initialize module with auto-dep loading.
+ *
+ * Same as INIT_MODULE_LIB but iterates the dep
+ * list declared by MODULE_DEPS() and calls
+ * load_module_shared() for each before registration.
+ *
+ * Usage:
+ *   MODULE_DEPS("milkfft", "milkimage_gen")
+ *   INIT_MODULE_LIB_DEPS(mymodule)
+ */
+#define INIT_MODULE_LIB_DEPS(modname)                                          \
+    static errno_t init_module_CLI(); /* forward declaration */                \
+    static int     INITSTATUS_##modname = 0;                                   \
+    void __attribute__((constructor)) libinit_##modname()                      \
+    {                                                                          \
+        if (INITSTATUS_##modname == 0) /* only run once */                     \
+        {                                                                      \
+            /* --- auto-load declared deps --- */                               \
+            for (int _di = 0;                                                  \
+                 _di < _module_ndeps; _di++)                                    \
+            {                                                                  \
+                load_module_shared(                                            \
+                    _module_deps[_di]);                                         \
+            }                                                                  \
+            strncpy(data.moduleshortname_default, MODULE_SHORTNAME_DEFAULT, STRINGMAXLEN_MODULE_SHORTNAME-1);    \
+            strncpy(data.moduledatestring, __DATE__, STRINGMAXLEN_MODULE_DATESTRING-1);                           \
+            strncpy(data.moduletimestring, __TIME__, STRINGMAXLEN_MODULE_TIMESTRING-1);                           \
+            strncpy(data.modulename, (#modname), STRINGMAXLEN_MODULE_NAME);                               \
+            /* Store dep list for RegisterModule */                             \
+            {                                                                  \
+                int _ndcopy =                                                  \
+                    (_module_ndeps > MODULE_MAX_DEPS)                          \
+                    ? MODULE_MAX_DEPS                                          \
+                    : _module_ndeps;                                            \
+                data.module_nbdep = _ndcopy;                                   \
+                for (int _di = 0;                                              \
+                     _di < _ndcopy; _di++)                                     \
+                {                                                              \
+                    strncpy(                                                    \
+                        data.module_depname[_di],                              \
+                        _module_deps[_di],                                     \
+                        STRINGMAXLEN_MODULE_LOADNAME                           \
+                            - 1);                                              \
+                }                                                              \
+            }                                                                  \
             RegisterModule(__FILE__,                                           \
                            PROJECT_NAME,                                       \
                            MODULE_DESCRIPTION,                                 \
@@ -214,6 +300,9 @@ extern uid_t suid;
 #define MODULE_TYPE_STARTUP    1
 #define MODULE_TYPE_CUSTOMLOAD 2
 
+/** Maximum number of declared dependencies per module */
+#define MODULE_MAX_DEPS 16
+
 typedef struct
 {
     int type;
@@ -238,6 +327,12 @@ typedef struct
     char timestring[STRINGMAXLEN_MODULE_TIMESTRING]; // Compilation time
 
     void *DLib_handle;
+
+    /** Number of declared dependencies */
+    int nbdep;
+    /** Dependency load names (mload convention) */
+    char depname[MODULE_MAX_DEPS]
+                [STRINGMAXLEN_MODULE_LOADNAME];
 
 } MODULE;
 
@@ -409,6 +504,12 @@ typedef struct
         STRINGMAXLEN_MODULE_DATESTRING];
     char moduletimestring[
         STRINGMAXLEN_MODULE_TIMESTRING];
+
+    /** Transient dep count for module being registered */
+    int module_nbdep;
+    /** Transient dep names for module being registered */
+    char module_depname[MODULE_MAX_DEPS]
+                       [STRINGMAXLEN_MODULE_LOADNAME];
 
     // COMMAND ALIASES
     // =================================================

--- a/src/cli/CLIcore/CLIcore/CLIcore_modules.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_modules.c
@@ -488,6 +488,19 @@ errno_t RegisterModule(
             "",
             STRINGMAXLEN_MODULE_LOADNAME - 1);
 
+    // Copy dependency info from transient DATA fields
+    data.module[data.moduleindex].nbdep =
+        data.module_nbdep;
+    for(int di = 0; di < data.module_nbdep; di++)
+    {
+        strncpy(
+            data.module[data.moduleindex].depname[di],
+            data.module_depname[di],
+            STRINGMAXLEN_MODULE_LOADNAME - 1);
+    }
+    // Reset transient dep storage
+    data.module_nbdep = 0;
+
     DEBUG_TRACE_FEXIT();
     return RETURN_SUCCESS;
 }

--- a/src/cli/CLIcore/CLIcore_standalone.h
+++ b/src/cli/CLIcore/CLIcore_standalone.h
@@ -189,7 +189,29 @@ static inline errno_t TUI_exit(void) { return 0; }
  * Module init — no-op in standalone
  * ===================================== */
 
+/* MODULE_DEPS — standalone stub.
+ * Defines the arrays (they exist but are
+ * never iterated since INIT_MODULE_LIB is
+ * a no-op in standalone builds).
+ */
+#define MODULE_DEPS(...)                              \
+    static const char *_module_deps[]                 \
+        __attribute__((unused)) = { __VA_ARGS__ };    \
+    static const int _module_ndeps                    \
+        __attribute__((unused)) =                     \
+        (int)(sizeof(_module_deps)                    \
+              / sizeof(_module_deps[0]));             \
+    static const int _module_deps_defined             \
+        __attribute__((unused)) = 1
+
 #define INIT_MODULE_LIB(modname)            \
+    static errno_t init_module_CLI(void);   \
+    static int INITSTATUS_##modname = 0;
+
+/* INIT_MODULE_LIB_DEPS — same as INIT_MODULE_LIB
+ * in standalone builds (no dep loading).
+ */
+#define INIT_MODULE_LIB_DEPS(modname)       \
     static errno_t init_module_CLI(void);   \
     static int INITSTATUS_##modname = 0;
 
@@ -221,6 +243,9 @@ typedef uint_fast8_t BOOL;
 #define MODULE_TYPE_STARTUP    1
 #define MODULE_TYPE_CUSTOMLOAD 2
 
+/** Maximum number of declared dependencies per module */
+#define MODULE_MAX_DEPS 16
+
 typedef struct
 {
     int  type;
@@ -240,6 +265,12 @@ typedef struct
     char timestring[
         STRINGMAXLEN_MODULE_TIMESTRING];
     void *DLib_handle;
+
+    /** Number of declared dependencies */
+    int nbdep;
+    /** Dependency load names (mload convention) */
+    char depname[MODULE_MAX_DEPS]
+                [STRINGMAXLEN_MODULE_LOADNAME];
 } MODULE;
 
 
@@ -351,6 +382,12 @@ typedef struct
         STRINGMAXLEN_MODULE_DATESTRING];
     char moduletimestring[
         STRINGMAXLEN_MODULE_TIMESTRING];
+
+    /** Transient dep count for module being registered */
+    int module_nbdep;
+    /** Transient dep names for module being registered */
+    char module_depname[MODULE_MAX_DEPS]
+                       [STRINGMAXLEN_MODULE_LOADNAME];
 } DATA;
 
 

--- a/src/milk_module_example/milk_module_example.c
+++ b/src/milk_module_example/milk_module_example.c
@@ -60,6 +60,14 @@
 #define MODULE_DESCRIPTION "Example module: template for creating new modules"
 
 
+// Declare module dependencies (loaded automatically before this module).
+// Use library names matching mload convention, e.g.:
+//   MODULE_DEPS("milkfft", "milkimage_gen")
+//   INIT_MODULE_LIB_DEPS(mymodulename)
+// If no dependencies, omit MODULE_DEPS and use INIT_MODULE_LIB instead.
+// MODULE_DEPS()
+
+
 #include "CLIcore.h"
 
 //


### PR DESCRIPTION
## Summary

Adds a declarative module dependency system. Modules can declare dependencies via `MODULE_DEPS("milkfft", "milkimage_gen")` and use `INIT_MODULE_LIB_DEPS(modname)` to auto-load them before registration. Modules without deps continue using `INIT_MODULE_LIB()` unchanged.

### Changes

- **`MODULE_DEPS(...)` macro** — declares dependency loadnames as static arrays
- **`INIT_MODULE_LIB_DEPS()` macro** — iterates deps, calls `load_module_shared()` for each, stores dep metadata before `RegisterModule()`
- **`MODULE` struct** — extended with `nbdep` / `depname[MODULE_MAX_DEPS]` fields
- **`RegisterModule()`** — copies dep metadata into the module slot
- **`CLIcore_standalone.h`** — synced with matching stubs
- **`milk_module_example.c`** — added commented-out usage template

### Verification

- Build: 100% compiled, zero errors
- Tests: 37/37 passed, 0 failures

## Prompt Summary

User requested automatic dependency loading when modules are loaded in the CLI.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None