### PR TITLE
refactor: modularize monolithic CLI functions (Phases 2-4)

### DIFF
--- a/src/cli/CLIcore/CLIcore/CLIcore_checkargs.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_checkargs.c
@@ -266,6 +266,152 @@ int CLI_checkarg_noerrmsg(int CLIargnum, uint32_t funcargtype)
  * CLIarg keep count of argument position in CLI call
  *
  */
+/**
+ * @brief Read one FPS parameter value into argdata.
+ *
+ * Dispatches on FPS parameter type and copies the
+ * value from the FPS shared memory into the
+ * corresponding argdata field.
+ *
+ * @param ptype  FPS parameter type
+ * @param fp     Pointer to the FPS parameter entry
+ * @param ad     Pointer to the argdata slot
+ */
+static void sync_fps_to_argdata(
+    uint32_t ptype,
+    FUNCTION_PARAMETER *fp,
+    CLICMDARGDATA      *ad
+)
+{
+    switch (ptype)
+    {
+        case FPTYPE_FLOAT32:
+            ad->val.f32 = fp->val.f32[0];
+            break;
+        case FPTYPE_FLOAT64:
+            ad->val.f64 = fp->val.f64[0];
+            break;
+        case FPTYPE_INT32:
+            ad->val.i32 = fp->val.i32[0];
+            break;
+        case FPTYPE_UINT32:
+            ad->val.ui32 = fp->val.ui32[0];
+            break;
+        case FPTYPE_INT64:
+            ad->val.i64 = fp->val.i64[0];
+            break;
+        case FPTYPE_UINT64:
+            ad->val.ui64 = fp->val.ui64[0];
+            break;
+        case FPTYPE_ONOFF:
+            ad->val.i64 = fp->val.i32[0];
+            break;
+        case FPTYPE_PID:
+            ad->val.i64 =
+                (int64_t) fp->val.pid[0];
+            break;
+        case FPTYPE_TIMESPEC:
+            ad->val.f64 =
+                (double) fp->val.ts[0].tv_sec
+                + (double) fp->val.ts[0]
+                    .tv_nsec * 1e-9;
+            break;
+        case FPTYPE_STRING:
+        case FPTYPE_STREAMNAME:
+        case FPTYPE_DIRNAME:
+        case FPTYPE_FILENAME:
+        case FPTYPE_FITSFILENAME:
+        case FPTYPE_EXECFILENAME:
+        case FPTYPE_FPSNAME:
+        case FPTYPE_PROCESS:
+        case FPTYPE_STRING_NOT_STREAM:
+            strncpy(
+                ad->val.s,
+                fp->val.string[0],
+                STRINGMAXLEN_CLICMDARG - 1);
+            break;
+    }
+}
+
+
+/**
+ * @brief Write a CLI token value into an FPS parameter.
+ *
+ * Dispatches on FPS parameter type and calls the
+ * appropriate functionparameter_SetParamValue_*
+ * function using the numeric or string value from
+ * the CLI token.
+ *
+ * @param fps     Pointer to the FPS struct
+ * @param fpstag  Parameter tag/key
+ * @param ptype   FPS parameter type
+ * @param numl    Integer value from CLI token
+ * @param numf    Float value from CLI token
+ * @param str     String value from CLI token
+ */
+static void set_fps_from_clitoken(
+    FUNCTION_PARAMETER_STRUCT *fps,
+    const char *fpstag,
+    uint32_t    ptype,
+    long        numl,
+    double      numf,
+    const char *str
+)
+{
+    switch (ptype)
+    {
+        case FPTYPE_INT64:
+            functionparameter_SetParamValue_INT64(
+                fps, fpstag, numl);
+            break;
+        case FPTYPE_UINT64:
+            functionparameter_SetParamValue_UINT64(
+                fps, fpstag, numl);
+            break;
+        case FPTYPE_INT32:
+            functionparameter_SetParamValue_INT32(
+                fps, fpstag, numl);
+            break;
+        case FPTYPE_UINT32:
+            functionparameter_SetParamValue_UINT32(
+                fps, fpstag, numl);
+            break;
+        case FPTYPE_FLOAT64:
+            functionparameter_SetParamValue_FLOAT64(
+                fps, fpstag, numf);
+            break;
+        case FPTYPE_FLOAT32:
+            functionparameter_SetParamValue_FLOAT32(
+                fps, fpstag, (float) numf);
+            break;
+        case FPTYPE_PID:
+            functionparameter_SetParamValue_INT64(
+                fps, fpstag, (int64_t) numl);
+            break;
+        case FPTYPE_TIMESPEC:
+            functionparameter_SetParamValue_TIMESPEC(
+                fps, fpstag, numf);
+            break;
+        case FPTYPE_STRING:
+        case FPTYPE_STREAMNAME:
+        case FPTYPE_DIRNAME:
+        case FPTYPE_FILENAME:
+        case FPTYPE_FITSFILENAME:
+        case FPTYPE_EXECFILENAME:
+        case FPTYPE_FPSNAME:
+        case FPTYPE_PROCESS:
+        case FPTYPE_STRING_NOT_STREAM:
+            functionparameter_SetParamValue_STRING(
+                fps, fpstag, str);
+            break;
+        case FPTYPE_ONOFF:
+            functionparameter_SetParamValue_ONOFF(
+                fps, fpstag, (int) numl);
+            break;
+    }
+}
+
+
 errno_t CLI_checkarg_array(
     CLICMDARGDEF fpscliarg[],
     int nbarg
@@ -286,49 +432,12 @@ errno_t CLI_checkarg_array(
             if(pindex != -1)
             {
                 uint32_t ptype = dcfpsptr->parray[pindex].type;
-                switch(ptype)
-                {
-                    case FPTYPE_FLOAT32:
-                        data.cmd[data.cmdindex].argdata[arg].val.f32 = dcfpsptr->parray[pindex].val.f32[0];
-                        break;
-                    case FPTYPE_FLOAT64:
-                        data.cmd[data.cmdindex].argdata[arg].val.f64 = dcfpsptr->parray[pindex].val.f64[0];
-                        break;
-                    case FPTYPE_INT32:
-                        data.cmd[data.cmdindex].argdata[arg].val.i32 = dcfpsptr->parray[pindex].val.i32[0];
-                        break;
-                    case FPTYPE_UINT32:
-                        data.cmd[data.cmdindex].argdata[arg].val.ui32 = dcfpsptr->parray[pindex].val.ui32[0];
-                        break;
-                    case FPTYPE_INT64:
-                        data.cmd[data.cmdindex].argdata[arg].val.i64 = dcfpsptr->parray[pindex].val.i64[0];
-                        break;
-                    case FPTYPE_UINT64:
-                        data.cmd[data.cmdindex].argdata[arg].val.ui64 = dcfpsptr->parray[pindex].val.ui64[0];
-                        break;
-                    case FPTYPE_ONOFF:
-                        data.cmd[data.cmdindex].argdata[arg].val.i64 = dcfpsptr->parray[pindex].val.i32[0];
-                        break;
-                    case FPTYPE_PID:
-                        data.cmd[data.cmdindex].argdata[arg].val.i64 = (int64_t)dcfpsptr->parray[pindex].val.pid[0];
-                        break;
-                    case FPTYPE_TIMESPEC:
-                        data.cmd[data.cmdindex].argdata[arg].val.f64 = (double)dcfpsptr->parray[pindex].val.ts[0].tv_sec + (double)dcfpsptr->parray[pindex].val.ts[0].tv_nsec * 1e-9;
-                        break;
-                    case FPTYPE_STRING:
-                    case FPTYPE_STREAMNAME:
-                    case FPTYPE_DIRNAME:
-                    case FPTYPE_FILENAME:
-                    case FPTYPE_FITSFILENAME:
-                    case FPTYPE_EXECFILENAME:
-                    case FPTYPE_FPSNAME:
-                    case FPTYPE_PROCESS:
-                    case FPTYPE_STRING_NOT_STREAM:
-                        strncpy(data.cmd[data.cmdindex].argdata[arg].val.s,
-                            dcfpsptr->parray[pindex].val.string[0],
-                            STRINGMAXLEN_CLICMDARG - 1);
-                        break;
-                }
+                sync_fps_to_argdata(
+                    ptype,
+                    &dcfpsptr->parray[pindex],
+                    &data.cmd[data.cmdindex]
+                        .argdata[arg]
+                );
             }
         }
     }
