### PR TITLE
fix: resolve setcol/setrow segmentation faults & add circle of disks script

### DIFF
--- a/scripts/makecircleofdisks.milk
+++ b/scripts/makecircleofdisks.milk
@@ -1,0 +1,113 @@
+#!/usr/bin/env milk-cli -s
+#
+# makecircleofdisks.milk
+# Creates a 2D image containing N filled disks,
+# regularly spaced along a circle.
+#
+# Usage:
+#   milk-cli -s makecircleofdisks.milk \
+#            [ndisks] [disk_radius] [circle_radius] \
+#            [image_size] [output_name]
+#
+# Arguments (all optional, defaults shown):
+#   $1  ndisks        Number of disks          (6)
+#   $2  disk_radius   Radius of each disk, px  (10)
+#   $3  circle_radius Radius of ring, px       (40)
+#   $4  imsize        Image side length, px    (128)
+#   $5  outname       Output SHM stream name   (circleofdisks)
+#
+# The output is a float32 image: 1.0 inside each
+# disk, 0.0 elsewhere.
+# It remains in shared memory after this script
+# exits and is also saved as <outname>.fits
+# (if iofits is available).
+#
+
+set -e
+
+# ── Parse arguments with defaults ──────────────────
+_ndisks=${1:-6}
+_drad=${2:-10}
+_crad=${3:-40}
+_imsz=${4:-128}
+_out=${5:-circleofdisks}
+
+echo "makecircleofdisks:"
+echo "  N=$_ndisks  disk_r=$_drad  circle_r=$_crad"
+echo "  size=${_imsz}x${_imsz}  out=$_out"
+
+# ── Cleanup handler ────────────────────────────────
+trap '_circdisk_cleanup' EXIT
+function _circdisk_cleanup {
+    mem.rm _cdc_xmap 0
+    mem.rm _cdc_ymap 0
+    mem.rm _cdc_dist 0
+}
+
+# ── Create working images ──────────────────────────
+mem.mk2Dim _cdc_xmap ${_imsz} ${_imsz}
+mem.mk2Dim _cdc_ymap ${_imsz} ${_imsz}
+mem.mk2Dim _cdc_dist ${_imsz} ${_imsz}
+mem.mk2Dim ${_out}   ${_imsz} ${_imsz}
+
+# Zero-fill output
+${_out} = ${_out} * 0.0
+
+# ── Build coordinate maps ──────────────────────────
+# _cdc_xmap[row,col] = col  (x-coordinate)
+# _cdc_ymap[row,col] = row  (y-coordinate)
+#
+# Strategy:
+#   setcol fills every pixel in column c with value c
+#   setrow fills every pixel in row    r with value r
+#
+echo "  building coordinate maps..."
+_cidx=0
+while [ $_cidx -lt ${_imsz} ]; do
+    arith.setcol _cdc_xmap $_cidx $_cidx
+    arith.setrow _cdc_ymap $_cidx $_cidx
+    _cidx=$(expr $_cidx + 1)
+done
+
+# ── Image centre pixel (0-based) ───────────────────
+_ctr=$(expr $_imsz / 2)
+
+# ── Loop: stamp one disk per angular position ──────
+_pi=3.14159265358979
+_radsq = $_drad * $_drad
+
+_idx=0
+while [ $_idx -lt $_ndisks ]; do
+
+    # Angle evenly spaced around the full circle
+    _ang = 2.0 * $_pi * $_idx / $_ndisks
+
+    # Disk centre (floating-point pixel coordinates)
+    _cxf = $_ctr + $_crad * cos($_ang)
+    _cyf = $_ctr + $_crad * sin($_ang)
+
+    echo "  disk $_idx: centre ($_cxf , $_cyf)"
+
+    # Squared Euclidean distance from every pixel
+    # to disk centre
+    _cdc_dist = (_cdc_xmap - $_cxf) * (_cdc_xmap - $_cxf) + (_cdc_ymap - $_cyf) * (_cdc_ymap - $_cyf)
+
+    # Accumulate: OR via  out |= (dist² <= r²)
+    ${_out} = where(${_out} + (_cdc_dist <= $_radsq) > 0.5, 1.0, 0.0)
+
+    _idx=$(expr $_idx + 1)
+done
+
+echo "  image '${_out}' ready in SHM"
+
+# ── Optional FITS save ─────────────────────────────
+set +e
+iofits.saveFITS ${_out} ${_out}.fits
+if [ $? -eq 0 ]; then
+    echo "  saved ${_out}.fits"
+else
+    echo "  (iofits not available – skipping FITS save)"
+fi
+set -e
+
+echo "makecircleofdisks: DONE"

