### PR TITLE
refactor: remove legacy _byID arithmetic API, migrate to IMGID

### DIFF
--- a/src/coremods/COREMOD_arith/execute_arith.c
+++ b/src/coremods/COREMOD_arith/execute_arith.c
@@ -536,30 +536,10 @@ int execute_arith(const char *cmd1)
             word_type[i]    = ARITHTOKENTYPE_VARIABLE;
             found_word_type = 1;
         }
-        if((image_ID(word[i], dcimg, dcnimg) != -1) && (found_word_type == 0))
+        if((imgid_exists(word[i])) && (found_word_type == 0))
         {
             word_type[i]    = ARITHTOKENTYPE_IMAGE;
             found_word_type = 1;
-        }
-        /* If word contains brackets, try bare name */
-        if (found_word_type == 0
-            && strchr(word[i], '[') != NULL)
-        {
-            char bare[100];
-            const char *bk = strchr(word[i], '[');
-            int blen = (int)(bk - word[i]);
-            if (blen > 0 && blen < 100)
-            {
-                memcpy(bare, word[i], blen);
-                bare[blen] = '\0';
-                if (image_ID(bare,
-                             dcimg, dcnimg) != -1)
-                {
-                    word_type[i] =
-                        ARITHTOKENTYPE_IMAGE;
-                    found_word_type = 1;
-                }
-            }
         }
         if(found_word_type == 0)
         {
@@ -696,15 +676,12 @@ int execute_arith(const char *cmd1)
 
             IMGID simg =
                 imgid_make_from_name(word[i]);
-            imageID sid = image_ID(
-                simg.name, dcimg, dcnimg);
-            if (sid < 0)
+            resolveIMGID(&simg, ERRMODE_NULL, dcimg, dcnimg);
+            if (simg.ID < 0)
             {
                 imgid_free(&simg);
                 continue;
             }
-            simg.ID = sid;
-            simg.im = &dcimg[sid];
 
             /* Materialize the slice */
             if (imgid_slice_materialize(
@@ -1928,7 +1905,7 @@ int execute_arith(const char *cmd1)
                 {
                     delete_variable_ID(word[0]);
                 }
-                if(image_ID(word[0], dcimg, dcnimg) != -1)
+                if(imgid_exists(word[0]))
                 {
                     delete_image_ID(word[0], DELETE_IMAGE_ERRMODE_WARNING);
                 }
@@ -1959,7 +1936,7 @@ int execute_arith(const char *cmd1)
             {
                 delete_variable_ID(name);
             }
-            if(image_ID(name, dcimg, dcnimg) != -1)
+            if(imgid_exists(name))
             {
                 delete_image_ID(name, DELETE_IMAGE_ERRMODE_WARNING);
             }

--- a/src/coremods/COREMOD_arith/image_arith__Cim_Cim__Cim.c
+++ b/src/coremods/COREMOD_arith/image_arith__Cim_Cim__Cim.c
@@ -24,13 +24,16 @@ errno_t
 arith_image_Cadd(const char *ID1_name, const char *ID2_name, const char *ID_out)
 {
     uint8_t atype1, atype2;
-    imageID ID1;
-    imageID ID2;
+    IMGID img1 = imgid_make_from_name(ID1_name);
+    resolveIMGID(&img1, ERRMODE_ABORT, dcimg, dcnimg);
+    IMGID img2 = imgid_make_from_name(ID2_name);
+    resolveIMGID(&img2, ERRMODE_ABORT, dcimg, dcnimg);
 
-    ID1    = image_ID(ID1_name, dcimg, dcnimg);
-    ID2    = image_ID(ID2_name, dcimg, dcnimg);
-    atype1 = dcimg[ID1].md[0].datatype;
-    atype2 = dcimg[ID2].md[0].datatype;
+    atype1 = img1.md->datatype;
+    atype2 = img2.md->datatype;
+
+    imgid_free(&img1);
+    imgid_free(&img2);
 
     if((atype1 == _DATATYPE_COMPLEX_FLOAT) &&
             (atype2 == _DATATYPE_COMPLEX_FLOAT))
@@ -60,13 +63,16 @@ errno_t
 arith_image_Csub(const char *ID1_name, const char *ID2_name, const char *ID_out)
 {
     uint8_t datatype1, datatype2;
-    imageID ID1;
-    imageID ID2;
+    IMGID img1 = imgid_make_from_name(ID1_name);
+    resolveIMGID(&img1, ERRMODE_ABORT, dcimg, dcnimg);
+    IMGID img2 = imgid_make_from_name(ID2_name);
+    resolveIMGID(&img2, ERRMODE_ABORT, dcimg, dcnimg);
 
-    ID1       = image_ID(ID1_name, dcimg, dcnimg);
-    ID2       = image_ID(ID2_name, dcimg, dcnimg);
-    datatype1 = dcimg[ID1].md[0].datatype;
-    datatype2 = dcimg[ID2].md[0].datatype;
+    datatype1 = img1.md->datatype;
+    datatype2 = img2.md->datatype;
+
+    imgid_free(&img1);
+    imgid_free(&img2);
 
     if((datatype1 == _DATATYPE_COMPLEX_FLOAT) &&
             (datatype2 == _DATATYPE_COMPLEX_FLOAT))
@@ -97,13 +103,16 @@ errno_t arith_image_Cmult(const char *ID1_name,
                           const char *ID_out)
 {
     uint8_t datatype1, datatype2;
-    imageID ID1;
-    imageID ID2;
+    IMGID img1 = imgid_make_from_name(ID1_name);
+    resolveIMGID(&img1, ERRMODE_ABORT, dcimg, dcnimg);
+    IMGID img2 = imgid_make_from_name(ID2_name);
+    resolveIMGID(&img2, ERRMODE_ABORT, dcimg, dcnimg);
 
-    ID1       = image_ID(ID1_name, dcimg, dcnimg);
-    ID2       = image_ID(ID2_name, dcimg, dcnimg);
-    datatype1 = dcimg[ID1].md[0].datatype;
-    datatype2 = dcimg[ID2].md[0].datatype;
+    datatype1 = img1.md->datatype;
+    datatype2 = img2.md->datatype;
+
+    imgid_free(&img1);
+    imgid_free(&img2);
 
     if((datatype1 == _DATATYPE_COMPLEX_FLOAT) &&
             (datatype2 == _DATATYPE_COMPLEX_FLOAT))
@@ -134,13 +143,16 @@ int arith_image_Cdiv(const char *ID1_name,
                      const char *ID_out)
 {
     uint8_t datatype1, datatype2;
-    imageID ID1;
-    imageID ID2;
+    IMGID img1 = imgid_make_from_name(ID1_name);
+    resolveIMGID(&img1, ERRMODE_ABORT, dcimg, dcnimg);
+    IMGID img2 = imgid_make_from_name(ID2_name);
+    resolveIMGID(&img2, ERRMODE_ABORT, dcimg, dcnimg);
 
-    ID1       = image_ID(ID1_name, dcimg, dcnimg);
-    ID2       = image_ID(ID2_name, dcimg, dcnimg);
-    datatype1 = dcimg[ID1].md[0].datatype;
-    datatype2 = dcimg[ID2].md[0].datatype;
+    datatype1 = img1.md->datatype;
+    datatype2 = img2.md->datatype;
+
+    imgid_free(&img1);
+    imgid_free(&img2);
 
     if((datatype1 == _DATATYPE_COMPLEX_FLOAT) &&
             (datatype2 == _DATATYPE_COMPLEX_FLOAT))

--- a/src/coremods/COREMOD_arith/image_arith__Cim_Cim__Cim.h
+++ b/src/coremods/COREMOD_arith/image_arith__Cim_Cim__Cim.h
@@ -13,10 +13,10 @@
 /* ------------------------------------------------------------------------- */
 
 /*
-int arith_image_Cadd_byID(long ID1, long ID2, long IDout);
-int arith_image_Csub_byID(long ID1, long ID2, long IDout);
-int arith_image_Cmult_byID(long ID1, long ID2, long IDout);
-int arith_image_Cdiv_byID(long ID1, long ID2, long IDout);
+
+
+
+
 */
 
 int arith_image_Cadd(const char *ID1_name,

--- a/src/coremods/COREMOD_arith/image_arith__im__im.c
+++ b/src/coremods/COREMOD_arith/image_arith__im__im.c
@@ -8,7 +8,7 @@
  * All call surfaces are generated from the UNARY_OPS
  * X-macro table:
  *
- *  - arith_image_<op>_byID(ID, IDout)
+
  *    Legacy API using raw image slot indices.
  *  - arith_image_<op>_IMGID(imgin, imgout)
  *    Modern IMGID API.
@@ -66,18 +66,10 @@
  * 1. Legacy by-ID wrappers  (ID, IDout)
  * ---------------------------------------------------------- */
 
-#define DEFINE_BYID(op, fptr) \
-int arith_image_##op##_byID(  \
-    long ID,                  \
-    long IDout)               \
-{                             \
-    arith_image_function_1_1_byID( \
-        ID, IDout, &fptr);    \
-    return 0;                 \
-}
 
-UNARY_OPS(DEFINE_BYID)
-#undef DEFINE_BYID
+
+
+
 
 
 /* ----------------------------------------------------------
@@ -122,17 +114,10 @@ UNARY_OPS(DEFINE_STRING)
  * 4. In-place-by-ID wrappers
  * ---------------------------------------------------------- */
 
-#define DEFINE_INPLACE_BYID(op, fptr) \
-int arith_image_##op##_inplace_byID(  \
-    long ID)                          \
-{                                     \
-    arith_image_function_1_1_inplace_byID( \
-        ID, &fptr);                   \
-    return 0;                         \
-}
 
-UNARY_OPS(DEFINE_INPLACE_BYID)
-#undef DEFINE_INPLACE_BYID
+
+
+
 
 
 /* ----------------------------------------------------------

--- a/src/coremods/COREMOD_arith/image_arith__im__im.h
+++ b/src/coremods/COREMOD_arith/image_arith__im__im.h
@@ -16,22 +16,22 @@ double Ppositive(double a);
 /* image  -> image                                                           */
 /* ------------------------------------------------------------------------- */
 
-int arith_image_acos_byID(long ID, long IDout);
-int arith_image_asin_byID(long ID, long IDout);
-int arith_image_atan_byID(long ID, long IDout);
-int arith_image_ceil_byID(long ID_name, long IDout);
-int arith_image_cos_byID(long ID, long IDout);
-int arith_image_cosh_byID(long ID, long IDout);
-int arith_image_exp_byID(long ID, long IDout);
-int arith_image_fabs_byID(long ID, long IDout);
-int arith_image_floor_byID(long ID, long IDout);
-int arith_image_ln_byID(long ID, long IDout);
-int arith_image_log_byID(long ID, long IDout);
-int arith_image_sqrt_byID(long ID, long IDout);
-int arith_image_sin_byID(long ID, long IDout);
-int arith_image_sinh_byID(long ID, long IDout);
-int arith_image_tan_byID(long ID, long IDout);
-int arith_image_tanh_byID(long ID, long IDout);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 int arith_image_acos(const char *ID_name, const char *ID_out);
 int arith_image_acos_IMGID(IMGID *imgin, IMGID *imgout);
@@ -84,22 +84,22 @@ int arith_image_tanh_IMGID(IMGID *imgin, IMGID *imgout);
 int arith_image_positive(const char *ID_name, const char *ID_out);
 int arith_image_positive_IMGID(IMGID *imgin, IMGID *imgout);
 
-int arith_image_acos_inplace_byID(long ID);
-int arith_image_asin_inplace_byID(long ID);
-int arith_image_atan_inplace_byID(long ID);
-int arith_image_ceil_inplace_byID(long ID);
-int arith_image_cos_inplace_byID(long ID);
-int arith_image_cosh_inplace_byID(long ID);
-int arith_image_exp_inplace_byID(long ID);
-int arith_image_fabs_inplace_byID(long ID);
-int arith_image_floor_inplace_byID(long ID);
-int arith_image_ln_inplace_byID(long ID);
-int arith_image_log_inplace_byID(long ID);
-int arith_image_sqrt_inplace_byID(long ID);
-int arith_image_sin_inplace_byID(long ID);
-int arith_image_sinh_inplace_byID(long ID);
-int arith_image_tan_inplace_byID(long ID);
-int arith_image_tanh_inplace_byID(long ID);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 int arith_image_acos_inplace(const char *ID_name);
 int arith_image_asin_inplace(const char *ID_name);

--- a/src/coremods/COREMOD_arith/image_arith__im_f__im.c
+++ b/src/coremods/COREMOD_arith/image_arith__im_f__im.c
@@ -209,15 +209,7 @@ CST_INPLACE_OPS(DEFINE_CST_INPLACE)
  * 4. In-place-by-ID wrappers
  * ---------------------------------------------------------- */
 
-#define DEFINE_CST_INPLACE_BYID(op, fptr) \
-int arith_image_cst##op##_inplace_byID(   \
-    long ID,                              \
-    double f1)                            \
-{                                         \
-    arith_image_function_1f_1_inplace_byID( \
-        ID, f1, &fptr);                   \
-    return 0;                             \
-}
 
-CST_INPLACE_OPS(DEFINE_CST_INPLACE_BYID)
-#undef DEFINE_CST_INPLACE_BYID
+
+
+

--- a/src/coremods/COREMOD_arith/image_arith__im_f__im.h
+++ b/src/coremods/COREMOD_arith/image_arith__im_f__im.h
@@ -81,24 +81,24 @@ int arith_image_csttestlt_inplace(const char *ID_name, double f1);
 
 int arith_image_csttestmt_inplace(const char *ID_name, double f1);
 
-int arith_image_cstfmod_inplace_byID(long ID, double f1);
 
-int arith_image_cstadd_inplace_byID(long ID, double f1);
 
-int arith_image_cstsub_inplace_byID(long ID, double f1);
 
-int arith_image_cstmult_inplace_byID(long ID, double f1);
 
-int arith_image_cstdiv_inplace_byID(long ID, double f1);
 
-int arith_image_cstdiv1_inplace_byID(long ID, double f1);
 
-int arith_image_cstpow_inplace_byID(long ID, double f1);
 
-int arith_image_cstmaxv_inplace_byID(long ID, double f1);
 
-int arith_image_cstminv_inplace_byID(long ID, double f1);
 
-int arith_image_csttestlt_inplace_byID(long ID, double f1);
 
-int arith_image_csttestmt_inplace_byID(long ID, double f1);
+
+
+
+
+
+
+
+
+
+
+

--- a/src/coremods/COREMOD_arith/image_arith__im_f_f__im.c
+++ b/src/coremods/COREMOD_arith/image_arith__im_f_f__im.c
@@ -100,11 +100,7 @@ int arith_image_trunc_inplace(const char *ID_name, double f1, double f2)
     return (0);
 }
 
-int arith_image_trunc_inplace_byID(long ID, double f1, double f2)
-{
-    arith_image_function_1ff_1_inplace_byID(ID, f1, f2, &Ptrunc);
-    return (0);
-}
+
 
 
 /* ================================================================

--- a/src/coremods/COREMOD_arith/image_arith__im_f_f__im.h
+++ b/src/coremods/COREMOD_arith/image_arith__im_f_f__im.h
@@ -11,9 +11,9 @@
 
 errno_t image_arith__im_f_f__im_addCLIcmd();
 
-int arith_image_trunc_byID(long ID, double f1, double f2, long IDout);
 
-int arith_image_trunc_inplace_byID(long IDname, double f1, double f2);
+
+
 
 int arith_image_trunc(const char *ID_name,
                       double      f1,

--- a/src/coremods/COREMOD_arith/image_arith__im_im__im.c
+++ b/src/coremods/COREMOD_arith/image_arith__im_im__im.c
@@ -177,15 +177,7 @@ BINARY_OPS_FULL(DEFINE_INPLACE)
  * Only generated for BINARY_OPS_FULL operations.
  * ---------------------------------------------------------- */
 
-#define DEFINE_INPLACE_BYID(op, fptr) \
-int arith_image_##op##_inplace_byID(         \
-    long ID1,                                \
-    long ID2)                                \
-{                                            \
-    arith_image_function_2_1_inplace_byID(   \
-        ID1, ID2, &fptr);                    \
-    return 0;                                \
-}
 
-BINARY_OPS_FULL(DEFINE_INPLACE_BYID)
-#undef DEFINE_INPLACE_BYID
+
+
+

--- a/src/coremods/COREMOD_arith/image_arith__im_im__im.h
+++ b/src/coremods/COREMOD_arith/image_arith__im_im__im.h
@@ -16,14 +16,14 @@ double Ptrunc(double a, double b, double c);
 /* predefined functions    image, image  -> image                                                    */
 /* ------------------------------------------------------------------------- */
 
-int arith_image_fmod_byID(long ID1, long ID2, long IDout);
-int arith_image_pow_byID(long ID1, long ID2, const char *IDout);
-int arith_image_add_byID(long ID1, long ID2, long IDout);
-int arith_image_sub_byID(long ID1, long ID2, long IDout);
-int arith_image_mult_byID(long ID1, long ID2, long IDout);
-int arith_image_div_byID(long ID1, long ID2, long IDout);
-int arith_image_minv_byID(long ID1, long ID2, long IDout);
-int arith_image_maxv_byID(long ID1, long ID2, long IDout);
+
+
+
+
+
+
+
+
 
 int arith_image_fmod(const char *ID1_name,
                      const char *ID2_name,
@@ -88,14 +88,14 @@ int arith_image_and_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
 int arith_image_or(const char *ID1_name, const char *ID2_name, const char *ID_out);
 int arith_image_or_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
 
-int arith_image_fmod_inplace_byID(long ID1, long ID2);
-int arith_image_pow_inplace_byID(long ID1, long ID2);
-int arith_image_add_inplace_byID(long ID1, long ID2);
-int arith_image_sub_inplace_byID(long ID1, long ID2);
-int arith_image_mult_inplace_byID(long ID1, long ID2);
-int arith_image_div_inplace_byID(long ID1, long ID2);
-int arith_image_minv_inplace_byID(long ID1, long ID2);
-int arith_image_maxv_inplace_byID(long ID1, long ID2);
+
+
+
+
+
+
+
+
 
 int arith_image_fmod_inplace(const char *ID1_name,
                              const char *ID2_name); // ID1 is output

--- a/src/coremods/COREMOD_arith/imfunctions.c
+++ b/src/coremods/COREMOD_arith/imfunctions.c
@@ -23,7 +23,7 @@
  *  - arith_image_function_imim_im__dd_d — image +
  *    image → image.
  *  - _IMGID suffix = modern IMGID API.
- *  - _byID suffix = legacy slot-index API.
+
  *  - _inplace suffix = result overwrites input.
  */
 
@@ -39,6 +39,7 @@
 
 #include "libmilkcommon/milk_compiler.h"
 #include "COREMOD_memory/COREMOD_memory.h"
+#include "imfunctions.h"
 
 // Suppress -Wunknown-pragmas for _Pragma("omp ...") expansions
 // when OpenMP is globally disabled in the build.
@@ -1089,7 +1090,7 @@ errno_t arith_image_function_1_1(const char *ID_name,
 }
 
 // imagein -> imagein (in place)
-errno_t arith_image_function_1_1_inplace_byID(imageID ID,
+errno_t arith_image_function_1_1_inplace_IMGID(IMGID *imgin,
         double (*pt2function)(double))
 {
     long    ii;
@@ -1099,15 +1100,15 @@ errno_t arith_image_function_1_1_inplace_byID(imageID ID,
 
     // printf("arith_image_function_1_1_inplace\n");
 
-    datatype = dcimg[ID].md[0].datatype;
+    datatype = imgin->im->md->datatype;
 
     //datatypeout = _DATATYPE_FLOAT;
     //if(datatype == _DATATYPE_DOUBLE)
     //   datatypeout = _DATATYPE_DOUBLE;
 
-    nelement = dcimg[ID].md[0].nelement;
+    nelement = imgin->im->md->nelement;
 
-    dcimg[ID].md[0].write = 0;
+    imgin->im->md->write = 0;
 #ifdef _OPENMP
     #pragma omp parallel if (nelement > OMP_NELEMENT_LIMIT)
     {
@@ -1120,8 +1121,8 @@ errno_t arith_image_function_1_1_inplace_byID(imageID ID,
 #endif
             for(ii = 0; ii < nelement; ii++)
             {
-                dcimg[ID].array.F[ii] =
-                    pt2function((double)(dcimg[ID].array.UI8[ii]));
+                imgin->im->array.F[ii] =
+                    pt2function((double)(imgin->im->array.UI8[ii]));
             }
         }
         else if(datatype == _DATATYPE_UINT16)
@@ -1131,8 +1132,8 @@ errno_t arith_image_function_1_1_inplace_byID(imageID ID,
 #endif
             for(ii = 0; ii < nelement; ii++)
             {
-                dcimg[ID].array.F[ii] =
-                    pt2function((double)(dcimg[ID].array.UI16[ii]));
+                imgin->im->array.F[ii] =
+                    pt2function((double)(imgin->im->array.UI16[ii]));
             }
         }
         else if(datatype == _DATATYPE_UINT32)
@@ -1142,8 +1143,8 @@ errno_t arith_image_function_1_1_inplace_byID(imageID ID,
 #endif
             for(ii = 0; ii < nelement; ii++)
             {
-                dcimg[ID].array.F[ii] =
-                    pt2function((double)(dcimg[ID].array.UI32[ii]));
+                imgin->im->array.F[ii] =
+                    pt2function((double)(imgin->im->array.UI32[ii]));
             }
         }
         else if(datatype == _DATATYPE_UINT64)
@@ -1153,8 +1154,8 @@ errno_t arith_image_function_1_1_inplace_byID(imageID ID,
 #endif
             for(ii = 0; ii < nelement; ii++)
             {
-                dcimg[ID].array.F[ii] =
-                    pt2function((double)(dcimg[ID].array.UI64[ii]));
+                imgin->im->array.F[ii] =
+                    pt2function((double)(imgin->im->array.UI64[ii]));
             }
         }
         else if(datatype == _DATATYPE_INT8)
@@ -1164,8 +1165,8 @@ errno_t arith_image_function_1_1_inplace_byID(imageID ID,
 #endif
             for(ii = 0; ii < nelement; ii++)
             {
-                dcimg[ID].array.F[ii] =
-                    pt2function((double)(dcimg[ID].array.SI8[ii]));
+                imgin->im->array.F[ii] =
+                    pt2function((double)(imgin->im->array.SI8[ii]));
             }
         }
         else if(datatype == _DATATYPE_INT16)
@@ -1175,8 +1176,8 @@ errno_t arith_image_function_1_1_inplace_byID(imageID ID,
 #endif
             for(ii = 0; ii < nelement; ii++)
             {
-                dcimg[ID].array.F[ii] =
-                    pt2function((double)(dcimg[ID].array.SI16[ii]));
+                imgin->im->array.F[ii] =
+                    pt2function((double)(imgin->im->array.SI16[ii]));
             }
         }
         else if(datatype == _DATATYPE_INT32)
@@ -1186,8 +1187,8 @@ errno_t arith_image_function_1_1_inplace_byID(imageID ID,
 #endif
             for(ii = 0; ii < nelement; ii++)
             {
-                dcimg[ID].array.F[ii] =
-                    pt2function((double)(dcimg[ID].array.SI32[ii]));
+                imgin->im->array.F[ii] =
+                    pt2function((double)(imgin->im->array.SI32[ii]));
             }
         }
         else if(datatype == _DATATYPE_INT64)
@@ -1197,8 +1198,8 @@ errno_t arith_image_function_1_1_inplace_byID(imageID ID,
 #endif
             for(ii = 0; ii < nelement; ii++)
             {
-                dcimg[ID].array.F[ii] =
-                    pt2function((double)(dcimg[ID].array.SI64[ii]));
+                imgin->im->array.F[ii] =
+                    pt2function((double)(imgin->im->array.SI64[ii]));
             }
         }
         else if(datatype == _DATATYPE_FLOAT)
@@ -1208,8 +1209,8 @@ errno_t arith_image_function_1_1_inplace_byID(imageID ID,
 #endif
             for(ii = 0; ii < nelement; ii++)
             {
-                dcimg[ID].array.F[ii] =
-                    pt2function((double)(dcimg[ID].array.F[ii]));
+                imgin->im->array.F[ii] =
+                    pt2function((double)(imgin->im->array.F[ii]));
             }
         }
         else if(datatype == _DATATYPE_DOUBLE)
@@ -1219,8 +1220,8 @@ errno_t arith_image_function_1_1_inplace_byID(imageID ID,
 #endif
             for(ii = 0; ii < nelement; ii++)
             {
-                dcimg[ID].array.D[ii] =
-                    (double) pt2function((double)(dcimg[ID].array.D[ii]));
+                imgin->im->array.D[ii] =
+                    (double) pt2function((double)(imgin->im->array.D[ii]));
             }
         }
 
@@ -1228,8 +1229,8 @@ errno_t arith_image_function_1_1_inplace_byID(imageID ID,
     }
 #endif
 
-    dcimg[ID].md[0].write = 0;
-    dcimg[ID].md[0].cnt0++;
+    imgin->im->md->write = 0;
+    imgin->im->md->cnt0++;
 
     return RETURN_SUCCESS;
 }
@@ -1238,150 +1239,11 @@ errno_t arith_image_function_1_1_inplace_byID(imageID ID,
 errno_t arith_image_function_1_1_inplace(const char *ID_name,
         double (*pt2function)(double))
 {
-    imageID ID;
-    long    ii;
-    long    nelement;
-    uint8_t datatype;
-    //, datatypeout;
-
-    // printf("arith_image_function_1_1_inplace\n");
-
-    ID       = image_ID(ID_name, dcimg, dcnimg);
-    datatype = dcimg[ID].md[0].datatype;
-
-    //    datatypeout = _DATATYPE_FLOAT;
-    //    if(datatype == _DATATYPE_DOUBLE)
-    //        datatypeout = _DATATYPE_DOUBLE;
-
-    nelement = dcimg[ID].md[0].nelement;
-
-    dcimg[ID].md[0].write = 0;
-#ifdef _OPENMP
-    #pragma omp parallel if (nelement > OMP_NELEMENT_LIMIT)
-    {
-#endif
-
-        if(datatype == _DATATYPE_UINT8)
-        {
-#ifdef _OPENMP
-            #pragma omp for simd
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                dcimg[ID].array.F[ii] =
-                    pt2function((double)(dcimg[ID].array.UI8[ii]));
-            }
-        }
-        if(datatype == _DATATYPE_UINT16)
-        {
-#ifdef _OPENMP
-            #pragma omp for simd
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                dcimg[ID].array.F[ii] =
-                    pt2function((double)(dcimg[ID].array.UI16[ii]));
-            }
-        }
-        if(datatype == _DATATYPE_UINT32)
-        {
-#ifdef _OPENMP
-            #pragma omp for simd
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                dcimg[ID].array.F[ii] =
-                    pt2function((double)(dcimg[ID].array.UI32[ii]));
-            }
-        }
-        if(datatype == _DATATYPE_UINT64)
-        {
-#ifdef _OPENMP
-            #pragma omp for simd
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                dcimg[ID].array.F[ii] =
-                    pt2function((double)(dcimg[ID].array.UI64[ii]));
-            }
-        }
-
-        if(datatype == _DATATYPE_INT8)
-        {
-#ifdef _OPENMP
-            #pragma omp for simd
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                dcimg[ID].array.F[ii] =
-                    pt2function((double)(dcimg[ID].array.SI8[ii]));
-            }
-        }
-        if(datatype == _DATATYPE_INT16)
-        {
-#ifdef _OPENMP
-            #pragma omp for simd
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                dcimg[ID].array.F[ii] =
-                    pt2function((double)(dcimg[ID].array.SI16[ii]));
-            }
-        }
-        if(datatype == _DATATYPE_INT32)
-        {
-#ifdef _OPENMP
-            #pragma omp for simd
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                dcimg[ID].array.F[ii] =
-                    pt2function((double)(dcimg[ID].array.SI32[ii]));
-            }
-        }
-        if(datatype == _DATATYPE_INT64)
-        {
-#ifdef _OPENMP
-            #pragma omp for simd
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                dcimg[ID].array.F[ii] =
-                    pt2function((double)(dcimg[ID].array.SI64[ii]));
-            }
-        }
-
-        if(datatype == _DATATYPE_FLOAT)
-        {
-#ifdef _OPENMP
-            #pragma omp for simd
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                dcimg[ID].array.F[ii] =
-                    pt2function((double)(dcimg[ID].array.F[ii]));
-            }
-        }
-        if(datatype == _DATATYPE_DOUBLE)
-        {
-#ifdef _OPENMP
-            #pragma omp for simd
-#endif
-            for(ii = 0; ii < nelement; ii++)
-            {
-                dcimg[ID].array.D[ii] =
-                    (double) pt2function((double)(dcimg[ID].array.D[ii]));
-            }
-        }
-
-#ifdef _OPENMP
-    }
-#endif
-
-    dcimg[ID].md[0].write = 0;
-    dcimg[ID].md[0].cnt0++;
-
-    return RETURN_SUCCESS;
+    IMGID img = imgid_make_from_name(ID_name);
+    resolveIMGID(&img, ERRMODE_ABORT, dcimg, dcnimg);
+    errno_t ret = arith_image_function_1_1_inplace_IMGID(&img, pt2function);
+    imgid_free(&img);
+    return ret;
 }
 
 /* ------------------------------------------------------------------------- */
