### PR TITLE
chore: add GitHub issue templates integrated with agent infrastructure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,107 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "[BUG] "
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: >-
+        Which subsystem is affected? See the component
+        table in the
+        [fix-bug workflow](.agents/workflows/fix-bug.md)
+        for guidance.
+      options:
+        - CLI (CLIcore / milk-cli)
+        - ImageStreamIO (shared memory streams)
+        - FPS (function parameter system)
+        - processinfo (heartbeat / telemetry)
+        - COREMOD (arith, memory, tools, iofits)
+        - Standalone fpsexec executable
+        - Plugin module
+        - Build system (CMake)
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: >-
+        Minimal steps to reproduce the bug. Include
+        exact commands.
+      placeholder: |
+        1. Start milk-cli:
+           ```
+           source ~/src/milk/local/bin/milk-setup.bash
+           echo "command" | milk-cli
+           ```
+        2. Or for standalone executables:
+           ```
+           milk-fpsexec-<name> <args>
+           ```
+        3. Observe error / crash / unexpected output
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs Actual Behavior
+      description: What did you expect, and what happened?
+      placeholder: |
+        **Expected:** ...
+        **Actual:** ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: >-
+        System information. Run `milk-cli -i` for
+        the milk version.
+      placeholder: |
+        - milk version: (output of `milk-cli -i`)
+        - OS: (e.g., Ubuntu 24.04)
+        - Compiler: (e.g., GCC 14.1)
+        - GPU: (if relevant)
+      value: |
+        - milk version:
+        - OS:
+        - Compiler:
+        - GPU:
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Log Output
+      description: >-
+        Paste any relevant log output or error messages.
+      render: text
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I searched existing issues for duplicates
+          required: true
+        - label: >-
+            I can reproduce this on the latest
+            `framework-dev` branch
+          required: false

