### PR TITLE
refactor: extract shared TCP/UDP transport layer boilerplate

### DIFF
--- a/src/coremods/COREMOD_memory/stream_TCP.c
+++ b/src/coremods/COREMOD_memory/stream_TCP.c
@@ -25,6 +25,7 @@
 #include "list_image.h"
 #include "read_shmim.h"
 #include "stream_sem.h"
+#include "stream_net_common.h"
 
 // set to 1 if transfering keywords
 static int TCPTRANSFERKW = 1;
@@ -420,10 +421,6 @@ imageID COREMOD_MEMORY_image_NETWORKtransmit(
     char              *ptr0; // source
     char              *ptr1; // source - offset by slice
     int                rs;
-
-    struct timespec ts;
-    long            scnt;
-    int             semval;
     int             semr;
     int             slice, oldslice;
     int             NBslices;
@@ -592,17 +589,9 @@ imageID COREMOD_MEMORY_image_NETWORKtransmit(
         fflush(stdout);
     }
 
-    if((img_p->md->sem == 0) || (mode == 1))
-    {
-        processinfo_WriteMessage(processinfo, "sync using counter");
-        UseSem = 0;
-    }
-    else
-    {
-        char msgstring[200];
-        snprintf(msgstring, 200, "sync using semaphore %d", semtrig);
-        processinfo_WriteMessage(processinfo, msgstring);
-    }
+    UseSem = stream_net_decide_sync(
+        img_p->md->sem, mode, semtrig,
+        processinfo);
 
     long frameincr = 0;
     long cnt0previous = 0;
@@ -628,38 +617,12 @@ imageID COREMOD_MEMORY_image_NETWORKtransmit(
         }
         else
         {
-            if(clock_gettime(CLOCK_MILK, &ts) == -1)
-            {
-                perror("clock_gettime");
-                exit(EXIT_FAILURE);
-            }
-            ts.tv_sec += 2;
+            semr = stream_net_sem_wait(
+                img_p, semtrig);
 
-            semr = ImageStreamIO_semtimedwait(img_p, semtrig, &ts);
-
-            if(iter == 0)
-            {
-                processinfo_WriteMessage(processinfo, "Driving sem to 0");
-                printf("Driving semaphore to zero ... ");
-                fflush(stdout);
-                semval = ImageStreamIO_semvalue(img_p, semtrig);
-                int semvalcnt = semval;
-                for(scnt = 0; scnt < semvalcnt; scnt++)
-                {
-                    semval = ImageStreamIO_semvalue(img_p, semtrig);
-                    printf("sem = %d\n", semval);
-                    fflush(stdout);
-                    ImageStreamIO_semtrywait(img_p, semtrig);
-                }
-                printf("done\n");
-                fflush(stdout);
-
-                semval = ImageStreamIO_semvalue(img_p, semtrig);
-                printf("-> sem = %d\n", semval);
-                fflush(stdout);
-
-                iter++;
-            }
+            stream_net_sem_drain(
+                img_p, semtrig,
+                &iter, processinfo);
         }
 
         processinfo_exec_start(processinfo);
@@ -672,20 +635,9 @@ imageID COREMOD_MEMORY_image_NETWORKtransmit(
                 frame_md.cnt0 = img_p->md->cnt0;
                 frame_md.cnt1 = img_p->md->cnt1;
 
-                slice = img_p->md->cnt1;
-                if(slice > oldslice + 1)
-                {
-                    slice = oldslice + 1;
-                }
-                if(NBslices > 1)
-                    if(oldslice == NBslices - 1)
-                    {
-                        slice = 0;
-                    }
-                if(slice > NBslices - 1)
-                {
-                    slice = 0;
-                }
+                slice = stream_net_clamp_slice(
+                    img_p->md->cnt1,
+                    oldslice, NBslices);
 
                 frame_md.cnt1 = slice;
 
@@ -803,8 +755,6 @@ imageID COREMOD_MEMORY_image_NETWORKreceive(int                         port,
     //size_t flushsize;
     char *socket_flush_buff;
 
-    struct sched_param schedpar;
-
     PROCESSINFO *processinfo;
     if(dcprocinfo == 1)
     {
@@ -826,32 +776,9 @@ imageID COREMOD_MEMORY_image_NETWORKreceive(int                         port,
     }
 
     // CATCH SIGNALS
+    set_signal_catch();
 
-    if(
-        sigaction(SIGTERM, &dcsigact, NULL) == -1 ||
-        sigaction(SIGINT, &dcsigact, NULL) == -1 ||
-        sigaction(SIGABRT, &dcsigact, NULL) == -1 ||
-        sigaction(SIGBUS, &dcsigact, NULL) == -1 ||
-        sigaction(SIGSEGV, &dcsigact, NULL) == -1 ||
-        sigaction(SIGHUP, &dcsigact, NULL) == -1 ||
-        sigaction(SIGPIPE, &dcsigact, NULL) == -1
-    )
-    {
-        printf("\nCan't catch a requested signal (TERM, INT, ABRT, BUS, SEGV, HUP, PIPE)\n");
-    }
-
-    schedpar.sched_priority = RT_priority;
-    if(seteuid(dceuid) != 0)  //This goes up to maximum privileges
-    {
-        PRINT_ERROR("seteuid error");
-    }
-    sched_setscheduler(0,
-                       SCHED_FIFO,
-                       &schedpar); //other option is SCHED_RR, might be faster
-    if(seteuid(dcruid) != 0)    //Go back to normal privileges
-    {
-        PRINT_ERROR("seteuid error");
-    }
+    stream_net_rt_sched_set(RT_priority);
 
     // create TCP socket
     if((fds_server = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP)) == -1)
@@ -1303,34 +1230,7 @@ imageID COREMOD_MEMORY_image_NETWORKreceive(int                         port,
             loopOK = 0;
             if(dcprocinfo == 1)
             {
-                if(dcsigTERM)
-                {
-                    processinfo_SIGexit(processinfo, SIGTERM);
-                }
-                else if(dcsigINT)
-                {
-                    processinfo_SIGexit(processinfo, SIGINT);
-                }
-                else if(dcsigABRT)
-                {
-                    processinfo_SIGexit(processinfo, SIGABRT);
-                }
-                else if(dcsigBUS)
-                {
-                    processinfo_SIGexit(processinfo, SIGBUS);
-                }
-                else if(dcsigSEGV)
-                {
-                    processinfo_SIGexit(processinfo, SIGSEGV);
-                }
-                else if(dcsigHUP)
-                {
-                    processinfo_SIGexit(processinfo, SIGHUP);
-                }
-                else if(dcsigPIPE)
-                {
-                    processinfo_SIGexit(processinfo, SIGPIPE);
-                }
+                DCSIG_PROCESS_EXIT(processinfo);
             }
         }
 

--- a/src/coremods/COREMOD_memory/stream_TCP.c
+++ b/src/coremods/COREMOD_memory/stream_TCP.c
@@ -776,7 +776,7 @@ imageID COREMOD_MEMORY_image_NETWORKreceive(int                         port,
     }
 
     // CATCH SIGNALS
-    set_signal_catch();
+    stream_net_signal_catch();
 
     stream_net_rt_sched_set(RT_priority);
 

--- a/src/coremods/COREMOD_memory/stream_UDP.c
+++ b/src/coremods/COREMOD_memory/stream_UDP.c
@@ -23,6 +23,7 @@
 #include "list_image.h"
 #include "read_shmim.h"
 #include "stream_sem.h"
+#include "stream_net_common.h"
 
 // set to 1 if transfering keywords
 static int TCPTRANSFERKW = 1;
@@ -242,10 +243,6 @@ imageID COREMOD_MEMORY_image_NETUDPtransmit(const char *IDname,
     char              *ptr_img_data_slice; // source - offset by slice
     int                res; // Return status for socket ops
     int                byte_sock_count;
-
-    struct timespec ts;
-    long            scnt;
-    int             semval;
     int             semr;
     int             slice, oldslice;
     int             NBslices;
@@ -394,17 +391,9 @@ imageID COREMOD_MEMORY_image_NETUDPtransmit(const char *IDname,
         fflush(stdout);
     }
 
-    if((dcimg[ID].md[0].sem == 0) || (do_counter_sync == 1))
-    {
-        processinfo_WriteMessage(processinfo, "sync using counter");
-        use_sem = 0;
-    }
-    else
-    {
-        char msgstring[200];
-        snprintf(msgstring, 200, "sync using semaphore %d", semtrig);
-        processinfo_WriteMessage(processinfo, msgstring);
-    }
+    use_sem = stream_net_decide_sync(
+        dcimg[ID].md[0].sem, do_counter_sync,
+        semtrig, processinfo);
 
     // ===========================
     // Start loop
@@ -427,38 +416,12 @@ imageID COREMOD_MEMORY_image_NETUDPtransmit(const char *IDname,
         }
         else
         {
-            if(clock_gettime(CLOCK_MILK, &ts) == -1)
-            {
-                perror("clock_gettime");
-                exit(EXIT_FAILURE);
-            }
-            ts.tv_sec += 2;
+            semr = stream_net_sem_wait(
+                dcimg + ID, semtrig);
 
-            semr = ImageStreamIO_semtimedwait(dcimg + ID, semtrig, &ts);
-
-            if(iter == 0)
-            {
-                processinfo_WriteMessage(processinfo, "Driving sem to 0");
-                printf("Driving semaphore to zero ... ");
-                fflush(stdout);
-                semval = ImageStreamIO_semvalue(dcimg + ID, semtrig);
-                int semvalcnt = semval;
-                for(scnt = 0; scnt < semvalcnt; scnt++)
-                {
-                    semval = ImageStreamIO_semvalue(dcimg + ID, semtrig);
-                    printf("sem = %d\n", semval);
-                    fflush(stdout);
-                    ImageStreamIO_semtrywait(dcimg + ID, semtrig);
-                }
-                printf("done\n");
-                fflush(stdout);
-
-                semval = ImageStreamIO_semvalue(dcimg + ID, semtrig);
-                printf("-> sem = %d\n", semval);
-                fflush(stdout);
-
-                iter++;
-            }
+            stream_net_sem_drain(
+                dcimg + ID, semtrig,
+                &iter, processinfo);
         }
 
         processinfo_exec_start(processinfo);
@@ -468,20 +431,9 @@ imageID COREMOD_MEMORY_image_NETUDPtransmit(const char *IDname,
             if(semr == 0)
             {
 
-                slice = dcimg[ID].md[0].cnt1;
-                if(slice > oldslice + 1)
-                {
-                    slice = oldslice + 1;
-                }
-                if(NBslices > 1)
-                    if(oldslice == NBslices - 1)
-                    {
-                        slice = 0;
-                    }
-                if(slice > NBslices - 1)
-                {
-                    slice = 0;
-                }
+                slice = stream_net_clamp_slice(
+                    dcimg[ID].md[0].cnt1,
+                    oldslice, NBslices);
 
                 // Fill up the transmission buffer
                 __builtin_memcpy(ptr_buff_metadata,
@@ -615,8 +567,6 @@ imageID COREMOD_MEMORY_image_NETUDPreceive(
     long                 framesize1;    // pixel data + metadata
     long                 framesizefull; // pixel data + metadata + kw
 
-    struct sched_param schedpar;
-
     PROCESSINFO *processinfo;
     if(dcprocinfo == 1)
     {
@@ -636,53 +586,9 @@ imageID COREMOD_MEMORY_image_NETUDPreceive(
     }
 
     // CATCH SIGNALS
-    {
-        if(sigaction(SIGTERM, &dcsigact, NULL) == -1)
-        {
-            printf("\ncan't catch SIGTERM\n");
-        }
+    set_signal_catch();
 
-        if(sigaction(SIGINT, &dcsigact, NULL) == -1)
-        {
-            printf("\ncan't catch SIGINT\n");
-        }
-
-        if(sigaction(SIGABRT, &dcsigact, NULL) == -1)
-        {
-            printf("\ncan't catch SIGABRT\n");
-        }
-
-        if(sigaction(SIGBUS, &dcsigact, NULL) == -1)
-        {
-            printf("\ncan't catch SIGBUS\n");
-        }
-
-        if(sigaction(SIGSEGV, &dcsigact, NULL) == -1)
-        {
-            printf("\ncan't catch SIGSEGV\n");
-        }
-
-        if(sigaction(SIGHUP, &dcsigact, NULL) == -1)
-        {
-            printf("\ncan't catch SIGHUP\n");
-        }
-
-        if(sigaction(SIGPIPE, &dcsigact, NULL) == -1)
-        {
-            printf("\ncan't catch SIGPIPE\n");
-        }
-    }
-
-    schedpar.sched_priority = RT_priority;
-    if(seteuid(dceuid) != 0)  //This goes up to maximum privileges
-    {
-        PRINT_ERROR("seteuid error");
-    }
-    sched_setscheduler(0, SCHED_FIFO, &schedpar);
-    if(seteuid(dcruid) != 0)    //Go back to normal privileges
-    {
-        PRINT_ERROR("seteuid error");
-    }
+    stream_net_rt_sched_set(RT_priority);
 
     // create UDP socket
     if((fds_server = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0)
@@ -1182,34 +1088,7 @@ imageID COREMOD_MEMORY_image_NETUDPreceive(
             loopOK = 0;
             if(dcprocinfo == 1)
             {
-                if(dcsigTERM == 1)
-                {
-                    processinfo_SIGexit(processinfo, SIGTERM);
-                }
-                else if(dcsigINT == 1)
-                {
-                    processinfo_SIGexit(processinfo, SIGINT);
-                }
-                else if(dcsigABRT == 1)
-                {
-                    processinfo_SIGexit(processinfo, SIGABRT);
-                }
-                else if(dcsigBUS == 1)
-                {
-                    processinfo_SIGexit(processinfo, SIGBUS);
-                }
-                else if(dcsigSEGV == 1)
-                {
-                    processinfo_SIGexit(processinfo, SIGSEGV);
-                }
-                else if(dcsigHUP == 1)
-                {
-                    processinfo_SIGexit(processinfo, SIGHUP);
-                }
-                else if(dcsigPIPE == 1)
-                {
-                    processinfo_SIGexit(processinfo, SIGPIPE);
-                }
+                DCSIG_PROCESS_EXIT(processinfo);
             }
         }
 

--- a/src/coremods/COREMOD_memory/stream_UDP.c
+++ b/src/coremods/COREMOD_memory/stream_UDP.c
@@ -586,7 +586,7 @@ imageID COREMOD_MEMORY_image_NETUDPreceive(
     }
 
     // CATCH SIGNALS
-    set_signal_catch();
+    stream_net_signal_catch();
 
     stream_net_rt_sched_set(RT_priority);
 

--- a/src/coremods/COREMOD_memory/stream_net_common.h
+++ b/src/coremods/COREMOD_memory/stream_net_common.h
@@ -105,19 +105,19 @@ static inline void stream_net_signal_catch(void)
     dcsigact.sa_flags = 0;
 
     if (sigaction(SIGTERM, &dcsigact, NULL) == -1)
-        printf("\ncan't catch SIGTERM\n");
+        PRINT_ERROR("can't catch SIGTERM");
     if (sigaction(SIGINT, &dcsigact, NULL) == -1)
-        printf("\ncan't catch SIGINT\n");
+        PRINT_ERROR("can't catch SIGINT");
     if (sigaction(SIGABRT, &dcsigact, NULL) == -1)
-        printf("\ncan't catch SIGABRT\n");
+        PRINT_ERROR("can't catch SIGABRT");
     if (sigaction(SIGBUS, &dcsigact, NULL) == -1)
-        printf("\ncan't catch SIGBUS\n");
+        PRINT_ERROR("can't catch SIGBUS");
     if (sigaction(SIGSEGV, &dcsigact, NULL) == -1)
-        printf("\ncan't catch SIGSEGV\n");
+        PRINT_ERROR("can't catch SIGSEGV");
     if (sigaction(SIGHUP, &dcsigact, NULL) == -1)
-        printf("\ncan't catch SIGHUP\n");
+        PRINT_ERROR("can't catch SIGHUP");
     if (sigaction(SIGPIPE, &dcsigact, NULL) == -1)
-        printf("\ncan't catch SIGPIPE\n");
+        PRINT_ERROR("can't catch SIGPIPE");
 #else
     set_signal_catch();
 #endif

--- a/src/coremods/COREMOD_memory/stream_net_common.h
+++ b/src/coremods/COREMOD_memory/stream_net_common.h
@@ -65,6 +65,31 @@
  * Signal handler installation
  * ========================================================= */
 
+#ifdef MILK_NO_CLI
+/**
+ * stream_net_sig_handler_standalone - set dcsig* flag
+ * for the received signal.
+ *
+ * Used only in MILK_NO_CLI builds where sig_handler()
+ * from CLIcore_standalone.h is a no-op and does not
+ * populate the dcsig* flags needed by DCSIG_ANY_SET().
+ */
+static void stream_net_sig_handler_standalone(int signo)
+{
+    switch (signo)
+    {
+    case SIGTERM: dcsigTERM = 1; break;
+    case SIGINT:  dcsigINT  = 1; break;
+    case SIGABRT: dcsigABRT = 1; break;
+    case SIGBUS:  dcsigBUS  = 1; break;
+    case SIGSEGV: dcsigSEGV = 1; break;
+    case SIGHUP:  dcsigHUP  = 1; break;
+    case SIGPIPE: dcsigPIPE = 1; break;
+    default: break;
+    }
+}
+#endif /* MILK_NO_CLI */
+
 /**
  * stream_net_signal_catch - install signal handlers
  *
@@ -75,7 +100,7 @@
 static inline void stream_net_signal_catch(void)
 {
 #ifdef MILK_NO_CLI
-    dcsigact.sa_handler = sig_handler;
+    dcsigact.sa_handler = stream_net_sig_handler_standalone;
     sigemptyset(&dcsigact.sa_mask);
     dcsigact.sa_flags = 0;
 

--- a/src/coremods/COREMOD_memory/stream_net_common.h
+++ b/src/coremods/COREMOD_memory/stream_net_common.h
@@ -13,6 +13,7 @@
 #include <sched.h>
 #include <signal.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -58,6 +59,44 @@
         else if (dcsigPIPE) \
             processinfo_SIGexit((pinfo), SIGPIPE); \
     } while (0)
+
+
+/* ============================================================
+ * Signal handler installation
+ * ========================================================= */
+
+/**
+ * stream_net_signal_catch - install signal handlers
+ *
+ * In CLI builds delegates to set_signal_catch().
+ * In standalone (MILK_NO_CLI) builds calls sigaction()
+ * directly, since set_signal_catch() is a no-op there.
+ */
+static inline void stream_net_signal_catch(void)
+{
+#ifdef MILK_NO_CLI
+    dcsigact.sa_handler = sig_handler;
+    sigemptyset(&dcsigact.sa_mask);
+    dcsigact.sa_flags = 0;
+
+    if (sigaction(SIGTERM, &dcsigact, NULL) == -1)
+        printf("\ncan't catch SIGTERM\n");
+    if (sigaction(SIGINT, &dcsigact, NULL) == -1)
+        printf("\ncan't catch SIGINT\n");
+    if (sigaction(SIGABRT, &dcsigact, NULL) == -1)
+        printf("\ncan't catch SIGABRT\n");
+    if (sigaction(SIGBUS, &dcsigact, NULL) == -1)
+        printf("\ncan't catch SIGBUS\n");
+    if (sigaction(SIGSEGV, &dcsigact, NULL) == -1)
+        printf("\ncan't catch SIGSEGV\n");
+    if (sigaction(SIGHUP, &dcsigact, NULL) == -1)
+        printf("\ncan't catch SIGHUP\n");
+    if (sigaction(SIGPIPE, &dcsigact, NULL) == -1)
+        printf("\ncan't catch SIGPIPE\n");
+#else
+    set_signal_catch();
+#endif
+}
 
 
 /* ============================================================

--- a/src/coremods/COREMOD_memory/stream_net_common.h
+++ b/src/coremods/COREMOD_memory/stream_net_common.h
@@ -1,0 +1,248 @@
+/**
+ * @file    stream_net_common.h
+ * @brief   Shared helpers for TCP/UDP stream transport
+ *
+ * Static inline functions and macros used by both
+ * stream_TCP.c and stream_UDP.c to eliminate
+ * duplicated boilerplate.
+ */
+
+#ifndef STREAM_NET_COMMON_H
+#define STREAM_NET_COMMON_H
+
+#include <sched.h>
+#include <signal.h>
+#include <stdio.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "ImageStreamIO/ImageStreamIO.h"
+#include "ImageStreamIO/ImageStruct.h"
+#include "processinfo.h"
+#include "processinfo_SIGexit.h"
+#include "processinfo_WriteMessage.h"
+#include "milkDebugTools.h"
+#include "milkdata.h"
+
+#ifndef CLOCK_MILK
+#define CLOCK_MILK CLOCK_REALTIME
+#endif
+
+
+/* ============================================================
+ * Signal dispatch — replaces 7-way if/else if chain
+ * calling processinfo_SIGexit() for each dcsig* flag.
+ * ========================================================= */
+
+/**
+ * DCSIG_PROCESS_EXIT - dispatch processinfo SIGexit
+ * for the first set dcsig* flag.
+ *
+ * Must be called only when DCSIG_ANY_SET() is true
+ * and dcprocinfo == 1.
+ */
+#define DCSIG_PROCESS_EXIT(pinfo) \
+    do { \
+        if (dcsigTERM) \
+            processinfo_SIGexit((pinfo), SIGTERM); \
+        else if (dcsigINT) \
+            processinfo_SIGexit((pinfo), SIGINT); \
+        else if (dcsigABRT) \
+            processinfo_SIGexit((pinfo), SIGABRT); \
+        else if (dcsigBUS) \
+            processinfo_SIGexit((pinfo), SIGBUS); \
+        else if (dcsigSEGV) \
+            processinfo_SIGexit((pinfo), SIGSEGV); \
+        else if (dcsigHUP) \
+            processinfo_SIGexit((pinfo), SIGHUP); \
+        else if (dcsigPIPE) \
+            processinfo_SIGexit((pinfo), SIGPIPE); \
+    } while (0)
+
+
+/* ============================================================
+ * RT scheduling setup
+ * ========================================================= */
+
+/**
+ * stream_net_rt_sched_set - set SCHED_FIFO priority
+ * @priority: 0-99, higher = more priority
+ *
+ * Temporarily elevates to euid, sets scheduler,
+ * then drops back to ruid.
+ */
+static inline void stream_net_rt_sched_set(
+    int priority)
+{
+    struct sched_param sp;
+    sp.sched_priority = priority;
+
+    if (seteuid(dceuid) != 0)
+    {
+        PRINT_ERROR("seteuid error");
+    }
+    sched_setscheduler(0, SCHED_FIFO, &sp);
+    if (seteuid(dcruid) != 0)
+    {
+        PRINT_ERROR("seteuid error");
+    }
+}
+
+
+/* ============================================================
+ * Semaphore drain — drive semaphore to zero on
+ * first iteration of transmit loop.
+ * ========================================================= */
+
+/**
+ * stream_net_sem_drain - drain semaphore on first
+ * iteration
+ * @img:      IMAGE pointer
+ * @semtrig:  semaphore index
+ * @iter_p:   pointer to iteration counter
+ * @pinfo:    PROCESSINFO pointer
+ *
+ * On the first call (*iter_p == 0), drains the
+ * semaphore and increments *iter_p.
+ */
+static inline void stream_net_sem_drain(
+    IMAGE *img,
+    int semtrig,
+    long long *iter_p,
+    PROCESSINFO *pinfo)
+{
+    if (*iter_p == 0)
+    {
+        processinfo_WriteMessage(
+            pinfo, "Driving sem to 0");
+        printf("Driving semaphore to zero ... ");
+        fflush(stdout);
+
+        int semval =
+            ImageStreamIO_semvalue(img, semtrig);
+        int semvalcnt = semval;
+        for (long scnt = 0;
+             scnt < semvalcnt; scnt++)
+        {
+            semval =
+                ImageStreamIO_semvalue(
+                    img, semtrig);
+            printf("sem = %d\n", semval);
+            fflush(stdout);
+            ImageStreamIO_semtrywait(
+                img, semtrig);
+        }
+        printf("done\n");
+        fflush(stdout);
+
+        semval =
+            ImageStreamIO_semvalue(img, semtrig);
+        printf("-> sem = %d\n", semval);
+        fflush(stdout);
+
+        (*iter_p)++;
+    }
+}
+
+
+/* ============================================================
+ * Slice tracking — clamp slice index to valid range
+ * ========================================================= */
+
+/**
+ * stream_net_clamp_slice - clamp frame slice index
+ * @raw_slice: incoming cnt1 value
+ * @old_slice: previous slice
+ * @nb_slices: total number of slices
+ *
+ * Returns the clamped slice index.
+ */
+static inline int stream_net_clamp_slice(
+    int raw_slice,
+    int old_slice,
+    int nb_slices)
+{
+    int slice = raw_slice;
+
+    if (slice > old_slice + 1)
+    {
+        slice = old_slice + 1;
+    }
+    if (nb_slices > 1)
+    {
+        if (old_slice == nb_slices - 1)
+        {
+            slice = 0;
+        }
+    }
+    if (slice > nb_slices - 1)
+    {
+        slice = 0;
+    }
+    return slice;
+}
+
+
+/* ============================================================
+ * Sync mode decision — sem vs counter
+ * ========================================================= */
+
+/**
+ * stream_net_decide_sync - decide semaphore vs
+ * counter synchronization
+ * @sem_count:  number of semaphores on image
+ * @force_cnt:  1 to force counter sync (mode param)
+ * @semtrig:    semaphore index to use if sem sync
+ * @pinfo:      PROCESSINFO pointer
+ *
+ * Returns 1 for semaphore sync, 0 for counter sync.
+ */
+static inline int stream_net_decide_sync(
+    int sem_count,
+    int force_cnt,
+    int semtrig,
+    PROCESSINFO *pinfo)
+{
+    if (sem_count == 0 || force_cnt == 1)
+    {
+        processinfo_WriteMessage(
+            pinfo, "sync using counter");
+        return 0;
+    }
+
+    char msg[200];
+    snprintf(msg, 200,
+             "sync using semaphore %d", semtrig);
+    processinfo_WriteMessage(pinfo, msg);
+    return 1;
+}
+
+
+/* ============================================================
+ * Semaphore-based wait with timeout
+ * ========================================================= */
+
+/**
+ * stream_net_sem_wait - timed semaphore wait
+ * @img:      IMAGE pointer
+ * @semtrig:  semaphore index
+ *
+ * Returns 0 on success, non-zero on timeout.
+ */
+static inline int stream_net_sem_wait(
+    IMAGE *img,
+    int semtrig)
+{
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MILK, &ts) == -1)
+    {
+        perror("clock_gettime");
+        exit(EXIT_FAILURE);
+    }
+    ts.tv_sec += 2;
+    return ImageStreamIO_semtimedwait(
+        img, semtrig, &ts);
+}
+
+
+#endif /* STREAM_NET_COMMON_H */


### PR DESCRIPTION
## Summary

Extracts duplicated transport boilerplate from `stream_TCP.c` and `stream_UDP.c` into a new `stream_net_common.h` header containing static inline helpers and macros. Follow-up fixes address signal handling correctness in standalone (`MILK_NO_CLI`) builds and a missing `<stdlib.h>` include.

## Changes

### stream_net_common.h (new file)

- Contains shared helpers: `DCSIG_PROCESS_EXIT`, `stream_net_rt_sched_set`, `stream_net_decide_sync`, `stream_net_sem_wait`, `stream_net_sem_drain`, `stream_net_clamp_slice`
- Added `stream_net_signal_catch()`: in CLI builds delegates to `set_signal_catch()`; in `MILK_NO_CLI` standalone builds installs `sigaction()` handlers directly (since `set_signal_catch()` is a no-op in `CLIcore_standalone.h`)
- Added private `stream_net_sig_handler_standalone()` that populates `dcsig*` flags so `DCSIG_ANY_SET()` and `processinfo_SIGexit()` work correctly in standalone builds
- Added `#include <stdlib.h>` so `exit(EXIT_FAILURE)` in `stream_net_sem_wait()` is properly declared
- Uses `PRINT_ERROR` for sigaction failure reporting, consistent with rest of file

### stream_TCP.c

- Replaced 130 lines of duplicated boilerplate with common helpers
- Replaced `set_signal_catch()` with `stream_net_signal_catch()`

### stream_UDP.c

- Replaced 151 lines of duplicated boilerplate with common helpers
- Replaced `set_signal_catch()` with `stream_net_signal_catch()`

## Verification

- [x] Build passes (`/compile-test`)
- [ ] Tests pass (`ctest --output-on-failure`)
- [ ] CLI robustness tests pass (if CLI changed)
- [ ] Documentation updated (README, help, docs/)

## Prompt Summary

Addressing audit item 6 (TCP/UDP shared transport layer). Follow-up: restore correct signal handler installation in `MILK_NO_CLI` standalone builds and make `stream_net_common.h` self-contained (`<stdlib.h>`).

## AI Authorship

- **Model:** Antigravity / Copilot
- **User edits:** None