@@ -1835,6 +1697,9 @@ errno_t arith_image_function_CF_CF__CF(
 #ifdef _OPENMP
     }
 #endif
+    imgid_free(&img1);
+    imgid_free(&img2);
+    imgid_free(&imgout);
     return RETURN_SUCCESS;
 }
 
@@ -1894,6 +1759,9 @@ errno_t arith_image_function_CD_CD__CD(
 #ifdef _OPENMP
     }
 #endif
+    imgid_free(&img1);
+    imgid_free(&img2);
+    imgid_free(&imgout);
     return RETURN_SUCCESS;
 }
 
@@ -1977,24 +1845,28 @@ int arith_image_function_1f_1(const char *ID_name, double f1, const char *ID_out
     return ret;
 }
 
-int arith_image_function_1f_1_inplace_byID(long ID, double f1, double (*pt2function)(double, double))
+int arith_image_function_1f_1_inplace_IMGID(IMGID *imgin, double f1, double (*pt2function)(double, double))
 {
-    long ii; uint_fast64_t nelement = dcimg[ID].md[0].nelement;
+    long ii; uint_fast64_t nelement = imgin->im->md[0].nelement;
 #ifdef _OPENMP
     #pragma omp parallel for simd if (nelement > OMP_NELEMENT_LIMIT)
 #endif
     for(ii = 0; ii < nelement; ii++)
     {
-        double v = get_pixel_double(&dcimg[ID], ii);
-        if (dcimg[ID].md[0].datatype == _DATATYPE_FLOAT) dcimg[ID].array.F[ii] = (float)pt2function(v, f1);
-        else if (dcimg[ID].md[0].datatype == _DATATYPE_DOUBLE) dcimg[ID].array.D[ii] = pt2function(v, f1);
+        double v = get_pixel_double(imgin->im, ii);
+        if (imgin->im->md[0].datatype == _DATATYPE_FLOAT) imgin->im->array.F[ii] = (float)pt2function(v, f1);
+        else if (imgin->im->md[0].datatype == _DATATYPE_DOUBLE) imgin->im->array.D[ii] = pt2function(v, f1);
     }
     return EXIT_SUCCESS;
 }
 
 int arith_image_function_1f_1_inplace(const char *ID_name, double f1, double (*pt2function)(double, double))
 {
-    return arith_image_function_1f_1_inplace_byID(image_ID(ID_name, dcimg, dcnimg), f1, pt2function);
+    IMGID img = imgid_make_from_name(ID_name);
+    resolveIMGID(&img, ERRMODE_ABORT, dcimg, dcnimg);
+    int ret = arith_image_function_1f_1_inplace_IMGID(&img, f1, pt2function);
+    imgid_free(&img);
+    return ret;
 }
 
 int arith_image_function_1ff_1_IMGID(IMGID *imgin, double f1, double f2, IMGID *imgout, double (*pt2function)(double, double, double))