--- a/.github/ISSUE_TEMPLATE/build_issue.yml
+++ b/.github/ISSUE_TEMPLATE/build_issue.yml
@@ -1,0 +1,74 @@
+name: Build Issue
+description: Report a compilation or CMake problem
+title: "[BUILD] "
+labels: ["build"]
+body:
+  - type: dropdown
+    id: build-tier
+    attributes:
+      label: Build Tier
+      description: >-
+        Which build tier are you targeting? See
+        [AGENTS.md](AGENTS.md#9-build-system-quick-reference)
+        for tier definitions.
+      options:
+        - Engine (-DUSE_COREMODS=OFF -DUSE_CLI=OFF)
+        - Core (-DUSE_CLI=OFF -DUSE_CFITSIO=OFF)
+        - Core+FITS (-DUSE_CLI=OFF)
+        - Full (defaults)
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: cmake-invocation
+    attributes:
+      label: CMake Invocation
+      description: >-
+        Paste the exact cmake command you ran.
+      placeholder: |
+        cmake .. -DCMAKE_INSTALL_PREFIX=...
+      render: bash
+    validations:
+      required: true
+
+  - type: textarea
+    id: error-output
+    attributes:
+      label: Error Output
+      description: >-
+        Paste the relevant compiler or CMake error
+        output. AI agents can use the
+        `diagnose-build-failure` skill to triage
+        these errors.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: System information.
+      value: |
+        - OS:
+        - Compiler + version:
+        - CMake version:
+        - Branch:
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: >-
+            I ran cmake from a clean _build directory
+          required: true
+        - label: >-
+            I am building from the `framework-dev`
+            branch (or a branch derived from it)
+          required: true
+        - label: I searched existing issues for duplicates
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Contributing Guide
+    url: https://github.com/milk-org/milk/blob/framework-dev/CONTRIBUTING.md
+    about: >-
+      Read the contributing guide before opening an issue
+  - name: Agent Onboarding (AGENTS.md)
+    url: https://github.com/milk-org/milk/blob/framework-dev/AGENTS.md
+    about: >-
+      AI coding agents — start here for onboarding

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,19 @@
+---
+name: Documentation Improvement
+about: Suggest a correction or addition to the docs
+title: "[DOCS] "
+labels: documentation
+assignees: ''
+---
+
+## What page or section?
+
+<!-- Link to the page, or name the file/section -->
+
+## What is wrong or missing?
+
+<!-- Describe the issue with the current documentation -->
+
+## Suggested fix
+
+<!-- How should it be improved? -->

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,91 @@
+name: Feature Request
+description: Propose a new feature or enhancement
+title: "[FEAT] "
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which subsystem does this affect?
+      options:
+        - CLI (CLIcore / milk-cli)
+        - ImageStreamIO (shared memory streams)
+        - FPS (function parameter system)
+        - processinfo (heartbeat / telemetry)
+        - COREMOD (arith, memory, tools, iofits)
+        - Standalone fpsexec executable
+        - Plugin module
+        - Build system (CMake)
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: >-
+        What capability is needed? Be concise.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: >-
+        Describe the real-world motivation. What problem
+        does this solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: approach
+    attributes:
+      label: Proposed Approach
+      description: >-
+        Optional. If you have ideas on implementation,
+        describe them here. For reference, new compute
+        units should follow the
+        [V2 template](src/milk_module_example/examplefunc_fps_cli_poc.c).
+        AI agents can use workflows like `/create-fpsexec`,
+        `/add-function`, `/add-stream-processor`, or
+        `/add-new-module`.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: What kind of change is this?
+      options:
+        - New function in existing module
+        - New standalone fpsexec executable
+        - New module / plugin
+        - CLI command change
+        - Stream processing loop
+        - API / library change
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: >-
+        Other approaches you considered and why they
+        were not preferred.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I searched existing issues for duplicates
+          required: true
+        - label: >-
+            I reviewed the dependency graph before
+            proposing cross-module changes
+          required: false

--- a/.github/ISSUE_TEMPLATE/performance_issue.yml
+++ b/.github/ISSUE_TEMPLATE/performance_issue.yml
@@ -1,0 +1,81 @@
+name: Performance Issue
+description: Report a performance bottleneck or regression
+title: "[PERF] "
+labels: ["performance"]
+body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which subsystem is affected?
+      options:
+        - CLI (CLIcore / milk-cli)
+        - ImageStreamIO (shared memory streams)
+        - FPS (function parameter system)
+        - processinfo (heartbeat / telemetry)
+        - COREMOD (arith, memory, tools, iofits)
+        - Standalone fpsexec executable
+        - Plugin module
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: >-
+        What is slow or degraded? Which function or
+        executable is affected?
+    validations:
+      required: true
+
+  - type: textarea
+    id: measurement
+    attributes:
+      label: Measurement / Profiling Data
+      description: >-
+        Include loop rates, latency numbers, profiler
+        output, or processinfo telemetry. AI agents
+        can use the `optimize-compute-function` skill
+        and `/inspect-machine-code` workflow to
+        investigate.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Performance
+      description: >-
+        What performance level do you expect or need?
+        Reference prior benchmarks if available.
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: >-
+        Hardware and software details relevant to
+        performance.
+      value: |
+        - CPU model:
+        - BLAS library (MKL / OpenBLAS / none):
+        - Compiler + flags:
+        - OS:
+        - milk version:
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I searched existing issues for duplicates
+          required: true
+        - label: >-
+            I measured with optimized build flags
+            (not a debug build)
+          required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,9 +90,9 @@ refactor: extract processinfo loop into helper
 
 ## Reporting Issues
 
-Use GitHub Issues. Include:
-
-- milk version (`milk-cli -i`)
-- OS and compiler version
-- Steps to reproduce
-- Expected vs actual behavior
+Use the [issue templates](https://github.com/milk-org/milk/issues/new/choose)
+when filing a bug, feature request, build problem, or
+performance issue. The templates guide you through the
+required information (version, reproduction steps, etc.)
+and are integrated with the project's agent workflows
+for faster triage.


### PR DESCRIPTION
## Summary

Add structured GitHub issue templates (YAML forms) for bug reports, feature requests, build issues, performance issues, and documentation improvements. Templates are integrated with the project's agent workflows and skills for faster AI-assisted triage.

### Changes
- **5 issue templates** in `.github/ISSUE_TEMPLATE/` with component/tier dropdowns, required fields, and pre-filled environment checklists
- **`config.yml`** — disables blank issues, links to CONTRIBUTING.md and AGENTS.md
- **`CONTRIBUTING.md`** — updated "Reporting Issues" section to reference templates

### Agent Integration
- Bug report → `/fix-bug` workflow component table
- Feature request → `/create-fpsexec`, `/add-function`, `/add-stream-processor` workflows
- Build issue → `diagnose-build-failure` skill, build tier table from AGENTS.md
- Performance → `optimize-compute-function` skill, `/inspect-machine-code` workflow

### Prompt Summary
User requested GitHub issue templates integrated with the project's agent infrastructure.

### AI Authorship
- **Model:** Antigravity
- **User edits:** None