### PR TITLE
refactor: replace init_cms boilerplate with FPS_CMDSETTINGS_INIT macro

### DIFF
--- a/src/cli/streamCTRL/mmon_ui.c
+++ b/src/cli/streamCTRL/mmon_ui.c
@@ -83,17 +83,8 @@ static CLICMDDATA CLIcmddata = {
     "", "", CLICMD_FIELDS_DEFAULTS
 };
 
-static CMDSETTINGS cms_mmon = {0};
+FPS_CMDSETTINGS_INIT(mmon, CLIcmddata, FPS_app_info)
 
-static __attribute__((constructor))
-void init_cms_mmon(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings = &cms_mmon;
-    }
-}
 
 static MILK_HOT errno_t compute_function()
 {

--- a/src/coremods/COREMOD_arith/image_crop.c
+++ b/src/coremods/COREMOD_arith/image_crop.c
@@ -93,24 +93,7 @@ static FPS_APP_INFO FPS_app_info_2d = {
 static CLICMDDATA CLIcmddata_2d = {
     "", "", CLICMD_FIELDS_NOPARAM
 };
-static CMDSETTINGS cms_2d = {0};
-
-static __attribute__((constructor))
-void init_cms_2d(void)
-{
-    strncpy(CLIcmddata_2d.key,
-            FPS_app_info_2d.cmdkey,
-            sizeof(CLIcmddata_2d.key) - 1);
-    strncpy(CLIcmddata_2d.description,
-            FPS_app_info_2d.description,
-            sizeof(CLIcmddata_2d.description)
-            - 1);
-    if (CLIcmddata_2d.cmdsettings
-        == NULL) {
-        CLIcmddata_2d.cmdsettings =
-            &cms_2d;
-    }
-}
+FPS_CMDSETTINGS_INIT(2d, CLIcmddata_2d, FPS_app_info_2d)
 
 static errno_t __attribute__((unused)) compute_2d()
 {
@@ -182,22 +165,7 @@ static CLICMDDATA CLIcmddata = {
     "", "", CLICMD_FIELDS_DEFAULTS
 };
 
-static CMDSETTINGS cms = {0};
-
-static __attribute__((constructor))
-void init_cms(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description)
-            - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_CMDSETTINGS_INIT(main, CLIcmddata, FPS_app_info)
 
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {

--- a/src/coremods/COREMOD_arith/image_crop3D.c
+++ b/src/coremods/COREMOD_arith/image_crop3D.c
@@ -93,24 +93,7 @@ static FPS_APP_INFO FPS_app_info_2d = {
 static CLICMDDATA CLIcmddata_2d = {
     "", "", CLICMD_FIELDS_NOPARAM
 };
-static CMDSETTINGS cms_2d = {0};
-
-static __attribute__((constructor))
-void init_cms_2d(void)
-{
-    strncpy(CLIcmddata_2d.key,
-            FPS_app_info_2d.cmdkey,
-            sizeof(CLIcmddata_2d.key) - 1);
-    strncpy(CLIcmddata_2d.description,
-            FPS_app_info_2d.description,
-            sizeof(CLIcmddata_2d.description)
-            - 1);
-    if (CLIcmddata_2d.cmdsettings
-        == NULL) {
-        CLIcmddata_2d.cmdsettings =
-            &cms_2d;
-    }
-}
+FPS_CMDSETTINGS_INIT(2d, CLIcmddata_2d, FPS_app_info_2d)
 
 static errno_t compute_2d()
 {
@@ -182,22 +165,7 @@ static CLICMDDATA CLIcmddata = {
     "", "", CLICMD_FIELDS_DEFAULTS
 };
 
-static CMDSETTINGS cms = {0};
-
-static __attribute__((constructor))
-void init_cms(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description)
-            - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_CMDSETTINGS_INIT(main, CLIcmddata, FPS_app_info)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/src/coremods/COREMOD_arith/image_setzero.c
+++ b/src/coremods/COREMOD_arith/image_setzero.c
@@ -104,22 +104,7 @@ static CLICMDDATA CLIcmddata = {
  * they are defined in one place only.
  * Also provide a valid cmdsettings object.
  */
-static CMDSETTINGS default_cmdsettings = {0};
-
-static __attribute__((constructor))
-void init_cmdsettings(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings =
-            &default_cmdsettings;
-    }
-}
+FPS_CMDSETTINGS_INIT(dft, CLIcmddata, FPS_app_info)
 
 
 /* ================================================================

--- a/src/coremods/COREMOD_iofits/savefits.c
+++ b/src/coremods/COREMOD_iofits/savefits.c
@@ -266,22 +266,7 @@ static CLICMDDATA CLIcmddata = {
     CLICMD_FIELDS_DEFAULTS
 };
 
-static CMDSETTINGS default_cmdsettings = {0};
-
-static __attribute__((constructor))
-void init_cmdsettings(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings =
-            &default_cmdsettings;
-    }
-}
+FPS_CMDSETTINGS_INIT(dft, CLIcmddata, FPS_app_info)
 
 
 /* ================================================================

--- a/src/coremods/COREMOD_memory/clearall.c
+++ b/src/coremods/COREMOD_memory/clearall.c
@@ -106,22 +106,7 @@ static CLICMDDATA CLIcmddata = {
     CLICMD_FIELDS_NOPARAM
 };
 
-static CMDSETTINGS default_cmdsettings = {0};
-
-static __attribute__((constructor))
-void init_cmdsettings(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings =
-            &default_cmdsettings;
-    }
-}
+FPS_CMDSETTINGS_INIT(dft, CLIcmddata, FPS_app_info)
 
 
 /* ================================================================

--- a/src/coremods/COREMOD_memory/fps_list.c
+++ b/src/coremods/COREMOD_memory/fps_list.c
@@ -135,22 +135,7 @@ static CLICMDDATA CLIcmddata = {
     CLICMD_FIELDS_NOPARAM
 };
 
-static CMDSETTINGS default_cmdsettings = {0};
-
-static __attribute__((constructor))
-void init_cmdsettings(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings =
-            &default_cmdsettings;
-    }
-}
+FPS_CMDSETTINGS_INIT(dft, CLIcmddata, FPS_app_info)
 
 
 /* ================================================================

--- a/src/coremods/COREMOD_memory/image_copy.c
+++ b/src/coremods/COREMOD_memory/image_copy.c
@@ -82,23 +82,7 @@ static CLICMDDATA CLIcmddata_cp = {
     "", "", CLICMD_FIELDS_NOPARAM
 };
 
-static CMDSETTINGS cms_cp = {0};
-
-static __attribute__((constructor))
-void init_cms_cp(void)
-{
-    strncpy(CLIcmddata_cp.key,
-            FPS_app_info_cp.cmdkey,
-            sizeof(CLIcmddata_cp.key) - 1);
-    strncpy(CLIcmddata_cp.description,
-            FPS_app_info_cp.description,
-            sizeof(
-                CLIcmddata_cp.description
-            ) - 1);
-    if (CLIcmddata_cp.cmdsettings == NULL) {
-        CLIcmddata_cp.cmdsettings = &cms_cp;
-    }
-}
+FPS_CMDSETTINGS_INIT(cp, CLIcmddata_cp, FPS_app_info_cp)
 
 static errno_t __attribute__((unused)) compute_cp()
 {
@@ -121,23 +105,7 @@ static CLICMDDATA CLIcmddata_mv = {
     "", "", CLICMD_FIELDS_NOPARAM
 };
 
-static CMDSETTINGS cms_mv = {0};
-
-static __attribute__((constructor))
-void init_cms_mv(void)
-{
-    strncpy(CLIcmddata_mv.key,
-            FPS_app_info_mv.cmdkey,
-            sizeof(CLIcmddata_mv.key) - 1);
-    strncpy(CLIcmddata_mv.description,
-            FPS_app_info_mv.description,
-            sizeof(
-                CLIcmddata_mv.description
-            ) - 1);
-    if (CLIcmddata_mv.cmdsettings == NULL) {
-        CLIcmddata_mv.cmdsettings = &cms_mv;
-    }
-}
+FPS_CMDSETTINGS_INIT(mv, CLIcmddata_mv, FPS_app_info_mv)
 
 static errno_t __attribute__((unused)) compute_mv()
 {
@@ -173,22 +141,7 @@ static CLICMDDATA CLIcmddata = {
     "", "", CLICMD_FIELDS_DEFAULTS
 };
 
-static CMDSETTINGS cms_shm = {0};
-
-static __attribute__((constructor))
-void init_cms_shm(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description)
-            - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings = &cms_shm;
-    }
-}
+FPS_CMDSETTINGS_INIT(shm, CLIcmddata, FPS_app_info)
 
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {

--- a/src/coremods/COREMOD_memory/image_keyword.c
+++ b/src/coremods/COREMOD_memory/image_keyword.c
@@ -68,27 +68,7 @@ static CLICMDDATA CLIcmddata_listkw = {
     CLICMD_FIELDS_NOPARAM
 };
 
-static CMDSETTINGS cms_listkw = {0};
-
-static __attribute__((constructor))
-void init_cms_listkw(void)
-{
-    strncpy(CLIcmddata_listkw.key,
-            FPS_app_info_listkw.cmdkey,
-            sizeof(CLIcmddata_listkw.key)
-            - 1);
-    strncpy(
-        CLIcmddata_listkw.description,
-        FPS_app_info_listkw.description,
-        sizeof(
-            CLIcmddata_listkw.description
-        ) - 1);
-    if (CLIcmddata_listkw.cmdsettings
-        == NULL) {
-        CLIcmddata_listkw.cmdsettings =
-            &cms_listkw;
-    }
-}
+FPS_CMDSETTINGS_INIT(listkw, CLIcmddata_listkw, FPS_app_info_listkw)
 
 static errno_t __attribute__((unused)) compute_listkw()
 {
@@ -153,23 +133,7 @@ static CLICMDDATA CLIcmddata = {
     CLICMD_FIELDS_DEFAULTS
 };
 
-static CMDSETTINGS cms_writkw = {0};
-
-static __attribute__((constructor))
-void init_cms_writkw(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description)
-            - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings =
-            &cms_writkw;
-    }
-}
+FPS_CMDSETTINGS_INIT(writkw, CLIcmddata, FPS_app_info)
 
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {

--- a/src/coremods/COREMOD_memory/image_set_counters.c
+++ b/src/coremods/COREMOD_memory/image_set_counters.c
@@ -90,27 +90,7 @@ static CLICMDDATA CLIcmddata_status = {
     CLICMD_FIELDS_NOPARAM
 };
 
-static CMDSETTINGS cms1 = {0};
-
-static __attribute__((constructor))
-void init_cms_status(void)
-{
-    strncpy(CLIcmddata_status.key,
-            FPS_app_info_status.cmdkey,
-            sizeof(CLIcmddata_status.key)
-            - 1);
-    strncpy(
-        CLIcmddata_status.description,
-        FPS_app_info_status.description,
-        sizeof(
-            CLIcmddata_status.description
-        ) - 1);
-    if (CLIcmddata_status.cmdsettings
-        == NULL) {
-        CLIcmddata_status.cmdsettings =
-            &cms1;
-    }
-}
+FPS_CMDSETTINGS_INIT(cms1, CLIcmddata_status, FPS_app_info_status)
 
 static errno_t __attribute__((unused)) compute_status()
 {
@@ -149,22 +129,7 @@ static CLICMDDATA CLIcmddata = {
     CLICMD_FIELDS_DEFAULTS
 };
 
-static CMDSETTINGS cms2 = {0};
-
-static __attribute__((constructor))
-void init_cms_cnt0(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description)
-            - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings = &cms2;
-    }
-}
+FPS_CMDSETTINGS_INIT(cms2, CLIcmddata, FPS_app_info)
 
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {
@@ -195,26 +160,7 @@ static CLICMDDATA CLIcmddata_cnt1 = {
     CLICMD_FIELDS_NOPARAM
 };
 
-static CMDSETTINGS cms3 = {0};
-
-static __attribute__((constructor))
-void init_cms_cnt1(void)
-{
-    strncpy(CLIcmddata_cnt1.key,
-            FPS_app_info_cnt1.cmdkey,
-            sizeof(CLIcmddata_cnt1.key)
-            - 1);
-    strncpy(CLIcmddata_cnt1.description,
-            FPS_app_info_cnt1.description,
-            sizeof(
-                CLIcmddata_cnt1.description
-            ) - 1);
-    if (CLIcmddata_cnt1.cmdsettings
-        == NULL) {
-        CLIcmddata_cnt1.cmdsettings =
-            &cms3;
-    }
-}
+FPS_CMDSETTINGS_INIT(cms3, CLIcmddata_cnt1, FPS_app_info_cnt1)
 
 static errno_t __attribute__((unused)) compute_cnt1()
 {

--- a/src/coremods/COREMOD_memory/list_image.c
+++ b/src/coremods/COREMOD_memory/list_image.c
@@ -58,27 +58,7 @@ static CLICMDDATA CLIcmddata_listim = {
     "", "", CLICMD_FIELDS_NOPARAM
 };
 
-static CMDSETTINGS cms_listim = {0};
-
-static __attribute__((constructor))
-void init_cms_listim(void)
-{
-    strncpy(CLIcmddata_listim.key,
-            FPS_app_info_listim.cmdkey,
-            sizeof(CLIcmddata_listim.key)
-            - 1);
-    strncpy(
-        CLIcmddata_listim.description,
-        FPS_app_info_listim.description,
-        sizeof(
-            CLIcmddata_listim.description
-        ) - 1);
-    if (CLIcmddata_listim.cmdsettings
-        == NULL) {
-        CLIcmddata_listim.cmdsettings =
-            &cms_listim;
-    }
-}
+FPS_CMDSETTINGS_INIT(listim, CLIcmddata_listim, FPS_app_info_listim)
 
 static errno_t __attribute__((unused)) compute_listim()
 {

--- a/src/coremods/COREMOD_memory/list_variable.c
+++ b/src/coremods/COREMOD_memory/list_variable.c
@@ -71,26 +71,7 @@ static CLICMDDATA CLIcmddata_listvar = {
     CLICMD_FIELDS_NOPARAM
 };
 
-static CMDSETTINGS default_cmdsettings1 = {0};
-
-static __attribute__((constructor))
-void init_cmdsettings_listvar(void)
-{
-    strncpy(CLIcmddata_listvar.key,
-            FPS_app_info_listvar.cmdkey,
-            sizeof(CLIcmddata_listvar.key)
-            - 1);
-    strncpy(CLIcmddata_listvar.description,
-            FPS_app_info_listvar.description,
-            sizeof(
-                CLIcmddata_listvar.description
-            ) - 1);
-    if (CLIcmddata_listvar.cmdsettings
-        == NULL) {
-        CLIcmddata_listvar.cmdsettings =
-            &default_cmdsettings1;
-    }
-}
+FPS_CMDSETTINGS_INIT(dft1, CLIcmddata_listvar, FPS_app_info_listvar)
 
 static errno_t __attribute__((unused)) compute_listvar()
 {
@@ -137,24 +118,7 @@ static CLICMDDATA CLIcmddata = {
     CLICMD_FIELDS_DEFAULTS
 };
 
-static CMDSETTINGS default_cmdsettings2 = {0};
-
-static __attribute__((constructor))
-void init_cmdsettings_listvarf(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info_listvarf.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info_listvarf.description,
-            sizeof(
-                CLIcmddata.description
-            ) - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings =
-            &default_cmdsettings2;
-    }
-}
+FPS_CMDSETTINGS_INIT(dft2, CLIcmddata, FPS_app_info_listvarf)
 
 static errno_t __attribute__((unused)) compute_listvarf()
 {

--- a/src/coremods/COREMOD_memory/saveall.c
+++ b/src/coremods/COREMOD_memory/saveall.c
@@ -72,26 +72,7 @@ static CLICMDDATA CLIcmddata_snap = {
     CLICMD_FIELDS_NOPARAM
 };
 
-static CMDSETTINGS cms_snap = {0};
-
-static __attribute__((constructor))
-void init_cms_snap(void)
-{
-    strncpy(CLIcmddata_snap.key,
-            FPS_app_info_snap.cmdkey,
-            sizeof(CLIcmddata_snap.key)
-            - 1);
-    strncpy(CLIcmddata_snap.description,
-            FPS_app_info_snap.description,
-            sizeof(
-                CLIcmddata_snap.description
-            ) - 1);
-    if (CLIcmddata_snap.cmdsettings
-        == NULL) {
-        CLIcmddata_snap.cmdsettings =
-            &cms_snap;
-    }
-}
+FPS_CMDSETTINGS_INIT(snap, CLIcmddata_snap, FPS_app_info_snap)
 
 static errno_t __attribute__((unused)) compute_snap()
 {
@@ -155,22 +136,7 @@ static CLICMDDATA CLIcmddata = {
     CLICMD_FIELDS_DEFAULTS
 };
 
-static CMDSETTINGS cms_seq = {0};
-
-static __attribute__((constructor))
-void init_cms_seq(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description)
-            - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings = &cms_seq;
-    }
-}
+FPS_CMDSETTINGS_INIT(seq, CLIcmddata, FPS_app_info)
 
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {

--- a/src/coremods/COREMOD_memory/shmim_setowner.c
+++ b/src/coremods/COREMOD_memory/shmim_setowner.c
@@ -98,27 +98,7 @@ static CLICMDDATA CLIcmddata_creator = {
     CLICMD_FIELDS_NOPARAM
 };
 
-static CMDSETTINGS cms1 = {0};
-
-static __attribute__((constructor))
-void init_cms_creator(void)
-{
-    strncpy(CLIcmddata_creator.key,
-            FPS_app_info_creator.cmdkey,
-            sizeof(CLIcmddata_creator.key)
-            - 1);
-    strncpy(
-        CLIcmddata_creator.description,
-        FPS_app_info_creator.description,
-        sizeof(
-            CLIcmddata_creator.description
-        ) - 1);
-    if (CLIcmddata_creator.cmdsettings
-        == NULL) {
-        CLIcmddata_creator.cmdsettings =
-            &cms1;
-    }
-}
+FPS_CMDSETTINGS_INIT(cms1, CLIcmddata_creator, FPS_app_info_creator)
 
 static errno_t __attribute__((unused)) compute_creator()
 {
@@ -154,22 +134,7 @@ static CLICMDDATA CLIcmddata = {
     CLICMD_FIELDS_DEFAULTS
 };
 
-static CMDSETTINGS cms2 = {0};
-
-static __attribute__((constructor))
-void init_cms_current(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description)
-            - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings = &cms2;
-    }
-}
+FPS_CMDSETTINGS_INIT(cms2, CLIcmddata, FPS_app_info)
 
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {
@@ -198,26 +163,7 @@ static CLICMDDATA CLIcmddata_init = {
     CLICMD_FIELDS_NOPARAM
 };
 
-static CMDSETTINGS cms3 = {0};
-
-static __attribute__((constructor))
-void init_cms_init(void)
-{
-    strncpy(CLIcmddata_init.key,
-            FPS_app_info_init.cmdkey,
-            sizeof(CLIcmddata_init.key)
-            - 1);
-    strncpy(CLIcmddata_init.description,
-            FPS_app_info_init.description,
-            sizeof(
-                CLIcmddata_init.description
-            ) - 1);
-    if (CLIcmddata_init.cmdsettings
-        == NULL) {
-        CLIcmddata_init.cmdsettings =
-            &cms3;
-    }
-}
+FPS_CMDSETTINGS_INIT(cms3, CLIcmddata_init, FPS_app_info_init)
 
 static errno_t __attribute__((unused)) compute_init()
 {

--- a/src/coremods/COREMOD_memory/stream_TCP.c
+++ b/src/coremods/COREMOD_memory/stream_TCP.c
@@ -99,27 +99,7 @@ static FPS_APP_INFO FPS_app_info_tsem = {
 static CLICMDDATA CLIcmddata_tsem = {
     "", "", CLICMD_FIELDS_NOPARAM
 };
-static CMDSETTINGS cms_tsem = {0};
-
-static __attribute__((constructor))
-void init_cms_tsem(void)
-{
-    strncpy(CLIcmddata_tsem.key,
-            FPS_app_info_tsem.cmdkey,
-            sizeof(CLIcmddata_tsem.key)
-            - 1);
-    strncpy(
-        CLIcmddata_tsem.description,
-        FPS_app_info_tsem.description,
-        sizeof(
-            CLIcmddata_tsem.description
-        ) - 1);
-    if (CLIcmddata_tsem.cmdsettings
-        == NULL) {
-        CLIcmddata_tsem.cmdsettings =
-            &cms_tsem;
-    }
-}
+FPS_CMDSETTINGS_INIT(tsem, CLIcmddata_tsem, FPS_app_info_tsem)
 
 static errno_t __attribute__((unused)) compute_tsem()
 {
@@ -179,22 +159,7 @@ static CLICMDDATA CLIcmddata = {
     "", "", CLICMD_FIELDS_DEFAULTS
 };
 
-static CMDSETTINGS cms_tx = {0};
-
-static __attribute__((constructor))
-void init_cms_tx(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description)
-            - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings = &cms_tx;
-    }
-}
+FPS_CMDSETTINGS_INIT(tx, CLIcmddata, FPS_app_info)
 
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {
@@ -237,26 +202,7 @@ static FPS_APP_INFO FPS_app_info_rx = {
 static CLICMDDATA CLIcmddata_rx = {
     "", "", CLICMD_FIELDS_NOPARAM
 };
-static CMDSETTINGS cms_rx = {0};
-
-static __attribute__((constructor))
-void init_cms_rx(void)
-{
-    strncpy(CLIcmddata_rx.key,
-            FPS_app_info_rx.cmdkey,
-            sizeof(CLIcmddata_rx.key) - 1);
-    strncpy(
-        CLIcmddata_rx.description,
-        FPS_app_info_rx.description,
-        sizeof(
-            CLIcmddata_rx.description
-        ) - 1);
-    if (CLIcmddata_rx.cmdsettings
-        == NULL) {
-        CLIcmddata_rx.cmdsettings =
-            &cms_rx;
-    }
-}
+FPS_CMDSETTINGS_INIT(rx, CLIcmddata_rx, FPS_app_info_rx)
 
 static errno_t __attribute__((unused)) compute_rx()
 {

--- a/src/coremods/COREMOD_memory/stream_UDP.c
+++ b/src/coremods/COREMOD_memory/stream_UDP.c
@@ -106,22 +106,7 @@ static CLICMDDATA CLIcmddata = {
     "", "", CLICMD_FIELDS_DEFAULTS
 };
 
-static CMDSETTINGS cms_tx = {0};
-
-static __attribute__((constructor))
-void init_cms_tx(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description)
-            - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings = &cms_tx;
-    }
-}
+FPS_CMDSETTINGS_INIT(tx, CLIcmddata, FPS_app_info)
 
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {
@@ -165,26 +150,7 @@ static FPS_APP_INFO FPS_app_info_rx = {
 static CLICMDDATA CLIcmddata_rx = {
     "", "", CLICMD_FIELDS_NOPARAM
 };
-static CMDSETTINGS cms_rx = {0};
-
-static __attribute__((constructor))
-void init_cms_rx(void)
-{
-    strncpy(CLIcmddata_rx.key,
-            FPS_app_info_rx.cmdkey,
-            sizeof(CLIcmddata_rx.key) - 1);
-    strncpy(
-        CLIcmddata_rx.description,
-        FPS_app_info_rx.description,
-        sizeof(
-            CLIcmddata_rx.description
-        ) - 1);
-    if (CLIcmddata_rx.cmdsettings
-        == NULL) {
-        CLIcmddata_rx.cmdsettings =
-            &cms_rx;
-    }
-}
+FPS_CMDSETTINGS_INIT(rx, CLIcmddata_rx, FPS_app_info_rx)
 
 static errno_t __attribute__((unused)) compute_rx()
 {

--- a/src/coremods/COREMOD_memory/stream_sem.c
+++ b/src/coremods/COREMOD_memory/stream_sem.c
@@ -127,27 +127,7 @@ static FPS_APP_INFO FPS_app_info_seminfo = {
 static CLICMDDATA CLIcmddata_seminfo = {
     "", "", CLICMD_FIELDS_IMSEM_INFO
 };
-static CMDSETTINGS cms1 = {0};
-
-static __attribute__((constructor))
-void init_cms1(void)
-{
-    strncpy(CLIcmddata_seminfo.key,
-            FPS_app_info_seminfo.cmdkey,
-            sizeof(CLIcmddata_seminfo.key)
-            - 1);
-    strncpy(
-        CLIcmddata_seminfo.description,
-        FPS_app_info_seminfo.description,
-        sizeof(
-            CLIcmddata_seminfo.description
-        ) - 1);
-    if (CLIcmddata_seminfo.cmdsettings
-        == NULL) {
-        CLIcmddata_seminfo.cmdsettings =
-            &cms1;
-    }
-}
+FPS_CMDSETTINGS_INIT(cms1, CLIcmddata_seminfo, FPS_app_info_seminfo)
 
 static errno_t __attribute__((unused)) compute_seminfo()
 {
@@ -170,27 +150,7 @@ static FPS_APP_INFO FPS_app_info_sempost = {
 static CLICMDDATA CLIcmddata_sempost = {
     "", "", CLICMD_FIELDS_IMSEM
 };
-static CMDSETTINGS cms2 = {0};
-
-static __attribute__((constructor))
-void init_cms2(void)
-{
-    strncpy(CLIcmddata_sempost.key,
-            FPS_app_info_sempost.cmdkey,
-            sizeof(CLIcmddata_sempost.key)
-            - 1);
-    strncpy(
-        CLIcmddata_sempost.description,
-        FPS_app_info_sempost.description,
-        sizeof(
-            CLIcmddata_sempost.description
-        ) - 1);
-    if (CLIcmddata_sempost.cmdsettings
-        == NULL) {
-        CLIcmddata_sempost.cmdsettings =
-            &cms2;
-    }
-}
+FPS_CMDSETTINGS_INIT(cms2, CLIcmddata_sempost, FPS_app_info_sempost)
 
 static errno_t __attribute__((unused)) compute_sempost()
 {
@@ -236,22 +196,7 @@ static CLICMDDATA CLIcmddata = {
     "", "", CLICMD_FIELDS_DEFAULTS
 };
 
-static CMDSETTINGS cms3 = {0};
-
-static __attribute__((constructor))
-void init_cms3(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description)
-            - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings = &cms3;
-    }
-}
+FPS_CMDSETTINGS_INIT(cms3, CLIcmddata, FPS_app_info)
 
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {
@@ -279,27 +224,7 @@ static FPS_APP_INFO FPS_app_info_semwait = {
 static CLICMDDATA CLIcmddata_semwait = {
     "", "", CLICMD_FIELDS_IMSEM
 };
-static CMDSETTINGS cms4 = {0};
-
-static __attribute__((constructor))
-void init_cms4(void)
-{
-    strncpy(CLIcmddata_semwait.key,
-            FPS_app_info_semwait.cmdkey,
-            sizeof(CLIcmddata_semwait.key)
-            - 1);
-    strncpy(
-        CLIcmddata_semwait.description,
-        FPS_app_info_semwait.description,
-        sizeof(
-            CLIcmddata_semwait.description
-        ) - 1);
-    if (CLIcmddata_semwait.cmdsettings
-        == NULL) {
-        CLIcmddata_semwait.cmdsettings =
-            &cms4;
-    }
-}
+FPS_CMDSETTINGS_INIT(cms4, CLIcmddata_semwait, FPS_app_info_semwait)
 
 static errno_t __attribute__((unused)) compute_semwait()
 {
@@ -323,27 +248,7 @@ static FPS_APP_INFO FPS_app_info_semflush = {
 static CLICMDDATA CLIcmddata_semflush = {
     "", "", CLICMD_FIELDS_IMSEM
 };
-static CMDSETTINGS cms5 = {0};
-
-static __attribute__((constructor))
-void init_cms5(void)
-{
-    strncpy(CLIcmddata_semflush.key,
-            FPS_app_info_semflush.cmdkey,
-            sizeof(CLIcmddata_semflush.key)
-            - 1);
-    strncpy(
-        CLIcmddata_semflush.description,
-        FPS_app_info_semflush.description,
-        sizeof(
-            CLIcmddata_semflush.description
-        ) - 1);
-    if (CLIcmddata_semflush.cmdsettings
-        == NULL) {
-        CLIcmddata_semflush.cmdsettings =
-            &cms5;
-    }
-}
+FPS_CMDSETTINGS_INIT(cms5, CLIcmddata_semflush, FPS_app_info_semflush)
 
 static errno_t __attribute__((unused)) compute_semflush()
 {

--- a/src/coremods/COREMOD_memory/stream_updateloop.c
+++ b/src/coremods/COREMOD_memory/stream_updateloop.c
@@ -97,27 +97,7 @@ static FPS_APP_INFO FPS_app_info_burst = {
 static CLICMDDATA CLIcmddata_burst = {
     "", "", CLICMD_FIELDS_NOPARAM
 };
-static CMDSETTINGS cms_burst = {0};
-
-static __attribute__((constructor))
-void init_cms_burst(void)
-{
-    strncpy(CLIcmddata_burst.key,
-            FPS_app_info_burst.cmdkey,
-            sizeof(CLIcmddata_burst.key)
-            - 1);
-    strncpy(
-        CLIcmddata_burst.description,
-        FPS_app_info_burst.description,
-        sizeof(
-            CLIcmddata_burst.description
-        ) - 1);
-    if (CLIcmddata_burst.cmdsettings
-        == NULL) {
-        CLIcmddata_burst.cmdsettings =
-            &cms_burst;
-    }
-}
+FPS_CMDSETTINGS_INIT(burst, CLIcmddata_burst, FPS_app_info_burst)
 
 static errno_t __attribute__((unused)) compute_burst()
 {
@@ -192,22 +172,7 @@ static CLICMDDATA CLIcmddata = {
     "", "", CLICMD_FIELDS_DEFAULTS
 };
 
-static CMDSETTINGS cms_main = {0};
-
-static __attribute__((constructor))
-void init_cms_main(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description)
-            - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings = &cms_main;
-    }
-}
+FPS_CMDSETTINGS_INIT(main, CLIcmddata, FPS_app_info)
 
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {
@@ -240,27 +205,7 @@ static FPS_APP_INFO FPS_app_info_strig = {
 static CLICMDDATA CLIcmddata_strig = {
     "", "", CLICMD_FIELDS_NOPARAM
 };
-static CMDSETTINGS cms_strig = {0};
-
-static __attribute__((constructor))
-void init_cms_strig(void)
-{
-    strncpy(CLIcmddata_strig.key,
-            FPS_app_info_strig.cmdkey,
-            sizeof(CLIcmddata_strig.key)
-            - 1);
-    strncpy(
-        CLIcmddata_strig.description,
-        FPS_app_info_strig.description,
-        sizeof(
-            CLIcmddata_strig.description
-        ) - 1);
-    if (CLIcmddata_strig.cmdsettings
-        == NULL) {
-        CLIcmddata_strig.cmdsettings =
-            &cms_strig;
-    }
-}
+FPS_CMDSETTINGS_INIT(strig, CLIcmddata_strig, FPS_app_info_strig)
 
 static errno_t __attribute__((unused)) compute_strig()
 {

--- a/src/coremods/COREMOD_tools/imdisplay3d.c
+++ b/src/coremods/COREMOD_tools/imdisplay3d.c
@@ -65,22 +65,7 @@ static CLICMDDATA CLIcmddata = {
     "", "", CLICMD_FIELDS_DEFAULTS
 };
 
-static CMDSETTINGS cms = {0};
-
-static __attribute__((constructor))
-void init_cms(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description)
-            - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_CMDSETTINGS_INIT(main, CLIcmddata, FPS_app_info)
 
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {

--- a/src/coremods/COREMOD_tools/mvprocCPUset.c
+++ b/src/coremods/COREMOD_tools/mvprocCPUset.c
@@ -64,27 +64,7 @@ static FPS_APP_INFO FPS_app_info_rtp = {
 static CLICMDDATA CLIcmddata_rtp = {
     "", "", CLICMD_FIELDS_NOPARAM
 };
-static CMDSETTINGS cms_rtp = {0};
-
-static __attribute__((constructor))
-void init_cms_rtp(void)
-{
-    strncpy(CLIcmddata_rtp.key,
-            FPS_app_info_rtp.cmdkey,
-            sizeof(CLIcmddata_rtp.key)
-            - 1);
-    strncpy(
-        CLIcmddata_rtp.description,
-        FPS_app_info_rtp.description,
-        sizeof(
-            CLIcmddata_rtp.description
-        ) - 1);
-    if (CLIcmddata_rtp.cmdsettings
-        == NULL) {
-        CLIcmddata_rtp.cmdsettings =
-            &cms_rtp;
-    }
-}
+FPS_CMDSETTINGS_INIT(rtp, CLIcmddata_rtp, FPS_app_info_rtp)
 
 static errno_t __attribute__((unused)) compute_rtp()
 {
@@ -113,27 +93,7 @@ static FPS_APP_INFO FPS_app_info_tset = {
 static CLICMDDATA CLIcmddata_tset = {
     "", "", CLICMD_FIELDS_NOPARAM
 };
-static CMDSETTINGS cms_tset = {0};
-
-static __attribute__((constructor))
-void init_cms_tset(void)
-{
-    strncpy(CLIcmddata_tset.key,
-            FPS_app_info_tset.cmdkey,
-            sizeof(CLIcmddata_tset.key)
-            - 1);
-    strncpy(
-        CLIcmddata_tset.description,
-        FPS_app_info_tset.description,
-        sizeof(
-            CLIcmddata_tset.description
-        ) - 1);
-    if (CLIcmddata_tset.cmdsettings
-        == NULL) {
-        CLIcmddata_tset.cmdsettings =
-            &cms_tset;
-    }
-}
+FPS_CMDSETTINGS_INIT(tset, CLIcmddata_tset, FPS_app_info_tset)
 
 static errno_t __attribute__((unused)) compute_tset()
 {
@@ -166,27 +126,7 @@ static FPS_APP_INFO FPS_app_info_tsete = {
 static CLICMDDATA CLIcmddata_tsete = {
     "", "", CLICMD_FIELDS_NOPARAM
 };
-static CMDSETTINGS cms_tsete = {0};
-
-static __attribute__((constructor))
-void init_cms_tsete(void)
-{
-    strncpy(CLIcmddata_tsete.key,
-            FPS_app_info_tsete.cmdkey,
-            sizeof(CLIcmddata_tsete.key)
-            - 1);
-    strncpy(
-        CLIcmddata_tsete.description,
-        FPS_app_info_tsete.description,
-        sizeof(
-            CLIcmddata_tsete.description
-        ) - 1);
-    if (CLIcmddata_tsete.cmdsettings
-        == NULL) {
-        CLIcmddata_tsete.cmdsettings =
-            &cms_tsete;
-    }
-}
+FPS_CMDSETTINGS_INIT(tsete, CLIcmddata_tsete, FPS_app_info_tsete)
 
 static errno_t __attribute__((unused)) compute_tsete()
 {
@@ -210,27 +150,7 @@ static FPS_APP_INFO FPS_app_info_cset = {
 static CLICMDDATA CLIcmddata_cset = {
     "", "", CLICMD_FIELDS_NOPARAM
 };
-static CMDSETTINGS cms_cset = {0};
-
-static __attribute__((constructor))
-void init_cms_cset(void)
-{
-    strncpy(CLIcmddata_cset.key,
-            FPS_app_info_cset.cmdkey,
-            sizeof(CLIcmddata_cset.key)
-            - 1);
-    strncpy(
-        CLIcmddata_cset.description,
-        FPS_app_info_cset.description,
-        sizeof(
-            CLIcmddata_cset.description
-        ) - 1);
-    if (CLIcmddata_cset.cmdsettings
-        == NULL) {
-        CLIcmddata_cset.cmdsettings =
-            &cms_cset;
-    }
-}
+FPS_CMDSETTINGS_INIT(cset, CLIcmddata_cset, FPS_app_info_cset)
 
 static errno_t __attribute__((unused)) compute_cset()
 {
@@ -281,23 +201,7 @@ static CLICMDDATA CLIcmddata = {
     "", "", CLICMD_FIELDS_DEFAULTS
 };
 
-static CMDSETTINGS cms_main = {0};
-
-static __attribute__((constructor))
-void init_cms_main(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description)
-            - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings =
-            &cms_main;
-    }
-}
+FPS_CMDSETTINGS_INIT(main, CLIcmddata, FPS_app_info)
 
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {

--- a/src/coremods/COREMOD_tools/statusstat.c
+++ b/src/coremods/COREMOD_tools/statusstat.c
@@ -67,22 +67,7 @@ static CLICMDDATA CLIcmddata = {
     "", "", CLICMD_FIELDS_DEFAULTS
 };
 
-static CMDSETTINGS cms = {0};
-
-static __attribute__((constructor))
-void init_cms(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description)
-            - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_CMDSETTINGS_INIT(main, CLIcmddata, FPS_app_info)
 
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {

--- a/src/engine/libfps/fps_cli_binding.h
+++ b/src/engine/libfps/fps_cli_binding.h
@@ -10,6 +10,7 @@
 #define FPS_CLI_BINDING_H
 
 #include <stdint.h>
+#include <string.h>
 
 #include "fps.h"
 #include "libmilkdata/milkdata_clicmd.h"

--- a/src/engine/libfps/fps_cli_binding.h
+++ b/src/engine/libfps/fps_cli_binding.h
@@ -80,4 +80,39 @@ typedef struct FPS_CLI_BINDING_
       NULL, NULL },
 
 
+
+/**
+ * @brief Define CMDSETTINGS + constructor for a command.
+ *
+ * Expands to a static CMDSETTINGS variable and an
+ * __attribute__((constructor)) function that copies
+ * cmdkey / description from the FPS_APP_INFO into
+ * the CLICMDDATA at load time.
+ *
+ * @param suffix  Unique C identifier (per .c file)
+ * @param cmddata CLICMDDATA variable (not a pointer)
+ * @param appinfo FPS_APP_INFO variable (not a pointer)
+ *
+ * Example:
+ *   FPS_CMDSETTINGS_INIT(rx, CLIcmddata_rx,
+ *                        FPS_app_info_rx)
+ */
+#define FPS_CMDSETTINGS_INIT(suffix, cmddata, appinfo) \
+static CMDSETTINGS fps_cms_##suffix = {0};             \
+static __attribute__((constructor))                    \
+void fps_init_cms_##suffix(void)                       \
+{                                                      \
+    strncpy((cmddata).key,                             \
+            (appinfo).cmdkey,                          \
+            sizeof((cmddata).key) - 1);                \
+    strncpy((cmddata).description,                     \
+            (appinfo).description,                     \
+            sizeof((cmddata).description) - 1);        \
+    if ((cmddata).cmdsettings == NULL) {                \
+        (cmddata).cmdsettings =                        \
+            &fps_cms_##suffix;                         \
+    }                                                  \
+}
+
+
 #endif /* FPS_CLI_BINDING_H */

--- a/src/milk_module_example/examplefunc2_FPS.c
+++ b/src/milk_module_example/examplefunc2_FPS.c
@@ -52,22 +52,8 @@ static CLICMDDATA CLIcmddata = {
     CLICMD_FIELDS_DEFAULTS
 };
 
-static CMDSETTINGS default_cmdsettings = {0};
+FPS_CMDSETTINGS_INIT(dft, CLIcmddata, FPS_app_info)
 
-static __attribute__((constructor))
-void init_cmdsettings(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings =
-            &default_cmdsettings;
-    }
-}
 
 
 /**

--- a/src/milk_module_example/examplefunc3_updatestreamloop.c
+++ b/src/milk_module_example/examplefunc3_updatestreamloop.c
@@ -47,22 +47,8 @@ static CLICMDDATA CLIcmddata = {
     CLICMD_FIELDS_DEFAULTS
 };
 
-static CMDSETTINGS default_cmdsettings = {0};
+FPS_CMDSETTINGS_INIT(dft, CLIcmddata, FPS_app_info)
 
-static __attribute__((constructor))
-void init_cmdsettings(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings =
-            &default_cmdsettings;
-    }
-}
 
 
 // Wrapper function, used by all CLI calls

--- a/src/milk_module_example/examplefunc4_streamprocess.c
+++ b/src/milk_module_example/examplefunc4_streamprocess.c
@@ -120,22 +120,8 @@ static CLICMDDATA CLIcmddata = {
     CLICMD_FIELDS_DEFAULTS
 };
 
-static CMDSETTINGS default_cmdsettings = {0};
+FPS_CMDSETTINGS_INIT(dft, CLIcmddata, FPS_app_info)
 
-static __attribute__((constructor))
-void init_cmdsettings(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings =
-            &default_cmdsettings;
-    }
-}
 
 
 /**

--- a/src/milk_module_example/examplefunc_fps_cli_poc.c
+++ b/src/milk_module_example/examplefunc_fps_cli_poc.c
@@ -532,22 +532,8 @@ CLICMDDATA CLIcmddata = {
  * dereferences CLIcmddata.cmdsettings, which is NULL
  * from CLICMD_FIELDS_DEFAULTS.
  */
-static CMDSETTINGS default_cmdsettings = {0};
+FPS_CMDSETTINGS_INIT(dft, CLIcmddata, FPS_app_info)
 
-static __attribute__((constructor))
-void init_cmdsettings(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings =
-            &default_cmdsettings;
-    }
-}
 
 
 /* ================================================================


### PR DESCRIPTION
## Summary

Introduces `FPS_CMDSETTINGS_INIT(suffix, cmddata, appinfo)` macro in `fps_cli_binding.h` and replaces 49 copy-pasted constructor stanzas across 26 files with single-line macro invocations.

## Changes

### fps_cli_binding.h — new macro

- Added `FPS_CMDSETTINGS_INIT` macro that expands to a static `CMDSETTINGS` variable plus an `__attribute__((constructor))` function copying `cmdkey`/`description` from `FPS_APP_INFO` into `CLICMDDATA` at load time.
- Added `#include <string.h>` to make the header self-contained (the macro uses `strncpy`; previously relied on transitive includes).

### Command files (26 files, milk + cacao)

- Replaced every 10–14 line `static CMDSETTINGS` + constructor block with a single `FPS_CMDSETTINGS_INIT(...)` invocation.
- **milk:** 84 insertions, 883 deletions
- **cacao:** 9 insertions, 91 deletions
- No behavioral change — pure mechanical replacement.

## Verification

- [x] Build passes (`/compile-test`)
- [ ] Tests pass (`ctest --output-on-failure`)
- [ ] CLI robustness tests pass (if CLI changed)
- [ ] Documentation updated (README, help, docs/)

Build: zero errors, zero new warnings. All standalone executables produce correct `-h1` output. `ctest` hung on a pre-existing `seq.start` issue unrelated to this change.

## Prompt Summary

User requested a codebase audit to identify code duplication, then asked to proceed with one refactoring item at a time as individual PRs, starting with the `init_cms` constructor boilerplate. Follow-up feedback requested `#include <string.h>` be added to `fps_cli_binding.h` to make the macro self-contained.

## AI Authorship

- **Model**: Antigravity / Claude (follow-up fix)
- **User edits**: None