@@ -2053,24 +1925,28 @@ int arith_image_function_1ff_1(const char *ID_name, double f1, double f2, const 
     return ret;
 }
 
-int arith_image_function_1ff_1_inplace_byID(long ID, double f1, double f2, double (*pt2function)(double, double, double))
+int arith_image_function_1ff_1_inplace_IMGID(IMGID *imgin, double f1, double f2, double (*pt2function)(double, double, double))
 {
-    long ii; uint_fast64_t nelement = dcimg[ID].md[0].nelement;
+    long ii; uint_fast64_t nelement = imgin->im->md[0].nelement;
 #ifdef _OPENMP
     #pragma omp parallel for simd if (nelement > OMP_NELEMENT_LIMIT)
 #endif
     for(ii = 0; ii < nelement; ii++)
     {
-        double v = get_pixel_double(&dcimg[ID], ii);
-        if (dcimg[ID].md[0].datatype == _DATATYPE_FLOAT) dcimg[ID].array.F[ii] = (float)pt2function(v, f1, f2);
-        else if (dcimg[ID].md[0].datatype == _DATATYPE_DOUBLE) dcimg[ID].array.D[ii] = pt2function(v, f1, f2);
+        double v = get_pixel_double(imgin->im, ii);
+        if (imgin->im->md[0].datatype == _DATATYPE_FLOAT) imgin->im->array.F[ii] = (float)pt2function(v, f1, f2);
+        else if (imgin->im->md[0].datatype == _DATATYPE_DOUBLE) imgin->im->array.D[ii] = pt2function(v, f1, f2);
     }
     return (0);
 }
 
 int arith_image_function_1ff_1_inplace(const char *ID_name, double f1, double f2, double (*pt2function)(double, double, double))
 {
-    return arith_image_function_1ff_1_inplace_byID(image_ID(ID_name, dcimg, dcnimg), f1, f2, pt2function);
+    IMGID img = imgid_make_from_name(ID_name);
+    resolveIMGID(&img, ERRMODE_ABORT, dcimg, dcnimg);
+    int ret = arith_image_function_1ff_1_inplace_IMGID(&img, f1, f2, pt2function);
+    imgid_free(&img);
+    return ret;
 }
 
 /* Specialized optimized arithmetic functions */

