### PR TITLE
refactor: move sequencer to standalone module with POSIX daemon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ project(milk LANGUAGES C)
 option(USE_COREMODS "Build core modules (COREMOD_*)"   ON)
 option(USE_CFITSIO  "Build FITS I/O (needs cfitsio)"   ON)
 option(USE_CLI      "Build interactive CLI (milk-cli)" ON)
+option(USE_SEQ      "Build sequencer module (requires CLI)" ON)
 option(USE_NCURSES  "Enable ncurses and TUI support"   ON)
 option(USE_READLINE "Enable readline support"          ON)
 option(USE_GSL      "Enable GSL for plugins"           ON)
@@ -65,6 +66,12 @@ option(USE_STATIC_LTO
 if(USE_CLI AND NOT USE_COREMODS)
   message(STATUS "USE_CLI requires USE_COREMODS; enabling USE_COREMODS")
   set(USE_COREMODS ON CACHE BOOL "" FORCE)
+endif()
+
+# USE_SEQ requires USE_CLI since it relies on CLIcore for commands
+if(USE_SEQ AND NOT USE_CLI)
+  message(STATUS "USE_SEQ requires USE_CLI; disabling USE_SEQ")
+  set(USE_SEQ OFF CACHE BOOL "" FORCE)
 endif()
 
 include(CheckLanguage)
@@ -284,6 +291,12 @@ if(USE_COREMODS)
   endforeach()
 else()
   message(STATUS "USE_COREMODS=OFF: skipping COREMOD_*")
+endif()
+
+if(USE_SEQ)
+  list(APPEND libsrcdir src/sequencer)
+  list(APPEND libname milksequencer)
+  message("======= adding module  sequencer")
 endif()
 
 # =======================================

--- a/src/cli/CLIcore/CLIcore/CLIcore_help_topics.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_help_topics.c
@@ -57,7 +57,7 @@ void print_milk_framework_help(void)
     printf(C_TITLE "                    milk OVERVIEW\n" C_RST);
     printf(C_TITLE "========================================================\n" C_RST);
     printf("\n");
-    printf("The milk framework is built around three core pillars for\n");
+    printf("The milk framework is built around four core pillars for\n");
     printf("high-performance, real-time data processing:\n");
     printf("\n");
 
@@ -79,6 +79,12 @@ void print_milk_framework_help(void)
     printf("Advanced real-time execution management, CPU affinity,\n");
     printf("scheduling policies, and stream-based process triggering.\n");
     printf("  " C_NOTE "Detailed guide:" C_RST " Run " C_CMD "milk-procinfo-help\n" C_RST);
+    printf("\n");
+
+    printf(C_HDR "4. Sequencer (seq API)\n" C_RST);
+    printf("Deterministic real-time scheduling and execution engine\n");
+    printf("for hardware calibration loops and automated routines.\n");
+    printf("  " C_NOTE "Detailed guide:" C_RST " Run " C_CMD "milk-seq-help\n" C_RST);
     printf("\n");
 
     printf(C_TITLE "--------------------------------------------------------\n" C_RST);

--- a/src/coremods/COREMOD_tools/CMakeLists.txt
+++ b/src/coremods/COREMOD_tools/CMakeLists.txt
@@ -14,7 +14,6 @@ set(SOURCEFILES
 	mvprocCPUset.c
 	statusstat.c
 	stringutils.c
-	seq_cli.c
 )
 
 set(INCLUDEFILES
@@ -26,7 +25,6 @@ set(INCLUDEFILES
 	mvprocCPUset.h
 	statusstat.h
 	stringutils.h
-	seq_cli.h
 )
 
 # TESTING

--- a/src/coremods/COREMOD_tools/COREMOD_tools.c
+++ b/src/coremods/COREMOD_tools/COREMOD_tools.c
@@ -21,7 +21,7 @@
 #include "imdisplay3d.h"
 #include "mvprocCPUset.h"
 #include "statusstat.h"
-#include "seq_cli.h"
+
 
 INIT_MODULE_LIB(COREMOD_tools)
 
@@ -33,7 +33,7 @@ static errno_t init_module_CLI()
     CLIADDCMD_COREMOD_tools__imdisplay3d();
     CLIADDCMD_COREMOD_tools__statusstat();
 
-    CLIADDCMD_COREMOD_tools__seq_cli();
+
 
     return RETURN_SUCCESS;
 }

--- a/src/engine/libfpsseq/CMakeLists.txt
+++ b/src/engine/libfpsseq/CMakeLists.txt
@@ -36,3 +36,7 @@ target_link_libraries(milk-seq PUBLIC
     milkdata milkprocessinfo ImageStreamIO
     pthread m rt)
 install(TARGETS milk-seq DESTINATION bin)
+
+# milk-seq-help standalone documentation
+add_executable(milk-seq-help milk-seq-help.c)
+install(TARGETS milk-seq-help DESTINATION bin)

--- a/src/engine/libfpsseq/milk-seq-help.c
+++ b/src/engine/libfpsseq/milk-seq-help.c
@@ -1,0 +1,66 @@
+/**
+ * @file    milk-seq-help.c
+ * @brief   Comprehensive documentation for milk-seq
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#define COLOR_RESET   "\033[0m"
+#define COLOR_BOLD    "\033[1m"
+#define COLOR_CYAN    "\033[36m"
+#define COLOR_GREEN   "\033[32m"
+#define COLOR_YELLOW  "\033[33m"
+
+int main()
+{
+    printf("\n");
+    printf(COLOR_BOLD COLOR_CYAN "                     MILK SEQUENCER (milk-seq)\n" COLOR_RESET);
+    printf(COLOR_BOLD "                     =========================\n\n" COLOR_RESET);
+
+    printf(COLOR_BOLD "1. ARCHITECTURE\n" COLOR_RESET);
+    printf("  The milk sequencer (`milk-seq`) is a standalone, real-time daemon used to\n");
+    printf("  execute commands deterministically and headlessly. It is designed for strict\n");
+    printf("  timing orchestration, such as hardware calibration or adaptive optics loops.\n\n");
+    printf("  Key features:\n");
+    printf("  - " COLOR_GREEN "Zero-Copy State:" COLOR_RESET " Exposes execution state via `/dev/shm/milkseq.<name>.shm`.\n");
+    printf("  - " COLOR_GREEN "Cross-Process Injection:" COLOR_RESET " Accepts commands injected via a named FIFO pipe.\n");
+    printf("  - " COLOR_GREEN "Deterministic Lock-Stepping:" COLOR_RESET " Provides `wait_fps` and `wait_seq` primitives.\n\n");
+
+    printf(COLOR_BOLD "2. BASIC USAGE\n" COLOR_RESET);
+    printf("  " COLOR_CYAN "milk-seq -n <name> -f <script.seq>\n" COLOR_RESET);
+    printf("  Starts a sequencer instance in the background parsing the script.\n\n");
+
+    printf("  Additionally, you can run commands from the CLI environment:\n");
+    printf("    " COLOR_YELLOW "seq.list" COLOR_RESET "                 List all active sequencer instances\n");
+    printf("    " COLOR_YELLOW "seq.start <name>" COLOR_RESET "         Start a blank sequencer\n");
+    printf("    " COLOR_YELLOW "seq.stop  <name>" COLOR_RESET "         Stop a sequencer safely\n");
+    printf("    " COLOR_YELLOW "seq.status <name>" COLOR_RESET "        View task status and error counts\n");
+    printf("    " COLOR_YELLOW "seq.submit <name> <cmd>" COLOR_RESET "  Inject a command from CLI to sequence\n\n");
+
+    printf(COLOR_BOLD "3. SCRIPTING COMMANDS\n" COLOR_RESET);
+    printf("  Inside a `.seq` file, standard bash executable calls are valid.\n");
+    printf("  However, the sequencer natively intercepts certain real-time commands:\n\n");
+
+    printf("  " COLOR_GREEN "wait_fps <name> <val>" COLOR_RESET "\n");
+    printf("      Pauses execution until the specified FPS parameter exactly equals <val>.\n");
+    printf("      Perfect for synchronizing with hardware loops.\n\n");
+
+    printf("  " COLOR_GREEN "wait_seq <name>" COLOR_RESET "\n");
+    printf("      Pauses execution until the target sequencer script completes.\n\n");
+
+    printf("  " COLOR_GREEN "if_fps_status <name> <val> <cmd>" COLOR_RESET "\n");
+    printf("      Executes <cmd> only if the FPS parameter matching <name> is equal to <val>.\n\n");
+
+    printf("  " COLOR_GREEN "on_error <abort|skip|retry>" COLOR_RESET "\n");
+    printf("      Sets global fault behavior robustly without complex test clauses.\n\n");
+
+    printf(COLOR_BOLD "4. OBSERVABILITY\n" COLOR_RESET);
+    printf("  Because the sequencer creates an SHM state struct, you can view its\n");
+    printf("  progression exactly. In the milk environment, you can read variables like:\n");
+    printf("    " COLOR_YELLOW "echo ${seq.myloop.status}" COLOR_RESET "\n");
+    printf("    " COLOR_YELLOW "echo ${seq.myloop.nb_tasks}" COLOR_RESET "\n\n");
+
+    return 0;
+}

--- a/src/engine/libfpsseq/milk-seq-help.c
+++ b/src/engine/libfpsseq/milk-seq-help.c
@@ -4,7 +4,6 @@
  */
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <unistd.h>
 
 #define COLOR_RESET   "\033[0m"
@@ -29,15 +28,22 @@ int main()
     printf("  - " COLOR_GREEN "Deterministic Lock-Stepping:" COLOR_RESET " Provides `wait_fps` and `wait_seq` primitives.\n\n");
 
     printf(COLOR_BOLD "2. BASIC USAGE\n" COLOR_RESET);
-    printf("  " COLOR_CYAN "milk-seq -n <name> -f <script.seq>\n" COLOR_RESET);
-    printf("  Starts a sequencer instance in the background parsing the script.\n\n");
+    printf("  " COLOR_CYAN "milk-seq -n <name> -f <script.seq> --daemon\n" COLOR_RESET);
+    printf("  Starts a daemonized sequencer that detaches from the terminal.\n\n");
 
-    printf("  Additionally, you can run commands from the CLI environment:\n");
+    printf(COLOR_BOLD "  Daemon Lifecycle:\n" COLOR_RESET);
+    printf("  - PID file:  " COLOR_GREEN "$MILK_SHM_DIR/milkseq.<name>.pid" COLOR_RESET "\n");
+    printf("  - Log file:  " COLOR_GREEN "$MILK_SHM_DIR/milkseq.<name>.log" COLOR_RESET "\n");
+    printf("  - Survives SSH disconnections (POSIX double-fork daemon).\n");
+    printf("  - Stopped via SIGTERM (seq.stop reads PID file).\n\n");
+
+    printf("  CLI commands (from milk-cli):\n");
     printf("    " COLOR_YELLOW "seq.list" COLOR_RESET "                 List all active sequencer instances\n");
-    printf("    " COLOR_YELLOW "seq.start <name>" COLOR_RESET "         Start a blank sequencer\n");
-    printf("    " COLOR_YELLOW "seq.stop  <name>" COLOR_RESET "         Stop a sequencer safely\n");
+    printf("    " COLOR_YELLOW "seq.start <name>" COLOR_RESET "         Start a daemonized sequencer\n");
+    printf("    " COLOR_YELLOW "seq.stop  <name>" COLOR_RESET "         Stop via SIGTERM (PID file)\n");
     printf("    " COLOR_YELLOW "seq.status <name>" COLOR_RESET "        View task status and error counts\n");
-    printf("    " COLOR_YELLOW "seq.submit <name> <cmd>" COLOR_RESET "  Inject a command from CLI to sequence\n\n");
+    printf("    " COLOR_YELLOW "seq.submit <name> <cmd>" COLOR_RESET "  Inject a command via FIFO\n");
+    printf("    " COLOR_YELLOW "seq.log <name>" COLOR_RESET "           Show tail of daemon log\n\n");
 
     printf(COLOR_BOLD "3. SCRIPTING COMMANDS\n" COLOR_RESET);
     printf("  Inside a `.seq` file, standard bash executable calls are valid.\n");

--- a/src/engine/libfpsseq/milk-seq.c
+++ b/src/engine/libfpsseq/milk-seq.c
@@ -38,8 +38,11 @@ static void print_help()
     printf("  --headless       Run silently without TUI (default)\n");
     printf("  --fifo <path>    Custom FIFO path (default: /tmp/milkseq.<name>.fifo)\n");
     printf("  --timeout <sec>  Exit after idle for <sec> seconds\n");
-    printf("  -h, --help       Show this help\n");
+    printf("  -h, --help       Show this brief help\n\n");
+    printf("For extensive documentation, including scripting syntax and\n");
+    printf("architecture overview, run `milk-seq-help`.\n");
 }
