### PR TITLE
feat(seq): extract fps sequencer to standalone libfpsseq and milk-seq daemon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,6 +480,7 @@ endif()
 
 # add libfps (standalone fps library exploration)
 add_subdirectory(src/engine/libfps)
+add_subdirectory(src/engine/libfpsseq)
 
 # add libmilkdata (core data layer, no CLI dependency)
 add_subdirectory(src/engine/libmilkdata)

--- a/src/engine/libfpsseq/CMakeLists.txt
+++ b/src/engine/libfpsseq/CMakeLists.txt
@@ -1,0 +1,26 @@
+set(FPSSEQ_SOURCES
+    fpsseq_shm.c
+    fpsseq_scheduler.c
+    fpsseq_fifo.c
+    fpsseq_cmdexec.c
+)
+
+add_library(milkfpsseq SHARED ${FPSSEQ_SOURCES})
+target_include_directories(milkfpsseq PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include/libfpsseq>
+)
+target_link_libraries(milkfpsseq PUBLIC
+    milkfps milkprocessinfo ImageStreamIO rt)
+install(TARGETS milkfpsseq
+    EXPORT milkTargets DESTINATION lib)
+install(FILES fpsseq.h fpsseq_types.h
+    DESTINATION include/libfpsseq)
+
+# milk-seq standalone executable
+add_executable(milk-seq milk-seq.c)
+target_link_libraries(milk-seq PUBLIC
+    milkfpsseq milkfps milkfpsStandalone
+    milkdata milkprocessinfo ImageStreamIO
+    pthread m rt)
+install(TARGETS milk-seq DESTINATION bin)

--- a/src/engine/libfpsseq/fpsseq.h
+++ b/src/engine/libfpsseq/fpsseq.h
@@ -1,0 +1,130 @@
+/**
+ * @file fpsseq.h
+ * @brief Public API for the milk-seq FPS Sequencer library
+ *
+ * Provides functions for shared memory lifecycle, task scheduling,
+ * FIFO command reading, and script execution.
+ */
+
+#ifndef FPSSEQ_H
+#define FPSSEQ_H
+
+#include "fpsseq_types.h"
+#include "fps_types.h"
+
+
+
+/* =========================================================================
+ * SHM Lifecycle (fpsseq_shm.c)
+ * ========================================================================= */
+
+/**
+ * @brief Create a new sequencer instance in shared memory
+ * @param name Sequencer name
+ * @return Pointer to mapped state, or NULL on error
+ */
+MILKSEQ_STATE *milkseq_create(const char *name);
+
+/**
+ * @brief Connect to an existing sequencer instance
+ * @param name Sequencer name
+ * @return Pointer to mapped state (read/write access), or NULL if not found
+ */
+MILKSEQ_STATE *milkseq_connect(const char *name);
+
+/**
+ * @brief Disconnect from a sequencer instance
+ * @param state Mapped pointer to unmap
+ * @return 0 on success
+ */
+int milkseq_disconnect(MILKSEQ_STATE *state);
+
+/**
+ * @brief Destroy a sequencer instance (unlink SHM and FIFO)
+ * @param name Sequencer name
+ * @return 0 on success
+ */
+int milkseq_destroy(const char *name);
+
+/**
+ * @brief List all active sequencer instances in the system
+ * @param names Array of buffers to hold names
+ * @param maxcount Maximum number of names to return
+ * @return Number of sequencers found
+ */
+int milkseq_list(char names[][FPSSEQ_NAME_MAX], int maxcount);
+
+
+/* =========================================================================
+ * Scheduler (fpsseq_scheduler.c)
+ * ========================================================================= */
+
+/**
+ * @brief Run one iteration of the sequencer task scheduler
+ *
+ * @param state Sequencer state mapped from SHM
+ * @param fps Array of all FPS entries
+ * @param keywnode Keyword tree root
+ * @param vars TUI-level variables (for backwards compat logging)
+ * @return Task index executed, or -1 if idle/no task
+ */
+int milkseq_scheduler_step(
+    MILKSEQ_STATE *state,
+    FUNCTION_PARAMETER_STRUCT *fps,
+    KEYWORD_TREE_NODE *keywnode,
+    FPSCTRL_PROCESS_VARS *vars);
+
+
+/* =========================================================================
+ * FIFO Input (fpsseq_fifo.c)
+ * ========================================================================= */
+
+/**
+ * @brief Read and enqueue commands from the named FIFO
+ *
+ * Continues reading until EAGAIN (non-blocking).
+ * @param state Sequence state mapped from SHM
+ * @param fifo_fd File descriptor of the opened FIFO (O_NONBLOCK)
+ * @return Number of commands read
+ */
+int milkseq_fifo_read(MILKSEQ_STATE *state, int fifo_fd);
+
+
+/* =========================================================================
+ * Command Execution (fpsseq_cmdexec.c)
+ * ========================================================================= */
+
+/**
+ * @brief Parse and execute one sequencer command string
+ *
+ * @param cmdline Command string to parse
+ * @param state Sequencer state (for task list injection)
+ * @param fps Array of all FPS entries
+ * @param keywnode Keyword tree root
+ * @param vars TUI-level variables
+ * @param taskstatus Output status flag of the executed task
+ * @return Return code
+ */
+int milkseq_exec_cmd(
+    const char *cmdline,
+    MILKSEQ_STATE *state,
+    FUNCTION_PARAMETER_STRUCT *fps,
+    KEYWORD_TREE_NODE *keywnode,
+    FPSCTRL_PROCESS_VARS *vars,
+    uint64_t *taskstatus);
+
+
+/* =========================================================================
+ * Script Loading (fpsseq_script.c - Phase 2)
+ * ========================================================================= */
+
+/**
+ * @brief Load and compile a .seq script into the task array
+ *
+ * @param state Sequencer state
+ * @param filename Path to script file
+ * @return 0 on success
+ */
+int milkseq_load_script(MILKSEQ_STATE *state, const char *filename);
+
+#endif // FPSSEQ_H