--- a/src/coremods/COREMOD_arith/imfunctions.c
+++ b/src/coremods/COREMOD_arith/imfunctions.c
@@ -1697,6 +1697,7 @@ errno_t arith_image_function_CF_CF__CF(
 #ifdef _OPENMP
     }
 #endif
+    RegisterIMGID(&imgout, dcimg, dcnimg);
     imgid_free(&img1);
     imgid_free(&img2);
     imgid_free(&imgout);
@@ -1759,6 +1760,7 @@ errno_t arith_image_function_CD_CD__CD(
 #ifdef _OPENMP
     }
 #endif
+    RegisterIMGID(&imgout, dcimg, dcnimg);
     imgid_free(&img1);
     imgid_free(&img2);
     imgid_free(&imgout);

--- a/src/coremods/COREMOD_arith/imfunctions.h
+++ b/src/coremods/COREMOD_arith/imfunctions.h
@@ -140,9 +140,6 @@ errno_t arith_img_function_2_1(
     double (*pt2function)(double, double)
 );
 
-errno_t arith_image_function_2_1_inplace_IMGID(
-    IMGID *imgin1, IMGID *imgin2, double (*pt2function)(double, double));
-
 errno_t arith_image_function_2_1_inplace(const char *ID_name1,
         const char *ID_name2,
         double (*pt2function)(double, double));

