### PR TITLE
feat(cli): add @fpsname.param=value assignment syntax

### DIFF
--- a/src/cli/CLIcore/CLIcore/CLIcore_UI_execute.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI_execute.c
@@ -247,14 +247,16 @@ static int cli_check_unquoted_restricted_symbols(
         }
         
         if (word_start) {
-            if (isalpha(c) || c == '_') {
+            if (isalpha(c) || c == '_'
+                || c == '@') {
                 valid_assign_prefix = 1;
             } else {
                 valid_assign_prefix = 0;
             }
             word_start = 0;
         } else {
-            if (!isalnum(c) && c != '_') {
+            if (!isalnum(c) && c != '_'
+                && c != '.' && c != '@') {
                 valid_assign_prefix = 0;
             }
         }

--- a/src/cli/CLIcore/CLIcore/CLIcore_script.h
+++ b/src/cli/CLIcore/CLIcore/CLIcore_script.h
@@ -121,6 +121,14 @@ errno_t cli_cmd_echo(void);
 /** fpsset — write FPS parameter */
 errno_t cli_cmd_fpsset(void);
 
+/** Set an FPS parameter by name.
+ *  Returns 0 on success, -1 on error. */
+int cli_fps_set_param(
+    const char *fpsname,
+    const char *pname,
+    const char *valstr
+);
+
 /** read — read a line into a variable */
 errno_t cli_cmd_read(void);
 

--- a/src/cli/CLIcore/CLIcore/CLIcore_script_builtin.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_script_builtin.c
@@ -78,7 +78,7 @@ errno_t cli_cmd_echo(void)
 
 
 /* ============================================================
- *  FPS Write — fpsset command
+ *  FPS Write — reusable helper and fpsset command
  * ============================================================
  */
 
@@ -88,54 +88,39 @@ errno_t cli_cmd_echo(void)
 #include "fps_connect.h"
 
 /**
- * @brief fpsset command — write FPS parameter
+ * @brief Set an FPS parameter by name
  *
- * Usage: fpsset fpsname.param value
+ * Connects to the named FPS, locates the
+ * parameter, writes the value string, and
+ * disconnects.  Reused by both the fpsset
+ * command and the @fpsname.param=value
+ * expansion syntax.
+ *
+ * @param fpsname  FPS shared-memory name
+ * @param pname    Parameter key inside FPS
+ * @param valstr   Value to write (as string)
+ * @return 0 on success, -1 on error
  */
-errno_t cli_cmd_fpsset(void)
+int cli_fps_set_param(
+    const char *fpsname,
+    const char *pname,
+    const char *valstr
+)
 {
-    if(data.cmdNBarg < 3)
-    {
-        printf("Usage: fpsset "
-               "<fpsname.param> <value>\n");
-        return RETURN_FAILURE;
-    }
-
-    const char *fullname =
-        data.cmdargtoken[1].val.string;
-    const char *valstr =
-        data.cmdargtoken[2].val.string;
-
-    /* Split fpsname.param at first dot */
-    char fpsname[256];
-    strncpy(fpsname, fullname,
-            sizeof(fpsname) - 1);
-    fpsname[sizeof(fpsname) - 1] = '\0';
-
-    char *dot = strchr(fpsname, '.');
-    if(dot == NULL)
-    {
-        printf("Error: fpsset requires "
-               "fpsname.paramname\n");
-        return RETURN_FAILURE;
-    }
-    *dot = '\0';
-    const char *pname = dot + 1;
-
-    /* Connect to FPS */
     FUNCTION_PARAMETER_STRUCT fps;
     int fpsconn =
         function_parameter_struct_connect(
-            fpsname, &fps, FPSCONNECT_SIMPLE);
+            fpsname, &fps,
+            FPSCONNECT_SIMPLE);
 
-    if(fpsconn == -1 || fps.parray == NULL)
+    if(fpsconn == -1
+       || fps.parray == NULL)
     {
         printf("Error: cannot connect to "
                "FPS '%s'\n", fpsname);
-        return RETURN_FAILURE;
+        return -1;
     }
 
-    /* Find parameter index */
     int pindex =
         functionparameter_GetParamIndex(
             &fps, pname);
@@ -157,17 +142,17 @@ errno_t cli_cmd_fpsset(void)
                pname, fpsname);
         function_parameter_struct_disconnect(
             &fps);
-        return RETURN_FAILURE;
+        return -1;
     }
 