--- a/src/engine/libfpsseq/fpsseq_cmdexec.c
+++ b/src/engine/libfpsseq/fpsseq_cmdexec.c
@@ -1,0 +1,1342 @@
+/**
+ * @file    fps_processcmdline.c
+ * @brief   FPS process command line
+ */
+
+#include <stdlib.h>
+
+#include "fpsseq.h"
+#include "fps_globals.h"
+
+#include "fps_scan.h"
+
+#include "fps_CONFstart.h"
+#include "fps_CONFstop.h"
+
+#include "fps_RUNstart.h"
+#include "fps_RUNstop.h"
+
+#include "fps_tmux.h"
+
+#include "fps_FPSremove.h"
+
+#include "fps_outlog.h"
+#include "fps_paramvalue.h"
+#include "fps_save2disk.h"
+
+#include "fps_WriteParameterToDisk.h"
+#include "fps_printparameter_valuestring.h"
+
+
+/** @brief process command line
+ *
+ * ## Purpose
+ *
+ * Process command line.
+ *
+ * ## Commands
+ *
+ * - logsymlink  : create log sym link
+ * - fpswfile    : write fps file to disk (writes to datadir)
+ * - setval      : set parameter value
+ * - getval      : get value, write to output log
+ * - fwrval      : get value, write to file or fifo
+ * - exec        : execute scripte (parameter must be FPTYPE_EXECFILENAME type)
+ * - tmuxstart   : start tmux session
+ * - tmuxstop    : stop tmux session
+ * - confstart   : start RUN process associated with parameter
+ * - confstop    : start RUN process associated with parameter
+ * - confupdate  : update configuration
+ * - confwupdate : update configuration, wait for completion to proceed
+ * - runstart    : start RUN process associated with parameter
+ * - runstop     : stop RUN process associated with parameter
+ * - fpsrm       : remove fps
+ * - cntinc      : counter test to check fifo connection
+ * - rescan      : rescan fps tree
+ * - exit        : exit fpsCTRL tool
+ *
+ * - queueprio   : change queue priority
+ *
+ *
+ */
+
+int milkseq_exec_cmd(
+    const char               *FPScmdline,
+    MILKSEQ_STATE            *state,
+    FUNCTION_PARAMETER_STRUCT *fps,
+    KEYWORD_TREE_NODE        *keywnode,
+    FPSCTRL_PROCESS_VARS     *fpsCTRLvar,
+    uint64_t                 *taskstatus
+)
+{
+    int  fpsindex;
+    long pindex;
+
+    // break FPScmdline in words
+    // [FPScommand] [FPSentryname]
+    //
+    char *pch;
+    int   nbword = 0;
+    int commandstringmaxlen = 200;
+    char  FPScommand[commandstringmaxlen];
+
+    int cmdOK    = 2; // 0 : failed, 1: OK
+    int cmdFOUND = 0; // toggles to 1 when command has been found
+
+    // first arg is always an FPS entry name
+    char FPSentryname[FUNCTION_PARAMETER_KEYWORD_STRMAXLEN *
+                                                           FUNCTION_PARAMETER_KEYWORD_MAXLEVEL];
+    char FPScmdarg1[FUNCTION_PARAMETER_STRMAXLEN];
+
+    char FPSarg0[FUNCTION_PARAMETER_KEYWORD_STRMAXLEN *
+                                                      FUNCTION_PARAMETER_KEYWORD_MAXLEVEL];
+    char FPSarg1[FUNCTION_PARAMETER_STRMAXLEN];
+    char FPSarg2[FUNCTION_PARAMETER_STRMAXLEN];
+    char FPSarg3[FUNCTION_PARAMETER_STRMAXLEN];
+
+    char msgstring[STRINGMAXLEN_FPS_LOGMSG];
+    char errmsgstring[STRINGMAXLEN_FPS_LOGMSG];
+    char inputcmd[STRINGMAXLEN_FPS_CMDLINE];
+
+    int inputcmdOK = 0; // 1 if command should be processed
+
+    static int testcnt; // test counter to be incremented by cntinc command
+
+    if(strlen(FPScmdline) > 0)  // only send command if non-empty
+    {
+        SNPRINTF_CHECK(inputcmd, STRINGMAXLEN_FPS_CMDLINE, "%s", FPScmdline);
+        inputcmdOK = 1;
+    }
+
+    // don't process lines starting with # (comment)
+    if(inputcmdOK == 1)
+    {
+        if(inputcmd[0] == '#')
+        {
+            inputcmdOK = 0;
+        }
+    }
+
+    if(inputcmdOK == 0)
+    {
+        return (-1);
+    }
+
+    functionparameter_outlog("DEBUG", "CMDRCV [%s]", inputcmd);
+    *taskstatus |= FPSTASK_STATUS_RECEIVED;
+
+    DEBUG_TRACEPOINT(" ");
+
+    if(strlen(inputcmd) > 1)
+    {
+        pch = strtok(inputcmd, " \t");
+        snprintf(FPScommand, commandstringmaxlen, "%s", pch);
+    }
+    else
+    {
+        pch = NULL;
+    }
+
+    DEBUG_TRACEPOINT(" ");
+
+    // Break command line into words
+    //
+    // output words are:
+    //
+    // FPScommand
+    // FPSarg0
+    // FPSarg1
+    // FPSarg2
+    // FPSarg3
+
+    while(pch != NULL)
+    {
+
+        nbword++;
+        pch = strtok(NULL, " \t");
+
+        if(nbword == 1)  // first arg (0)
+        {
+            char *pos;
+            snprintf(FPSarg0,
+                     FUNCTION_PARAMETER_KEYWORD_STRMAXLEN * FUNCTION_PARAMETER_KEYWORD_MAXLEVEL,
+                     "%s", pch);
+            if((pos = strchr(FPSarg0, '\n')) != NULL)
+            {
+                *pos = '\0';
+            }
+        }
+
+        if(nbword == 2)
+        {
+            char *pos;
+            if(snprintf(FPSarg1, FUNCTION_PARAMETER_STRMAXLEN, "%s", pch) >=
+                    FUNCTION_PARAMETER_STRMAXLEN)
+            {
+                printf("WARNING: string truncated\n");
+                printf("STRING: %s\n", pch);
+            }
+            if((pos = strchr(FPSarg1, '\n')) != NULL)
+            {
+                *pos = '\0';
+            }
+        }
+
+        if(nbword == 3)
+        {
+            char *pos;
+            if(snprintf(FPSarg2, FUNCTION_PARAMETER_STRMAXLEN, "%s", pch) >=
+                    FUNCTION_PARAMETER_STRMAXLEN)
+            {
+                printf("WARNING: string truncated\n");
+                printf("STRING: %s\n", pch);
+            }
+            if((pos = strchr(FPSarg2, '\n')) != NULL)
+            {
+                *pos = '\0';
+            }
+        }
+
+        if(nbword == 4)
+        {
+            char *pos;
+            if(snprintf(FPSarg3, FUNCTION_PARAMETER_STRMAXLEN, "%s", pch) >=
+                    FUNCTION_PARAMETER_STRMAXLEN)
+            {
+                printf("WARNING: string truncated\n");
+                printf("STRING: %s\n", pch);
+            }
+            if((pos = strchr(FPSarg3, '\n')) != NULL)
+            {
+                *pos = '\0';
+            }
+        }
+    }
+
+    DEBUG_TRACEPOINT(" ");
+
+    if(nbword == 0)
+    {
+        cmdFOUND = 1; // do nothing, proceed
+        cmdOK    = 2;
+    }
+
+    // Handle commands for which FPSarg0 is NOT an FPS entry
+
+    // exit
+    if((cmdFOUND == 0) && (strcmp(FPScommand, "exit") == 0))
+    {
+        cmdFOUND = 1;
+        if(nbword != 1)
+        {
+            functionparameter_outlog("ERROR", "COMMAND exit takes NBARGS = 0");
+            *taskstatus |= FPSTASK_STATUS_ERR_NBARG;
+            cmdOK = 0;
+        }
+        else
+        {
+            fpsCTRLvar->exitloop = 1;
+            functionparameter_outlog("DEBUG", "EXIT");
+        }
+    }
+
+    // rescan
+    if((cmdFOUND == 0) && (strcmp(FPScommand, "rescan") == 0))
+    {
+        cmdFOUND = 1;
+        if(nbword != 1)
+        {
+            functionparameter_outlog("ERROR",
+                                     "COMMAND rescan takes NBARGS = 0");
+            *taskstatus |= FPSTASK_STATUS_ERR_NBARG;
+            cmdOK = 0;
+        }
+        else
+        {
+            functionparameter_scan_fps(fpsCTRLvar->mode,
+                                       fpsCTRLvar->fpsnamemask,
+                                       fps,
+                                       keywnode,
+                                       &fpsCTRLvar->NBkwn,
+                                       &fpsCTRLvar->NBfps,
+                                       &fpsCTRLvar->NBindex,
+                                       0);
+            functionparameter_outlog("DEBUG", "RESCAN");
+        }
+    }
+
+    // cntinc
+    if((cmdFOUND == 0) && (strcmp(FPScommand, "cntinc") == 0))
+    {
+        cmdFOUND = 1;
+        if(nbword != 2)
+        {
+            functionparameter_outlog("ERROR",
+                                     "COMMAND cntinc takes NBARGS = 1");
+            *taskstatus |= FPSTASK_STATUS_ERR_NBARG;
+            cmdOK = 0;
+        }
+        else
+        {
+            testcnt++;
+            functionparameter_outlog("DEBUG",
+                                     "TEST [%d] counter = %d",
+                                     atoi(FPSarg0),
+                                     testcnt);
+        }
+    }
+
+    // logsymlink
+    if((cmdFOUND == 0) && (strcmp(FPScommand, "logsymlink") == 0))
+    {
+        cmdFOUND = 1;
+        if(nbword != 2)
+        {
+
+            functionparameter_outlog("ERROR",
+                                     "COMMAND logsymlink takes NBARGS = 1");
+            *taskstatus |= FPSTASK_STATUS_ERR_NBARG;
+            cmdOK = 0;
+        }
+        else
+        {
+            char logfname[STRINGMAXLEN_FULLFILENAME];
+            getFPSlogfname(logfname);
+
+            functionparameter_outlog("DEBUG",
+                                     "CREATE SYM LINK %s <- %s",
+                                     FPSarg0,
+                                     logfname);
+
+            if(symlink(logfname, FPSarg0) != 0)
+            {
+                PRINT_ERROR("symlink error %s %s", logfname, FPSarg0);
+            }
+        }
+    }
+
+    // queueprio
+    if((cmdFOUND == 0) && (strcmp(FPScommand, "queueprio") == 0))
+    {
+        cmdFOUND = 1;
+        if(nbword != 3)
+        {
+            functionparameter_outlog("ERROR",
+                                     "COMMAND queueprio takes NBARGS = 2");
+            *taskstatus |= FPSTASK_STATUS_ERR_NBARG;
+            cmdOK = 0;
+        }
+        else
+        {
+            int queue = atoi(FPSarg0);
+            int prio  = atoi(FPSarg1);
+
+            if((queue >= 0) && (queue < NB_FPSCTRL_TASKQUEUE_MAX))
+            {
+                state->queuelist[queue].priority = prio;
+                functionparameter_outlog("FPSCTRL",
+                                         "%s",
+                                         "QUEUE %d PRIO = %d",
+                                         queue,
+                                         prio);
+            }
+        }
+    }
+
+    // From this point on, FPSarg0 is expected to be a FPS entry
+    // so we resolve it and look for fps
+    int kwnindex = -1;
+    if(cmdFOUND == 0)
+    {
+        strcpy(FPSentryname, FPSarg0);
+        strcpy(FPScmdarg1, FPSarg1);
+
+        // look for entry, if found, kwnindex points to it
+        if(nbword > 1)
+        {
+            //                printf("Looking for entry for %s\n", FPSentryname);
+
+            int kwnindexscan = 0;
+            while((kwnindex == -1) && (kwnindexscan < fpsCTRLvar->NBkwn))
+            {
+                if(strcmp(keywnode[kwnindexscan].keywordfull, FPSentryname) ==
+                        0)
+                {
+                    kwnindex = kwnindexscan;
+                }
+                kwnindexscan++;
+            }
+        }
+
+        if(kwnindex != -1)
+        {
+            fpsindex = keywnode[kwnindex].fpsindex;
+            pindex   = keywnode[kwnindex].pindex;
+            functionparameter_outlog("DEBUG",
+                                     "FPS ENTRY FOUND : %-40s  %d %ld",
+                                     FPSentryname,
+                                     fpsindex,
+                                     pindex);
+        }
+        else
+        {
+            functionparameter_outlog("ERROR",
+                                     "FPS ENTRY NOT FOUND : %-40s",
+                                     FPSentryname);
+            *taskstatus |= FPSTASK_STATUS_ERR_NOFPS;
+            cmdOK = 0;
+        }
+    }
+
+    if(kwnindex != -1)  // if FPS has been found
+    {
+
+        // tmuxstart
+        //
+        if((cmdFOUND == 0) && (strcmp(FPScommand, "tmuxstart") == 0))
+        {
+            cmdFOUND = 1;
+            if(nbword != 2)
+            {
+                functionparameter_outlog("ERROR",
+                                         "%s",
+                                         "COMMAND tmuxstart takes NBARGS = 1");
+                *taskstatus |= FPSTASK_STATUS_ERR_NBARG;
+                cmdOK = 0;
+            }
+            else
+            {
+                DEBUG_TRACEPOINT(" ");
+                functionparameter_FPS_tmux_init(&fps[fpsindex]);
+
+                functionparameter_outlog("FPSCTRL",
+                                         "TMUXSTART %s",
+                                         fps[fpsindex].md->name);
+                cmdOK = 1;
+            }
+        }
+
+        // tmuxstop
+        //
+        if((cmdFOUND == 0) && (strcmp(FPScommand, "tmuxstop") == 0))
+        {
+            cmdFOUND = 1;
+            if(nbword != 2)
+            {
+                functionparameter_outlog("ERROR",
+                                         "%s",
+                                         "COMMAND tmuxstop takes NBARGS = 1");
+                *taskstatus |= FPSTASK_STATUS_ERR_NBARG;
+                cmdOK = 0;
+            }
+            else
+            {
+                DEBUG_TRACEPOINT(" ");
+                functionparameter_FPS_tmux_kill(&fps[fpsindex]);
+
+                functionparameter_outlog("FPSCTRL",
+                                         "TMUXSTOP %s",
+                                         fps[fpsindex].md->name);
+                cmdOK = 1;
+            }
+        }
+
+        // confstart
+        //
+        if((cmdFOUND == 0) && (strcmp(FPScommand, "confstart") == 0))
+        {
+            cmdFOUND = 1;
+            if(nbword != 2)
+            {
+                functionparameter_outlog("ERROR",
+                                         "%s",
+                                         "COMMAND confstart takes NBARGS = 1");
+                *taskstatus |= FPSTASK_STATUS_ERR_NBARG;
+                cmdOK = 0;
+            }
+            else
+            {
+                DEBUG_TRACEPOINT(" ");
+                functionparameter_CONFstart(&fps[fpsindex]);
+
+                functionparameter_outlog("FPSCTRL",
+                                         "CONFSTART %s",
+                                         fps[fpsindex].md->name);
+                cmdOK = 1;
+            }
+        }
+
+        // confstop
+        //
+        if((cmdFOUND == 0) && (strcmp(FPScommand, "confstop") == 0))
+        {
+            cmdFOUND = 1;
+            if(nbword != 2)
+            {
+                functionparameter_outlog("ERROR",
+                                         "COMMAND confstop takes NBARGS = 1");
+                *taskstatus |= FPSTASK_STATUS_ERR_NBARG;
+                cmdOK = 0;
+            }
+            else
+            {
+                DEBUG_TRACEPOINT(" ");
+                functionparameter_CONFstop(&fps[fpsindex]);
+                functionparameter_outlog("FPSCTRL",
+                                         "CONFSTOP %s",
+                                         fps[fpsindex].md->name);
+                cmdOK = 1;
+            }
+        }
+
+        // confupdate
+        //
+        DEBUG_TRACEPOINT(" ");
+        if((cmdFOUND == 0) && (strcmp(FPScommand, "confupdate") == 0))
+        {
+            cmdFOUND = 1;
+            if(nbword != 2)
+            {
+                functionparameter_outlog("ERROR",
+                                         "COMMAND confupdate takes NBARGS = 1");
+                *taskstatus |= FPSTASK_STATUS_ERR_NBARG;
+                cmdOK = 0;
+            }
+            else
+            {
+                DEBUG_TRACEPOINT(" ");
+                fps[fpsindex].md->signal |=
+                    FUNCTION_PARAMETER_STRUCT_SIGNAL_CHECKED; // update status: check waiting to be done
+                fps[fpsindex].md->signal |=
+                    FUNCTION_PARAMETER_STRUCT_SIGNAL_UPDATE; // request an update
+
+                functionparameter_outlog("FPSCTRL",
+                                         "CONFUPDATE %s",
+                                         fps[fpsindex].md->name);
+                cmdOK = 1;
+            }
+        }
+
+        // confwupdate
+        // Wait until update is cleared
+        // if not successful, retry until time lapsed
+
+        DEBUG_TRACEPOINT(" ");
+        if((cmdFOUND == 0) && (strcmp(FPScommand, "confwupdate") == 0))
+        {
+            cmdFOUND = 1;
+            if(nbword != 2)
+            {
+                functionparameter_outlog(
+                    "ERROR",
+                    "COMMAND confwupdate takes NBARGS = 1");
+                *taskstatus |= FPSTASK_STATUS_ERR_NBARG;
+                cmdOK = 0;
+            }
+            else
+            {
+                int          looptry     = 1;
+                int          looptrycnt  = 0;
+                unsigned int timercnt    = 0;
+                useconds_t   dt          = 100;
+                unsigned int timercntmax = 10000; // 1 sec max
+
+                while(looptry == 1)
+                {
+
+                    DEBUG_TRACEPOINT(" ");
+                    fps[fpsindex].md->signal |=
+                        FUNCTION_PARAMETER_STRUCT_SIGNAL_CHECKED; // update status: check waiting to be done
+                    fps[fpsindex].md->signal |=
+                        FUNCTION_PARAMETER_STRUCT_SIGNAL_UPDATE; // request an update
+
+                    while(((fps[fpsindex].md->signal &
+                            FUNCTION_PARAMETER_STRUCT_SIGNAL_CHECKED)) &&
+                            (timercnt < timercntmax))
+                    {
+                        usleep(dt);
+                        timercnt++;
+                    }
+                    usleep(dt);
+                    timercnt++;
+
+                    functionparameter_outlog("DEBUG",
+                                             "CONFWUPDATE [%d] waited %d us on FPS %d %s. "
+                                             "conferrcnt = %d",
+                                             looptrycnt,
+                                             dt * timercnt,
+                                             fpsindex,
+                                             fps[fpsindex].md->name,
+                                             fps[fpsindex].md->conferrcnt);
+
+                    looptrycnt++;
+
+                    if(fps[fpsindex].md->conferrcnt ==
+                            0) // no error ! we can proceed
+                    {
+                        looptry = 0;
+                    }
+
+                    if(timercnt > timercntmax)  // ran out of time ... giving up
+                    {
+                        looptry = 0;
+                    }
+                }
+
+                cmdOK = 1;
+            }
+        }
+
+        // runstart
+        //
+        if((cmdFOUND == 0) && (strcmp(FPScommand, "runstart") == 0))
+        {
+            cmdFOUND = 1;
+            if(nbword != 2)
+            {
+                functionparameter_outlog("ERROR",
+                                         "COMMAND runstart takes NBARGS = 1");
+                *taskstatus |= FPSTASK_STATUS_ERR_NBARG;
+                cmdOK = 0;
+            }
+            else
+            {
+                DEBUG_TRACEPOINT(" ");
+                functionparameter_RUNstart(&fps[fpsindex]);
+
+                functionparameter_outlog("FPSCTRL",
+                                         "RUNSTART %s",
+                                         fps[fpsindex].md->name);
+                cmdOK = 1;
+            }
+        }
+
+
+        // runwait
+        // wait until run process is completed
+        //
+        if((cmdFOUND == 0) && (strcmp(FPScommand, "runwait") == 0))
+        {
+            cmdFOUND = 1;
+            if(nbword != 2)
+            {
+                functionparameter_outlog("ERROR",
+                                         "COMMAND runwait takes NBARGS = 1");
+                *taskstatus |= FPSTASK_STATUS_ERR_NBARG;
+                cmdOK = 0;
+            }
+            else
+            {
+                DEBUG_TRACEPOINT(" ");
+
+                unsigned int timercnt    = 0;
+                useconds_t   dt          = 10000;
+                unsigned int timercntmax = 100000; // 10000 sec max
+
+                while(((fps[fpsindex].md->status &
+                        FUNCTION_PARAMETER_STRUCT_STATUS_CMDRUN)) &&
+                        (timercnt < timercntmax))
+                {
+                    usleep(dt);
+                    timercnt++;
+                }
+                functionparameter_outlog("FPSCTRL",
+                                         "RUNWAIT waited %d us on FPS %s",
+                                         dt * timercnt,
+                                         fps[fpsindex].md->name);
+                cmdOK = 1;
+            }
+        }
+
+
+        // runstop
+        //
+        if((cmdFOUND == 0) && (strcmp(FPScommand, "runstop") == 0))
+        {
+            cmdFOUND = 1;
+            if(nbword != 2)
+            {
+                functionparameter_outlog("ERROR",
+                                         "COMMAND runstop takes NBARGS = 1");
+                *taskstatus |= FPSTASK_STATUS_ERR_NBARG;
+                cmdOK = 0;
+            }
+            else
+            {
+                DEBUG_TRACEPOINT(" ");
+                functionparameter_RUNstop(&fps[fpsindex]);
+                functionparameter_outlog("FPSCTRL",
+                                         "RUNSTOP %s",
+                                         fps[fpsindex].md->name);
+                cmdOK = 1;
+            }
+        }
+
+
+        // fpswfile : write FPS to file
+        //
+        if((cmdFOUND == 0) && (strcmp(FPScommand, "runstop") == 0))
+        {
+            cmdFOUND = 1;
+            if(nbword != 2)
+            {
+                functionparameter_outlog("ERROR",
+                                         "COMMAND fpswfile takes NBARGS = 1");
+                *taskstatus |= FPSTASK_STATUS_ERR_NBARG;
+                cmdOK = 0;
+            }
+            else
+            {
+                DEBUG_TRACEPOINT(" ");
+                functionparameter_SaveFPS2disk(&fps[fpsindex]);
+                functionparameter_outlog("FPSCTRL",
+                                         "FPSWFILE %s",
+                                         fps[fpsindex].md->name);
+                cmdOK = 1;
+            }
+        }
+
+
+        // fpsrm
+        //
+        if((cmdFOUND == 0) && (strcmp(FPScommand, "fpsrm") == 0))
+        {
+            cmdFOUND = 1;
+            if(nbword != 2)
+            {
+                functionparameter_outlog("ERROR",
+                                         "COMMAND fpsrm takes NBARGS = 1");
+                *taskstatus |= FPSTASK_STATUS_ERR_NBARG;
+                cmdOK = 0;
+            }
+            else
+            {
+                DEBUG_TRACEPOINT("Removing fps number %d", fpsindex);
+                functionparameter_FPSremove(&fps[fpsindex]);
+                DEBUG_TRACEPOINT("Posting to fps log %s",
+                                 fps[fpsindex].md->name);
+                functionparameter_outlog("FPSCTRL",
+                                         "FPSRM %s",
+                                         fps[fpsindex].md->name);
+                cmdOK = 1;
+            }
+        }
+
+        DEBUG_TRACEPOINT(" ");
+
+        // exec
+        //
+        if((cmdFOUND == 0) && (strcmp(FPScommand, "exec") == 0))
+        {
+            cmdFOUND = 1;
+            if(nbword != 2)
+            {
+                functionparameter_outlog("ERROR",
+                                         "COMMAND exec takes NBARGS = 1");
+                *taskstatus |= FPSTASK_STATUS_ERR_NBARG;
+                cmdOK = 0;
+            }
+            else
+            {
+                DEBUG_TRACEPOINT(" ");
+                if(fps[fpsindex].parray[pindex].type == FPTYPE_EXECFILENAME)
+                {
+                    EXECUTE_SYSTEM_COMMAND(
+                        "tmux send-keys -t %s:run \"cd %s\" "
+                        "C-m",
+                        fps[fpsindex].md->name,
+                        fps[fpsindex].md->workdir);
+                    EXECUTE_SYSTEM_COMMAND(
+                        "tmux send-keys -t %s:run \"%s %s\" "
+                        "C-m",
+                        fps[fpsindex].md->name,
+                        fps[fpsindex].parray[pindex].val.string[0],
+                        fps[fpsindex].md->name);
+                    cmdOK = 1;
+                }
+                else
+                {
+                    functionparameter_outlog(
+                        "ERROR",
+                        "COMMAND exec requires EXECFILENAME "
+                        "type parameter");
+                    *taskstatus |= FPSTASK_STATUS_ERR_ARGTYPE;
+                    cmdOK = 0;
+                }
+            }
+        }
+
+
+        // setval
+        //
+        if((cmdFOUND == 0) && (strcmp(FPScommand, "setval") == 0))
+        {
+            cmdFOUND = 1;
+            if(nbword != 3)
+            {
+                SNPRINTF_CHECK(errmsgstring,
+                               STRINGMAXLEN_FPS_LOGMSG,
+                               "COMMAND setval takes NBARGS = 2");
+                functionparameter_outlog("ERROR", "%s", errmsgstring);
+                *taskstatus |= FPSTASK_STATUS_ERR_NBARG;
+                cmdOK = 0;
+            }
+            else
+            {
+                int updated = 0;
+
+                switch(fps[fpsindex].parray[pindex].type)
+                {
+
+                case FPTYPE_INT32:
+                {
+                    char *endptr;
+                    long  valn = strtol(FPScmdarg1, &endptr, 10);
+
+                    if(*endptr == '\0')
+                    {
+                        // OK
+                        if(functionparameter_SetParamValue_INT32(
+                                    &fps[fpsindex],
+                                    FPSentryname,
+                                    valn) == EXIT_SUCCESS)
+                        {
+                            updated = 1;
+
+                            functionparameter_outlog("SETVAL",
+                                                     "%s INT32 %ld",
+                                                     FPSentryname,
+                                                     valn);
+                        }
+                    }
+                    else
+                    {
+                        *taskstatus |= FPSTASK_STATUS_ERR_TYPECONV;
+                        cmdOK = 0;
+                        SNPRINTF_CHECK(errmsgstring,
+                                       STRINGMAXLEN_FPS_LOGMSG,
+                                       "argument is not INT32");
+                        functionparameter_outlog("ERROR", "%s", errmsgstring);
+                    }
+                }
+                break;
+
+                case FPTYPE_UINT32:
+                {
+                    char *endptr;
+                    long  valn = strtol(FPScmdarg1, &endptr, 10);
+
+                    if((*endptr == '\0') && (valn >= 0))
+                    {
+                        // OK
+                        if(functionparameter_SetParamValue_UINT32(
+                                    &fps[fpsindex],
+                                    FPSentryname,
+                                    valn) == EXIT_SUCCESS)
+                        {
+                            updated = 1;
+
+                            functionparameter_outlog("SETVAL",
+                                                     "%s UINT32 "
+                                                     "%ld",
+                                                     FPSentryname,
+                                                     valn);
+                        }
+                    }
+                    else
+                    {
+                        *taskstatus |= FPSTASK_STATUS_ERR_TYPECONV;
+                        cmdOK = 0;
+                        SNPRINTF_CHECK(errmsgstring,
+                                       STRINGMAXLEN_FPS_LOGMSG,
+                                       "argument is not UINT32");
+                        functionparameter_outlog("ERROR", "%s", errmsgstring);
+                    }
+                }
+                break;
+
+                case FPTYPE_INT64:
+                {
+                    char *endptr;
+                    long  valn = strtol(FPScmdarg1, &endptr, 10);
+
+                    if(*endptr == '\0')
+                    {
+                        // OK
+                        if(functionparameter_SetParamValue_INT64(
+                                    &fps[fpsindex],
+                                    FPSentryname,
+                                    valn) == EXIT_SUCCESS)
+                        {
+                            updated = 1;
+
+                            functionparameter_outlog("SETVAL",
+                                                     "%s INT64 "
+                                                     "%ld",
+                                                     FPSentryname,
+                                                     valn);
+                        }
+                    }
+                    else
+                    {
+                        *taskstatus |= FPSTASK_STATUS_ERR_TYPECONV;
+                        cmdOK = 0;
+                        SNPRINTF_CHECK(errmsgstring,
+                                       STRINGMAXLEN_FPS_LOGMSG,
+                                       "argument is not INT64");
+                        functionparameter_outlog("ERROR", "%s", errmsgstring);
+                    }
+                }
+                break;
+
+                case FPTYPE_UINT64:
+                {
+                    char *endptr;
+                    long  valn = strtol(FPScmdarg1, &endptr, 10);
+
+                    if((*endptr == '\0') && (valn >= 0))
+                    {
+                        // OK
+                        if(functionparameter_SetParamValue_UINT64(
+                                    &fps[fpsindex],
+                                    FPSentryname,
+                                    valn) == EXIT_SUCCESS)
+                        {
+                            updated = 1;
+
+                            functionparameter_outlog("SETVAL",
+                                                     "%s UINT64 "
+                                                     "%ld",
+                                                     FPSentryname,
+                                                     valn);
+                        }
+                    }
+                    else
+                    {
+                        *taskstatus |= FPSTASK_STATUS_ERR_TYPECONV;
+                        cmdOK = 0;
+                        SNPRINTF_CHECK(errmsgstring,
+                                       STRINGMAXLEN_FPS_LOGMSG,
+                                       "argument is not UINT64");
+                        functionparameter_outlog("ERROR", "%s", errmsgstring);
+                    }
+                }
+                break;
+
+                case FPTYPE_FLOAT64:
+                {
+                    char  *endptr;
+                    double valf64 = strtod(FPScmdarg1, &endptr);
+
+                    if(*endptr == '\0')
+                    {
+                        // OK
+                        if(functionparameter_SetParamValue_FLOAT64(
+                                    &fps[fpsindex],
+                                    FPSentryname,
+                                    valf64) == EXIT_SUCCESS)
+                        {
+                            updated = 1;
+
+                            functionparameter_outlog("SETVAL",
+                                                     "%s FLOAT64 "
+                                                     "%f",
+                                                     FPSentryname,
+                                                     valf64);
+                        }
+                    }
+                    else
+                    {
+                        *taskstatus |= FPSTASK_STATUS_ERR_TYPECONV;
+                        cmdOK = 0;
+                        SNPRINTF_CHECK(errmsgstring,
+                                       STRINGMAXLEN_FPS_LOGMSG,
+                                       "argument is not FLOAT64");
+                        functionparameter_outlog("ERROR", "%s", errmsgstring);
+                    }
+                }
+                break;
+
+                case FPTYPE_FLOAT32:
+                {
+                    char  *endptr;
+                    double valf32 = strtof(FPScmdarg1, &endptr);
+
+                    if(*endptr == '\0')
+                    {
+                        // OK
+                        if(functionparameter_SetParamValue_FLOAT32(
+                                    &fps[fpsindex],
+                                    FPSentryname,
+                                    valf32) == EXIT_SUCCESS)
+                        {
+                            updated = 1;
+
+                            functionparameter_outlog("SETVAL",
+                                                     "%s FLOAT32 "
+                                                     "%f",
+                                                     FPSentryname,
+                                                     valf32);
+                        }
+                    }
+                    else
+                    {
+                        *taskstatus |= FPSTASK_STATUS_ERR_TYPECONV;
+                        cmdOK = 0;
+                        SNPRINTF_CHECK(errmsgstring,
+                                       STRINGMAXLEN_FPS_LOGMSG,
+                                       "argument is not FLOAT32");
+                        functionparameter_outlog("ERROR", "%s", errmsgstring);
+                    }
+                }
+                break;
+
+                case FPTYPE_PID:
+                {
+                    char *endptr;
+                    long  valn = strtol(FPScmdarg1, &endptr, 10);
+
+                    if(*endptr == '\0')
+                    {
+                        // OK
+                        if(functionparameter_SetParamValue_INT64(
+                                    &fps[fpsindex],
+                                    FPSentryname,
+                                    valn) == EXIT_SUCCESS)
+                        {
+                            updated = 1;
+
+                            functionparameter_outlog("SETVAL",
+                                                     "%s PID "
+                                                     "%ld",
+                                                     FPSentryname,
+                                                     valn);
+                        }
+                    }
+                    else
+                    {
+                        *taskstatus |= FPSTASK_STATUS_ERR_TYPECONV;
+                        cmdOK = 0;
+                        SNPRINTF_CHECK(errmsgstring,
+                                       STRINGMAXLEN_FPS_LOGMSG,
+                                       "argument is not INT64");
+                        functionparameter_outlog("ERROR", "%s", errmsgstring);
+                    }
+                }
+                break;
+
+                case FPTYPE_TIMESPEC:
+                {
+                    char  *endptr;
+                    double valf32 = strtof(FPScmdarg1, &endptr);
+
+                    if(*endptr == '\0')
+                    {
+                        // OK
+                        if(functionparameter_SetParamValue_TIMESPEC(
+                                    &fps[fpsindex],
+                                    FPSentryname,
+                                    valf32) == EXIT_SUCCESS)
+                        {
+                            updated = 1;
+
+                            functionparameter_outlog("SETVAL",
+                                                     "%s TIMESPEC "
+                                                     "%f",
+                                                     FPSentryname,
+                                                     valf32);
+                        }
+                    }
+                    else
+                    {
+                        *taskstatus |= FPSTASK_STATUS_ERR_TYPECONV;
+                        cmdOK = 0;
+                        SNPRINTF_CHECK(errmsgstring,
+                                       STRINGMAXLEN_FPS_LOGMSG,
+                                       "argument is not "
+                                       "FLOAT->TIMESPEC");
+                        functionparameter_outlog("ERROR", "%s", errmsgstring);
+                    }
+                }
+                break;
+
+                case FPTYPE_FILENAME:
+                    if(functionparameter_SetParamValue_STRING(&fps[fpsindex],
+                            FPSentryname,
+                            FPScmdarg1) ==
+                            EXIT_SUCCESS)
+                    {
+                        updated = 1;
+                    }
+                    functionparameter_outlog("SETVAL",
+                                             "%s FILENAME %s",
+                                             FPSentryname,
+                                             FPScmdarg1);
+                    break;
+
+                case FPTYPE_FITSFILENAME:
+                    if(functionparameter_SetParamValue_STRING(&fps[fpsindex],
+                            FPSentryname,
+                            FPScmdarg1) ==
+                            EXIT_SUCCESS)
+                    {
+                        updated = 1;
+                    }
+                    functionparameter_outlog("SETVAL",
+                                             "%s FITSFILENAME %s",
+                                             FPSentryname,
+                                             FPScmdarg1);
+                    break;
+
+                case FPTYPE_EXECFILENAME:
+                    if(functionparameter_SetParamValue_STRING(&fps[fpsindex],
+                            FPSentryname,
+                            FPScmdarg1) ==
+                            EXIT_SUCCESS)
+                    {
+                        updated = 1;
+                    }
+                    functionparameter_outlog("SETVAL",
+                                             "%s EXECFILENAME %s",
+                                             FPSentryname,
+                                             FPScmdarg1);
+                    break;
+
+                case FPTYPE_DIRNAME:
+                    if(functionparameter_SetParamValue_STRING(&fps[fpsindex],
+                            FPSentryname,
+                            FPScmdarg1) ==
+                            EXIT_SUCCESS)
+                    {
+                        updated = 1;
+                    }
+                    functionparameter_outlog("SETVAL",
+                                             "%s DIRNAME %s",
+                                             FPSentryname,
+                                             FPScmdarg1);
+                    break;
+
+                case FPTYPE_STREAMNAME:
+                    if(functionparameter_SetParamValue_STRING(&fps[fpsindex],
+                            FPSentryname,
+                            FPScmdarg1) ==
+                            EXIT_SUCCESS)
+                    {
+                        updated = 1;
+                    }
+                    functionparameter_outlog("SETVAL",
+                                             "%s STREAMNAME %s",
+                                             FPSentryname,
+                                             FPScmdarg1);
+                    break;
+
+                case FPTYPE_STRING:
+                    if(functionparameter_SetParamValue_STRING(&fps[fpsindex],
+                            FPSentryname,
+                            FPScmdarg1) ==
+                            EXIT_SUCCESS)
+                    {
+                        updated = 1;
+                    }
+                    functionparameter_outlog("SETVAL",
+                                             "%s STRING  %s",
+                                             FPSentryname,
+                                             FPScmdarg1);
+                    break;
+
+                case FPTYPE_ONOFF:
+                    if(strncmp(FPScmdarg1, "ON", 2) == 0)
+                    {
+                        if(functionparameter_SetParamValue_ONOFF(
+                                    &fps[fpsindex],
+                                    FPSentryname,
+                                    1) == EXIT_SUCCESS)
+                        {
+                            updated = 1;
+                        }
+                        functionparameter_outlog("SETVAL",
+                                                 "%s ONOFF ON",
+                                                 FPSentryname);
+                    }
+                    if(strncmp(FPScmdarg1, "OFF", 3) == 0)
+                    {
+                        if(functionparameter_SetParamValue_ONOFF(
+                                    &fps[fpsindex],
+                                    FPSentryname,
+                                    0) == EXIT_SUCCESS)
+                        {
+                            updated = 1;
+                        }
+                        functionparameter_outlog("SETVAL",
+                                                 "%s ONOFF OFF",
+                                                 FPSentryname);
+                    }
+                    break;
+
+                case FPTYPE_FPSNAME:
+                    if(functionparameter_SetParamValue_STRING(&fps[fpsindex],
+                            FPSentryname,
+                            FPScmdarg1) ==
+                            EXIT_SUCCESS)
+                    {
+                        updated = 1;
+                    }
+                    functionparameter_outlog("SETVAL",
+                                             "%s FPSNAME %s",
+                                             FPSentryname,
+                                             FPScmdarg1);
+                    break;
+
+                default:
+                    SNPRINTF_CHECK(errmsgstring,
+                                   STRINGMAXLEN_FPS_LOGMSG,
+                                   "argument type not recognized");
+                    functionparameter_outlog("ERROR", "%s", errmsgstring);
+                    *taskstatus |= FPSTASK_STATUS_ERR_ARGTYPE;
+                    break;
+                }
+
+                // notify fpsCTRL that parameter has been updated
+                if(updated == 1)
+                {
+                    cmdOK = 1;
+                    functionparameter_WriteParameterToDisk(&fps[fpsindex],
+                                                           pindex,
+                                                           "setval",
+                                                           "InputCommandFile");
+                    fps[fpsindex].md->signal |=
+                        FUNCTION_PARAMETER_STRUCT_SIGNAL_UPDATE;
+                }
+                else
+                {
+                    cmdOK = 0;
+                }
+            }
+        }
+
+
+        // getval or fwrval
+        //
+        if((cmdFOUND == 0) && ((strcmp(FPScommand, "getval") == 0) ||
+                               (strcmp(FPScommand, "fwrval") == 0)))
+        {
+            cmdFOUND = 1;
+            cmdOK    = 0;
+
+            if((strcmp(FPScommand, "getval") == 0) && (nbword != 2))
+            {
+                functionparameter_outlog("ERROR", "COMMAND getval NBARGS = 1");
+            }
+            else if((strcmp(FPScommand, "fwrval") == 0) && (nbword != 3))
+            {
+                functionparameter_outlog("ERROR", "COMMAND fwrval NBARGS = 2");
+            }
+            else
+            {
+                errno_t ret;
+                ret = functionparameter_PrintParameter_ValueString(
+                          &fps[fpsindex].parray[pindex],
+                          msgstring,
+                          STRINGMAXLEN_FPS_LOGMSG);
+
+                if(ret == RETURN_SUCCESS)
+                {
+                    cmdOK = 1;
+                }
+                else
+                {
+                    cmdOK = 0;
+                }
+
+
+                if(cmdOK == 1)
+                {
+                    if(strcmp(FPScommand, "getval") == 0)
+                    {
+                        functionparameter_outlog("GETVAL", "%s", msgstring);
+                    }
+                    if(strcmp(FPScommand, "fwrval") == 0)
+                    {
+
+                        FILE *fpouttmp = fopen(FPScmdarg1, "a");
+                        functionparameter_outlog_file("FWRVAL",
+                                                      msgstring,
+                                                      fpouttmp);
+                        fclose(fpouttmp);
+
+                        functionparameter_outlog("FWRVAL", "%s", msgstring);
+                        char msgstring1[STRINGMAXLEN_FPS_LOGMSG];
+                        SNPRINTF_CHECK(msgstring1,
+                                       STRINGMAXLEN_FPS_LOGMSG,
+                                       "WROTE to file %s",
+                                       FPScmdarg1);
+                        functionparameter_outlog("FWRVAL", "%s", msgstring1);
+                    }
+                }
+            }
+        }
+    }
+
+    if(cmdOK == 0)
+    {
+        SNPRINTF_CHECK(msgstring,
+                       STRINGMAXLEN_FPS_LOGMSG,
+                       "\"%s\" > %s",
+                       FPScmdline,
+                       errmsgstring);
+        functionparameter_outlog("CMDFAIL", "%s", msgstring);
+        *taskstatus |= FPSTASK_STATUS_CMDFAIL;
+    }
+
+    if(cmdOK == 1)
+    {
+        SNPRINTF_CHECK(msgstring,
+                       STRINGMAXLEN_FPS_LOGMSG,
+                       "\"%s\"",
+                       FPScmdline);
+        functionparameter_outlog("DEBUG", "CMDOK %s", msgstring);
+        *taskstatus |= FPSTASK_STATUS_CMDOK;
+    }
+
+    if(cmdFOUND == 0)
+    {
+        SNPRINTF_CHECK(msgstring,
+                       STRINGMAXLEN_FPS_LOGMSG,
+                       "COMMAND NOT FOUND: %s",
+                       FPScommand);
+        functionparameter_outlog("ERROR", "%s", msgstring);
+        *taskstatus |= FPSTASK_STATUS_CMDNOTFOUND;
+    }
+
+    DEBUG_TRACEPOINT(" ");
+
+    return fpsindex;
+}
+
+
+errno_t milkseq_load_script(
+    MILKSEQ_STATE *state,
+    const char *filename)
+{
+    FILE *fpinputcmd = fopen(filename, "r");
+
+    if (fpinputcmd != NULL) {
+        char *FPScmdline = NULL;
+        size_t len = 0;
+        ssize_t read_bytes;
+
+        while ((read_bytes = getline(&FPScmdline, &len, fpinputcmd)) != -1) {
+            uint64_t taskstatus = 0;
+            printf("Processing line : %s\n", FPScmdline);
+            milkseq_exec_cmd(FPScmdline, state, NULL, NULL, NULL, &taskstatus);
+        }
+        if (FPScmdline) {
+            free(FPScmdline);
+        }
+        fclose(fpinputcmd);
+    } else {
+        return -1;
+    }
+
+    return RETURN_SUCCESS;
+}