--- a/src/coremods/COREMOD_arith/imfunctions.h
+++ b/src/coremods/COREMOD_arith/imfunctions.h
@@ -105,9 +105,7 @@ errno_t arith_image_function_imdd_im__ddd_d_IMGID(IMGID *imgin,
         IMGID *imgout,
         double (*pt2function)(double, double, double));
 
-errno_t arith_image_function_1_1_byID(imageID ID,
-                                      imageID IDout,
-                                      double (*pt2function)(double));
+
 
 errno_t arith_image_function_1_1(const char *ID_name,
                                  const char *ID_out,
@@ -118,7 +116,7 @@ errno_t arith_image_function_1_1_IMGID(IMGID *imgin,
                                        double (*pt2function)(double));
 
 // imagein -> imagein (in place)
-errno_t arith_image_function_1_1_inplace_byID(imageID ID,
+errno_t arith_image_function_1_1_inplace_IMGID(IMGID *imgin,
         double (*pt2function)(double));
 
 // imagein -> imagein (in place)
@@ -142,8 +140,8 @@ errno_t arith_img_function_2_1(
     double (*pt2function)(double, double)
 );
 
-errno_t arith_image_function_2_1_inplace_byID(
-    imageID ID1, imageID ID2, double (*pt2function)(double, double));
+errno_t arith_image_function_2_1_inplace_IMGID(
+    IMGID *imgin1, IMGID *imgin2, double (*pt2function)(double, double));
 
 errno_t arith_image_function_2_1_inplace(const char *ID_name1,
         const char *ID_name2,
@@ -171,8 +169,8 @@ int arith_image_function_1f_1_IMGID(IMGID *imgin,
                                     IMGID *imgout,
                                     double (*pt2function)(double, double));
 
-int arith_image_function_1f_1_inplace_byID(
-    long ID, double f1, double (*pt2function)(double, double));
+int arith_image_function_1f_1_inplace_IMGID(
+    IMGID *imgin, double f1, double (*pt2function)(double, double));
 
 int arith_image_function_1f_1_inplace(const char *ID_name,
                                       double      f1,
@@ -197,7 +195,7 @@ int arith_image_function_1ff_1_inplace(const char *ID_name,
                                                double,
                                                double));
 
-int arith_image_function_1ff_1_inplace_byID(long   ID,
+int arith_image_function_1ff_1_inplace_IMGID(IMGID *imgin,
         double f1,
         double f2,
         double (*pt2function)(double,

--- a/src/coremods/COREMOD_memory/imageID.h
+++ b/src/coremods/COREMOD_memory/imageID.h
@@ -140,14 +140,22 @@ static inline imageID resolveIMGID(
 
 static inline int imgid_exists(const char *name)
 {
-    if (name == NULL || name[0] == '\0') {
+    if(name == NULL || name[0] == '\0')
+    {
         return 0;
     }
-    IMGID img = imgid_make_from_name(name);
+
+    IMGID img;
+    img.ID        = -1;
+    img.im        = NULL;
+    img.md        = NULL;
+    img.createcnt = 0;
+    strncpy(img.name, name, STRINGMAXLEN_IMAGE_NAME - 1);
+    img.name[STRINGMAXLEN_IMAGE_NAME - 1] = '\0';
+
     resolveIMGID(&img, ERRMODE_NULL, dcimg, dcnimg);
-    int exists = (img.ID != -1);
-    imgid_free(&img);
-    return exists;
+
+    return (img.ID != -1);
 }
 
 

--- a/src/coremods/COREMOD_memory/imageID.h
+++ b/src/coremods/COREMOD_memory/imageID.h
@@ -138,9 +138,17 @@ static inline imageID resolveIMGID(
     return img->ID;
 }
 
-
-
-
+static inline int imgid_exists(const char *name)
+{
+    if (name == NULL || name[0] == '\0') {
+        return 0;
+    }
+    IMGID img = imgid_make_from_name(name);
+    resolveIMGID(&img, ERRMODE_NULL, dcimg, dcnimg);
+    int exists = (img.ID != -1);
+    imgid_free(&img);
+    return exists;
+}
 
 
 static inline IMGID makesetIMGID(CONST_WORD name, imageID ID)


### PR DESCRIPTION
## Summary

Completes the migration of `COREMOD_arith` from the legacy `image_ID()`
slot-index API to the modern `IMGID` framework. All `_byID`-suffixed
arithmetic functions and the `DEFINE_BYID` macro generators have been
deleted; call sites now use `IMGID`-based resolution throughout.

## Changes

### `COREMOD_memory/imageID.h`
- Added `imgid_exists()` fast boolean helper using stack-allocated `IMGID`
  (no heap allocation) for checking stream existence without raw index manipulation

### `COREMOD_arith/execute_arith.c`
- Replaced `image_ID()` existence checks with `imgid_exists()`
- Removed the brittle manual `[...]` bracket-parsing substring hack
  that duplicated `IMGID` stream-modifier logic

### `COREMOD_arith/image_arith__*.c` / `*.h`
- Stripped `DEFINE_BYID` / `DEFINE_INPLACE_BYID` macro generators
  from all five `image_arith__` translation units
- Removed exported `_byID` function declarations from all headers
- Replaced `image_ID()` probing in `image_arith__Cim_Cim__Cim.c`
  with `resolveIMGID()` IMGID resolution

### `COREMOD_arith/imfunctions.c` / `imfunctions.h`
- Renamed `arith_image_function_1_1_inplace_byID()` →
  `arith_image_function_1_1_inplace_IMGID()`
- Renamed `arith_image_function_1f_1_inplace_byID()` →
  `arith_image_function_1f_1_inplace_IMGID()`
- Renamed `arith_image_function_1ff_1_inplace_byID()` →
  `arith_image_function_1ff_1_inplace_IMGID()`
- Replaced all `dcimg[ID]` slot access with `IMGID` pointer
  dereferences inside each renamed function body
- Updated `imfunctions.h` to remove `_byID` declarations and
  orphaned `arith_image_function_2_1_inplace_IMGID` prototype
- Fixed `arith_image_function_CF_CF__CF()`: added `RegisterIMGID()`
  call so newly created complex-float output is tracked in `dcimg`
- Fixed `arith_image_function_CD_CD__CD()`: same fix for the
  complex-double variant — prevents memory leak and untracked output

## Verification

- [x] Full framework build passes (`make -j24`) — zero errors
- [x] 38/38 `ctest` tests pass
- [x] 257/257 CLI robustness tests pass (`tests/cli/run_cli_robustness_tests.sh`)
- [x] `arith.calc` arithmetic expression parsing verified working (no regression)

## Prompt Summary

The user requested deletion of the deprecated `_byID` arithmetic
functions that were kept after the initial `IMGID` migration. The goal
was a hard removal (not deprecation wrappers) to eliminate technical
debt and enforce consistent use of the `IMGID` pipeline across the
entire `COREMOD_arith` module. Follow-up fixes addressed review
feedback: `imgid_exists()` was rewritten to avoid heap allocation, an
orphaned prototype was removed from `imfunctions.h`, and missing
`RegisterIMGID()` registrations were added to the CF and CD complex
arithmetic functions.

## AI Authorship

- **Model**: Antigravity / GitHub Copilot
- **User edits**: None — all changes were generated by the agent