--- a/src/coremods/COREMOD_arith/image_set_col.c
+++ b/src/coremods/COREMOD_arith/image_set_col.c
@@ -32,9 +32,9 @@ static FPS_APP_INFO FPS_app_info = {
  * 2.  LOCAL PARAMETER VARIABLES
  * ============================================================= */
 
-static char      setcol_inimname[256] = "";
-static float    *setcol_pixval   = NULL;
-static uint32_t *setcol_colindex = NULL;
+static char     setcol_inimname[256] = "";
+static float    setcol_pixval        = 0.0f;
+static uint32_t setcol_colindex      = 0;
 
 
 /* ================================================================
@@ -62,11 +62,8 @@ static uint32_t *setcol_colindex = NULL;
 
 static MILK_HOT errno_t fpsexec(IMAGE *inimg)
 {
-    if (!setcol_pixval || !setcol_colindex) {
-        return RETURN_FAILURE;
-    }
-    float    val = *setcol_pixval;
-    uint32_t col = *setcol_colindex;
+    float    val = setcol_pixval;
+    uint32_t col = setcol_colindex;
     uint32_t xsize = inimg->md[0].size[0];
     uint32_t ysize = inimg->md[0].size[1];
 

--- a/src/coremods/COREMOD_arith/image_set_col.c
+++ b/src/coremods/COREMOD_arith/image_set_col.c
@@ -32,7 +32,7 @@ static FPS_APP_INFO FPS_app_info = {
  * 2.  LOCAL PARAMETER VARIABLES
  * ============================================================= */
 
-static char     *setcol_inimname = NULL;
+static char      setcol_inimname[256] = "";
 static float    *setcol_pixval   = NULL;
 static uint32_t *setcol_colindex = NULL;
 
@@ -42,7 +42,7 @@ static uint32_t *setcol_colindex = NULL;
  * ============================================================= */
 
 #define FPS_PARAMS(X) \
-    X(".imname", &setcol_inimname, \
+    X(".imname", setcol_inimname, \
       FPTYPE_STREAMNAME, 1, \
       FPFLAG_DEFAULT_INPUT, \
       "input image") \

--- a/src/coremods/COREMOD_arith/image_set_row.c
+++ b/src/coremods/COREMOD_arith/image_set_row.c
@@ -32,9 +32,9 @@ static FPS_APP_INFO FPS_app_info = {
  * 2.  LOCAL PARAMETER VARIABLES
  * ============================================================= */
 
-static char      setrow_inimname[256] = "";
-static float    *setrow_pixval   = NULL;
-static uint32_t *setrow_rowindex = NULL;
+static char     setrow_inimname[256] = "";
+static float    setrow_pixval        = 0.0f;
+static uint32_t setrow_rowindex      = 0;
 
 
 /* ================================================================
@@ -69,11 +69,8 @@ static uint32_t *setrow_rowindex = NULL;
  */
 static MILK_HOT errno_t fpsexec(IMAGE *inimg)
 {
-    if (!setrow_pixval || !setrow_rowindex) {
-        return RETURN_FAILURE;
-    }
-    float    val = *setrow_pixval;
-    uint32_t row = *setrow_rowindex;
+    float    val = setrow_pixval;
+    uint32_t row = setrow_rowindex;
     uint32_t xsize = inimg->md[0].size[0];
 
     if (row >= inimg->md[0].size[1]) {

--- a/src/coremods/COREMOD_arith/image_set_row.c
+++ b/src/coremods/COREMOD_arith/image_set_row.c
@@ -32,7 +32,7 @@ static FPS_APP_INFO FPS_app_info = {
  * 2.  LOCAL PARAMETER VARIABLES
  * ============================================================= */
 
-static char     *setrow_inimname = NULL;
+static char      setrow_inimname[256] = "";
 static float    *setrow_pixval   = NULL;
 static uint32_t *setrow_rowindex = NULL;
 
@@ -44,7 +44,7 @@ static uint32_t *setrow_rowindex = NULL;
  * ============================================================= */
 
 #define FPS_PARAMS(X) \
-    X(".imname", &setrow_inimname, \
+    X(".imname", setrow_inimname, \
       FPTYPE_STREAMNAME, 1, \
       FPFLAG_DEFAULT_INPUT, \
       "input image") \


### PR DESCRIPTION
## Summary

The `arith.setcol` and `arith.setrow` commands were crashing the CLI with a segmentation fault (`SIGSEGV`) due to incorrect FPS V2 parameter bindings. This PR fixes the root causes of those crashes and adds a `milk-cli` script (`makecircleofdisks.milk`) to generate circular disk patterns.

## Changes

### COREMOD_arith — FPS V2 Parameter Binding Fix (`image_set_col.c`, `image_set_row.c`)

- Replaced unallocated pointer initializations (`char *setcol_inimname = NULL`) with fixed-size arrays (`char setcol_inimname[256] = ""`) to correctly bind stream name parameters.
- Converted `setcol_pixval`/`setcol_colindex` (and their `setrow` equivalents) from pointer types (`float*`, `uint32_t*`) to plain scalars (`float`, `uint32_t`). Under FPS V2, the CLI sync writes scalar values directly into `binding.ptr`; using addresses of pointer variables caused the sync to overwrite the pointer itself, corrupting memory and triggering segfaults on subsequent dereferences.
- Removed now-redundant NULL-pointer guards and pointer dereferences in `fpsexec()`, using the scalar values directly. This matches the V2 template pattern in `examplefunc_fps_cli_poc.c`.

### New Script — `scripts/makecircleofdisks.milk`

- Generates a configurable ring of disk stamps evenly distributed around a circle.
- Uses `mem.mk2Dim` for coordinate map initialization and `arith.setcol`/`arith.setrow` for stamping.
- Restructured while-loop math incrementers with `$(expr ...)` to avoid tokenizer issues with `$((...))` blocks.
- Forced strict command namespaces (`arith.setcol`, `arith.setrow`, `iofits.saveFITS`) to eliminate erratic shell fallback interceptions.
- Condensed calculator formulas onto single lines to avoid deep tokenizer errors from line-continuation `\`.

## Verification

- [ ] Build passes (`/compile-test`)
- [ ] Tests pass (`ctest --output-on-failure`)
- [ ] CLI robustness tests pass (if CLI changed)
- [ ] Documentation updated (README, help, docs/)

## Prompt Summary

The user requested a native `milk-cli` script to stamp a configurable number of discs evenly around a coordinate circle. The script exposed shell bypass bugs (`sh 1: Illegal number`) which, after parsing fixes, revealed a deep-seated `SIGSEGV` across sequential invocations of `setcol`/`setrow` in `COREMOD_arith`. Investigation showed the root cause was incorrect FPS V2 parameter bindings — scalar params bound via addresses of pointer variables. Both the binding bug and the script pipeline have been fixed.

## AI Authorship

- **Model**: Antigravity / Copilot
- **User edits**: None