--- a/src/engine/libfpsseq/fpsseq_fifo.c
+++ b/src/engine/libfpsseq/fpsseq_fifo.c
@@ -1,0 +1,153 @@
+/**
+ * @file fpsseq_fifo.c
+ * @brief Reads incoming commands from FIFO into the task list
+ *
+ * Populates the sequence state task arrays from the named FIFO asynchronously.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "fpsseq.h"
+#include "timeutils.h"
+
+int milkseq_fifo_read(MILKSEQ_STATE *state, int fifo_fd)
+{
+    if (!state || fifo_fd < 0) return 0;
+
+    int cmdcnt = 0;
+    char buff[512];
+    int total_bytes = 0;
+    int bytes;
+    char buf0[1];
+
+    int lineOK = 1;
+
+    while (lineOK == 1) {
+        total_bytes = 0;
+        lineOK = 0;
+        for (;;) {
+            bytes = read(fifo_fd, buf0, 1);
+            if (bytes > 0) {
+                if (total_bytes < (int)sizeof(buff) - 1) {
+                    buff[total_bytes] = buf0[0];
+                    total_bytes++;
+                }
+            } else {
+                if (errno == EWOULDBLOCK || errno == EAGAIN) {
+                    break;
+                } else {
+                    return cmdcnt;
+                }
+            }
+
+            if (buf0[0] == '\n') {
+                buff[total_bytes - 1] = '\0';
+                char *FPScmdline = buff;
+
+                // Find next free task index
+                uint32_t cmdindex = 0;
+                int cmdindexOK = 0;
+                while (cmdindexOK == 0 && cmdindex < state->NBtasks_max) {
+                    if (state->tasklist[cmdindex].status == 0) {
+                        cmdindexOK = 1;
+                    } else {
+                        cmdindex++;
+                    }
+                }
+
+                if (cmdindex == state->NBtasks_max) {
+                    printf("ERROR: fpscmdarray is full. Reached max tasks.\n");
+                    // cannot accept more right now.
+                    break;
+                }
+
+                int cmdFOUND = 0;
+
+                if (FPScmdline[0] == '#' || FPScmdline[0] == ' ' || total_bytes < 2) {
+                    cmdFOUND = 1;
+                }
+
+                if (cmdFOUND == 0 && strncmp(FPScmdline, "taskcntzero", 11) == 0) {
+                    cmdFOUND = 1;
+                    state->task_input_counter = 0;
+                }
+
+                if (cmdFOUND == 0 && strncmp(FPScmdline, "setqindex", 9) == 0) {
+                    cmdFOUND = 1;
+                    char stringtmp[200];
+                    int queue_index;
+                    if (sscanf(FPScmdline, "%s %d", stringtmp, &queue_index) == 2) {
+                        if (queue_index > -1 && queue_index < NB_FPSCTRL_TASKQUEUE_MAX) {
+                            state->current_queue = queue_index;
+                        }
+                    }
+                }
+
+                if (cmdFOUND == 0 && strncmp(FPScmdline, "setqprio", 8) == 0) {
+                    cmdFOUND = 1;
+                    char stringtmp[200];
+                    int queue_priority;
+                    if (sscanf(FPScmdline, "%s %d", stringtmp, &queue_priority) == 2) {
+                        if (queue_priority < 0) queue_priority = 0;
+                        state->queuelist[state->current_queue].priority = queue_priority;
+                    }
+                }
+
+                if (cmdFOUND == 0 && strncmp(FPScmdline, "waitonrunON", 11) == 0) {
+                    cmdFOUND = 1;
+                    state->current_waitonrun = 1;
+                }
+                if (cmdFOUND == 0 && strncmp(FPScmdline, "waitonrunOFF", 12) == 0) {
+                    cmdFOUND = 1;
+                    state->current_waitonrun = 0;
+                }
+                if (cmdFOUND == 0 && strncmp(FPScmdline, "waitonconfON", 12) == 0) {
+                    cmdFOUND = 1;
+                    state->current_waitonconf = 1;
+                }
+                if (cmdFOUND == 0 && strncmp(FPScmdline, "waitonconfOFF", 13) == 0) {
+                    cmdFOUND = 1;
+                    state->current_waitonconf = 0;
+                }
+
+                // If not handled above, treat as normal task
+                if (cmdFOUND == 0) {
+                    strncpy(state->tasklist[cmdindex].cmdstring, FPScmdline, STRINGMAXLEN_FPS_CMDLINE - 1);
+                    state->tasklist[cmdindex].cmdstring[STRINGMAXLEN_FPS_CMDLINE - 1] = '\0';
+
+                    state->tasklist[cmdindex].status = FPSTASK_STATUS_ACTIVE | FPSTASK_STATUS_SHOW;
+                    state->tasklist[cmdindex].inputindex = state->task_input_counter;
+                    state->tasklist[cmdindex].queue = state->current_queue;
+                    clock_gettime(CLOCK_MILK, &state->tasklist[cmdindex].creationtime);
+
+                    state->tasklist[cmdindex].status |= FPSTASK_STATUS_WAITING;
+
+                    if (state->current_waitonrun == 1) {
+                        state->tasklist[cmdindex].flag |= FPSTASK_FLAG_WAITONRUN;
+                    } else {
+                        state->tasklist[cmdindex].flag &= ~FPSTASK_FLAG_WAITONRUN;
+                    }
+
+                    if (state->current_waitonconf == 1) {
+                        state->tasklist[cmdindex].flag |= FPSTASK_FLAG_WAITONCONF;
+                    } else {
+                        state->tasklist[cmdindex].flag &= ~FPSTASK_FLAG_WAITONCONF;
+                    }
+
+                    state->task_input_counter++;
+                    state->NBtasks_active++;
+                    cmdcnt++;
+                }
+
+                lineOK = 1;
+                break; // Break the char reading loop to start next line
+            }
+        }
+    }
+
+    return cmdcnt;
+}

--- a/src/engine/libfpsseq/fpsseq_scheduler.c
+++ b/src/engine/libfpsseq/fpsseq_scheduler.c
@@ -1,0 +1,156 @@
+/**
+ * @file fpsseq_scheduler.c
+ * @brief Task scheduling logic for the milk-seq FPS Sequencer
+ *
+ * Scans task queues, checks dependencies (WAITONRUN, WAITONCONF),
+ * and dispatches commands to the execution engine.
+ */
+
+#include <limits.h>
+
+
+#include "fpsseq.h"
+
+#include "timeutils.h"
+
+int milkseq_scheduler_step(
+    MILKSEQ_STATE *state,
+    FUNCTION_PARAMETER_STRUCT *fps,
+    KEYWORD_TREE_NODE *keywnode,
+    FPSCTRL_PROCESS_VARS *vars)
+{
+    if (!state) return 0;
+
+    int QUEUE_NOTASK = -1;
+    int QUEUE_WAIT = -2;
+    int QUEUE_SCANREADY = -3;
+
+    int NBtaskLaunched = 0;
+    int queue_nexttask[NB_FPSCTRL_TASKQUEUE_MAX];
+
+    for (uint32_t qi = 0; qi < NB_FPSCTRL_TASKQUEUE_MAX; qi++) {
+        queue_nexttask[qi] = QUEUE_SCANREADY;
+
+        while (queue_nexttask[qi] == QUEUE_SCANREADY) {
+            uint64_t inputindexmin = UINT_MAX;
+            int cmdindexExec = -1;
+            int cmdOK = 0;
+
+            queue_nexttask[qi] = QUEUE_NOTASK;
+
+            // Find oldest active task in this queue
+            for (uint32_t cmdindex = 0; cmdindex < state->NBtasks_max && cmdindex < NB_FPSCTRL_TASK_MAX; cmdindex++) {
+                if ((state->tasklist[cmdindex].status & FPSTASK_STATUS_ACTIVE) &&
+                    (state->tasklist[cmdindex].queue == qi)) {
+                    if (state->tasklist[cmdindex].inputindex < inputindexmin) {
+                        inputindexmin = state->tasklist[cmdindex].inputindex;
+                        cmdindexExec = cmdindex;
+                        cmdOK = 1;
+                    }
+                }
+            }
+
+            if (cmdOK == 1) {
+                if (!(state->tasklist[cmdindexExec].status & FPSTASK_STATUS_RUNNING)) {
+                    queue_nexttask[qi] = cmdindexExec;
+                } else {
+                    // Check if running task completed
+                    int task_completed = 1;
+
+                    if (state->tasklist[cmdindexExec].flag & FPSTASK_FLAG_WAITONRUN) {
+                        if (fps[state->tasklist[cmdindexExec].fpsindex].md->status & FUNCTION_PARAMETER_STRUCT_STATUS_CMDRUN) {
+                            task_completed = 0;
+                            queue_nexttask[qi] = QUEUE_WAIT;
+                        }
+                    }
+
+                    if (state->tasklist[cmdindexExec].flag & FPSTASK_FLAG_WAITONCONF) {
+                        if (fps[state->tasklist[cmdindexExec].fpsindex].md->status & FUNCTION_PARAMETER_STRUCT_SIGNAL_CHECKED) {
+                            task_completed = 0;
+                            queue_nexttask[qi] = QUEUE_WAIT;
+                        }
+                    }
+
+                    if (task_completed == 1) {
+                        state->tasklist[cmdindexExec].status &= ~FPSTASK_STATUS_RUNNING;
+                        state->tasklist[cmdindexExec].status |= FPSTASK_STATUS_COMPLETED;
+                        state->tasklist[cmdindexExec].status &= ~FPSTASK_STATUS_ACTIVE;
+
+                        clock_gettime(CLOCK_MILK, &state->tasklist[cmdindexExec].completiontime);
+                        queue_nexttask[qi] = QUEUE_SCANREADY;
+
+                        if (state->NBtasks_active > 0) state->NBtasks_active--;
+                        state->NBtasks_completed++;
+                    }
+                }
+            }
+        }
+    }
+
+    // Remove old tasks (purge)
+    struct timespec tnow;
+    double tnowd;
+    clock_gettime(CLOCK_MILK, &tnow);
+    tnowd = 1.0 * tnow.tv_sec + 1.0e-9 * tnow.tv_nsec;
+
+    uint32_t taskcnt = state->NBtasks_max;
+    // We want to keep at most NB_FPSCTRL_TASK_MAX - NB_FPSCTRL_TASK_PURGESIZE empty spots?? No, backwards.
+    // The original logic checks if active tasks + completed tasks > size - purgesize, then deletes oldest.
+    // Actually the original logic counted completed tasks, and if taskcnt > limit, zeroed out the status of the oldest.
+    while (taskcnt > state->NBtasks_max - NB_FPSCTRL_TASK_PURGESIZE) {
+        taskcnt = 0;
+        double oldest_age = 0.0;
+        long oldest_index = -1;
+
+        for (uint32_t cmdindex = 0; cmdindex < state->NBtasks_max && cmdindex < NB_FPSCTRL_TASK_MAX; cmdindex++) {
+            if (state->tasklist[cmdindex].status & FPSTASK_STATUS_COMPLETED) {
+                double age = tnowd - (1.0 * state->tasklist[cmdindex].completiontime.tv_sec +
+                                      1.0e-9 * state->tasklist[cmdindex].completiontime.tv_nsec);
+                if (age > oldest_age) {
+                    oldest_age = age;
+                    oldest_index = cmdindex;
+                }
+                taskcnt++;
+            }
+        }
+        if (taskcnt > state->NBtasks_max - NB_FPSCTRL_TASK_PURGESIZE && oldest_index != -1) {
+            state->tasklist[oldest_index].status = 0; // mark empty
+        } else {
+            break;
+        }
+    }
+
+    // Find highest priority queue with a ready task
+    int nexttask_priority = -1;
+    int nexttask_cmdindex = -1;
+    for (uint32_t qi = 0; qi < NB_FPSCTRL_TASKQUEUE_MAX; qi++) {
+        if (queue_nexttask[qi] != QUEUE_NOTASK && queue_nexttask[qi] != QUEUE_WAIT) {
+            if (state->queuelist[qi].priority > nexttask_priority) {
+                nexttask_priority = state->queuelist[qi].priority;
+                nexttask_cmdindex = queue_nexttask[qi];
+            }
+        }
+    }
+
+    if (nexttask_cmdindex != -1 && nexttask_priority > 0) {
+        int cmdindexExec = nexttask_cmdindex;
+        uint64_t taskstatus = 0;
+
+        state->tasklist[cmdindexExec].fpsindex = milkseq_exec_cmd(
+            state->tasklist[cmdindexExec].cmdstring,
+            state,
+            fps,
+            keywnode,
+            vars,
+            &taskstatus);
+
+        NBtaskLaunched++;
+        state->tasklist[cmdindexExec].status |= taskstatus;
+        clock_gettime(CLOCK_MILK, &state->tasklist[cmdindexExec].activationtime);
+
+        state->tasklist[cmdindexExec].status |= FPSTASK_STATUS_RUNNING;
+        state->tasklist[cmdindexExec].status &= ~FPSTASK_STATUS_WAITING;
+    }
+
+    return NBtaskLaunched;
+}