-    /* Set value based on parameter type */
     uint32_t ptype =
         fps.parray[pindex].type;
 
     if(ptype & FPTYPE_INT64)
     {
         fps.parray[pindex].val.i64[0] =
-            (int64_t) strtol(valstr, NULL, 0);
+            (int64_t) strtol(
+                valstr, NULL, 0);
         fps.parray[pindex].cnt0++;
     }
     else if(ptype & FPTYPE_FLOAT64)
@@ -188,23 +173,28 @@ errno_t cli_cmd_fpsset(void)
            || strcmp(valstr, "on") == 0
            || strcmp(valstr, "1") == 0)
         {
-            fps.parray[pindex].val.i64[0] = 1;
+            fps.parray[pindex]
+                .val.i64[0] = 1;
         }
         else
         {
-            fps.parray[pindex].val.i64[0] = 0;
+            fps.parray[pindex]
+                .val.i64[0] = 0;
         }
         fps.parray[pindex].cnt0++;
     }
     else if(ptype & FPTYPE_STRING)
     {
         strncpy(
-            fps.parray[pindex].val.string[0],
+            fps.parray[pindex]
+                .val.string[0],
             valstr,
-            FUNCTION_PARAMETER_STRMAXLEN - 1);
-        fps.parray[pindex].val.string[0][
-            FUNCTION_PARAMETER_STRMAXLEN - 1]
-            = '\0';
+            FUNCTION_PARAMETER_STRMAXLEN
+            - 1);
+        fps.parray[pindex]
+            .val.string[0][
+                FUNCTION_PARAMETER_STRMAXLEN
+                - 1] = '\0';
         fps.parray[pindex].cnt0++;
     }
     else
@@ -213,7 +203,51 @@ errno_t cli_cmd_fpsset(void)
                "type 0x%x\n", ptype);
     }
 
-    function_parameter_struct_disconnect(&fps);
+    function_parameter_struct_disconnect(
+        &fps);
+    return 0;
+}
+
+/**
+ * @brief fpsset command — write FPS parameter
+ *
+ * Usage: fpsset fpsname.param value
+ */
+errno_t cli_cmd_fpsset(void)
+{
+    if(data.cmdNBarg < 3)
+    {
+        printf("Usage: fpsset "
+               "<fpsname.param> <value>\n");
+        return RETURN_FAILURE;
+    }
+
+    const char *fullname =
+        data.cmdargtoken[1].val.string;
+    const char *valstr =
+        data.cmdargtoken[2].val.string;
+
+    char fpsname[256];
+    strncpy(fpsname, fullname,
+            sizeof(fpsname) - 1);
+    fpsname[sizeof(fpsname) - 1] = '\0';
+
+    char *dot = strchr(fpsname, '.');
+    if(dot == NULL)
+    {
+        printf("Error: fpsset requires "
+               "fpsname.paramname\n");
+        return RETURN_FAILURE;
+    }
+    *dot = '\0';
+    const char *pname = dot + 1;
+
+    if(cli_fps_set_param(
+           fpsname, pname, valstr) != 0)
+    {
+        return RETURN_FAILURE;
+    }
+
     return RETURN_SUCCESS;
 }
 

--- a/src/cli/CLIcore/CLIcore/CLIcore_script_expand.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_script_expand.c
@@ -445,6 +445,21 @@ void cli_expand_fpsvar(
                 }
                 valstr[vlen] = '\0';
 
