### PR TITLE
docs: improve visual style with teal palette, hero banner, and SVG logo

### DIFF
--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240" width="240" height="240">
+  <defs>
+    <linearGradient id="teal" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00bfa5"/>
+      <stop offset="100%" stop-color="#0097a7"/>
+    </linearGradient>
+    <linearGradient id="beam" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#4dd0e1" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#00bfa5" stop-opacity="0.3"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Outer ring — deformable mirror -->
+  <circle cx="120" cy="120" r="105" fill="none"
+          stroke="url(#teal)" stroke-width="6"
+          opacity="0.85"/>
+
+  <!-- Inner ring — pupil aperture -->
+  <circle cx="120" cy="120" r="72" fill="none"
+          stroke="url(#teal)" stroke-width="4"
+          opacity="0.6"/>
+
+  <!-- Wavefront correction segments (6 petals) -->
+  <g opacity="0.5" fill="url(#teal)">
+    <path d="M120 48 Q140 84 120 120 Q100 84 120 48Z"/>
+    <path d="M120 192 Q100 156 120 120 Q140 156 120 192Z"/>
+    <path d="M48 120 Q84 100 120 120 Q84 140 48 120Z"/>
+    <path d="M192 120 Q156 140 120 120 Q156 100 192 120Z"/>
+    <path d="M62 62 Q96 80 120 120 Q80 96 62 62Z"/>
+    <path d="M178 178 Q144 160 120 120 Q160 144 178 178Z"/>
+  </g>
+
+  <!-- Central point — on-axis star -->
+  <circle cx="120" cy="120" r="10" fill="url(#beam)"/>
+  <circle cx="120" cy="120" r="4" fill="#e0f7fa"/>
+
+  <!-- Diffraction spikes -->
+  <g stroke="#4dd0e1" stroke-width="1.5" opacity="0.45">
+    <line x1="120" y1="30" x2="120" y2="210"/>
+    <line x1="30" y1="120" x2="210" y2="120"/>
+  </g>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,27 @@
-# milk Documentation
+<div class="md-hero" markdown>
 
-Welcome to the `milk` documentation — a high-performance
-real-time image processing framework for Adaptive Optics
-and scientific computing.
+# :telescope: milk
+
+<p class="md-hero__tagline">
+High-performance real-time image processing framework
+for Adaptive Optics and scientific computing.
+Microsecond-latency pipelines through zero-copy
+shared memory.
+</p>
+
+<p class="md-hero__badges">
+<a href="https://github.com/milk-org/milk">
+<img alt="GitHub stars" src="https://img.shields.io/github/stars/milk-org/milk?style=flat-square&color=00bfa5">
+</a>
+<a href="https://github.com/milk-org/milk/blob/framework-dev/LICENSE">
+<img alt="License" src="https://img.shields.io/github/license/milk-org/milk?style=flat-square&color=0097a7">
+</a>
+<a href="https://github.com/milk-org/milk/actions">
+<img alt="Build" src="https://img.shields.io/github/actions/workflow/status/milk-org/milk/docs.yml?style=flat-square&label=docs&color=26a69a">
+</a>
+</p>
+
+</div>
 
 `milk` orchestrates many small compute units that
 communicate through zero-copy shared memory tensors,

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block announce %}
+  <a href="{{ 'whatsnew/' | url }}">
+    <span class="twemoji">{% include ".icons/material/star-four-points.svg" %}</span>
+    <strong>What's New</strong> — see recent features and upgrades
+  </a>
+{% endblock %}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,17 +1,125 @@
-/* Extra styles for milk documentation — vLLM-inspired */
+/* ===== milk documentation — custom theme ===== */
 