--- a/src/engine/libfpsseq/fpsseq_shm.c
+++ b/src/engine/libfpsseq/fpsseq_shm.c
@@ -1,0 +1,161 @@
+/**
+ * @file fpsseq_shm.c
+ * @brief Shared memory lifecycle for the milk-seq FPS Sequencer
+ *
+ * Handles creation, connection, and destruction of the /dev/shm
+ * mapped state structs used by sequencer instances.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include "fpsseq.h"
+#include "fps_types.h"
+
+#define SHM_PREFIX "/milkseq."
+#define FIFO_PREFIX "/tmp/milkseq."
+
+static void build_shm_name(char *dest, size_t size, const char *name)
+{
+    snprintf(dest, size, "%s%s.shm", SHM_PREFIX, name);
+}
+
+static void build_fifo_name(char *dest, size_t size, const char *name)
+{
+    snprintf(dest, size, "%s%s.fifo", FIFO_PREFIX, name);
+}
+
+MILKSEQ_STATE *milkseq_create(const char *name)
+{
+    if (!name || strlen(name) == 0) return NULL;
+
+    char shm_name[256];
+    build_shm_name(shm_name, sizeof(shm_name), name);
+
+    // Unlink old if it exists
+    shm_unlink(shm_name);
+
+    int fd = shm_open(shm_name, O_CREAT | O_RDWR | O_EXCL, 0666);
+    if (fd == -1) {
+        perror("shm_open milkseq");
+        return NULL;
+    }
+
+    if (ftruncate(fd, sizeof(MILKSEQ_STATE)) == -1) {
+        perror("ftruncate milkseq");
+        close(fd);
+        shm_unlink(shm_name);
+        return NULL;
+    }
+
+    MILKSEQ_STATE *state = mmap(NULL, sizeof(MILKSEQ_STATE), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    close(fd);
+
+    if (state == MAP_FAILED) {
+        perror("mmap milkseq");
+        shm_unlink(shm_name);
+        return NULL;
+    }
+
+    // Initialize state
+    memset(state, 0, sizeof(MILKSEQ_STATE));
+    strncpy(state->name, name, FPSSEQ_NAME_MAX - 1);
+    state->status = MILKSEQ_STATUS_IDLE;
+    state->pid = getpid();
+    clock_gettime(CLOCK_REALTIME, &state->starttime);
+
+    // Set max limits based on configured arrays
+    state->NBtasks_max = NB_FPSCTRL_TASK_MAX;
+
+    // Let the default queue (index 0) have an active priority
+    state->queuelist[0].priority = 10;
+
+    // Create FIFO
+    build_fifo_name(state->fifo_path, sizeof(state->fifo_path), name);
+    unlink(state->fifo_path); // remove stale
+    if (mkfifo(state->fifo_path, 0666) == -1) {
+        perror("mkfifo milkseq");
+        // Non-fatal, but warn
+    }
+
+    return state;
+}
+
+MILKSEQ_STATE *milkseq_connect(const char *name)
+{
+    if (!name || strlen(name) == 0) return NULL;
+
+    char shm_name[256];
+    build_shm_name(shm_name, sizeof(shm_name), name);
+
+    int fd = shm_open(shm_name, O_RDWR, 0); // Allow write for status updates
+    if (fd == -1) {
+        return NULL; // Not found
+    }
+
+    MILKSEQ_STATE *state = mmap(NULL, sizeof(MILKSEQ_STATE), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    close(fd);
+
+    if (state == MAP_FAILED) {
+        perror("mmap milkseq connect");
+        return NULL;
+    }
+
+    return state;
+}
+
+int milkseq_disconnect(MILKSEQ_STATE *state)
+{
+    if (!state) return -1;
+    return munmap(state, sizeof(MILKSEQ_STATE));
+}
+
+int milkseq_destroy(const char *name)
+{
+    if (!name || strlen(name) == 0) return -1;
+
+    char shm_name[256];
+    char fifo_name[256];
+    build_shm_name(shm_name, sizeof(shm_name), name);
+    build_fifo_name(fifo_name, sizeof(fifo_name), name);
+
+    int err1 = shm_unlink(shm_name);
+    int err2 = unlink(fifo_name);
+
+    return (err1 == 0 && err2 == 0) ? 0 : -1;
+}
+
+int milkseq_list(char names[][FPSSEQ_NAME_MAX], int maxcount)
+{
+    int count = 0;
+    DIR *d;
+    struct dirent *dir;
+    d = opendir("/dev/shm");
+    if (d) {
+        while ((dir = readdir(d)) != NULL) {
+            // Match milkseq.*.shm
+            if (strncmp(dir->d_name, "milkseq.", 8) == 0) {
+                char *ext = strstr(dir->d_name, ".shm");
+                if (ext) {
+                    if (count < maxcount) {
+                        size_t namelen = ext - (dir->d_name + 8);
+                        if (namelen < FPSSEQ_NAME_MAX) {
+                            strncpy(names[count], dir->d_name + 8, namelen);
+                            names[count][namelen] = '\0';
+                            count++;
+                        }
+                    } else {
+                        break; // Array full
+                    }
+                }
+            }
+        }
+        closedir(d);
+    }
+    return count;
+}

--- a/src/engine/libfpsseq/fpsseq_types.h
+++ b/src/engine/libfpsseq/fpsseq_types.h
@@ -1,0 +1,66 @@
+/**
+ * @file fpsseq_types.h
+ * @brief Core data structures for the milk-seq FPS Sequencer
+ *
+ * Extends the basic FPSCTRL_TASK_ENTRY and FPSCTRL_TASK_QUEUE types
+ * to support multi-instance shared memory execution.
+ */
+
+#ifndef FPSSEQ_TYPES_H
+#define FPSSEQ_TYPES_H
+
+#include <stdint.h>
+#include <sys/types.h>
+#include <time.h>
+
+#include "fps_types.h"
+
+#define FPSSEQ_NAME_MAX 64
+#define FPSSEQ_FIFO_PATH_MAX 256
+#define FPSSEQ_SCRIPT_PATH_MAX 512
+#define FPSSEQ_ERROR_STR_MAX 512
+
+/* Status flags for the sequencer itself */
+#define MILKSEQ_STATUS_IDLE     0x0001
+#define MILKSEQ_STATUS_RUNNING  0x0002
+#define MILKSEQ_STATUS_ERROR    0x0004
+#define MILKSEQ_STATUS_STOPPING 0x0008
+
+/**
+ * @brief Sequencer instance state, mapped into shared memory.
+ *
+ * One per running milk-seq instance.
+ * SHM path: /dev/shm/milkseq.<name>.shm
+ */
+typedef struct {
+    char     name[FPSSEQ_NAME_MAX];
+    uint32_t status;
+    pid_t    pid;
+    struct timespec starttime;
+
+    /* Task array (extracted from fpsCTRL) */
+    uint32_t NBtasks_max;
+    uint32_t NBtasks_active;
+    uint32_t NBtasks_completed;
+    uint64_t task_input_counter;
+    FPSCTRL_TASK_ENTRY tasklist[NB_FPSCTRL_TASK_MAX];
+
+    /* Queue array (extracted from fpsCTRL) */
+    FPSCTRL_TASK_QUEUE queuelist[NB_FPSCTRL_TASKQUEUE_MAX];
+
+    /* external IO */
+    char fifo_path[FPSSEQ_FIFO_PATH_MAX];
+    char script_path[FPSSEQ_SCRIPT_PATH_MAX];
+
+    /* FIFO/Script parsing context */
+    uint32_t current_queue;
+    int32_t current_waitonrun;
+    int32_t current_waitonconf;
+
+    /* Error tracking */
+    uint32_t error_count;
+    char     last_error[FPSSEQ_ERROR_STR_MAX];
+
+} MILKSEQ_STATE;
+
+#endif // FPSSEQ_TYPES_H