+                /* Expand @fps.param refs, $VAR and
+                 * $((...)) in the value before
+                 * setting the parameter, so that
+                 * e.g. @fps.gain=$var or
+                 * @fps.gain=$((a+b)) works. */
+                cli_expand_fpsvar(
+                    valstr,
+                    (int) sizeof(valstr));
+                cli_expand_env(
+                    valstr,
+                    (int) sizeof(valstr));
+                cli_expand_arith(
+                    valstr,
+                    (int) sizeof(valstr));
+
                 /* Split token at first dot */
                 char tcopy[512];
                 strncpy(tcopy, token,

--- a/src/cli/CLIcore/CLIcore/CLIcore_script_expand.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_script_expand.c
@@ -383,6 +383,26 @@ void cli_expand_fpsvar(
 
                 cli_fps_set_param(
                     fpsname, pname, valstr);
+
+                /* If this assignment is the whole
+                 * command, ensure the expanded
+                 * line is not empty so that the
+                 * dispatcher does not fall back
+                 * to a spurious "command not
+                 * found" / shell execution.
+                 * Insert a POSIX no-op ":" as
+                 * a harmless placeholder. */
+                if(opos == 0)
+                {
+                    if(opos < maxlen - 1)
+                    {
+                        out[opos++] = ':';
+                    }
+                    if(opos < maxlen - 1)
+                    {
+                        out[opos++] = ' ';
+                    }
+                }
                 continue;
             }
 

--- a/src/cli/CLIcore/CLIcore/CLIcore_script_expand.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_script_expand.c
@@ -355,18 +355,93 @@ void cli_expand_fpsvar(
             {
                 i++; /* skip '=' */
 
-                /* Collect value (to whitespace,
-                 * semicolon, or NUL) */
+                /* Collect value up to statement end
+                 * (semicolon, newline, or NUL),
+                 * allowing spaces, parentheses, and
+                 * quoted strings. */
                 char valstr[512];
-                int  vlen = 0;
+                int  vlen      = 0;
+                int  depth     = 0; /* paren depth */
+                int  in_single = 0;
+                int  in_double = 0;
+                int  escape    = 0;
+
+                /* Skip leading whitespace after '=' */
+                while(line[i] == ' '
+                      || line[i] == '\t')
+                {
+                    i++;
+                }
+
                 while(line[i] != '\0'
-                      && line[i] != ' '
-                      && line[i] != '\t'
-                      && line[i] != ';'
-                      && line[i] != '\n'
                       && vlen < 511)
                 {
-                    valstr[vlen++] = line[i++];
+                    char c = line[i];
+
+                    if(!escape)
+                    {
+                        if(c == '\\')
+                        {
+                            escape = 1;
+                            valstr[vlen++] = c;
+                            i++;
+                            continue;
+                        }
+
+                        if(!in_single
+                           && !in_double)
+                        {
+                            if(c == '(')
+                            {
+                                depth++;
+                            }
+                            else if(c == ')'
+                                    && depth > 0)
+                            {
+                                depth--;
+                            }
+
+                            /* Stop at ';' or
+                             * newline only when
+                             * not nested. */
+                            if(depth == 0
+                                    && (c == ';'
+                                        || c == '\n'))
+                            {
+                                break;
+                            }
+                        }
+
+                        if(!in_double
+                           && c == '\'')
+                        {
+                            in_single =
+                                !in_single;
+                        }
+                        else if(!in_single
+                                && c == '"')
+                        {
+                            in_double =
+                                !in_double;
+                        }
+                    }
+                    else
+                    {
+                        /* Escaped character */
+                        escape = 0;
+                    }
+
+                    valstr[vlen++] = c;
+                    i++;
+                }
+
+                /* Trim trailing whitespace */
+                while(vlen > 0
+                      && (valstr[vlen - 1] == ' '
+                          || valstr[vlen - 1]
+                          == '\t'))
+                {
+                    vlen--;
                 }
                 valstr[vlen] = '\0';
 

--- a/src/cli/CLIcore/CLIcore/CLIcore_script_expand.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_script_expand.c
@@ -349,6 +349,43 @@ void cli_expand_fpsvar(
             }
             token[tlen] = '\0';
 
+            /* ---- Write path: @fps.param=val ---- */
+            if(line[i] == '='
+               && strchr(token, '.') != NULL)
+            {
+                i++; /* skip '=' */
+
+                /* Collect value (to whitespace,
+                 * semicolon, or NUL) */
+                char valstr[512];
+                int  vlen = 0;
+                while(line[i] != '\0'
+                      && line[i] != ' '
+                      && line[i] != '\t'
+                      && line[i] != ';'
+                      && line[i] != '\n'
+                      && vlen < 511)
+                {
+                    valstr[vlen++] = line[i++];
+                }
+                valstr[vlen] = '\0';
+
+                /* Split token at first dot */
+                char tcopy[512];
+                strncpy(tcopy, token,
+                        sizeof(tcopy) - 1);
+                tcopy[sizeof(tcopy) - 1] =
+                    '\0';
+                char *dot = strchr(tcopy, '.');
+                *dot = '\0';
+                const char *fpsname = tcopy;
+                const char *pname = dot + 1;
+
+                cli_fps_set_param(
+                    fpsname, pname, valstr);
+                continue;
+            }
+
             char *dot = strchr(token, '.');
             if(dot == NULL)
             {

--- a/src/cli/CLIcore/CLIcore/CLIcore_script_expand.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_script_expand.c
@@ -316,7 +316,17 @@ double arith_expr(ArithParser *p)
 /**
  * @brief Expand @fpsname.param tokens in place
  *
- * @param line   Command line buffer
+ * Tokens of the form @fpsname.param are replaced with
+ * the current value of that FPS parameter (read path).
+ * Tokens of the form @fpsname.param=value write the
+ * value to the parameter instead.
+ *
+ * Expansion is suppressed when the @ character appears
+ * inside single or double quotes, or after a backslash
+ * escape, so that e.g. echo "@fps.p=1" passes the
+ * literal string through unchanged.
+ *
+ * @param line   Command line buffer (modified in place)
  * @param maxlen Buffer size
  */
 void cli_expand_fpsvar(
@@ -325,13 +335,52 @@ void cli_expand_fpsvar(
 )
 {
     char out[STRINGMAXLEN_CLICMDLINE];
-    int  opos = 0;
-    int  i = 0;
+    int  opos      = 0;
+    int  i         = 0;
+    int  in_single = 0; /* inside ' ... ' */
+    int  in_double = 0; /* inside " ... " */
+    int  out_esc   = 0; /* backslash escape */
 
     while(line[i] != '\0'
             && opos < maxlen - 1)
     {
-        if(line[i] == '@')
+        char c = line[i];
+
+        /* ---- Outer quote / escape tracking ---- */
+        if(out_esc)
+        {
+            out_esc = 0;
+            out[opos++] = c;
+            i++;
+            continue;
+        }
+
+        if(c == '\\' && !in_single)
+        {
+            out_esc = 1;
+            out[opos++] = c;
+            i++;
+            continue;
+        }
+
+        if(c == '\'' && !in_double)
+        {
+            in_single = !in_single;
+            out[opos++] = c;
+            i++;
+            continue;
+        }
+
+        if(c == '"' && !in_single)
+        {
+            in_double = !in_double;
+            out[opos++] = c;
+            i++;
+            continue;
+        }
+
+        /* Skip @ expansion when inside quotes */
+        if(c == '@' && !in_single && !in_double)
         {
             i++; /* skip @ */
             char token[512];


### PR DESCRIPTION
## Summary

Add symmetric FPS write syntax so that reading (`@fpsname.param`) and writing (`@fpsname.param=value`) use the same `@` notation, eliminating the need for the separate `fpsset fpsname.param value` command in scripts.

### Syntax examples

```bash
# New symmetric syntax
@loopctrl.gain=0.3
@loopctrl.gain=$newgain

# Existing command (still works)
fpsset loopctrl.gain 0.3
```

## Changes

- **`CLIcore_script_builtin.c`** — Extract `cli_fps_set_param()` helper from `cli_cmd_fpsset()` for reuse
- **`CLIcore_script_expand.c`** — Intercept `@token=value` in `cli_expand_fpsvar()` before read expansion; route to `cli_fps_set_param()`
- **`CLIcore_UI_execute.c`** — Update restricted-symbol gate to accept `@` and `.` in assignment prefix context
- **`CLIcore_script.h`** — Add `cli_fps_set_param()` prototype

## Testing

- Build: clean (0 errors)
- ctest: 37/37 passed

Fixes #180

## Prompt Summary

User requested implementation of issue #180 — adding `@fpsname.param=value` FPS assignment syntax to the CLI for symmetric read/write notation.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None