### PR TITLE
docs: add feature-planner skill for structured planning

### DIFF
--- a/.agents/rules/error-handling-practices.md
+++ b/.agents/rules/error-handling-practices.md
@@ -1,3 +1,8 @@
+---
+description: Standardized error handling and logging
+  via milkDebugTools.h macros.
+---
+
 # Error Handling Practices
 
 The `milk` project standardizes its error handling and logging via macros defined in `src/engine/libmilkdata/milkDebugTools.h`. To ensure consistency, robustness, and ease of debugging across the codebase, all C source code must adhere to the following practices.

--- a/.agents/skills/feature-planner/SKILL.md
+++ b/.agents/skills/feature-planner/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: feature-planner
+description: Structured feature planning and
+  architectural decomposition for new capabilities
+---
+
+# Feature Planner
+
+This skill guides the agent through structured
+planning before any code is written. It ensures
+new features are decomposed into concrete tasks,
+checked against the architecture, and sequenced
+for safe incremental delivery.
+
+## When to Use
+
+- User describes a **new feature** or capability
+- User asks to "plan", "design", or "architect"
+  a change
+- A task involves **multiple modules**, build
+  tiers, or cross-cutting concerns
+- You are unsure how a feature fits into the
+  existing architecture
+
+**Skip this skill** for:
+- Single-file bug fixes
+- Documentation-only changes
+- Straightforward template-based tasks (use the
+  relevant workflow instead)
+
+## Phase 1 — Classify the Change
+
+Determine the scope by answering these questions:
+
+| Question | Options |
+|----------|---------|
+| **Build tier** | Engine / Core / Full? |
+| **New or extension?** | New module, new file in existing module, or modification? |
+| **Scope** | Single module / cross-module / framework-level? |
+| **Template** | V2 compute unit / stream processor / plain function / CLI builtin / none? |
+
+If the feature spans multiple tiers or modules,
+flag this early — it likely needs phased delivery.
+
+## Phase 2 — Map the Architecture
+
+### 2.1 Dependency Analysis
+
+1. Read `docs/dependency_graph.md` — identify
+   which libraries and modules are in scope.
+2. Check whether new cross-module dependencies
+   are needed. If so, verify they respect the
+   layered build order:
+   ```
+   Engine → Core → Full
+   (no reverse dependencies allowed)
+   ```
+3. List any new `target_link_libraries` entries
+   that will be needed in CMake.
+
+### 2.2 Shared Memory Contracts
+
+For each new shared-memory object, document:
+
+| Object | Type | Name Pattern | Details |
+|--------|------|-------------|---------|
+| Stream | `IMAGE` | e.g., `wfs0_raw` | dtype, dimensions, shared flag |
+| FPS | `FUNCTION_PARAMETER_STRUCT` | e.g., `fps.myproc` | parameter list with types |
+| Processinfo | `PROCESSINFO` | auto | loop type (finite/infinite) |
+
+### 2.3 CLI Surface
+
+- New CLI commands? (keyword, args, help text)
+- New standalone executables? (`milk-fpsexec-*`)
+- Changes to existing command behavior?
+
+## Phase 3 — Enumerate Touchpoints
+
+### 3.1 Code Touchpoints
+
+List every file that will be created or modified.
+Group by component:
+
+```
+### [Component Name]
+- [NEW] filename.c — purpose
+- [MODIFY] filename.c — what changes
+- [MODIFY] CMakeLists.txt — new targets/links
+```
+
+### 3.2 Documentation Touchpoints
+
+Check which documentation rules will fire:
+
+| Rule | Applies? | Action needed |
+|------|----------|---------------|
+| `readme-update` | Module files added/removed? | Update module README |
+| `help-consistency` | CLI commands changed? | Cross-check help sources |
+| `whatsnew-update` | Significant feature? | Add entry to whatsnew.md |
+| `maintain-programmers-guide` | Architecture changed? | Update programmers_guide.md |
+| `script-docs` | Scripts changed? | Update docs/scripts.md |
+| `documentation-site` | New doc page needed? | Add to mkdocs.yml nav |
+
+### 3.3 Test Touchpoints
+
+- Existing tests that may break?
+- New tests needed? (unit, CLI robustness, ctest)
+- Performance benchmarks affected?
+
+## Phase 4 — Sequence the Work
+
+Break the implementation into **phases**, where
+each phase is independently compilable and
+testable:
+
+```markdown
+### Phase 1: [Foundation]
+- What to implement
+- How to verify (compile, test)
+- Estimated complexity (low/med/high)
+
+### Phase 2: [Core Logic]
+- What to implement
+- Dependencies on Phase 1
+- How to verify
+
+### Phase 3: [Integration + Polish]
+- Wire up CLI / docs / tests
+- How to verify end-to-end
+```
+
+**Rules for phasing:**
+- Each phase must compile and pass tests
+- Dependencies flow forward (Phase 2 depends on
+  Phase 1, never backward)
+- Put infrastructure/API changes in early phases
+- Put CLI integration and documentation in later
+  phases
+- Keep phases small enough to review in one PR
+  (prefer 1 PR per phase)
+
+## Phase 5 — Risk Assessment
+
+Flag any of these if they apply:
+
+| Risk | Mitigation |
+|------|------------|
+| Cross-module dependency added | Verify with `dependency_graph.md`; consider `_compute` variant |
+| Performance-sensitive path | Consult `performance-practices.md`; plan benchmarking |
+| Breaking API change | Document migration path; consider deprecation period |
+| Standalone linkage | Verify with `add_milk_standalone()`; check `_compute` variants |
+| Large refactor | Use `refactor-c-source` skill; split into multiple PRs |
+| Concurrency / shared memory | Consult `concurrency-practices.md` |
+
+## Output Format
+
+Present the plan using the template in
+`templates/feature-plan-template.md`. Write it
+as the implementation plan artifact and request
+user review before proceeding to execution.
+
+## Integration with Existing Rules
+
+This skill does **not** replace any existing
+rules — it orchestrates them. During planning,
+explicitly check which rules will fire during
+execution and account for them in the plan.
+
+Key rules to consult during planning:
+- `architecture-principles.md` — dependency
+  direction
+- `cmake-conventions.md` — build target setup
+- `fpsexec-conventions.md` — V2 template layout
+- `module-deps-declaration.md` — MODULE_DEPS
+- `performance-practices.md` — hot path design