-/* Tighten the header shadow for a cleaner look */
-.md-header {
-  box-shadow: 0 0 0.2rem rgba(0, 0, 0, 0.1),
-              0 0.2rem 0.4rem rgba(0, 0, 0, 0.2);
+/* ---------- Smooth scroll ---------- */
+html {
+  scroll-behavior: smooth;
 }
 
-/* Slightly wider content area for readability */
+/* ---------- Layout ---------- */
 .md-grid {
   max-width: 1440px;
 }
 
-/* Details/summary blocks — match admonition styling */
+/* ---------- Header ---------- */
+.md-header {
+  box-shadow:
+    0 0 0.2rem rgba(0, 0, 0, 0.1),
+    0 0.2rem 0.4rem rgba(0, 0, 0, 0.2);
+}
+
+/* ---------- Navigation tabs ---------- */
+.md-tabs__link--active {
+  font-weight: 700;
+}
+
+/* ---------- Hero banner (home page) ---------- */
+.md-hero {
+  padding: 2.4rem 1.2rem 1.6rem;
+  background: linear-gradient(
+    135deg,
+    rgba(0, 191, 165, 0.12) 0%,
+    rgba(0, 151, 167, 0.08) 100%
+  );
+  border-radius: 0.6rem;
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+[data-md-color-scheme="slate"] .md-hero {
+  background: linear-gradient(
+    135deg,
+    rgba(0, 191, 165, 0.18) 0%,
+    rgba(0, 151, 167, 0.10) 100%
+  );
+}
+
+.md-hero h1 {
+  font-size: 2.2rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.4rem;
+}
+
+.md-hero .md-hero__tagline {
+  font-size: 1.1rem;
+  opacity: 0.8;
+  max-width: 42em;
+  margin: 0 auto;
+}
+
+.md-hero .md-hero__badges {
+  margin-top: 0.8rem;
+}
+
+.md-hero .md-hero__badges img {
+  margin: 0 0.2rem;
+  vertical-align: middle;
+}
+
+/* ---------- Card grid hover ---------- */
+.md-typeset .grid.cards > ul > li {
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.md-typeset .grid.cards > ul > li:hover {
+  transform: translateY(-3px);
+  box-shadow:
+    0 0.3rem 0.8rem rgba(0, 0, 0, 0.12),
+    0 0.1rem 0.3rem rgba(0, 0, 0, 0.08);
+}
+
+[data-md-color-scheme="slate"]
+  .md-typeset .grid.cards > ul > li:hover {
+  box-shadow:
+    0 0.3rem 0.8rem rgba(0, 0, 0, 0.35),
+    0 0.1rem 0.3rem rgba(0, 0, 0, 0.2);
+}
+
+/* ---------- Section dividers ---------- */
+.md-typeset hr {
+  border: none;
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(0, 191, 165, 0.35),
+    transparent
+  );
+}
+
+/* ---------- Code blocks ---------- */
+.highlight pre {
+  border-radius: 0.3rem;
+  border-left: 3px solid rgba(0, 191, 165, 0.45);
+}
+
+[data-md-color-scheme="slate"] .highlight pre {
+  border-left-color: rgba(0, 191, 165, 0.35);
+}
+
+/* ---------- Tables — zebra striping ---------- */
+.md-typeset table:not([class]) tbody tr:nth-child(even) {
+  background-color: rgba(0, 191, 165, 0.04);
+}
+
+[data-md-color-scheme="slate"]
+  .md-typeset table:not([class]) tbody tr:nth-child(even) {
+  background-color: rgba(0, 191, 165, 0.06);
+}
+
+/* ---------- Details / summary ---------- */
 details {
   margin-bottom: 1em;
 }
@@ -21,12 +129,31 @@ details summary {
   padding: 0.4em 0;
 }
 
-/* Code blocks — softer background */
-.highlight pre {
-  border-radius: 0.3rem;
+/* ---------- Announce banner ---------- */
+.md-banner {
+  font-size: 0.78rem;
 }
 
-/* Navigation tabs — bolder active state */
-.md-tabs__link--active {
-  font-weight: 700;
+/* ---------- Mermaid diagram theming ---------- */
+.mermaid svg {
+  max-width: 100%;
+}
+
+/* Teal node fills in light mode */
+.mermaid .node rect,
+.mermaid .node circle,
+.mermaid .node polygon {
+  stroke: #0097a7 !important;
+}
+
+[data-md-color-scheme="slate"] .mermaid .node rect,
+[data-md-color-scheme="slate"] .mermaid .node circle,
+[data-md-color-scheme="slate"]
+  .mermaid .node polygon {
+  stroke: #4dd0e1 !important;
+}
+
+/* ---------- Footer — softer divider ---------- */
+.md-footer {
+  border-top: 2px solid rgba(0, 191, 165, 0.15);
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,19 +9,22 @@ edit_uri: edit/framework-dev/docs/
 
 theme:
   name: material
+  custom_dir: docs/overrides
+  logo: assets/logo.svg
+  favicon: assets/logo.svg
   font:
-    text: Roboto
-    code: Roboto Mono
+    text: Inter
+    code: JetBrains Mono
   palette:
     - scheme: default
-      primary: indigo
-      accent: indigo
+      primary: teal
+      accent: cyan
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     - scheme: slate
-      primary: indigo
-      accent: indigo
+      primary: teal
+      accent: cyan
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
@@ -138,6 +141,9 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.mark
+  - pymdownx.tasklist:
+      custom_checkbox: true
   - toc:
       permalink: true
       toc_depth: 3


### PR DESCRIPTION
## Summary

Overhauls the MkDocs documentation site visuals to make a stronger first impression, without changing any content.

### Changes

- **Palette**: indigo → teal/cyan (science/optics vibe)
- **Fonts**: Roboto → Inter (text), Roboto Mono → JetBrains Mono (code)
- **SVG logo**: stylized AO lens motif for header + favicon
- **Hero banner**: gradient background with tagline and GitHub badges (stars, license, build)
- **Announce bar**: "What's New" link at the top of every page
- **CSS enhancements**: card hover lift, gradient `<hr>` dividers, code block teal accents, table zebra-striping, smooth scroll — all adapting to light/dark mode
- **Extensions**: `pymdownx.mark` (==highlight==) and `pymdownx.tasklist` (checkboxes)

### Files changed (5)

| File | Change |
|------|--------|
| `mkdocs.yml` | Palette, fonts, logo/favicon, extensions |
| `docs/stylesheets/extra.css` | Full CSS rewrite (~150 lines) |
| `docs/index.md` | Hero section with badges |
| `docs/assets/logo.svg` | New SVG logo |
| `docs/overrides/main.html` | Announce bar template |

### Prompt Summary

User asked for documentation style improvements and visuals. Agent proposed teal palette, SVG logo, hero banner, card effects, and CSS polish — user approved and requested PR submission.

### AI Authorship

- **Model**: Antigravity
- **User edits**: None