+
 
 int main(int argc, char **argv)
 {

--- a/src/engine/libfpsseq/milk-seq.c
+++ b/src/engine/libfpsseq/milk-seq.c
@@ -87,18 +87,36 @@ static int daemonize(
         _exit(0);
     }
 
-    /* Redirect stdout/stderr to log file */
+    /* Redirect stdout/stderr to log file (or /dev/null on failure) */
     int logfd = open(
         logpath,
         O_WRONLY | O_CREAT | O_APPEND,
         0644);
-    if (logfd >= 0) {
-        dup2(logfd, STDOUT_FILENO);
-        dup2(logfd, STDERR_FILENO);
-        close(logfd);
+    if (logfd < 0) {
+        /* Fall back to /dev/null to avoid inheriting the terminal */
+        logfd = open("/dev/null", O_WRONLY);
+        if (logfd < 0) {
+            return -1;
+        }
     }
-    close(STDIN_FILENO);
+    if (dup2(logfd, STDOUT_FILENO) < 0 ||
+        dup2(logfd, STDERR_FILENO) < 0)
+    {
+        close(logfd);
+        return -1;
+    }
+    close(logfd);
 
+    /* Redirect stdin from /dev/null */
+    int nullfd = open("/dev/null", O_RDONLY);
+    if (nullfd < 0) {
+        return -1;
+    }
+    if (dup2(nullfd, STDIN_FILENO) < 0) {
+        close(nullfd);
+        return -1;
+    }
+    close(nullfd);
     /* Write PID file */
     {
         FILE *fp = fopen(pidpath, "w");

--- a/src/engine/libfpsseq/milk-seq.c
+++ b/src/engine/libfpsseq/milk-seq.c
@@ -117,13 +117,18 @@ static int daemonize(
         return -1;
     }
     close(nullfd);
-    /* Write PID file */
+    /* Write PID file atomically and exclusively */
     {
-        FILE *fp = fopen(pidpath, "w");
-        if (fp) {
-            fprintf(fp, "%d\n", (int)getpid());
-            fclose(fp);
+        int pidfd = open(pidpath, O_WRONLY | O_CREAT | O_EXCL, 0600);
+        if (pidfd < 0) {
+            /* Fail daemonization if PID file cannot be created */
+            return -1;
         }
+        if (dprintf(pidfd, "%d\n", (int)getpid()) < 0) {
+            close(pidfd);
+            return -1;
+        }
+        close(pidfd);
     }
 
     return 0;

--- a/src/engine/libfpsseq/milk-seq.c
+++ b/src/engine/libfpsseq/milk-seq.c
@@ -2,7 +2,10 @@
  * @file milk-seq.c
  * @brief Standalone milk-seq sequencer daemon
  *
- * Runs the robust standalone sequencer engine out-of-process.
+ * Runs the robust standalone sequencer engine
+ * out-of-process. Supports --daemon for POSIX
+ * daemonization (double-fork, setsid, PID file,
+ * log file redirect).
  */
 
 #include <stdio.h>
@@ -28,6 +31,86 @@ static void sigterm_handler(int signum)
     keep_running = 0;
 }
 
+/**
+ * @brief Resolve SHM directory for PID/log files
+ *
+ * Checks $MILK_SHM_DIR, then /milk/shm,
+ * then falls back to /tmp.
+ */
+static const char *get_shm_dir(void)
+{
+    const char *dir = getenv("MILK_SHM_DIR");
+    if (dir && dir[0] != '\0') {
+        return dir;
+    }
+    struct stat st;
+    if (stat("/milk/shm", &st) == 0
+        && S_ISDIR(st.st_mode))
+    {
+        return "/milk/shm";
+    }
+    return "/tmp";
+}
+
+/**
+ * @brief POSIX double-fork daemonization
+ *
+ * Detaches from terminal, creates new session,
+ * writes PID file, redirects stdout/stderr to
+ * log file. Returns 0 in the daemon child,
+ * or -1 on error. The original process exits.
+ */
+static int daemonize(
+    const char *pidpath,
+    const char *logpath)
+{
+    /* First fork — parent exits */
+    pid_t pid = fork();
+    if (pid < 0) {
+        return -1;
+    }
+    if (pid > 0) {
+        _exit(0); /* parent exits */
+    }
+
+    /* New session leader */
+    if (setsid() < 0) {
+        return -1;
+    }
+
+    /* Second fork — prevent re-acquiring tty */
+    pid = fork();
+    if (pid < 0) {
+        return -1;
+    }
+    if (pid > 0) {
+        _exit(0);
+    }
+
+    /* Redirect stdout/stderr to log file */
+    int logfd = open(
+        logpath,
+        O_WRONLY | O_CREAT | O_APPEND,
+        0644);
+    if (logfd >= 0) {
+        dup2(logfd, STDOUT_FILENO);
+        dup2(logfd, STDERR_FILENO);
+        close(logfd);
+    }
+    close(STDIN_FILENO);
+
+    /* Write PID file */
+    {
+        FILE *fp = fopen(pidpath, "w");
+        if (fp) {
+            fprintf(fp, "%d\n", (int)getpid());
+            fclose(fp);
+        }
+    }
+
+    return 0;
+}
+
 static void print_help()
 {
     printf("milk-seq - Standalone FPS Sequencer Engine\n\n");
@@ -36,11 +119,15 @@ static void print_help()
     printf("  -n <name>        Sequencer name (required)\n");
     printf("  -f <script.seq>  Sequence file to load on startup\n");
     printf("  --headless       Run silently without TUI (default)\n");
+    printf("  --daemon         Daemonize (fork, detach from terminal)\n");
     printf("  --fifo <path>    Custom FIFO path (default: /tmp/milkseq.<name>.fifo)\n");
     printf("  --timeout <sec>  Exit after idle for <sec> seconds\n");
     printf("  -h, --help       Show this brief help\n\n");
-    printf("For extensive documentation, including scripting syntax and\n");
-    printf("architecture overview, run `milk-seq-help`.\n");
+    printf("When --daemon is used, PID file and log are written to\n");
+    printf("$MILK_SHM_DIR (default /milk/shm):\n");
+    printf("  PID: $MILK_SHM_DIR/milkseq.<name>.pid\n");
+    printf("  Log: $MILK_SHM_DIR/milkseq.<name>.log\n\n");
+    printf("For extensive documentation, run `milk-seq-help`.\n");
 }
 
 
@@ -50,6 +137,9 @@ int main(int argc, char **argv)
     char script_file[FPSSEQ_SCRIPT_PATH_MAX] = {0};
     char custom_fifo[FPSSEQ_FIFO_PATH_MAX] = {0};
     int timeout_sec = 0;
+    int do_daemon = 0;
+    char pidpath[256] = {0};
+    char logpath[256] = {0};
 
     // Parse arguments
     int i = 1;
@@ -72,6 +162,9 @@ int main(int argc, char **argv)
         } else if (strcmp(argv[i], "--headless") == 0) {
             // currently implied
             i++;
+        } else if (strcmp(argv[i], "--daemon") == 0) {
+            do_daemon = 1;
+            i++;
         } else {
             fprintf(stderr, "Unknown flag: %s\n", argv[i]);
             print_help();
@@ -80,8 +173,30 @@ int main(int argc, char **argv)
     }
 
     if (seq_name[0] == '\0') {
-        fprintf(stderr, "Error: Sequencer name (-n) is required.\n");
+        fprintf(stderr,
+                "Error: Sequencer name (-n) is "
+                "required.\n");
         return 1;
+    }
+
+    /* Build PID/log file paths */
+    {
+        const char *shmdir = get_shm_dir();
+        snprintf(pidpath, sizeof(pidpath),
+                 "%s/milkseq.%s.pid",
+                 shmdir, seq_name);
+        snprintf(logpath, sizeof(logpath),
+                 "%s/milkseq.%s.log",
+                 shmdir, seq_name);
+    }
+
+    /* Daemonize if requested */
+    if (do_daemon) {
+        if (daemonize(pidpath, logpath) < 0) {
+            fprintf(stderr,
+                    "Failed to daemonize\n");
+            return 1;
+        }
     }
 
     // Set up signals
@@ -182,6 +297,11 @@ int main(int argc, char **argv)
 
     close(fifo_fd);
     milkseq_destroy(seq_name);
+
+    /* Clean up PID file */
+    if (do_daemon && pidpath[0] != '\0') {
+        unlink(pidpath);
+    }
 
     free(keywnode);
     return 0;

--- a/src/sequencer/CMakeLists.txt
+++ b/src/sequencer/CMakeLists.txt
@@ -29,3 +29,21 @@ target_link_libraries(${LIBNAME} PUBLIC m milkfps milkfpsseq CLIcore)
 
 install(TARGETS ${LIBNAME} EXPORT milkTargets DESTINATION lib)
 install(FILES ${INCLUDEFILES} DESTINATION include/${SRCNAME})
+
+# Add CTest checks to verify that the sequencer module's CLI commands are registered.
+# These tests are only enabled when BUILD_TESTING is ON.
+if(BUILD_TESTING)
+
+    # Verify that the 'seq.list' command is available via the CLI.
+    add_test(
+        NAME sequencer_cmd_help_seq_list
+        COMMAND milk cmd? seq.list
+    )
+
+    # Verify that the 'seq.start' command is available via the CLI.
+    add_test(
+        NAME sequencer_cmd_help_seq_start
+        COMMAND milk cmd? seq.start
+    )
+
+endif()

--- a/src/sequencer/CMakeLists.txt
+++ b/src/sequencer/CMakeLists.txt
@@ -37,13 +37,13 @@ if(BUILD_TESTING)
     # Verify that the 'seq.list' command is available via the CLI.
     add_test(
         NAME sequencer_cmd_help_seq_list
-        COMMAND milk cmd? seq.list
+        COMMAND ${CMAKE_BINARY_DIR}/milk-cli cmd? seq.list
     )
 
     # Verify that the 'seq.start' command is available via the CLI.
     add_test(
         NAME sequencer_cmd_help_seq_start
-        COMMAND milk cmd? seq.start
+        COMMAND ${CMAKE_BINARY_DIR}/milk-cli cmd? seq.start
     )
 
 endif()

--- a/src/sequencer/CMakeLists.txt
+++ b/src/sequencer/CMakeLists.txt
@@ -1,0 +1,31 @@
+# library name
+set(LIBNAME "milksequencer")
+set(SRCNAME "sequencer")
+
+message("")
+message(" SRCNAME = ${SRCNAME} -> LIBNAME = ${LIBNAME}")
+
+set(SOURCEFILES
+	${SRCNAME}.c
+	seq_cli.c
+)
+
+set(INCLUDEFILES
+	${SRCNAME}.h
+	seq_cli.h
+)
+
+# DEFAULT SETTINGS
+# Do not change unless needed
+# =====================================================================
+
+project(lib_${LIBNAME}_project)
+
+add_library(${LIBNAME} SHARED ${SOURCEFILES})
+
+target_include_directories(${LIBNAME} PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/..>
+											$<INSTALL_INTERFACE:include>)
+target_link_libraries(${LIBNAME} PUBLIC m milkfps milkfpsseq CLIcore)
+
+install(TARGETS ${LIBNAME} EXPORT milkTargets DESTINATION lib)
+install(FILES ${INCLUDEFILES} DESTINATION include/${SRCNAME})

--- a/src/sequencer/seq_cli.c
+++ b/src/sequencer/seq_cli.c
@@ -207,27 +207,27 @@ static errno_t cli_seq_stop(void)
 /**
  * @brief Register all commands
  */
-errno_t CLIADDCMD_COREMOD_tools__seq_cli(void)
+errno_t CLIADDCMD_sequencer__seq_cli(void)
 {
-    RegisterCLIcommand("seq.list", __func__, cli_seq_list,
+    RegisterCLIcommand("list", __func__, cli_seq_list,
                        "List active sequencer instances",
                        "seq.list", "seq.list", "");
                        
-    RegisterCLIcommand("seq.submit", __func__, cli_seq_submit,
+    RegisterCLIcommand("submit", __func__, cli_seq_submit,
                        "Submit a command to a sequencer",
                        "seq.submit <name> <cmd...>", 
                        "seq.submit loop01 sleep 1.5", "");
 
-    RegisterCLIcommand("seq.status", __func__, cli_seq_status,
+    RegisterCLIcommand("status", __func__, cli_seq_status,
                        "Show status of a sequencer",
                        "seq.status <name>", "seq.status loop01", "");
 
-    RegisterCLIcommand("seq.start", __func__, cli_seq_start,
+    RegisterCLIcommand("start", __func__, cli_seq_start,
                        "Start a new sequencer instance",
                        "seq.start <name> [-f script.seq]", 
                        "seq.start calib -f test.seq", "");
 
-    RegisterCLIcommand("seq.stop", __func__, cli_seq_stop,
+    RegisterCLIcommand("stop", __func__, cli_seq_stop,
                        "Stop a sequencer instance safely",
                        "seq.stop <name>", "seq.stop calib", "");
 

--- a/src/sequencer/seq_cli.c
+++ b/src/sequencer/seq_cli.c
@@ -12,9 +12,30 @@
 #include "CLIcore.h"
 #include "fpsseq.h"
 #include <fcntl.h>
+#include <signal.h>
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+/**
+ * @brief Resolve SHM directory for PID/log files
+ *
+ * Mirrors the logic in milk-seq.c.
+ */
+static const char *get_shm_dir(void)
+{
+    const char *dir = getenv("MILK_SHM_DIR");
+    if (dir && dir[0] != '\0') {
+        return dir;
+    }
+    struct stat st;
+    if (stat("/milk/shm", &st) == 0
+        && S_ISDIR(st.st_mode))
+    {
+        return "/milk/shm";
+    }
+    return "/tmp";
+}
 
 /**
  * @brief List all running sequencer instances
@@ -141,7 +162,7 @@ static errno_t cli_seq_status(void)
 }
 
 /**
- * @brief Start a sequencer process
+ * @brief Start a sequencer as a POSIX daemon
  */
 static errno_t cli_seq_start(void)
 {
@@ -149,31 +170,47 @@ static errno_t cli_seq_start(void)
         return RETURN_SUCCESS;
     }
 
-    const char *seqname = data.cmdargtoken[1].val.string;
+    const char *seqname =
+        data.cmdargtoken[1].val.string;
     char cmd[512];
-    
-    // Check if script file provided via -f
-    if (data.cmdargtoken[2].type == 4 && strcmp(data.cmdargtoken[2].val.string, "-f") == 0) {
+
+    if (data.cmdargtoken[2].type == 4
+        && strcmp(
+               data.cmdargtoken[2].val.string,
+               "-f") == 0)
+    {
         if (data.cmdargtoken[3].type == 0) {
-            printf("ERROR: Missing script file after -f\n");
+            printf(
+                "ERROR: Missing script file "
+                "after -f\n");
             return RETURN_SUCCESS;
         }
-        snprintf(cmd, sizeof(cmd), "milk-seq -n %s -f %s --headless &", 
-                 seqname, data.cmdargtoken[3].val.string);
+        snprintf(
+            cmd, sizeof(cmd),
+            "milk-seq -n %s -f %s --daemon",
+            seqname,
+            data.cmdargtoken[3].val.string);
     } else {
-        snprintf(cmd, sizeof(cmd), "milk-seq -n %s --headless &", seqname);
+        snprintf(
+            cmd, sizeof(cmd),
+            "milk-seq -n %s --daemon",
+            seqname);
     }
 
     printf("Starting sequencer: %s\n", cmd);
     if (system(cmd) == -1) {
-        printf("ERROR: Failed to launch sequencer.\n");
+        printf(
+            "ERROR: Failed to launch "
+            "sequencer.\n");
     }
-    
+
     return RETURN_SUCCESS;
 }
 
 /**
- * @brief Stop a sequencer process
+ * @brief Stop a sequencer via SIGTERM (PID file)
+ *
+ * Falls back to FIFO "exit" if PID file is absent.
  */
 static errno_t cli_seq_stop(void)
 {
@@ -181,26 +218,129 @@ static errno_t cli_seq_stop(void)
         return RETURN_SUCCESS;
     }
 
-    const char *seqname = data.cmdargtoken[1].val.string;
-    MILKSEQ_STATE *state = milkseq_connect(seqname);
+    const char *seqname =
+        data.cmdargtoken[1].val.string;
+
+    /* Try PID file first */
+    char pidpath[256];
+    snprintf(pidpath, sizeof(pidpath),
+             "%s/milkseq.%s.pid",
+             get_shm_dir(), seqname);
+
+    FILE *fp = fopen(pidpath, "r");
+    if (fp) {
+        int pid = 0;
+        if (fscanf(fp, "%d", &pid) == 1
+            && pid > 0)
+        {
+            if (kill((pid_t)pid, SIGTERM) == 0)
+            {
+                printf(
+                    "SIGTERM sent to '%s' "
+                    "(PID %d).\n",
+                    seqname, pid);
+                fclose(fp);
+                return RETURN_SUCCESS;
+            }
+            printf(
+                "WARNING: kill(%d) failed, "
+                "trying FIFO fallback.\n",
+                pid);
+        }
+        fclose(fp);
+    }
+
+    /* Fallback: FIFO "exit" command */
+    MILKSEQ_STATE *state =
+        milkseq_connect(seqname);
     if (!state) {
-        printf("ERROR: Sequencer '%s' not found.\n", seqname);
+        printf(
+            "ERROR: Sequencer '%s' not "
+            "found.\n", seqname);
         return RETURN_SUCCESS;
     }
 
-    int fd = open(state->fifo_path, O_WRONLY | O_NONBLOCK);
+    int fd = open(
+        state->fifo_path,
+        O_WRONLY | O_NONBLOCK);
     if (fd >= 0) {
         if (write(fd, "exit\n", 5) < 0) {
-            printf("ERROR: Failed to write to FIFO.\n");
+            printf(
+                "ERROR: Failed to write "
+                "to FIFO.\n");
         } else {
-            printf("Stop command sent to '%s'.\n", seqname);
+            printf(
+                "Stop command sent to "
+                "'%s' via FIFO.\n",
+                seqname);
         }
         close(fd);
     } else {
-        printf("ERROR: Could not open FIFO for '%s'.\n", seqname);
+        printf(
+            "ERROR: Could not open FIFO "
+            "for '%s'.\n", seqname);
     }
 
     milkseq_disconnect(state);
+    return RETURN_SUCCESS;
+}
+
+/**
+ * @brief Print tail of sequencer log file
+ */
+static errno_t cli_seq_log(void)
+{
+    if (CLI_checkarg(1, 4) == 0) {
+        return RETURN_SUCCESS;
+    }
+
+    const char *seqname =
+        data.cmdargtoken[1].val.string;
+
+    char logpath[256];
+    snprintf(logpath, sizeof(logpath),
+             "%s/milkseq.%s.log",
+             get_shm_dir(), seqname);
+
+    FILE *fp = fopen(logpath, "r");
+    if (!fp) {
+        printf(
+            "No log file found: %s\n",
+            logpath);
+        return RETURN_SUCCESS;
+    }
+
+    /* Count lines */
+    int nlines = 0;
+    int ch;
+    while ((ch = fgetc(fp)) != EOF) {
+        if (ch == '\n') {
+            nlines++;
+        }
+    }
+
+    /* Seek to last 50 lines */
+    int skip = (nlines > 50) ? nlines - 50 : 0;
+    rewind(fp);
+    int cur = 0;
+    while (cur < skip) {
+        ch = fgetc(fp);
+        if (ch == EOF) {
+            break;
+        }
+        if (ch == '\n') {
+            cur++;
+        }
+    }
+
+    printf("--- %s (last %d lines) ---\n",
+           logpath, nlines - skip);
+    while ((ch = fgetc(fp)) != EOF) {
+        putchar(ch);
+    }
+    printf("--- end ---\n");
+
+    fclose(fp);
     return RETURN_SUCCESS;
 }
 
@@ -227,9 +367,17 @@ errno_t CLIADDCMD_sequencer__seq_cli(void)
                        "seq.start <name> [-f script.seq]", 
                        "seq.start calib -f test.seq", "");
 
-    RegisterCLIcommand("stop", __func__, cli_seq_stop,
-                       "Stop a sequencer instance safely",
-                       "seq.stop <name>", "seq.stop calib", "");
+    RegisterCLIcommand(
+        "stop", __func__, cli_seq_stop,
+        "Stop a sequencer instance safely",
+        "seq.stop <name>",
+        "seq.stop calib", "");
+
+    RegisterCLIcommand(
+        "log", __func__, cli_seq_log,
+        "Show tail of sequencer log",
+        "seq.log <name>",
+        "seq.log calib", "");
 
     return RETURN_SUCCESS;
 }

--- a/src/sequencer/seq_cli.h
+++ b/src/sequencer/seq_cli.h
@@ -13,7 +13,7 @@
 #endif
 
 #ifndef MILK_NO_CLI
-errno_t CLIADDCMD_COREMOD_tools__seq_cli(void);
+errno_t CLIADDCMD_sequencer__seq_cli(void);
 #endif
 
 #endif

--- a/src/sequencer/sequencer.c
+++ b/src/sequencer/sequencer.c
@@ -1,0 +1,22 @@
+/**
+ * @file    sequencer.c
+ * @brief   Sequencer CLI Integration Module
+ */
+
+#define MODULE_SHORTNAME_DEFAULT "seq"
+#define MODULE_DESCRIPTION       "sequencer control module"
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "CLIcore.h"
+#include "seq_cli.h"
+
+INIT_MODULE_LIB(sequencer)
+
+static errno_t init_module_CLI()
+{
+    CLIADDCMD_sequencer__seq_cli();
+    return RETURN_SUCCESS;
+}
+#endif /* MILK_NO_CLI */

--- a/src/sequencer/sequencer.h
+++ b/src/sequencer/sequencer.h
@@ -1,0 +1,4 @@
+#ifndef _SEQUENCER_H
+#define _SEQUENCER_H
+
+#endif

--- a/src/sequencer/sequencer.h
+++ b/src/sequencer/sequencer.h
@@ -1,4 +1,4 @@
-#ifndef _SEQUENCER_H
-#define _SEQUENCER_H
+#ifndef SEQUENCER_H
+#define SEQUENCER_H
 
 #endif


### PR DESCRIPTION
## Summary

Decouples the sequencer from `COREMOD_tools` into an independent `src/sequencer/` module and adds proper POSIX daemonization to `milk-seq`.

### Commit 1: Module extraction
- New `src/sequencer/` with `INIT_MODULE_LIB(sequencer)` (shortname `seq`) — commands register as `seq.list`, `seq.start`, etc.
- New `USE_SEQ` CMake option (default ON, requires `USE_CLI`)
- Removed `seq_cli.c/h` from `COREMOD_tools`
- New `milk-seq-help` documentation executable
- Sequencer added as 4th pillar in `milk-help`

### Commit 2: POSIX daemon
- `--daemon` flag: double-fork, `setsid()`, PID file, log redirect
- Files written to `$MILK_SHM_DIR` (default `/milk/shm`)
- `seq.start` launches via `--daemon` (replaces `system("... &")`)
- `seq.stop` sends `SIGTERM` via PID file (FIFO fallback)
- New `seq.log <name>` command to tail daemon log from CLI

### Prompt Summary
User requested sequencer decoupled from COREMOD_tools into an optional module named `sequencer`. Chose POSIX `daemon()` over tmux/systemd for process lifecycle, with PID/log files in `$MILK_SHM_DIR`.

### AI Authorship
- **Model:** Antigravity
- **User edits:** None