@@ -368,67 +477,12 @@ errno_t CLI_checkarg_array(
 
                 // Update the parameter in FPS
                 uint32_t ptype = dcfpsptr->parray[pindex].type;
-                switch(ptype)
-                {
-                    case FPTYPE_INT64:
-                        functionparameter_SetParamValue_INT64(dcfpsptr,
-                            fpstag,
-                            data.cmdargtoken[2].val.numl);
-                        break;
-                    case FPTYPE_UINT64:
-                        functionparameter_SetParamValue_UINT64(dcfpsptr,
-                            fpstag,
-                            data.cmdargtoken[2].val.numl);
-                        break;
-                    case FPTYPE_INT32:
-                        functionparameter_SetParamValue_INT32(dcfpsptr,
-                            fpstag,
-                            data.cmdargtoken[2].val.numl);
-                        break;
-                    case FPTYPE_UINT32:
-                        functionparameter_SetParamValue_UINT32(dcfpsptr,
-                            fpstag,
-                            data.cmdargtoken[2].val.numl);
-                        break;
-                    case FPTYPE_FLOAT64:
-                        functionparameter_SetParamValue_FLOAT64(dcfpsptr,
-                            fpstag,
-                            data.cmdargtoken[2].val.numf);
-                        break;
-                    case FPTYPE_FLOAT32:
-                        functionparameter_SetParamValue_FLOAT32(dcfpsptr,
-                            fpstag,
-                            (float)data.cmdargtoken[2].val.numf);
-                        break;
-                    case FPTYPE_PID:
-                        functionparameter_SetParamValue_INT64(dcfpsptr,
-                            fpstag,
-                            (int64_t)data.cmdargtoken[2].val.numl);
-                        break;
-                    case FPTYPE_TIMESPEC:
-                        functionparameter_SetParamValue_TIMESPEC(dcfpsptr,
-                            fpstag,
-                            data.cmdargtoken[2].val.numf);
-                        break;
-                    case FPTYPE_STRING:
-                    case FPTYPE_STREAMNAME:
-                    case FPTYPE_DIRNAME:
-                    case FPTYPE_FILENAME:
-                    case FPTYPE_FITSFILENAME:
-                    case FPTYPE_EXECFILENAME:
-                    case FPTYPE_FPSNAME:
-                    case FPTYPE_PROCESS:
-                    case FPTYPE_STRING_NOT_STREAM:
-                        functionparameter_SetParamValue_STRING(dcfpsptr,
-                            fpstag,
-                            data.cmdargtoken[2].val.string);
-                        break;
-                    case FPTYPE_ONOFF:
-                        functionparameter_SetParamValue_ONOFF(dcfpsptr,
-                            fpstag,
-                            (int)data.cmdargtoken[2].val.numl);
-                        break;
-                }
+                set_fps_from_clitoken(
+                    dcfpsptr, fpstag, ptype,
+                    data.cmdargtoken[2].val.numl,
+                    data.cmdargtoken[2].val.numf,
+                    data.cmdargtoken[2].val.string
+                );
 
                 char valstr[STRINGMAXLEN_FPSCLIARG_TAG];
                 functionparameter_GetParamValueString(&dcfpsptr->parray[pindex],
@@ -518,68 +572,19 @@ errno_t CLI_checkarg_array(
                     fpscliarg[argindexmatch].fpstag);
                 if(pindex != -1)
                 {
-                    uint32_t ptype = dcfpsptr->parray[pindex].type;
-                    switch(ptype)
-                    {
-                        case FPTYPE_INT64:
-                            functionparameter_SetParamValue_INT64(dcfpsptr,
-                                fpscliarg[argindexmatch].fpstag,
-                                data.cmdargtoken[2].val.numl);
-                            break;
-                        case FPTYPE_UINT64:
-                            functionparameter_SetParamValue_UINT64(dcfpsptr,
-                                fpscliarg[argindexmatch].fpstag,
-                                data.cmdargtoken[2].val.numl);
-                            break;
-                        case FPTYPE_INT32:
-                            functionparameter_SetParamValue_INT32(dcfpsptr,
-                                fpscliarg[argindexmatch].fpstag,
-                                data.cmdargtoken[2].val.numl);
-                            break;
-                        case FPTYPE_UINT32:
-                            functionparameter_SetParamValue_UINT32(dcfpsptr,
-                                fpscliarg[argindexmatch].fpstag,
-                                data.cmdargtoken[2].val.numl);
-                            break;
-                        case FPTYPE_FLOAT64:
-                            functionparameter_SetParamValue_FLOAT64(dcfpsptr,
-                                fpscliarg[argindexmatch].fpstag,
-                                data.cmdargtoken[2].val.numf);
-                            break;
-                        case FPTYPE_FLOAT32:
-                            functionparameter_SetParamValue_FLOAT32(dcfpsptr,
-                                fpscliarg[argindexmatch].fpstag,
-                                (float)data.cmdargtoken[2].val.numf);
-                            break;
-                        case FPTYPE_PID:
-                            functionparameter_SetParamValue_INT64(dcfpsptr,
-                                fpscliarg[argindexmatch].fpstag,
-                                (int64_t)data.cmdargtoken[2].val.numl);
-                            break;
-                        case FPTYPE_TIMESPEC:
-                            functionparameter_SetParamValue_TIMESPEC(dcfpsptr,
-                                fpscliarg[argindexmatch].fpstag,
-                                data.cmdargtoken[2].val.numf);
-                            break;
-                        case FPTYPE_STRING:
-                        case FPTYPE_STREAMNAME:
-                        case FPTYPE_DIRNAME:
-                        case FPTYPE_FILENAME:
-                        case FPTYPE_FITSFILENAME:
-                        case FPTYPE_EXECFILENAME:
-                        case FPTYPE_FPSNAME:
-                        case FPTYPE_PROCESS:
-                        case FPTYPE_STRING_NOT_STREAM:
-                            functionparameter_SetParamValue_STRING(dcfpsptr,
-                                fpscliarg[argindexmatch].fpstag,
-                                data.cmdargtoken[2].val.string);
-                            break;
-                        case FPTYPE_ONOFF:
-                            functionparameter_SetParamValue_ONOFF(dcfpsptr,
-                                fpscliarg[argindexmatch].fpstag,
-                                (int)data.cmdargtoken[2].val.numl);
-                            break;
-                    }
+                    set_fps_from_clitoken(
+                        dcfpsptr,
+                        fpscliarg[argindexmatch]
+                            .fpstag,
+                        dcfpsptr->parray[pindex]
+                            .type,
+                        data.cmdargtoken[2]
+                            .val.numl,
+                        data.cmdargtoken[2]
+                            .val.numf,
+                        data.cmdargtoken[2]
+                            .val.string
+                    );
                 }
             }
         }

--- a/src/cli/CLIcore/CLIcore/CLIcore_script_expand.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_script_expand.c
@@ -336,6 +336,380 @@ double arith_expr(ArithParser *p)
  * @param line   Command line buffer (modified in place)
  * @param maxlen Buffer size
  */
