### PR TITLE
docs: add What's New page and whatsnew-update agent rule

### DIFF
--- a/.agents/rules/whatsnew-update.md
+++ b/.agents/rules/whatsnew-update.md
@@ -1,0 +1,52 @@
+---
+description: Update What's New page when significant
+  features are added.
+---
+
+# What's New Page Updates
+
+When a PR introduces a **significant** feature,
+you MUST add an entry to `docs/whatsnew.md`.
+
+## What Qualifies
+
+Include:
+
+- New user-facing features or commands
+- Major refactors that change APIs or behavior
+- Performance improvements with measurable impact
+- New build modes or infrastructure
+- New standalone executables
+
+Exclude:
+
+- Minor bugfixes and typo corrections
+- CI-only changes
+- Internal code cleanup with no API impact
+- Documentation-only PRs (unless a new doc
+  page is added)
+
+## Entry Format
+
+Prepend a one-line entry to the current month
+under the correct branch heading (`framework-dev`
+or `dev`). Create a new `### YYYY-MM` sub-heading
+if the month doesn't exist yet.
+
+```markdown
+- **YYYY-MM-DD** — Short description `#tag1`
+  `#tag2`
+  ([PR #NNN](https://github.com/milk-org/milk/pull/NNN))
+```
+
+### Rules
+
+1. Keep the description to **one line** (≤ 80 chars
+   before the tag+link continuation line).
+2. Use one or more tags from: `#cli`,
+   `#performance`, `#streams`, `#fps`, `#build`,
+   `#docs`, `#api`, `#refactor`.
+3. Link to the PR. If no PR exists yet, link to the
+   commit SHA instead.
+4. Newest entries go **first** within their month.
+5. Date is the merge date (or commit date if no PR).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,7 @@ and enforced. Know what they require:
 | `readme-update.md` | Update module README when files change |
 | `run-milk-commands.md` | Environment setup, SHM cleanup, tmux guidance |
 | `script-docs.md` | Update `docs/scripts.md` when scripts change |
+| `whatsnew-update.md` | Add entry to `docs/whatsnew.md` for significant features |
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -178,6 +178,8 @@ pillars — **ImageStreamIO**, **FPS**, and
 
 ## :link: More Resources
 
+- **[What's New](whatsnew.md)** — recent features
+  and upgrades
 - [CLI Syntax Reference](cli/CLIcore.md) ·
   [Readline Keys](cli/helpreadline.md)
 - [Scripts Reference](scripts.md) ·

--- a/docs/whatsnew.md
+++ b/docs/whatsnew.md
@@ -1,0 +1,147 @@
+---
+tags: [changelog, releases]
+---
+
+# What's New
+
+Significant features and upgrades, newest first.
+Minor bugfixes are omitted — see the
+[commit log](https://github.com/milk-org/milk/commits/framework-dev)
+for the full history.
+
+**Filter by tag** — use your browser's find
+(Ctrl+F) with any `#tag` below:
+`#cli` `#performance` `#streams` `#fps`
+`#build` `#docs` `#api` `#refactor`
+
+---
+
+## framework-dev
+
+### 2026-03
+
+- **2026-03-25** — Module dependency system with
+  `MODULE_DEPS` macro `#api` `#build`
+  ([PR #169](https://github.com/milk-org/milk/pull/169))
+- **2026-03-24** — Remove legacy `s>` stream modifier;
+  consolidate to `@S:` syntax `#streams` `#refactor`
+  ([PR #168](https://github.com/milk-org/milk/pull/168))
+- **2026-03-24** — Split CLIcore monolithic sources into
+  smaller modules `#cli` `#refactor`
+  ([PR #165](https://github.com/milk-org/milk/pull/165))
+- **2026-03-24** — CLI bitwise ops, string functions,
+  processinfo integration `#cli`
+  ([PR #164](https://github.com/milk-org/milk/pull/164))
+- **2026-03-24** — Compound assignments, ternary operator,
+  numeric literals, `until` loops `#cli`
+  ([PR #163](https://github.com/milk-org/milk/pull/163))
+- **2026-03-24** — Dual prompt/command history with
+  type-tagged log `#cli`
+  ([PR #161](https://github.com/milk-org/milk/pull/161))
+- **2026-03-23** — FITSIO-like stream slicing syntax
+  (`im[0:19,10:29]`) `#streams` `#cli`
+  ([PR #157](https://github.com/milk-org/milk/pull/157))
+- **2026-03-23** — CLI pipe operator `|>`, `on_fpschange`,
+  `listim` glob, error context `#cli`
+  ([PR #153](https://github.com/milk-org/milk/pull/153))
+- **2026-03-23** — Notify user of adopted default
+  arguments `#cli`
+  ([PR #152](https://github.com/milk-org/milk/pull/152))
+- **2026-03-23** — Advanced CLI introspection, regex
+  `=~`, array splats, dynamic PS1 `#cli`
+  ([PR #151](https://github.com/milk-org/milk/pull/151))
+- **2026-03-22** — Native shell expansions and arithmetic
+  evaluation in CLI scripts `#cli`
+  ([PR #150](https://github.com/milk-org/milk/pull/150))
+- **2026-03-22** — Advanced script template and argparse
+  improvements `#cli`
+  ([PR #147](https://github.com/milk-org/milk/pull/147))
+
+### 2026-02
+
+- **2026-02** — Remove function-pointer overhead from
+  pixel loops `#performance`
+  ([PR #146](https://github.com/milk-org/milk/pull/146))
+- **2026-02** — Dynamic FIFO handling for CLI `#cli`
+  ([PR #144](https://github.com/milk-org/milk/pull/144))
+- **2026-02** — Typed CLI variables & subprocess shell
+  pipe parsing `#cli`
+  ([PR #141](https://github.com/milk-org/milk/pull/141))
+- **2026-02** — Add `-c` (command) flag to milk-cli
+  `#cli`
+  ([PR #139](https://github.com/milk-org/milk/pull/139))
+- **2026-02** — Bi-directional environment variable sync
+  and subshell assignments `#cli`
+  ([PR #138](https://github.com/milk-org/milk/pull/138))
+- **2026-02** — Machine-readable JSON and TSV output for
+  CLI `#cli` `#api`
+  ([PR #136](https://github.com/milk-org/milk/pull/136))
+- **2026-02** — CLI `wordexp()` simplification and smart
+  fallback `#cli`
+  ([PR #130](https://github.com/milk-org/milk/pull/130))
+- **2026-02** — Pipe to shell commands (grep, sort, wc)
+  `#cli`
+  ([PR #126](https://github.com/milk-org/milk/pull/126))
+- **2026-02** — `ghistory` / `lhistory` with time range,
+  glob, session highlight `#cli`
+  ([PR #124](https://github.com/milk-org/milk/pull/124))
+- **2026-02** — Break help into topics; `help-<topic>`
+  commands `#cli`
+  ([PR #121](https://github.com/milk-org/milk/pull/121))
+- **2026-02** — CLI scripting variables, aliases,
+  bookmarks, and history `#cli`
+  ([PR #116](https://github.com/milk-org/milk/pull/116))
+- **2026-02** — Session-aware history commands `#cli`
+  ([PR #111](https://github.com/milk-org/milk/pull/111))
+- **2026-02** — Advanced scripting: env vars, conditional
+  chaining, history, continuation `#cli`
+  ([PR #107](https://github.com/milk-org/milk/pull/107),
+  [PR #109](https://github.com/milk-org/milk/pull/109))
+
+### 2026-01
+
+- **2026-01** — Standalone `fpsexec` executables for
+  image_gen (mkpolygon, mkdisk, mkspdisk) `#fps` `#build`
+  ([PR #103](https://github.com/milk-org/milk/pull/103),
+  [PR #104](https://github.com/milk-org/milk/pull/104))
+- **2026-01** — Fully static musl fpsexec build support
+  `#build` `#performance`
+  ([PR #99](https://github.com/milk-org/milk/pull/99))
+- **2026-01** — `USE_STATIC_LTO` cross-module LTO for
+  fpsexec standalones `#build` `#performance`
+  ([PR #55](https://github.com/milk-org/milk/pull/55))
+- **2026-01** — Context-aware tab completion for streams
+  and FPS `#cli`
+  ([PR #92](https://github.com/milk-org/milk/pull/92))
+- **2026-01** — Runtime perf sweeps 1–10: SIMD alignment,
+  restrict, omp simd, BLAS MVM, powf specialization,
+  `__builtin_memcpy`, UINT16 fast-path `#performance`
+  ([PR #53](https://github.com/milk-org/milk/pull/53),
+  [PR #91](https://github.com/milk-org/milk/pull/91))
+- **2026-01** — PGO per-executable profile isolation
+  `#build` `#performance`
+- **2026-01** — GCC optimization infrastructure
+  (`milk_compiler.h`) + codebase-wide annotations
+  `#performance` `#api`
+- **2026-01** — Reduce transitive includes in
+  `CLIcore.h` and `fps.h` `#build` `#refactor`
+  ([PR #54](https://github.com/milk-org/milk/pull/54))
+- **2026-01** — MkDocs Material documentation site
+  `#docs`
+  ([PR #57](https://github.com/milk-org/milk/pull/57))
+- **2026-01** — Codebase-wide IMGID API migration
+  (streams, FFT, linalgebra, image_basic, …)
+  `#api` `#refactor`
+- **2026-01** — Gen 4 V2 CLI registration for all modules
+  `#cli` `#refactor`
+- **2026-01** — FPS parameter tab-completion + argument
+  hints `#cli` `#fps`
+  ([PR #71](https://github.com/milk-org/milk/pull/71))
+
+---
+
+## dev
+
+*No recent significant changes. Entries will be
+added here when `framework-dev` features are merged
+into `dev`.*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ docs_dir: docs
 
 nav:
   - Home: index.md
+  - "What's New": whatsnew.md
   - Tags Index: tags.md
   - Getting Started:
     - Installation: install/compile.md


### PR DESCRIPTION
## Summary

Add a changelog-style "What's New" documentation page and an agent rule to keep it current.

### Changes

- **`docs/whatsnew.md`** — New page with seeded entries from recent `framework-dev` PRs (#55–#170), grouped by month under branch headings, with inline filterable tags (`#cli`, `#performance`, `#streams`, `#fps`, `#build`, `#docs`, `#api`, `#refactor`).
- **`.agents/rules/whatsnew-update.md`** — Agent rule triggered on significant PRs; instructs agents to prepend a one-line entry with date, description, tags, and PR link.
- **`mkdocs.yml`** — Added nav entry under Home.
- **`docs/index.md`** — Added link in More Resources section.
- **`AGENTS.md`** — Added rule to section 6 table.

### Prompt Summary

User requested a "What's New?" page listing significant features with dates, PR/commit links, and tags for filtering. Also requested a rule/skill to ensure automatic updates by agents. Minor bugfixes are excluded by policy.

### AI Authorship

- **Model**: Antigravity
- **User edits**: None