--- a/.agents/skills/feature-planner/templates/feature-plan-template.md
+++ b/.agents/skills/feature-planner/templates/feature-plan-template.md
@@ -1,0 +1,86 @@
+# Feature Plan: [Title]
+
+## Overview
+
+**Goal**: [One-sentence description of the feature]
+**Scope**: [Engine / Core / Full] · [New module /
+Extension / Modification]
+**Template**: [V2 compute unit / stream processor /
+plain function / CLI builtin / none]
+
+## Architecture Impact
+
+### Build Tier
+
+- **Affected tier(s)**: [Engine / Core / Full]
+- **New dependencies**: [list or "none"]
+- **Dependency direction valid**: [yes/no — check
+  `dependency_graph.md`]
+
+### Shared Memory Objects
+
+| Object | Type | Name | Details |
+|--------|------|------|---------|
+| | Stream / FPS / Procinfo | | dtype, dims, params |
+
+### CLI Surface
+
+- **New commands**: [list or "none"]
+- **New executables**: [list or "none"]
+- **Modified commands**: [list or "none"]
+
+## File Changes
+
+### [Component 1]
+
+| Action | File | Purpose |
+|--------|------|---------|
+| NEW | `file.c` | description |
+| MODIFY | `file.c` | what changes |
+| MODIFY | `CMakeLists.txt` | new targets |
+
+### [Component 2]
+
+| Action | File | Purpose |
+|--------|------|---------|
+| ... | ... | ... |
+
+## Documentation Updates
+
+- [ ] Module README
+- [ ] Help text cross-check (`help-consistency`)
+- [ ] What's New entry
+- [ ] Programmer's guide (if architectural)
+- [ ] MkDocs page (if new user-facing feature)
+
+## Implementation Phases
+
+### Phase 1: [Foundation]
+
+**Changes**: [list]
+**Verify**: [compile-test, specific tests]
+**Complexity**: [low / medium / high]
+
+### Phase 2: [Core Logic]
+
+**Depends on**: Phase 1
+**Changes**: [list]
+**Verify**: [compile-test, specific tests]
+**Complexity**: [low / medium / high]
+
+### Phase 3: [Integration]
+
+**Depends on**: Phase 2
+**Changes**: [CLI wiring, docs, tests]
+**Verify**: [end-to-end test, CLI robustness]
+**Complexity**: [low / medium / high]
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| | low/med/high | |
+
+## Open Questions
+
+1. [Any decisions that need user input]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,7 @@ when domain-specific tasks require extended capabilities.
 
 | Skill | When to use |
 |-------|-------------|
+| `feature-planner` | Structured planning and decomposition for new features |
 | `batch-kernel-doc` | Systematic Kernel-Doc documentation passes |
 | `cli-test-writer` | Writing CLI robustness test cases |
 | `cmake-patterns` | Module CMake setup, standalone builds, `_compute` variants |

--- a/docs/code_assist.md
+++ b/docs/code_assist.md
@@ -72,6 +72,7 @@ contains a `SKILL.md` with detailed instructions.
 
 | Skill | Folder | What it provides |
 |-------|--------|------------------|
+| Feature planner | [`feature-planner`](https://github.com/milk-org/milk/blob/framework-dev/.agents/skills/feature-planner/SKILL.md) | Structured planning and architectural decomposition for new features. |
 | Batch Kernel-Doc | [`batch-kernel-doc`](https://github.com/milk-org/milk/blob/framework-dev/.agents/skills/batch-kernel-doc/SKILL.md) | Systematic function documentation with scanning, templates, and batch processing. |
 | CLI test writer | [`cli-test-writer`](https://github.com/milk-org/milk/blob/framework-dev/.agents/skills/cli-test-writer/SKILL.md) | Writing test cases for the CLI robustness suite with coverage analysis. |
 | CMake patterns | [`cmake-patterns`](https://github.com/milk-org/milk/blob/framework-dev/.agents/skills/cmake-patterns/SKILL.md) | Module CMake setup, standalone builds, `_compute` variants. |


### PR DESCRIPTION
## Summary

Adds a new `feature-planner` skill that guides agents through structured architectural planning before code is written, filling the gap between high-level feature requests and implementation.

## Changes

### `.agents/skills/feature-planner/`
- **SKILL.md** — 5-phase planning methodology (Classify → Map Architecture → Enumerate Touchpoints → Sequence Work → Assess Risks)
- **templates/feature-plan-template.md** — Structured output template for consistent plan format

### Index updates
- **AGENTS.md** — Added skill to § 7 skills table
- **docs/code_assist.md** — Added skill to skills index

### Minor fix
- **`.agents/rules/error-handling-practices.md`** — Added missing YAML frontmatter (all other rules had it)

## Verification

- [x] No C/CMake changes — no compile-test needed
- [x] Documentation-only change

## Prompt Summary

User asked whether a planning-focused agent should be added to help architect new features. After discussion, agreed that a **skill** (not a separate agent) is the right approach — it runs inside the same agent context, avoids handoff friction, and inherits all existing rules. The skill was designed to orchestrate existing rules during the planning phase rather than duplicate architectural knowledge.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None