+/**
+ * @brief Handle @fpsname.param=value write path.
+ *
+ * Parses value (with quote/escape/paren awareness),
+ * recursively expands it, then calls cli_fps_set_param.
+ *
+ * @param line   Full command line
+ * @param[in,out] i  Current parse position (after '=')
+ * @param token  "fpsname.param" token
+ * @param out    Output buffer
+ * @param[in,out] opos  Output position
+ * @param maxlen Output buffer size
+ */
+static void expand_fpsvar_write(
+    char       *line,
+    int        *i,
+    const char *token,
+    char       *out,
+    int        *opos,
+    int         maxlen
+)
+{
+    char valstr[512];
+    int  vlen      = 0;
+    int  depth     = 0;
+    int  in_sq     = 0;
+    int  in_dq     = 0;
+    int  esc       = 0;
+    int  pos       = *i;
+
+    while (line[pos] == ' '
+           || line[pos] == '\t')
+    {
+        pos++;
+    }
+
+    while (line[pos] != '\0'
+           && vlen < 511)
+    {
+        char ch = line[pos];
+
+        if (!esc)
+        {
+            if (ch == '\\')
+            {
+                esc = 1;
+                valstr[vlen++] = ch;
+                pos++;
+                continue;
+            }
+            if (!in_sq && !in_dq)
+            {
+                if (ch == '(')
+                {
+                    depth++;
+                }
+                else if (ch == ')'
+                         && depth > 0)
+                {
+                    depth--;
+                }
+                if (depth == 0
+                    && (ch == ';'
+                        || ch == '\n'))
+                {
+                    break;
+                }
+            }
+            if (!in_dq && ch == '\'')
+            {
+                in_sq = !in_sq;
+            }
+            else if (!in_sq && ch == '"')
+            {
+                in_dq = !in_dq;
+            }
+        }
+        else
+        {
+            esc = 0;
+        }
+        valstr[vlen++] = ch;
+        pos++;
+    }
+
+    while (vlen > 0
+           && (valstr[vlen - 1] == ' '
+               || valstr[vlen - 1] == '\t'))
+    {
+        vlen--;
+    }
+    valstr[vlen] = '\0';
+
+    cli_expand_fpsvar(
+        valstr, (int) sizeof(valstr));
+    cli_expand_env(
+        valstr, (int) sizeof(valstr));
+    cli_expand_arith(
+        valstr, (int) sizeof(valstr));
+
+    char tcopy[512];
+    strncpy(tcopy, token,
+            sizeof(tcopy) - 1);
+    tcopy[sizeof(tcopy) - 1] = '\0';
+    char *dot = strchr(tcopy, '.');
+    *dot = '\0';
+    cli_fps_set_param(tcopy, dot + 1, valstr);
+
+    /* Insert no-op ":" if this is the entire cmd */
+    if (*opos == 0)
+    {
+        if (*opos < maxlen - 1)
+        {
+            out[(*opos)++] = ':';
+        }
+        if (*opos < maxlen - 1)
+        {
+            out[(*opos)++] = ' ';
+        }
+    }
+    *i = pos;
+}
+
+
+/**
+ * @brief Expand @seq.NAME.prop sequencer tokens.
+ *
+ * Connects to sequencer SHM and reads status, tasks,
+ * errors, pid, or completed properties.
+ *
+ * @param pname  "NAME.prop" (after "seq.")
+ * @param out    Output buffer
+ * @param[in,out] opos  Output position
+ * @param maxlen Output buffer size
+ * @return 1 if expanded, 0 if no dot found
+ */
+static int expand_fpsvar_seq(
+    char *pname,
+    char *out,
+    int  *opos,
+    int   maxlen
+)
+{
+    char *dot2 = strchr(pname, '.');
+    if (dot2 == NULL)
+    {
+        return 0;
+    }
+    *dot2 = '\0';
+    const char *seqname = pname;
+    const char *seqprop = dot2 + 1;
+
+    MILKSEQ_STATE *seqst =
+        milkseq_connect(seqname);
+    if (seqst == NULL)
+    {
+        return 1;
+    }
+
+    char vstr[512];
+    vstr[0] = '\0';
+
+    if (strcmp(seqprop, "status") == 0)
+    {
+        const char *s = "IDLE";
+        uint32_t st = seqst->status;
+        if (st & MILKSEQ_STATUS_ERROR)
+        {
+            s = "ERROR";
+        }
+        else if (st & MILKSEQ_STATUS_STOPPING)
+        {
+            s = "STOPPING";
+        }
+        else if (st & MILKSEQ_STATUS_RUNNING)
+        {
+            s = "RUNNING";
+        }
+        strncpy(vstr, s,
+                sizeof(vstr) - 1);
+        vstr[sizeof(vstr) - 1] = '\0';
+    }
+    else if (strcmp(seqprop, "tasks") == 0)
+    {
+        snprintf(vstr, sizeof(vstr),
+                 "%u",
+                 seqst->NBtasks_active);
+    }
+    else if (strcmp(seqprop, "errors") == 0)
+    {
+        snprintf(vstr, sizeof(vstr),
+                 "%u",
+                 seqst->error_count);
+    }
+    else if (strcmp(seqprop, "pid") == 0)
+    {
+        snprintf(vstr, sizeof(vstr),
+                 "%d", (int) seqst->pid);
+    }
+    else if (strcmp(seqprop, "completed") == 0)
+    {
+        snprintf(vstr, sizeof(vstr),
+                 "%u",
+                 seqst->NBtasks_completed);
+    }
+
+    milkseq_disconnect(seqst);
+
+    int vlen = (int) strlen(vstr);
+    int avail = maxlen - 1 - *opos;
+    int clen = vlen < avail ? vlen : avail;
+    memcpy(out + *opos, vstr, (size_t) clen);
+    *opos += clen;
+    return 1;
+}
+
+
+/**
+ * @brief Expand @procname.prop via processinfo SHM.
+ *
+ * Scans pinfolist for a matching process name, maps
+ * its SHM, and reads the requested property.
+ *
+ * @param fpsname  Process name to look up
+ * @param pname    Property name (pid, loopstat, etc.)
+ * @param out      Output buffer
+ * @param[in,out] opos  Output position
+ * @param maxlen   Output buffer size
+ * @return 1 if expanded, 0 if not found
+ */
+static int expand_fpsvar_procinfo(
+    const char *fpsname,
+    const char *pname,
+    char       *out,
+    int        *opos,
+    int         maxlen
+)
+{
+    if (pinfolist == NULL)
+    {
+        return 0;
+    }
+
+    pid_t found_pid = 0;
+    for (int pi = 0;
+         pi < PROCESSINFOLISTSIZE; pi++)
+    {
+        if (pinfolist->active[pi]
+            && strcmp(
+                pinfolist->pnamearray[pi],
+                fpsname) == 0)
+        {
+            found_pid =
+                pinfolist->PIDarray[pi];
+            break;
+        }
+    }
+    if (found_pid <= 0)
+    {
+        return 0;
+    }
+
+    char pfname[512];
+    char procdname[256];
+    processinfo_procdirname(procdname);
+    snprintf(pfname, sizeof(pfname),
+             "%s/proc.%d.shm",
+             procdname,
+             (int) found_pid);
+    int pfd = -1;
+    PROCESSINFO *pi =
+        processinfo_shm_link(pfname, &pfd);
+    if (pi == MAP_FAILED || pi == NULL)
+    {
+        if (pfd >= 0)
+        {
+            close(pfd);
+        }
+        return 0;
+    }
+
+    char vstr[512];
+    vstr[0] = '\0';
+
+    if (strcmp(pname, "pid") == 0)
+    {
+        snprintf(vstr, sizeof(vstr),
+                 "%d", (int) pi->PID);
+    }
+    else if (strcmp(pname, "loopstat") == 0)
+    {
+        snprintf(vstr, sizeof(vstr),
+                 "%d", pi->loopstat);
+    }
+    else if (strcmp(pname, "loopcnt") == 0)
+    {
+        snprintf(vstr, sizeof(vstr),
+                 "%ld", pi->loopcnt);
+    }
+    else if (strcmp(pname, "loopfreq") == 0)
+    {
+        double hz = 0.0;
+        if (pi->dtmedian_iter_ns > 0)
+        {
+            hz = 1.0e9
+                 / (double)
+                   pi->dtmedian_iter_ns;
+        }
+        snprintf(vstr, sizeof(vstr),
+                 "%.1f", hz);
+    }
+    else if (strcmp(pname, "exectime") == 0)
+    {
+        double us =
+            (double) pi->dtmedian_exec_ns
+            / 1000.0;
+        snprintf(vstr, sizeof(vstr),
+                 "%.1f", us);
+    }
+    else if (strcmp(pname, "rtprio") == 0)
+    {
+        snprintf(vstr, sizeof(vstr),
+                 "%d", pi->RT_priority);
+    }
+    else if (strcmp(pname, "ctrlval") == 0)
+    {
+        snprintf(vstr, sizeof(vstr),
+                 "%d", pi->CTRLval);
+    }
+    else if (strcmp(pname, "trigmode") == 0)
+    {
+        snprintf(vstr, sizeof(vstr),
+                 "%d", pi->triggermode);
+    }
+    else if (strcmp(pname,
+                    "statusmsg") == 0)
+    {
+        strncpy(vstr, pi->statusmsg,
+                sizeof(vstr) - 1);
+        vstr[sizeof(vstr) - 1] = '\0';
+    }
+    else if (strcmp(pname, "tmux") == 0)
+    {
+        strncpy(vstr, pi->tmuxname,
+                sizeof(vstr) - 1);
+        vstr[sizeof(vstr) - 1] = '\0';
+    }
+    else if (strcmp(pname,
+                    "description") == 0)
+    {
+        strncpy(vstr, pi->description,
+                sizeof(vstr) - 1);
+        vstr[sizeof(vstr) - 1] = '\0';
+    }
+    else if (strcmp(pname,
+                    "missedframes") == 0)
+    {
+        snprintf(vstr, sizeof(vstr),
+                 "%lu",
+                 (unsigned long)
+                 pi->triggermissedframe_cumul);
+    }
+
+    int vlen = (int) strlen(vstr);
+    int avail = maxlen - 1 - *opos;
+    int clen = vlen < avail ? vlen : avail;
+    memcpy(out + *opos, vstr, (size_t) clen);
+    *opos += clen;
+    munmap(pi, sizeof(PROCESSINFO));
+    close(pfd);
+    return 1;
+}
+
+
 void cli_expand_fpsvar(
     char *line,
     int   maxlen
@@ -409,146 +783,10 @@ void cli_expand_fpsvar(
             if(line[i] == '='
                && strchr(token, '.') != NULL)
             {
-                i++; /* skip '=' */
-
-                /* Collect value up to statement end
-                 * (semicolon, newline, or NUL),
-                 * allowing spaces, parentheses, and
-                 * quoted strings. */
-                char valstr[512];
-                int  vlen      = 0;
-                int  depth     = 0; /* paren depth */
-                int  in_single = 0;
-                int  in_double = 0;
-                int  escape    = 0;
-
-                /* Skip leading whitespace after '=' */
-                while(line[i] == ' '
-                      || line[i] == '\t')
-                {
-                    i++;
-                }
-
-                while(line[i] != '\0'
-                      && vlen < 511)
-                {
-                    char c = line[i];
-
-                    if(!escape)
-                    {
-                        if(c == '\\')
-                        {
-                            escape = 1;
-                            valstr[vlen++] = c;
-                            i++;
-                            continue;
-                        }
-
-                        if(!in_single
-                           && !in_double)
-                        {
-                            if(c == '(')
-                            {
-                                depth++;
-                            }
-                            else if(c == ')'
-                                    && depth > 0)
-                            {
-                                depth--;
-                            }
-
-                            /* Stop at ';' or
-                             * newline only when
-                             * not nested. */
-                            if(depth == 0
-                                    && (c == ';'
-                                        || c == '\n'))
-                            {
-                                break;
-                            }
-                        }
-
-                        if(!in_double
-                           && c == '\'')
-                        {
-                            in_single =
-                                !in_single;
-                        }
-                        else if(!in_single
-                                && c == '"')
-                        {
-                            in_double =
-                                !in_double;
-                        }
-                    }
-                    else
-                    {
-                        /* Escaped character */
-                        escape = 0;
-                    }
-
-                    valstr[vlen++] = c;
-                    i++;
-                }
-
-                /* Trim trailing whitespace */
-                while(vlen > 0
-                      && (valstr[vlen - 1] == ' '
-                          || valstr[vlen - 1]
-                          == '\t'))
-                {
-                    vlen--;
-                }
-                valstr[vlen] = '\0';
-
-                /* Expand @fps.param refs, $VAR and
-                 * $((...)) in the value before
-                 * setting the parameter, so that
-                 * e.g. @fps.gain=$var or
-                 * @fps.gain=$((a+b)) works. */
-                cli_expand_fpsvar(
-                    valstr,
-                    (int) sizeof(valstr));
-                cli_expand_env(
-                    valstr,
-                    (int) sizeof(valstr));
-                cli_expand_arith(
-                    valstr,
-                    (int) sizeof(valstr));
-
-                /* Split token at first dot */
-                char tcopy[512];
-                strncpy(tcopy, token,
-                        sizeof(tcopy) - 1);
-                tcopy[sizeof(tcopy) - 1] =
-                    '\0';
-                char *dot = strchr(tcopy, '.');
-                *dot = '\0';
-                const char *fpsname = tcopy;
-                const char *pname = dot + 1;
-
-                cli_fps_set_param(
-                    fpsname, pname, valstr);
-
-                /* If this assignment is the whole
-                 * command, ensure the expanded
-                 * line is not empty so that the
-                 * dispatcher does not fall back
-                 * to a spurious "command not
-                 * found" / shell execution.
-                 * Insert a POSIX no-op ":" as
-                 * a harmless placeholder. */
-                if(opos == 0)
-                {
-                    if(opos < maxlen - 1)
-                    {
-                        out[opos++] = ':';
-                    }
-                    if(opos < maxlen - 1)
-                    {
-                        out[opos++] = ' ';
-                    }
-                }
+                i++;
+                expand_fpsvar_write(
+                    line, &i, token,
+                    out, &opos, maxlen);
                 continue;
             }
 
@@ -572,106 +810,14 @@ void cli_expand_fpsvar(
 
             *dot = '\0';
             const char *fpsname = token;
-            const char *pname = dot + 1;
+            char *pname = dot + 1;
 
             /* ---- Sequencer: @seq.NAME.prop ---- */
             if(strcmp(fpsname, "seq") == 0)
             {
-                char *dot2 = strchr(pname, '.');
-                if(dot2 != NULL)
-                {
-                    *dot2 = '\0';
-                    const char *seqname = pname;
-                    const char *seqprop = dot2 + 1;
-
-                    MILKSEQ_STATE *seqst =
-                        milkseq_connect(seqname);
-                    if(seqst != NULL)
-                    {
-                        char vstr[512];
-                        vstr[0] = '\0';
-
-                        if(strcmp(seqprop,
-                            "status") == 0)
-                        {
-                            const char *s = "IDLE";
-                            uint32_t st =
-                                seqst->status;
-                            if(st
-                               & MILKSEQ_STATUS_ERROR)
-                            {
-                                s = "ERROR";
-                            }
-                            else if(st
-                               & MILKSEQ_STATUS_STOPPING)
-                            {
-                                s = "STOPPING";
-                            }
-                            else if(st
-                               & MILKSEQ_STATUS_RUNNING)
-                            {
-                                s = "RUNNING";
-                            }
-                            strncpy(vstr, s,
-                                sizeof(vstr) - 1);
-                            vstr[sizeof(vstr) - 1]
-                                = '\0';
-                        }
-                        else if(strcmp(seqprop,
-                            "tasks") == 0)
-                        {
-                            snprintf(
-                                vstr,
-                                sizeof(vstr),
-                                "%u",
-                                seqst
-                                ->NBtasks_active);
-                        }
-                        else if(strcmp(seqprop,
-                            "errors") == 0)
-                        {
-                            snprintf(
-                                vstr,
-                                sizeof(vstr),
-                                "%u",
-                                seqst
-                                ->error_count);
-                        }
-                        else if(strcmp(seqprop,
-                            "pid") == 0)
-                        {
-                            snprintf(
-                                vstr,
-                                sizeof(vstr),
-                                "%d",
-                                (int) seqst->pid);
-                        }
-                        else if(strcmp(seqprop,
-                            "completed") == 0)
-                        {
-                            snprintf(
-                                vstr,
-                                sizeof(vstr),
-                                "%u",
-                                seqst
-                                ->NBtasks_completed);
-                        }
-
-                        milkseq_disconnect(seqst);
-
-                        int vlen =
-                            (int) strlen(vstr);
-                        int avail =
-                            maxlen - 1 - opos;
-                        int clen =
-                            vlen < avail
-                            ? vlen : avail;
-                        memcpy(out + opos,
-                               vstr,
-                               (size_t) clen);
-                        opos += clen;
-                    }
-                }
+                expand_fpsvar_seq(
+                    pname, out,
+                    &opos, maxlen);
                 continue;
             }
 
@@ -685,201 +831,9 @@ void cli_expand_fpsvar(
                     || fps.parray == NULL)
             {
                 /* FPS not found — try procinfo */
-                if(pinfolist != NULL)
-                {
-                    pid_t found_pid = 0;
-                    for(int pi = 0;
-                        pi < PROCESSINFOLISTSIZE;
-                        pi++)
-                    {
-                        if(pinfolist->active[pi]
-                           && strcmp(
-                               pinfolist
-                                   ->pnamearray[pi],
-                               fpsname) == 0)
-                        {
-                            found_pid =
-                                pinfolist
-                                    ->PIDarray[pi];
-                            break;
-                        }
-                    }
-                    if(found_pid > 0)
-                    {
-                        char pfname[512];
-                        char procdname[256];
-                        processinfo_procdirname(
-                            procdname);
-                        snprintf(
-                            pfname,
-                            sizeof(pfname),
-                            "%s/proc.%d.shm",
-                            procdname,
-                            (int) found_pid);
-                        int pfd = -1;
-                        PROCESSINFO *pi =
-                            processinfo_shm_link(
-                                pfname, &pfd);
-                        if(pi != MAP_FAILED
-                           && pi != NULL)
-                        {
-                            char vstr[512];
-                            vstr[0] = '\0';
-                            if(strcmp(pname,
-                                "pid") == 0)
-                            {
-                                snprintf(
-                                    vstr,
-                                    sizeof(vstr),
-                                    "%d",
-                                    (int) pi->PID);
-                            }
-                            else if(strcmp(pname,
-                                "loopstat") == 0)
-                            {
-                                snprintf(
-                                    vstr,
-                                    sizeof(vstr),
-                                    "%d",
-                                    pi->loopstat);
-                            }
-                            else if(strcmp(pname,
-                                "loopcnt") == 0)
-                            {
-                                snprintf(
-                                    vstr,
-                                    sizeof(vstr),
-                                    "%ld",
-                                    pi->loopcnt);
-                            }
-                            else if(strcmp(pname,
-                                "loopfreq") == 0)
-                            {
-                                double hz = 0.0;
-                                if(pi
-                                    ->dtmedian_iter_ns
-                                   > 0)
-                                {
-                                    hz = 1.0e9
-                                        / (double)
-                                          pi
-                                          ->dtmedian_iter_ns;
-                                }
-                                snprintf(
-                                    vstr,
-                                    sizeof(vstr),
-                                    "%.1f", hz);
-                            }
-                            else if(strcmp(pname,
-                                "exectime") == 0)
-                            {
-                                double us =
-                                    (double)
-                                    pi
-                                    ->dtmedian_exec_ns
-                                    / 1000.0;
-                                snprintf(
-                                    vstr,
-                                    sizeof(vstr),
-                                    "%.1f", us);
-                            }
-                            else if(strcmp(pname,
-                                "rtprio") == 0)
-                            {
-                                snprintf(
-                                    vstr,
-                                    sizeof(vstr),
-                                    "%d",
-                                    pi
-                                    ->RT_priority);
-                            }
-                            else if(strcmp(pname,
-                                "ctrlval") == 0)
-                            {
-                                snprintf(
-                                    vstr,
-                                    sizeof(vstr),
-                                    "%d",
-                                    pi->CTRLval);
-                            }
-                            else if(strcmp(pname,
-                                "trigmode") == 0)
-                            {
-                                snprintf(
-                                    vstr,
-                                    sizeof(vstr),
-                                    "%d",
-                                    pi
-                                    ->triggermode);
-                            }
-                            else if(strcmp(pname,
-                                "statusmsg") == 0)
-                            {
-                                strncpy(
-                                    vstr,
-                                    pi->statusmsg,
-                                    sizeof(vstr)
-                                    - 1);
-                                vstr[sizeof(vstr)
-                                     - 1] = '\0';
-                            }
-                            else if(strcmp(pname,
-                                "tmux") == 0)
-                            {
-                                strncpy(
-                                    vstr,
-                                    pi->tmuxname,
-                                    sizeof(vstr)
-                                    - 1);
-                                vstr[sizeof(vstr)
-                                     - 1] = '\0';
-                            }
-                            else if(strcmp(pname,
-                                "description")
-                                == 0)
-                            {
-                                strncpy(
-                                    vstr,
-                                    pi
-                                    ->description,
-                                    sizeof(vstr)
-                                    - 1);
-                                vstr[sizeof(vstr)
-                                     - 1] = '\0';
-                            }
-                            else if(strcmp(pname,
-                                "missedframes")
-                                == 0)
-                            {
-                                snprintf(
-                                    vstr,
-                                    sizeof(vstr),
-                                    "%lu",
-                                    (unsigned long)
-                                    pi
-                                    ->triggermissedframe_cumul);
-                            }
-                            int vlen =
-                                (int) strlen(vstr);
-                            int avail =
-                                maxlen - 1 - opos;
-                            int clen =
-                                vlen < avail
-                                ? vlen : avail;
-                            memcpy(out + opos,
-                                   vstr,
-                                   (size_t) clen);
-                            opos += clen;
-                            munmap(pi,
-                                sizeof(PROCESSINFO));
-                            close(pfd);
-                        }
-                        else if(pfd >= 0)
-                        {
-                            close(pfd);
-                        }
-                    }
-                }
+                expand_fpsvar_procinfo(
+                    fpsname, pname,
+                    out, &opos, maxlen);
                 continue;
             }
 
@@ -1049,6 +1003,239 @@ void cli_expand_arith(
  * @param expr   The content between [ and ]
  * @return 1 = true, 0 = false
  */
+/**
+ * @brief Evaluate unary file-system tests.
+ *
+ * Handles -f, -d, -e, -s, -r, -w, -x, -L.
+ *
+ * @param op     Operator string (e.g. "-f")
+ * @param arg    File path argument
+ * @param[out] result  Test result (0 or 1)
+ * @return 1 if operator was handled, 0 if not
+ */
+static int test_unary_file(
+    const char *op,
+    const char *arg,
+    int        *result
+)
+{
+    if (strcmp(op, "-r") == 0)
+    {
+        *result =
+            access(arg, R_OK) == 0 ? 1 : 0;
+        return 1;
+    }
+    if (strcmp(op, "-w") == 0)
+    {
+        *result =
+            access(arg, W_OK) == 0 ? 1 : 0;
+        return 1;
+    }
+    if (strcmp(op, "-x") == 0)
+    {
+        *result =
+            access(arg, X_OK) == 0 ? 1 : 0;
+        return 1;
+    }
+    if (strcmp(op, "-L") == 0)
+    {
+        struct stat sb;
+        *result = (lstat(arg, &sb) == 0
+                   && S_ISLNK(sb.st_mode))
+                  ? 1 : 0;
+        return 1;
+    }
+    if (strcmp(op, "-f") == 0)
+    {
+        struct stat sb;
+        *result = (stat(arg, &sb) == 0
+                   && S_ISREG(sb.st_mode))
+                  ? 1 : 0;
+        return 1;
+    }
+    if (strcmp(op, "-d") == 0)
+    {
+        struct stat sb;
+        *result = (stat(arg, &sb) == 0
+                   && S_ISDIR(sb.st_mode))
+                  ? 1 : 0;
+        return 1;
+    }
+    if (strcmp(op, "-e") == 0)
+    {
+        struct stat sb;
+        *result = stat(arg, &sb) == 0
+                  ? 1 : 0;
+        return 1;
+    }
+    if (strcmp(op, "-s") == 0)
+    {
+        struct stat sb;
+        *result = (stat(arg, &sb) == 0
+                   && sb.st_size > 0)
+                  ? 1 : 0;
+        return 1;
+    }
+    return 0;
+}
+
+
+/**
+ * @brief Evaluate SHM/process unary tests.
+ *
+ * Handles -S (stream), -F (FPS), -P (process),
+ * -v (variable), -n (non-empty), -z (empty).
+ *
+ * @param op     Operator string
+ * @param arg    Argument
+ * @param[out] result  Test result
+ * @return 1 if handled, 0 if not
+ */
+static int test_unary_shm(
+    const char *op,
+    const char *arg,
+    int        *result
+)
+{
+    if (strcmp(op, "-n") == 0)
+    {
+        *result =
+            strlen(arg) > 0 ? 1 : 0;
+        return 1;
+    }
+    if (strcmp(op, "-z") == 0)
+    {
+        *result =
+            strlen(arg) == 0 ? 1 : 0;
+        return 1;
+    }
+    if (strcmp(op, "-v") == 0)
+    {
+        const char *vv = cli_var_get(arg);
+        if (vv != NULL)
+        {
+            *result = 1;
+            return 1;
+        }
+        *result =
+            getenv(arg) != NULL ? 1 : 0;
+        return 1;
+    }
+    if (strcmp(op, "-S") == 0)
+    {
+        char shmpath[512];
+        struct stat sb;
+        snprintf(shmpath, sizeof(shmpath),
+                 "/dev/shm/%s.im.shm", arg);
+        *result = stat(shmpath, &sb) == 0
+                  ? 1 : 0;
+        return 1;
+    }
+    if (strcmp(op, "-F") == 0)
+    {
+        char shmpath[512];
+        struct stat sb;
+        snprintf(shmpath, sizeof(shmpath),
+                 "/dev/shm/fps.%s.shm", arg);
+        *result = stat(shmpath, &sb) == 0
+                  ? 1 : 0;
+        return 1;
+    }
+    if (strcmp(op, "-P") == 0)
+    {
+        *result = 0;
+        if (pinfolist != NULL)
+        {
+            for (int pi = 0;
+                 pi < PROCESSINFOLISTSIZE;
+                 pi++)
+            {
+                if (pinfolist->active[pi]
+                    && strcmp(
+                        pinfolist
+                            ->pnamearray[pi],
+                        arg) == 0)
+                {
+                    *result = 1;
+                    break;
+                }
+            }
+        }
+        return 1;
+    }
+    return 0;
+}
+
+
+/**
+ * @brief Evaluate binary comparison operators.
+ *
+ * Handles -eq/-ne/-lt/-gt/-le/-ge (numeric)
+ * and ==/=, != (string).
+ *
+ * @param lhs  Left operand string
+ * @param op   Operator string
+ * @param rhs  Right operand string
+ * @param[out] result  Comparison result
+ * @return 1 if handled, 0 if not
+ */
+static int test_binary_op(
+    const char *lhs,
+    const char *op,
+    const char *rhs,
+    int        *result
+)
+{
+    double lv = strtod(lhs, NULL);
+    double rv = strtod(rhs, NULL);
+
+    if (strcmp(op, "-eq") == 0)
+    {
+        *result = (lv == rv) ? 1 : 0;
+        return 1;
+    }
+    if (strcmp(op, "-ne") == 0)
+    {
+        *result = (lv != rv) ? 1 : 0;
+        return 1;
+    }
+    if (strcmp(op, "-lt") == 0)
+    {
+        *result = (lv < rv) ? 1 : 0;
+        return 1;
+    }
+    if (strcmp(op, "-gt") == 0)
+    {
+        *result = (lv > rv) ? 1 : 0;
+        return 1;
+    }
+    if (strcmp(op, "-le") == 0)
+    {
+        *result = (lv <= rv) ? 1 : 0;
+        return 1;
+    }
+    if (strcmp(op, "-ge") == 0)
+    {
+        *result = (lv >= rv) ? 1 : 0;
+        return 1;
+    }
+    if (strcmp(op, "==") == 0
+        || strcmp(op, "=") == 0)
+    {
+        *result = strcmp(lhs, rhs) == 0
+                  ? 1 : 0;
+        return 1;
+    }
+    if (strcmp(op, "!=") == 0)
+    {
+        *result = strcmp(lhs, rhs) != 0
+                  ? 1 : 0;
+        return 1;
+    }
+    return 0;
+}
+
+
 int cli_eval_test(const char *expr)
 {
     /* Tokenize expression */
@@ -1176,136 +1363,22 @@ int cli_eval_test(const char *expr)
         }
     }
 
-    /* Unary: -n str, -z str */
-    if(ntok == 2
-       && strcmp(tokens[0], "-n") == 0)
+    /* Unary tests: string, file, SHM, variable */
+    if(ntok == 2)
     {
-        return strlen(tokens[1]) > 0 ? 1 : 0;
-    }
-    if(ntok == 2
-       && strcmp(tokens[0], "-z") == 0)
-    {
-        return strlen(tokens[1]) == 0 ? 1 : 0;
-    }
-
-    /* File tests: -f, -d, -e, -s, -r, -w, -x, -L */
-    if(ntok == 2
-       && strcmp(tokens[0], "-r") == 0)
-    {
-        return access(tokens[1], R_OK) == 0 ? 1 : 0;
-    }
-    if(ntok == 2
-       && strcmp(tokens[0], "-w") == 0)
-    {
-        return access(tokens[1], W_OK) == 0 ? 1 : 0;
-    }
-    if(ntok == 2
-       && strcmp(tokens[0], "-x") == 0)
-    {
-        return access(tokens[1], X_OK) == 0 ? 1 : 0;
-    }
-    if(ntok == 2
-       && strcmp(tokens[0], "-L") == 0)
-    {
-        struct stat sb;
-        return (lstat(tokens[1], &sb) == 0
-                && S_ISLNK(sb.st_mode))
-               ? 1 : 0;
-    }
-    if(ntok == 2
-       && strcmp(tokens[0], "-f") == 0)
-    {
-        struct stat sb;
-        return (stat(tokens[1], &sb) == 0
-                && S_ISREG(sb.st_mode))
-               ? 1 : 0;
-    }
-    if(ntok == 2
-       && strcmp(tokens[0], "-d") == 0)
-    {
-        struct stat sb;
-        return (stat(tokens[1], &sb) == 0
-                && S_ISDIR(sb.st_mode))
-               ? 1 : 0;
-    }
-    if(ntok == 2
-       && strcmp(tokens[0], "-e") == 0)
-    {
-        struct stat sb;
-        return stat(tokens[1], &sb) == 0
-               ? 1 : 0;
-    }
-    if(ntok == 2
-       && strcmp(tokens[0], "-s") == 0)
-    {
-        struct stat sb;
-        return (stat(tokens[1], &sb) == 0
-                && sb.st_size > 0)
-               ? 1 : 0;
-    }
-
-    /* Variable test: -v VAR */
-    if(ntok == 2
-       && strcmp(tokens[0], "-v") == 0)
-    {
-        const char *vv =
-            cli_var_get(tokens[1]);
-        if(vv != NULL)
+        int result;
+        if(test_unary_shm(
+               tokens[0], tokens[1],
+               &result))
         {
-            return 1;
+            return result;
         }
-        const char *ev =
-            getenv(tokens[1]);
-        return ev != NULL ? 1 : 0;
-    }
-
-    /* SHM stream test: -S name */
-    if(ntok == 2
-       && strcmp(tokens[0], "-S") == 0)
-    {
-        char shmpath[512];
-        struct stat sb;
-        snprintf(shmpath, sizeof(shmpath),
-                 "/dev/shm/%s.im.shm",
-                 tokens[1]);
-        return stat(shmpath, &sb) == 0
-               ? 1 : 0;
-    }
-
-    /* FPS test: -F name */
-    if(ntok == 2
-       && strcmp(tokens[0], "-F") == 0)
-    {
-        char shmpath[512];
-        struct stat sb;
-        snprintf(shmpath, sizeof(shmpath),
-                 "/dev/shm/fps.%s.shm",
-                 tokens[1]);
-        return stat(shmpath, &sb) == 0
-               ? 1 : 0;
-    }
-
-    /* Process test: -P name */
-    if(ntok == 2
-       && strcmp(tokens[0], "-P") == 0)
-    {
-        if(pinfolist != NULL)
+        if(test_unary_file(
+               tokens[0], tokens[1],
+               &result))
         {
-            for(int pi = 0;
-                pi < PROCESSINFOLISTSIZE;
-                pi++)
-            {
-                if(pinfolist->active[pi]
-                   && strcmp(
-                       pinfolist
-                           ->pnamearray[pi],
-                       tokens[1]) == 0)
-                {
-                    return 1;
-                }
-            }
+            return result;
         }
-        return 0;
     }
 
     /* Logical NOT: ! expr */
@@ -1341,46 +1414,12 @@ int cli_eval_test(const char *expr)
     /* Binary: val1 op val2 */
     if(ntok >= 3)
     {
-        const char *lhs = tokens[0];
-        const char *op = tokens[1];
-        const char *rhs = tokens[2];
-
-        double lv = strtod(lhs, NULL);
-        double rv = strtod(rhs, NULL);
-
-        if(strcmp(op, "-eq") == 0)
+        int result;
+        if(test_binary_op(
+               tokens[0], tokens[1],
+               tokens[2], &result))
         {
-            return (lv == rv) ? 1 : 0;
-        }
-        if(strcmp(op, "-ne") == 0)
-        {
-            return (lv != rv) ? 1 : 0;
-        }
-        if(strcmp(op, "-lt") == 0)
-        {
-            return (lv < rv) ? 1 : 0;
-        }
-        if(strcmp(op, "-gt") == 0)
-        {
-            return (lv > rv) ? 1 : 0;
-        }
-        if(strcmp(op, "-le") == 0)
-        {
-            return (lv <= rv) ? 1 : 0;
-        }
-        if(strcmp(op, "-ge") == 0)
-        {
-            return (lv >= rv) ? 1 : 0;
-        }
-        if(strcmp(op, "==") == 0 || strcmp(op, "=") == 0)
-        {
-            return strcmp(lhs, rhs) == 0
-                   ? 1 : 0;
-        }
-        if(strcmp(op, "!=") == 0)
-        {
-            return strcmp(lhs, rhs) != 0
-                   ? 1 : 0;
+            return result;
         }
     }
 

--- a/src/cli/CLIcore/CLIcore/CLIcore_script_expand.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_script_expand.c
@@ -598,8 +598,8 @@ static int expand_fpsvar_procinfo(
         return 0;
     }
 
-    char pfname[512];
-    char procdname[256];
+    char pfname[STRINGMAXLEN_FULLFILENAME];
+    char procdname[STRINGMAXLEN_DIRNAME];
     processinfo_procdirname(procdname);
     snprintf(pfname, sizeof(pfname),
              "%s/proc.%d.shm",

--- a/src/cli/CLIcore/cli_calc_functions.c
+++ b/src/cli/CLIcore/cli_calc_functions.c
@@ -11,6 +11,244 @@
 #include "CLIcore_script.h"
 #include "cli_calc_internal.h"
 
+/**
+ * @brief Image OP image binary operation.
+ *
+ * Dispatches to the appropriate arith_image_*
+ * function for two image operands.
+ *
+ * @param op    Token operator type
+ * @param lname Left image name
+ * @param rname Right image name
+ * @param tmpn  Temporary output image name
+ * @return 1 on success, 0 on unsupported op
+ */
+static int binop_img_img(
+    cli_token_type op,
+    const char *lname,
+    const char *rname,
+    const char *tmpn
+)
+{
+    switch (op)
+    {
+        case TOK_OP_PLUS:
+            arith_image_add(
+                lname, rname, tmpn);
+            break;
+        case TOK_OP_MINUS:
+            arith_image_sub(
+                lname, rname, tmpn);
+            break;
+        case TOK_OP_STAR:
+            arith_image_mult(
+                lname, rname, tmpn);
+            break;
+        case TOK_OP_SLASH:
+            arith_image_div(
+                lname, rname, tmpn);
+            break;
+        case TOK_OP_MOD:
+            arith_image_fmod(
+                lname, rname, tmpn);
+            break;
+        case TOK_OP_CARET:
+            arith_image_pow(
+                lname, rname, tmpn);
+            break;
+        case TOK_OP_LT:
+            arith_image_testlt(
+                lname, rname, tmpn);
+            break;
+        case TOK_OP_LE:
+            arith_image_testle(
+                lname, rname, tmpn);
+            break;
+        case TOK_OP_GT:
+            arith_image_testmt(
+                lname, rname, tmpn);
+            break;
+        case TOK_OP_GE:
+            arith_image_testge(
+                lname, rname, tmpn);
+            break;
+        case TOK_OP_EQ:
+            arith_image_teste(
+                lname, rname, tmpn);
+            break;
+        case TOK_OP_NEQ:
+            arith_image_testne(
+                lname, rname, tmpn);
+            break;
+        case TOK_OP_AND:
+            arith_image_and(
+                lname, rname, tmpn);
+            break;
+        case TOK_OP_OR:
+            arith_image_or(
+                lname, rname, tmpn);
+            break;
+        default:
+            return 0;
+    }
+    return 1;
+}
+
+
+/**
+ * @brief Image OP scalar binary operation.
+ *
+ * @param op    Token operator type
+ * @param iname Image name (left operand)
+ * @param rv    Scalar value (right operand)
+ * @param tmpn  Output image name
+ * @return 1 on success, 0 on unsupported op
+ */
+static int binop_img_scalar(
+    cli_token_type op,
+    const char *iname,
+    double rv,
+    const char *tmpn
+)
+{
+    switch (op)
+    {
+        case TOK_OP_PLUS:
+            arith_image_cstadd(
+                iname, rv, tmpn);
+            break;
+        case TOK_OP_MINUS:
+            arith_image_cstadd(
+                iname, -rv, tmpn);
+            break;
+        case TOK_OP_STAR:
+            arith_image_cstmult(
+                iname, rv, tmpn);
+            break;
+        case TOK_OP_SLASH:
+            arith_image_cstdiv(
+                iname, rv, tmpn);
+            break;
+        case TOK_OP_MOD:
+            arith_image_cstfmod(
+                iname, rv, tmpn);
+            break;
+        case TOK_OP_CARET:
+            arith_image_cstpow(
+                iname, rv, tmpn);
+            break;
+        case TOK_OP_LT:
+            arith_image_csttestlt(
+                iname, rv, tmpn);
+            break;
+        case TOK_OP_LE:
+            arith_image_csttestle(
+                iname, rv, tmpn);
+            break;
+        case TOK_OP_GT:
+            arith_image_csttestmt(
+                iname, rv, tmpn);
+            break;
+        case TOK_OP_GE:
+            arith_image_csttestge(
+                iname, rv, tmpn);
+            break;
+        case TOK_OP_EQ:
+            arith_image_cstteste(
+                iname, rv, tmpn);
+            break;
+        case TOK_OP_NEQ:
+            arith_image_csttestne(
+                iname, rv, tmpn);
+            break;
+        case TOK_OP_AND:
+            arith_image_cstand(
+                iname, rv, tmpn);
+            break;
+        case TOK_OP_OR:
+            arith_image_cstor(
+                iname, rv, tmpn);
+            break;
+        default:
+            return 0;
+    }
+    return 1;
+}
+
+
+/**
+ * @brief Scalar OP image binary operation.
+ *
+ * @param op    Token operator type
+ * @param lv    Scalar value (left operand)
+ * @param iname Image name (right operand)
+ * @param tmpn  Output image name
+ * @return 1 on success, 0 on unsupported op
+ */
+static int binop_scalar_img(
+    cli_token_type op,
+    double lv,
+    const char *iname,
+    const char *tmpn
+)
+{
+    switch (op)
+    {
+        case TOK_OP_PLUS:
+            arith_image_cstadd(
+                iname, lv, tmpn);
+            break;
+        case TOK_OP_MINUS:
+            arith_image_cstsubm(
+                iname, lv, tmpn);
+            break;
+        case TOK_OP_STAR:
+            arith_image_cstmult(
+                iname, lv, tmpn);
+            break;
+        case TOK_OP_SLASH:
+            arith_image_cstdiv1(
+                iname, lv, tmpn);
+            break;
+        case TOK_OP_LT:
+            arith_image_csttestmt(
+                iname, lv, tmpn);
+            break;
+        case TOK_OP_LE:
+            arith_image_csttestge(
+                iname, lv, tmpn);
+            break;
+        case TOK_OP_GT:
+            arith_image_csttestlt(
+                iname, lv, tmpn);
+            break;
+        case TOK_OP_GE:
+            arith_image_csttestle(
+                iname, lv, tmpn);
+            break;
+        case TOK_OP_EQ:
+            arith_image_cstteste(
+                iname, lv, tmpn);
+            break;
+        case TOK_OP_NEQ:
+            arith_image_csttestne(
+                iname, lv, tmpn);
+            break;
+        case TOK_OP_AND:
+            arith_image_cstand(
+                iname, lv, tmpn);
+            break;
+        case TOK_OP_OR:
+            arith_image_cstor(
+                iname, lv, tmpn);
+            break;
+        default:
+            return 0;
+    }
+    return 1;
+}
+
+
 val_t eval_binop(
     cli_token_type op,
     val_t left,
@@ -32,71 +270,14 @@ val_t eval_binop(
             {
                 return mk_string("");
             }
-            switch (op)
+            if (!binop_img_img(
+                    op, left.sval,
+                    right.sval, tmpn))
             {
-                case TOK_OP_PLUS:
-                    arith_image_add(
-                        left.sval,
-                        right.sval,
-                        tmpn
-                    );
-                    break;
-                case TOK_OP_MINUS:
-                    arith_image_sub(
-                        left.sval,
-                        right.sval,
-                        tmpn
-                    );
-                    break;
-                case TOK_OP_STAR:
-                    arith_image_mult(
-                        left.sval,
-                        right.sval,
-                        tmpn
-                    );
-                    break;
-                case TOK_OP_SLASH:
-                    arith_image_div(
-                        left.sval,
-                        right.sval,
-                        tmpn
-                    );
-                    break;
-                case TOK_OP_MOD:
-                    arith_image_fmod(left.sval, right.sval, tmpn);
-                    break;
-                case TOK_OP_CARET:
-                    arith_image_pow(left.sval, right.sval, tmpn);
-                    break;
-                case TOK_OP_LT:
-                    arith_image_testlt(left.sval, right.sval, tmpn);
-                    break;
-                case TOK_OP_LE:
-                    arith_image_testle(left.sval, right.sval, tmpn);
-                    break;
-                case TOK_OP_GT:
-                    arith_image_testmt(left.sval, right.sval, tmpn);
-                    break;
-                case TOK_OP_GE:
-                    arith_image_testge(left.sval, right.sval, tmpn);
-                    break;
-                case TOK_OP_EQ:
-                    arith_image_teste(left.sval, right.sval, tmpn);
-                    break;
-                case TOK_OP_NEQ:
-                    arith_image_testne(left.sval, right.sval, tmpn);
-                    break;
-                case TOK_OP_AND:
-                    arith_image_and(left.sval, right.sval, tmpn);
-                    break;
-                case TOK_OP_OR:
-                    arith_image_or(left.sval, right.sval, tmpn);
-                    break;
-                default:
-                    parse_errmsg(
-                        "Unsupported image op"
-                    );
-                    return mk_string("");
+                parse_errmsg(
+                    "Unsupported image op"
+                );
+                return mk_string("");
             }
             return mk_string(tmpn);
         }
@@ -109,62 +290,14 @@ val_t eval_binop(
                 return mk_string("");
             }
             double rv = to_double(right);
-
-            switch (op)
+            if (!binop_img_scalar(
+                    op, left.sval,
+                    rv, tmpn))
             {
-                case TOK_OP_PLUS:
-                    arith_image_cstadd(
-                        left.sval, rv, tmpn);
-                    break;
-                case TOK_OP_MINUS:
-                    arith_image_cstadd(
-                        left.sval, -rv, tmpn);
-                    break;
-                case TOK_OP_STAR:
-                    arith_image_cstmult(
-                        left.sval, rv, tmpn);
-                    break;
-                case TOK_OP_SLASH:
-                    arith_image_cstdiv(
-                        left.sval, rv, tmpn);
-                    break;
-                case TOK_OP_MOD:
-                    arith_image_cstfmod(
-                        left.sval, rv, tmpn);
-                    break;
-                case TOK_OP_CARET:
-                    arith_image_cstpow(
-                        left.sval, rv, tmpn);
-                    break;
-                case TOK_OP_LT:
-                    arith_image_csttestlt(left.sval, rv, tmpn);
-                    break;
-                case TOK_OP_LE:
-                    arith_image_csttestle(left.sval, rv, tmpn);
-                    break;
-                case TOK_OP_GT:
-                    arith_image_csttestmt(left.sval, rv, tmpn);
-                    break;
-                case TOK_OP_GE:
-                    arith_image_csttestge(left.sval, rv, tmpn);
-                    break;
-                case TOK_OP_EQ:
-                    arith_image_cstteste(left.sval, rv, tmpn);
-                    break;
-                case TOK_OP_NEQ:
-                    arith_image_csttestne(left.sval, rv, tmpn);
-                    break;
-                case TOK_OP_AND:
-                    arith_image_cstand(left.sval, rv, tmpn);
-                    break;
-                case TOK_OP_OR:
-                    arith_image_cstor(left.sval, rv, tmpn);
-                    break;
-                default:
-                    parse_errmsg(
-                        "Unsupported image op"
-                    );
-                    return mk_string("");
+                parse_errmsg(
+                    "Unsupported image op"
+                );
+                return mk_string("");
             }
             return mk_string(tmpn);
         }
@@ -177,54 +310,14 @@ val_t eval_binop(
                 return mk_string("");
             }
             double lv = to_double(left);
-
-            switch (op)
+            if (!binop_scalar_img(
+                    op, lv,
+                    right.sval, tmpn))
             {
-                case TOK_OP_PLUS:
-                    arith_image_cstadd(
-                        right.sval, lv, tmpn);
-                    break;
-                case TOK_OP_MINUS:
-                    arith_image_cstsubm(
-                        right.sval, lv, tmpn);
-                    break;
-                case TOK_OP_STAR:
-                    arith_image_cstmult(
-                        right.sval, lv, tmpn);
-                    break;
-                case TOK_OP_SLASH:
-                    arith_image_cstdiv1(
-                        right.sval, lv, tmpn);
-                    break;
-                case TOK_OP_LT:
-                    arith_image_csttestmt(right.sval, lv, tmpn);
-                    break;
-                case TOK_OP_LE:
-                    arith_image_csttestge(right.sval, lv, tmpn);
-                    break;
-                case TOK_OP_GT:
-                    arith_image_csttestlt(right.sval, lv, tmpn);
-                    break;
-                case TOK_OP_GE:
-                    arith_image_csttestle(right.sval, lv, tmpn);
-                    break;
-                case TOK_OP_EQ:
-                    arith_image_cstteste(right.sval, lv, tmpn);
-                    break;
-                case TOK_OP_NEQ:
-                    arith_image_csttestne(right.sval, lv, tmpn);
-                    break;
-                case TOK_OP_AND:
-                    arith_image_cstand(right.sval, lv, tmpn);
-                    break;
-                case TOK_OP_OR:
-                    arith_image_cstor(right.sval, lv, tmpn);
-                    break;
-                default:
-                    parse_errmsg(
-                        "Unsupported image op"
-                    );
-                    return mk_string("");
+                parse_errmsg(
+                    "Unsupported image op"
+                );
+                return mk_string("");
             }
             return mk_string(tmpn);
         }


### PR DESCRIPTION
## Summary

Refactors 4 monolithic CLI functions into 11 static helpers across 3 files for improved readability and maintainability, with zero functional regressions. Also fixes a stack buffer overflow risk in `expand_fpsvar_procinfo` identified during review.

## Changes

### Phase 2 — Script Expansion (`CLIcore_script_expand.c`)

- `cli_expand_fpsvar` → `expand_fpsvar_write`, `expand_fpsvar_seq`, `expand_fpsvar_procinfo`
- `cli_eval_test` → `test_unary_file`, `test_unary_shm`, `test_binary_op`
- **Bug fix**: `expand_fpsvar_procinfo` — replaced `procdname[256]` with `procdname[STRINGMAXLEN_DIRNAME]` (800 bytes) and `pfname[512]` with `pfname[STRINGMAXLEN_FULLFILENAME]` (1000 bytes) to match the sizes used internally by `processinfo_procdirname()`, preventing potential stack buffer overflow when `MILK_PROC_DIR` is long

### Phase 3 — Calculator (`cli_calc_functions.c`)

- `eval_binop` → `binop_img_img`, `binop_img_scalar`, `binop_scalar_img`

### Phase 4 — Argument Checking (`CLIcore_checkargs.c`)

- `CLI_checkarg_array` → `sync_fps_to_argdata`, `set_fps_from_clitoken`

## Verification

- [x] Build passes (`/compile-test`)
- [x] Tests pass (`ctest --output-on-failure`) — 37/37
- [x] CLI robustness tests pass — 252/252 with 0 regressions
- [ ] Documentation updated (README, help, docs/)

## Prompt Summary

The user requested refactoring monolithic functions in the `milk-cli` source code into modular, maintainable, and readable `static` helper functions to improve readability without altering the external API. A follow-up review identified a stack buffer overflow risk in `expand_fpsvar_procinfo` which was also addressed.

## AI Authorship

- **Model**: Antigravity, Claude
- **User edits**: None

<!-- START COPILOT CODING AGENT TIPS -->
---

📱 Kick off Copilot coding agent tasks wherever you are with [GitHub Mobile](https://gh.io/cca-mobile-docs), available on iOS and Android.