--- a/src/engine/libfpsseq/milk-seq.c
+++ b/src/engine/libfpsseq/milk-seq.c
@@ -1,0 +1,185 @@
+/**
+ * @file milk-seq.c
+ * @brief Standalone milk-seq sequencer daemon
+ *
+ * Runs the robust standalone sequencer engine out-of-process.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <time.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#include "fpsseq.h"
+#include "fps.h"
+#include "fps_scan.h"
+
+static int keep_running = 1;
+
+static void sigterm_handler(int signum)
+{
+    (void)signum;
+    keep_running = 0;
+}
+
+static void print_help()
+{
+    printf("milk-seq - Standalone FPS Sequencer Engine\n\n");
+    printf("Usage: milk-seq -n <name> [options]\n\n");
+    printf("Options:\n");
+    printf("  -n <name>        Sequencer name (required)\n");
+    printf("  -f <script.seq>  Sequence file to load on startup\n");
+    printf("  --headless       Run silently without TUI (default)\n");
+    printf("  --fifo <path>    Custom FIFO path (default: /tmp/milkseq.<name>.fifo)\n");
+    printf("  --timeout <sec>  Exit after idle for <sec> seconds\n");
+    printf("  -h, --help       Show this help\n");
+}
+
+int main(int argc, char **argv)
+{
+    char seq_name[FPSSEQ_NAME_MAX] = {0};
+    char script_file[FPSSEQ_SCRIPT_PATH_MAX] = {0};
+    char custom_fifo[FPSSEQ_FIFO_PATH_MAX] = {0};
+    int timeout_sec = 0;
+
+    // Parse arguments
+    int i = 1;
+    while (i < argc) {
+        if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
+            print_help();
+            return 0;
+        } else if (strcmp(argv[i], "-n") == 0 && i + 1 < argc) {
+            strncpy(seq_name, argv[i+1], FPSSEQ_NAME_MAX - 1);
+            i += 2;
+        } else if (strcmp(argv[i], "-f") == 0 && i + 1 < argc) {
+            strncpy(script_file, argv[i+1], FPSSEQ_SCRIPT_PATH_MAX - 1);
+            i += 2;
+        } else if (strcmp(argv[i], "--fifo") == 0 && i + 1 < argc) {
+            strncpy(custom_fifo, argv[i+1], FPSSEQ_FIFO_PATH_MAX - 1);
+            i += 2;
+        } else if (strcmp(argv[i], "--timeout") == 0 && i + 1 < argc) {
+            timeout_sec = atoi(argv[i+1]);
+            i += 2;
+        } else if (strcmp(argv[i], "--headless") == 0) {
+            // currently implied
+            i++;
+        } else {
+            fprintf(stderr, "Unknown flag: %s\n", argv[i]);
+            print_help();
+            return 1;
+        }
+    }
+
+    if (seq_name[0] == '\0') {
+        fprintf(stderr, "Error: Sequencer name (-n) is required.\n");
+        return 1;
+    }
+
+    // Set up signals
+    struct sigaction action;
+    memset(&action, 0, sizeof(struct sigaction));
+    action.sa_handler = sigterm_handler;
+    sigaction(SIGTERM, &action, NULL);
+    sigaction(SIGINT, &action, NULL);
+
+    // Initialize milk process info (required for fps library tracking)
+    // we name ourselves milk-seq.<name>
+    char procname[64];
+    snprintf(procname, sizeof(procname), "milk-seq.%s", seq_name);
+    processinfo_setup(procname, "milk-seq", "FPS Sequencer", "main", __FILE__, __LINE__);
+
+    // Create sequencer state
+    MILKSEQ_STATE *state = milkseq_create(seq_name);
+    if (!state) {
+        fprintf(stderr, "Failed to create sequencer state '%s'\n", seq_name);
+        return 1;
+    }
+
+    if (custom_fifo[0] != '\0') {
+        strncpy(state->fifo_path, custom_fifo, sizeof(state->fifo_path) - 1);
+        // Destroy default fifo and make custom
+        char default_fifo[FPSSEQ_FIFO_PATH_MAX];
+        snprintf(default_fifo, sizeof(default_fifo), "/tmp/milkseq.%s.fifo", seq_name);
+        if (strcmp(default_fifo, custom_fifo) != 0) {
+            unlink(default_fifo);
+        }
+        mkfifo(state->fifo_path, 0666);
+    }
+
+    int fifo_fd = open(state->fifo_path, O_RDONLY | O_NONBLOCK);
+    if (fifo_fd == -1) {
+        fprintf(stderr, "Failed to open FIFO %s\n", state->fifo_path);
+        milkseq_destroy(seq_name);
+        return 1;
+    }
+
+    // Load initial script if provided
+    if (script_file[0] != '\0') {
+        strncpy(state->script_path, script_file, sizeof(state->script_path) - 1);
+        if (milkseq_load_script(state, script_file) != 0) {
+            fprintf(stderr, "Failed to load script: %s\n", script_file);
+        }
+    }
+
+    printf("milk-seq started: %s\n", seq_name);
+    state->status = MILKSEQ_STATUS_RUNNING;
+
+    long iter = 0;
+    time_t last_idle_time = time(NULL);
+
+    // We need to keep track of the local fps list to feed to the scheduler
+    FUNCTION_PARAMETER_STRUCT fps[NB_FPS_MAX];
+    memset(fps, 0, sizeof(FUNCTION_PARAMETER_STRUCT) * NB_FPS_MAX);
+    KEYWORD_TREE_NODE *keywnode = calloc(NB_KEYWNODE_MAX, sizeof(KEYWORD_TREE_NODE));
+    FPSCTRL_PROCESS_VARS fpsCTRLvar = {0};
+
+    // Scan initial FPS tree
+    int NBkwn = 0;
+    int fpsindex = 0;
+    long pindex = 0;
+    functionparameter_scan_fps(1, "_ALL", fps, keywnode, &NBkwn, &fpsindex, &pindex, 0);
+
+    // Main Run Loop
+    while (keep_running) {
+        // Read FIFO
+        int cmds_read = milkseq_fifo_read(state, fifo_fd);
+
+        // Periodically rescan the FPS tree (like fpsCTRL does)
+        if (iter % 100 == 0) {
+            functionparameter_scan_fps(1, "_ALL", fps, keywnode, &NBkwn, &fpsindex, &pindex, 0);
+        }
+
+        // Run scheduler step
+        int launched = milkseq_scheduler_step(state, fps, keywnode, &fpsCTRLvar);
+
+        if (cmds_read > 0 || launched > 0 || state->NBtasks_active > 0) {
+            last_idle_time = time(NULL);
+        } else if (timeout_sec > 0 && (time(NULL) - last_idle_time) > timeout_sec) {
+            printf("Idle timeout reached. Exiting.\n");
+            break;
+        }
+
+        if (fpsCTRLvar.exitloop) {
+            printf("Exit command received. Shutting down.\n");
+            break;
+        }
+
+        usleep(10000); // 10ms tick
+        iter++;
+    }
+
+    state->status = MILKSEQ_STATUS_STOPPING;
+    printf("Shutting down milk-seq...\n");
+
+    close(fifo_fd);
+    milkseq_destroy(seq_name);
+
+    free(keywnode);
+    return 0;
+}


### PR DESCRIPTION
This PR implements Phase 1 of the FPS Sequencer Decoupling project, extracting the task sequencer logic from `milk-fpsCTRL` into a headless engine (`libfpsseq`) and a standalone daemon (`milk-seq`). 

**Changes:**
- Created `src/engine/libfpsseq/` peer library to house all decoupled sequencer logic with zero TUI dependencies.
- Added `MILKSEQ_STATE` in shared memory (`/dev/shm/milkseq.<name>.shm`) to track active tasks, queues, and sequence lifecycle data across processes.
- Extracted priority scheduling logic and FIFO ingestion from `fpsCTRL` and adapted them for multithreaded standalone execution.
- Added `-n <name>` named instance support to allow running multiple orchestration daemons concurrently.
- Integrated `libfpsseq` and `milk-seq` into the CMake build system.

**Verification:**
- Verified `milk-seq` compiles successfully and links against required isolated library tiers.
- Validated `milk-seq` cleanly creates expected shared memory allocations and handles standard command ingestion via `/tmp/milkseq.<name>.fifo`.
- Ensured daemon shuts down gracefully when executing an `exit` command.

## Prompt Summary
The user requested that the powerful FPS sequencer be separated from the `milk-fpsCTRL` TUI into a dedicated standalone engine, enabling capabilities like multi-instance parallel orchestration and better integration with `milk-cli`. Phase 1 cleanly extracts scheduling code into a standard library without affecting existing functionality.

## AI Authorship
- **Model(s) used**: Antigravity
- **User edits**: None. All code extraction and execution implementations for Phase 1 were generated by the AI agent.
