### PR TITLE
refactor: add DCSIG_ANY_SET() macro, consolidate signal-check sites

### DIFF
--- a/plugins/milk-extra-src/image_basic/streamfeed.c
+++ b/plugins/milk-extra-src/image_basic/streamfeed.c
@@ -138,7 +138,41 @@ long IMAGE_BASIC_streamfeed(const char *__restrict IDname,
 
     ptr1 = (char *) dcimg[IDs].array.F; // destination
 
-    set_signal_catch();
+    if(sigaction(SIGINT, &dcsigact, NULL) == -1)
+    {
+        perror("sigaction");
+        exit(EXIT_FAILURE);
+    }
+    if(sigaction(SIGTERM, &dcsigact, NULL) == -1)
+    {
+        perror("sigaction");
+        exit(EXIT_FAILURE);
+    }
+    if(sigaction(SIGBUS, &dcsigact, NULL) == -1)
+    {
+        perror("sigaction");
+        exit(EXIT_FAILURE);
+    }
+    if(sigaction(SIGSEGV, &dcsigact, NULL) == -1)
+    {
+        perror("sigaction");
+        exit(EXIT_FAILURE);
+    }
+    if(sigaction(SIGABRT, &dcsigact, NULL) == -1)
+    {
+        perror("sigaction");
+        exit(EXIT_FAILURE);
+    }
+    if(sigaction(SIGHUP, &dcsigact, NULL) == -1)
+    {
+        perror("sigaction");
+        exit(EXIT_FAILURE);
+    }
+    if(sigaction(SIGPIPE, &dcsigact, NULL) == -1)
+    {
+        perror("sigaction");
+        exit(EXIT_FAILURE);
+    }
 
     k      = 0;
     loopOK = 1;

--- a/plugins/milk-extra-src/image_basic/streamfeed.c
+++ b/plugins/milk-extra-src/image_basic/streamfeed.c
@@ -58,22 +58,8 @@ static CLICMDARGDEF farg[] = {
 static CLICMDDATA CLIcmddata = {
     "", "", CLICMD_FIELDS_DEFAULTS
 };
-static CMDSETTINGS cms = {0};
-
-static __attribute__((constructor))
-void init_cms(void)
-{
-    strncpy(CLIcmddata.key,
-            FPS_app_info.cmdkey,
-            sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description,
-            FPS_app_info.description,
-            sizeof(CLIcmddata.description)
-            - 1);
-    if (CLIcmddata.cmdsettings == NULL) {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_CMDSETTINGS_INIT(
+    streamfeed, CLIcmddata, FPS_app_info)
 
 static MILK_HOT errno_t compute_function()
 {
@@ -152,41 +138,7 @@ long IMAGE_BASIC_streamfeed(const char *__restrict IDname,
 
     ptr1 = (char *) dcimg[IDs].array.F; // destination
 
-    if(sigaction(SIGINT, &dcsigact, NULL) == -1)
-    {
-        perror("sigaction");
-        exit(EXIT_FAILURE);
-    }
-    if(sigaction(SIGTERM, &dcsigact, NULL) == -1)
-    {
-        perror("sigaction");
-        exit(EXIT_FAILURE);
-    }
-    if(sigaction(SIGBUS, &dcsigact, NULL) == -1)
-    {
-        perror("sigaction");
-        exit(EXIT_FAILURE);
-    }
-    if(sigaction(SIGSEGV, &dcsigact, NULL) == -1)
-    {
-        perror("sigaction");
-        exit(EXIT_FAILURE);
-    }
-    if(sigaction(SIGABRT, &dcsigact, NULL) == -1)
-    {
-        perror("sigaction");
-        exit(EXIT_FAILURE);
-    }
-    if(sigaction(SIGHUP, &dcsigact, NULL) == -1)
-    {
-        perror("sigaction");
-        exit(EXIT_FAILURE);
-    }
-    if(sigaction(SIGPIPE, &dcsigact, NULL) == -1)
-    {
-        perror("sigaction");
-        exit(EXIT_FAILURE);
-    }
+    set_signal_catch();
 
     k      = 0;
     loopOK = 1;
@@ -208,10 +160,7 @@ long IMAGE_BASIC_streamfeed(const char *__restrict IDname,
             k = 0;
         }
 
-        if((dcsigINT == 1) || (dcsigTERM == 1) ||
-                (dcsigABRT == 1) || (dcsigBUS == 1) ||
-                (dcsigSEGV == 1) || (dcsigHUP == 1) ||
-                (dcsigPIPE == 1))
+        if(DCSIG_ANY_SET())
         {
             loopOK = 0;
         }

--- a/src/cli/streamCTRL/streamCTRL_TUI.c
+++ b/src/cli/streamCTRL/streamCTRL_TUI.c
@@ -1816,10 +1816,7 @@ errno_t streamCTRL_CTRLscreen()
         DEBUG_TRACEPOINT(" ");
 
         loopcnt++;
-        if((dcsigTERM == 1) || (dcsigINT == 1) ||
-                (dcsigABRT == 1) || (dcsigBUS == 1) ||
-                (dcsigSEGV == 1) || (dcsigHUP == 1) ||
-                (dcsigPIPE == 1))
+        if(DCSIG_ANY_SET())
         {
             sTUIparam.loopOK = 0;
         }

--- a/src/coremods/COREMOD_memory/stream_TCP.c
+++ b/src/coremods/COREMOD_memory/stream_TCP.c
@@ -740,10 +740,7 @@ imageID COREMOD_MEMORY_image_NETWORKtransmit(
         // process signals, increment loop counter
         processinfo_exec_end(processinfo);
 
-        if((dcsigINT == 1) || (dcsigTERM == 1) ||
-                (dcsigABRT == 1) || (dcsigBUS == 1) ||
-                (dcsigSEGV == 1) || (dcsigHUP == 1) ||
-                (dcsigPIPE == 1))
+        if(DCSIG_ANY_SET())
         {
             loopOK = 0;
         }
@@ -1301,8 +1298,7 @@ imageID COREMOD_MEMORY_image_NETWORKreceive(int                         port,
         }
 
         // process signals
-        if(dcsigTERM || dcsigINT || dcsigABRT || dcsigBUS ||
-                dcsigSEGV || dcsigHUP || dcsigPIPE)
+        if(DCSIG_ANY_SET())
         {
             loopOK = 0;
             if(dcprocinfo == 1)

--- a/src/coremods/COREMOD_memory/stream_UDP.c
+++ b/src/coremods/COREMOD_memory/stream_UDP.c
@@ -539,10 +539,7 @@ imageID COREMOD_MEMORY_image_NETUDPtransmit(const char *IDname,
         // process signals, increment loop counter
         processinfo_exec_end(processinfo);
 
-        if((dcsigINT == 1) || (dcsigTERM == 1) ||
-                (dcsigABRT == 1) || (dcsigBUS == 1) ||
-                (dcsigSEGV == 1) || (dcsigHUP == 1) ||
-                (dcsigPIPE == 1))
+        if(DCSIG_ANY_SET())
         {
             loopOK = 0;
         }
@@ -1180,9 +1177,7 @@ imageID COREMOD_MEMORY_image_NETUDPreceive(
 
         // process signals
 
-        if((dcsigTERM | dcsigINT | dcsigABRT |
-                dcsigBUS | dcsigSEGV | dcsigHUP |
-                dcsigPIPE) != 0)
+        if(DCSIG_ANY_SET())
         {
             loopOK = 0;
             if(dcprocinfo == 1)

--- a/src/engine/libmilkdata/milkdata_macros.h
+++ b/src/engine/libmilkdata/milkdata_macros.h
@@ -51,7 +51,20 @@
 #define dcsigHUP      (milk_data.signal_HUP)
 #define dcsigPIPE     (milk_data.signal_PIPE)
 
+/**
+ * True if any fatal signal has been received.
+ *
+ * Use in loop-exit checks instead of repeating
+ * a multi-line OR chain of dcsig* flags.
+ */
+#define DCSIG_ANY_SET() \
+    (dcsigINT  || dcsigTERM || \
+     dcsigABRT || dcsigBUS  || \
+     dcsigSEGV || dcsigHUP  || \
+     dcsigPIPE)
+
 /* Process info */
+
 #define dcpinfo       (milk_data.pinfo)
 #define dcprocinfo    (milk_data.processinfo)
 #define dcprocinfoact (milk_data.processinfoActive)


### PR DESCRIPTION
## Summary

Adds a `DCSIG_ANY_SET()` convenience macro to `milkdata_macros.h` and uses it to replace duplicated 4-line OR chains that check all 7 fatal signal flags (`INT`, `TERM`, `ABRT`, `BUS`, `SEGV`, `HUP`, `PIPE`). Also replaces the hand-rolled `CMDSETTINGS` constructor in `streamfeed.c` with the `FPS_CMDSETTINGS_INIT(...)` macro.

## Changes

### `milkdata_macros.h`
- Add `DCSIG_ANY_SET()` macro that evaluates true if any of the 7 fatal signal flags is set

### `stream_TCP.c`
- 2 signal-check OR-chains → `DCSIG_ANY_SET()`

### `stream_UDP.c`
- 2 signal-check OR-chains → `DCSIG_ANY_SET()`

### `streamCTRL_TUI.c`
- 1 signal-check OR-chain → `DCSIG_ANY_SET()`

### `streamfeed.c`
- Signal-check OR-chain in loop → `DCSIG_ANY_SET()`
- Hand-rolled `CMDSETTINGS` constructor replaced with `FPS_CMDSETTINGS_INIT(...)`
- Explicit `sigaction()+perror()+exit()` blocks retained as-is to preserve fail-fast semantics and correct behaviour in `MILK_NO_CLI` builds (where `set_signal_catch()` is a no-op stub)

## Verification

- [x] Build passes (`/compile-test`)
- [ ] Tests pass (`ctest --output-on-failure`)
- [ ] CLI robustness tests pass (if CLI changed)
- [ ] Documentation updated (README, help, docs/)

## Prompt Summary

Continuation of codebase redundancy audit (Item 5: signal handling cleanup). Following reviewer feedback, the `set_signal_catch()` consolidation in `streamfeed.c` was reverted to preserve fail-fast `exit(EXIT_FAILURE)` semantics on `sigaction` failure and to ensure signal handlers are installed in `MILK_NO_CLI` standalone builds.

## AI Authorship

- **Model:** Antigravity / Copilot
- **User edits:** None