### PR TITLE
feat: add wait_any unified event multiplexing command

### DIFF
--- a/.agents/skills/milk-script-writer/SKILL.md
+++ b/.agents/skills/milk-script-writer/SKILL.md
@@ -364,6 +364,17 @@ proclist                 # List active procs
 proclist --json          # List as JSON array
 ```
 
+### Unified Event Wait
+
+```bash
+# Block until any event fires; $? = event index
+wait_any [-t T] S:stream F:fps.p=v P:proc:STATE
+# Operators: = != >= <=
+wait_any -t 10 S:cam F:dmcomb.gain>=0.5
+wait_any -t -1 P:wfsloop:STOP P:wfsloop:CRASHED
+# $? = 0..N-1 (event), 254 (timeout), 255 (error)
+```
+
 ### I/O
 
 ```bash

--- a/docs/cli/scripting.md
+++ b/docs/cli/scripting.md
@@ -115,6 +115,37 @@ if [ $? -eq 0 ]; then
 fi
 ```
 
+### Unified Event Multiplexing
+
+The `wait_any` command blocks until **any one** of multiple heterogeneous events fires, eliminating polling loops in orchestration scripts:
+
+```bash
+wait_any [-t timeout] event1 [event2] [event3] ...
+```
+
+Each event is a single token with a prefix:
+
+| Prefix | Fires when | Example |
+|--------|------------|---------|
+| `S:<stream>` | Stream `cnt0` changes | `S:wfs_cam` |
+| `F:<fps>.<param><op><val>` | FPS param matches | `F:dmcomb.abort=1` |
+| `P:<proc>:<state>` | Process reaches state | `P:wfsloop:STOP` |
+
+FPS comparison operators: `=`, `!=`, `>=`, `<=`.
+
+The return value `$?` is the 0-based index of the event that fired, `254` on timeout, or `255` on parse error.
+
+```bash
+#!/usr/bin/env milk-cli -s
+# Wait for new frame OR operator abort
+wait_any -t 60 S:wfs_cam F:dmcomb.abort=1
+if [ $? -eq 0 ]; then
+    echo "New frame arrived"
+elif [ $? -eq 1 ]; then
+    echo "Operator requested abort"
+fi
+```
+
 ### FPS Parameter Expansion
 
 You can effortlessly read FPS (Function Processing System) parameters directly into bash variables using the native `@fpsname.param` syntax:

--- a/src/cli/libmilkscript/CLIcore_help_topics.c
+++ b/src/cli/libmilkscript/CLIcore_help_topics.c
@@ -439,6 +439,22 @@ void help_topic_flowcontrol(void)
            C_RST "\n");
     printf("  Waits for stream update then runs cmd\n");
     printf("\n");
+    printf(C_HDR "Unified Event Wait:\n" C_RST);
+    printf("  " C_CMD "wait_any [-t T] "
+           "S:s F:f.p=v P:n:STATE"
+           C_RST "\n");
+    printf("  Block until any event fires; "
+           "returns index as $?\n");
+    printf("  " C_NOTE "S:" C_RST
+           "stream  "
+           C_NOTE "F:" C_RST
+           "fps.param  "
+           C_NOTE "P:" C_RST
+           "proc:state\n");
+    printf("  Comparisons: "
+           C_CMD "= != >= <=" C_RST
+           " (e.g. F:dmcomb.gain>=0.5)\n");
+    printf("\n");
 }
 
 
@@ -601,6 +617,16 @@ void help_topic_milk(void)
            "  Block up to T sec for FPS\n");
     printf("  " C_CMD "on_update <name> { cmd }" C_RST
            "  Trigger on stream write\n");
+    printf("  " C_CMD "wait_any [-t T] events" C_RST
+           "  Multiplex S:/F:/P: events\n");
+    printf("\n");
+    printf(C_HDR "Introspection (JSON):\n" C_RST);
+    printf("  " C_CMD "fpsdump --json <fps>" C_RST
+           "  FPS params as JSON\n");
+    printf("  " C_CMD "streamlist --json   " C_RST
+           "  Streams as JSON\n");
+    printf("  " C_CMD "proclist --json     " C_RST
+           "  Processes as JSON\n");
     printf("\n");
     printf(C_HDR "FPS Parameters:\n" C_RST);
     printf("  " C_CMD "@fpsname.param   " C_RST

--- a/src/cli/libmilkscript/CLIcore_script_intercept.c
+++ b/src/cli/libmilkscript/CLIcore_script_intercept.c
@@ -2948,6 +2948,20 @@ int cli_script_intercept(const char *line)
                 NULL, " \t", &sav);
         }
 
+        /* Detect overflow: loop exited
+         * because nevents hit the cap
+         * but tokens remain */
+        if(tok != NULL)
+        {
+            fprintf(stderr,
+                    "ERROR: wait_any: "
+                    "too many events "
+                    "(max %d)\n",
+                    WA_MAX_EVENTS);
+            cli_last_retval = 255;
+            return 1;
+        }
+
         if(nevents == 0)
         {
             printf("Usage: wait_any "

--- a/src/cli/libmilkscript/CLIcore_script_intercept.c
+++ b/src/cli/libmilkscript/CLIcore_script_intercept.c
@@ -2627,7 +2627,10 @@ int cli_script_intercept(const char *line)
             CMP_GE,
             CMP_LE
         };
-#define WA_MAX_EVENTS 16
+        enum
+        {
+            WA_MAX_EVENTS = 16
+        };
 
         struct wa_event
         {

--- a/src/cli/libmilkscript/CLIcore_script_intercept.c
+++ b/src/cli/libmilkscript/CLIcore_script_intercept.c
@@ -2605,6 +2605,750 @@ int cli_script_intercept(const char *line)
         }
     }
 
+    /* ==============================
+     * wait_any — unified event mux
+     * ============================== */
+
+    if(starts_with(p, "wait_any ")
+       || starts_with(p, "wait_any\t")
+       || strcmp(p, "wait_any") == 0)
+    {
+        /* --- local types --- */
+        enum
+        {
+            WA_STREAM,
+            WA_FPS_PARAM,
+            WA_PROC_STATE
+        };
+        enum
+        {
+            CMP_EQ,
+            CMP_NE,
+            CMP_GE,
+            CMP_LE
+        };
+#define WA_MAX_EVENTS 16
+
+        struct wa_event
+        {
+            int  type;
+            char name[256];
+            /* FPS */
+            char param[256];
+            char target_val[256];
+            int  cmp_op;
+            /* Process */
+            int target_state;
+            /* Runtime handles */
+            IMAGE img;
+            uint64_t start_cnt0;
+            int img_open;
+            FUNCTION_PARAMETER_STRUCT fps;
+            int fps_pindex;
+            int fps_open;
+        };
+
+        struct wa_event events[WA_MAX_EVENTS];
+        int nevents = 0;
+        double timeout = 30.0;
+
+        /* --- parse arguments --- */
+        char argbuf[STRINGMAXLEN_CLICMDLINE];
+        strncpy(argbuf, p,
+                STRINGMAXLEN_CLICMDLINE - 1);
+        argbuf[STRINGMAXLEN_CLICMDLINE - 1]
+            = '\0';
+
+        char *sav = NULL;
+        char *tok = strtok_r(
+            argbuf, " \t", &sav);
+        /* skip "wait_any" */
+        tok = strtok_r(NULL, " \t", &sav);
+
+        while(tok != NULL
+              && nevents < WA_MAX_EVENTS)
+        {
+            /* -t timeout */
+            if(strcmp(tok, "-t") == 0)
+            {
+                tok = strtok_r(
+                    NULL, " \t", &sav);
+                if(tok != NULL)
+                {
+                    timeout =
+                        strtod(tok, NULL);
+                }
+                tok = strtok_r(
+                    NULL, " \t", &sav);
+                continue;
+            }
+
+            struct wa_event *ev =
+                &events[nevents];
+            memset(ev, 0, sizeof(*ev));
+
+            if(strncmp(tok, "S:", 2) == 0)
+            {
+                /* S:<streamname> */
+                ev->type = WA_STREAM;
+                strncpy(ev->name,
+                        tok + 2,
+                        sizeof(ev->name)
+                        - 1);
+                nevents++;
+            }
+            else if(strncmp(tok, "F:", 2)
+                    == 0)
+            {
+                /* F:<fps>.<param><op><val>
+                 * Find first dot after
+                 * prefix for fps.param
+                 * split */
+                ev->type = WA_FPS_PARAM;
+                const char *body =
+                    tok + 2;
+                const char *dot =
+                    strchr(body, '.');
+                if(dot == NULL)
+                {
+                    fprintf(stderr,
+                            "wait_any: "
+                            "bad F: "
+                            "token: %s\n",
+                            tok);
+                    cli_last_retval = 255;
+                    return 1;
+                }
+                /* fps name */
+                int nlen =
+                    (int)(dot - body);
+                if(nlen
+                   >= (int) sizeof(
+                       ev->name))
+                {
+                    nlen =
+                        (int) sizeof(
+                            ev->name)
+                        - 1;
+                }
+                memcpy(ev->name, body,
+                       (size_t) nlen);
+                ev->name[nlen] = '\0';
+
+                /* param<op>val */
+                const char *rest =
+                    dot + 1;
+
+                /* Scan for operator:
+                 * check 2-char first */
+                const char *op_pos = NULL;
+                int op_len = 0;
+                ev->cmp_op = CMP_EQ;
+
+                op_pos =
+                    strstr(rest, ">=");
+                if(op_pos != NULL)
+                {
+                    ev->cmp_op = CMP_GE;
+                    op_len = 2;
+                }
+                if(op_pos == NULL)
+                {
+                    op_pos = strstr(
+                        rest, "<=");
+                    if(op_pos != NULL)
+                    {
+                        ev->cmp_op =
+                            CMP_LE;
+                        op_len = 2;
+                    }
+                }
+                if(op_pos == NULL)
+                {
+                    op_pos = strstr(
+                        rest, "!=");
+                    if(op_pos != NULL)
+                    {
+                        ev->cmp_op =
+                            CMP_NE;
+                        op_len = 2;
+                    }
+                }
+                if(op_pos == NULL)
+                {
+                    op_pos =
+                        strchr(rest, '=');
+                    if(op_pos != NULL)
+                    {
+                        ev->cmp_op =
+                            CMP_EQ;
+                        op_len = 1;
+                    }
+                }
+
+                if(op_pos == NULL)
+                {
+                    fprintf(stderr,
+                            "wait_any: "
+                            "no operator "
+                            "in F: "
+                            "token: %s\n",
+                            tok);
+                    cli_last_retval = 255;
+                    return 1;
+                }
+
+                /* param name */
+                int plen =
+                    (int)(op_pos - rest);
+                if(plen
+                   >= (int) sizeof(
+                       ev->param))
+                {
+                    plen =
+                        (int) sizeof(
+                            ev->param)
+                        - 1;
+                }
+                memcpy(ev->param, rest,
+                       (size_t) plen);
+                ev->param[plen] = '\0';
+
+                /* target value */
+                strncpy(
+                    ev->target_val,
+                    op_pos + op_len,
+                    sizeof(
+                        ev->target_val)
+                    - 1);
+
+                nevents++;
+            }
+            else if(strncmp(tok, "P:", 2)
+                    == 0)
+            {
+                /* P:<name>:<STATE> */
+                ev->type = WA_PROC_STATE;
+                const char *body =
+                    tok + 2;
+                const char *colon =
+                    strchr(body, ':');
+                if(colon == NULL)
+                {
+                    fprintf(stderr,
+                            "wait_any: "
+                            "bad P: "
+                            "token: %s\n",
+                            tok);
+                    cli_last_retval = 255;
+                    return 1;
+                }
+                int nlen =
+                    (int)(colon - body);
+                if(nlen
+                   >= (int) sizeof(
+                       ev->name))
+                {
+                    nlen =
+                        (int) sizeof(
+                            ev->name)
+                        - 1;
+                }
+                memcpy(ev->name, body,
+                       (size_t) nlen);
+                ev->name[nlen] = '\0';
+
+                const char *st =
+                    colon + 1;
+                if(strcasecmp(st,
+                              "INIT")
+                   == 0)
+                {
+                    ev->target_state =
+                        PROCESSINFO_LOOPSTAT_INIT;
+                }
+                else if(strcasecmp(
+                            st,
+                            "ACTIVE")
+                        == 0)
+                {
+                    ev->target_state =
+                        PROCESSINFO_LOOPSTAT_ACTIVE;
+                }
+                else if(strcasecmp(
+                            st, "PAUSE")
+                        == 0)
+                {
+                    ev->target_state =
+                        PROCESSINFO_LOOPSTAT_PAUSE;
+                }
+                else if(strcasecmp(
+                            st, "STOP")
+                        == 0)
+                {
+                    ev->target_state =
+                        PROCESSINFO_LOOPSTAT_STOP;
+                }
+                else if(strcasecmp(
+                            st, "ERROR")
+                        == 0)
+                {
+                    ev->target_state =
+                        PROCESSINFO_LOOPSTAT_ERROR;
+                }
+                else if(strcasecmp(
+                            st, "SPIN")
+                        == 0)
+                {
+                    ev->target_state =
+                        PROCESSINFO_LOOPSTAT_SPIN;
+                }
+                else if(strcasecmp(
+                            st,
+                            "CRASHED")
+                        == 0)
+                {
+                    ev->target_state =
+                        PROCESSINFO_LOOPSTAT_CRASHED;
+                }
+                else
+                {
+                    ev->target_state =
+                        (int) strtol(
+                            st,
+                            NULL,
+                            0);
+                }
+                nevents++;
+            }
+            else
+            {
+                fprintf(stderr,
+                        "wait_any: "
+                        "unknown event "
+                        "prefix: %s\n",
+                        tok);
+                cli_last_retval = 255;
+                return 1;
+            }
+            tok = strtok_r(
+                NULL, " \t", &sav);
+        }
+
+        if(nevents == 0)
+        {
+            printf("Usage: wait_any "
+                   "[-t timeout] "
+                   "S:stream "
+                   "[F:fps.p=v] "
+                   "[P:proc:STATE]\n");
+            cli_last_retval = 255;
+            return 1;
+        }
+
+        /* --- open event handles --- */
+        int any_open = 0;
+        for(int i = 0; i < nevents; i++)
+        {
+            struct wa_event *ev =
+                &events[i];
+            ev->img_open = 0;
+            ev->fps_open = 0;
+
+            if(ev->type == WA_STREAM)
+            {
+                if(ImageStreamIO_read_sharedmem_image_toIMAGE(
+                       ev->name,
+                       &ev->img)
+                   == IMAGESTREAMIO_SUCCESS)
+                {
+                    ev->start_cnt0 =
+                        ev->img.md
+                            ->cnt0;
+                    ev->img_open = 1;
+                    any_open = 1;
+                }
+            }
+            else if(ev->type
+                    == WA_FPS_PARAM)
+            {
+                if(function_parameter_struct_connect(
+                       ev->name,
+                       &ev->fps,
+                       FPSCONNECT_SIMPLE)
+                       != -1
+                   && ev->fps.parray
+                       != NULL)
+                {
+                    ev->fps_pindex =
+                        functionparameter_GetParamIndex(
+                            &ev->fps,
+                            ev->param);
+                    if(ev->fps_pindex
+                       < 0)
+                    {
+                        /* Try with
+                         * leading dot */
+                        char dname[512];
+                        snprintf(
+                            dname,
+                            sizeof(dname),
+                            ".%s",
+                            ev->param);
+                        ev->fps_pindex =
+                            functionparameter_GetParamIndex(
+                                &ev->fps,
+                                dname);
+                    }
+                    if(ev->fps_pindex
+                       >= 0)
+                    {
+                        ev->fps_open = 1;
+                        any_open = 1;
+                    }
+                    else
+                    {
+                        function_parameter_struct_disconnect(
+                            &ev->fps);
+                    }
+                }
+            }
+            else if(ev->type
+                    == WA_PROC_STATE)
+            {
+                /* procstate uses
+                 * global pinfolist;
+                 * always "open" */
+                any_open = 1;
+            }
+        }
+
+        if(!any_open)
+        {
+            fprintf(stderr,
+                    "wait_any: "
+                    "no events could "
+                    "be opened\n");
+            cli_last_retval = 255;
+            goto wa_cleanup;
+        }
+
+        /* --- poll loop --- */
+        {
+            struct timespec ts_start;
+            clock_gettime(
+                CLOCK_MONOTONIC,
+                &ts_start);
+            cli_last_retval = 254;
+
+            while(!cli_break_flag)
+            {
+                for(int i = 0;
+                    i < nevents; i++)
+                {
+                    struct wa_event *ev =
+                        &events[i];
+                    int fired = 0;
+
+                    if(ev->type
+                           == WA_STREAM
+                       && ev->img_open)
+                    {
+                        if(ev->img.md
+                               ->cnt0
+                           != ev
+                               ->start_cnt0)
+                        {
+                            fired = 1;
+                        }
+                    }
+                    else if(
+                        ev->type
+                            == WA_FPS_PARAM
+                        && ev->fps_open)
+                    {
+                        char vstr[512];
+                        functionparameter_GetParamValueString(
+                            &ev->fps
+                                 .parray
+                                     [ev->fps_pindex],
+                            vstr,
+                            sizeof(vstr));
+
+                        switch(
+                            ev->cmp_op)
+                        {
+                        case CMP_EQ:
+                        {
+                            if(strcmp(
+                                   vstr,
+                                   ev->target_val)
+                               == 0)
+                            {
+                                fired = 1;
+                                break;
+                            }
+                            char *e1 =
+                                NULL;
+                            char *e2 =
+                                NULL;
+                            double d1 =
+                                strtod(
+                                    vstr,
+                                    &e1);
+                            double d2 =
+                                strtod(
+                                    ev->target_val,
+                                    &e2);
+                            if(e1 != vstr
+                               && *e1
+                                   == '\0'
+                               && e2
+                                   != ev
+                                       ->target_val
+                               && *e2
+                                   == '\0'
+                               && d1
+                                   == d2)
+                            {
+                                fired = 1;
+                            }
+                        }
+                        break;
+                        case CMP_NE:
+                        {
+                            int eq = 0;
+                            if(strcmp(
+                                   vstr,
+                                   ev->target_val)
+                               == 0)
+                            {
+                                eq = 1;
+                            }
+                            else
+                            {
+                                char *e1 =
+                                    NULL;
+                                char *e2 =
+                                    NULL;
+                                double d1 =
+                                    strtod(
+                                        vstr, &e1);
+                                double d2 =
+                                    strtod(
+                                        ev->target_val,
+                                        &e2);
+                                if(e1
+                                       != vstr
+                                   && *e1
+                                       == '\0'
+                                   && e2
+                                       != ev
+                                           ->target_val
+                                   && *e2
+                                       == '\0'
+                                   && d1
+                                       == d2)
+                                {
+                                    eq = 1;
+                                }
+                            }
+                            if(!eq)
+                            {
+                                fired = 1;
+                            }
+                        }
+                        break;
+                        case CMP_GE:
+                        case CMP_LE:
+                        {
+                            char *e1 =
+                                NULL;
+                            char *e2 =
+                                NULL;
+                            double d1 =
+                                strtod(
+                                    vstr,
+                                    &e1);
+                            double d2 =
+                                strtod(
+                                    ev->target_val,
+                                    &e2);
+                            if(e1 != vstr
+                               && *e1
+                                   == '\0'
+                               && e2
+                                   != ev
+                                       ->target_val
+                               && *e2
+                                   == '\0')
+                            {
+                                if(ev->cmp_op
+                                       == CMP_GE
+                                   && d1
+                                       >= d2)
+                                {
+                                    fired
+                                        = 1;
+                                }
+                                if(ev->cmp_op
+                                       == CMP_LE
+                                   && d1
+                                       <= d2)
+                                {
+                                    fired
+                                        = 1;
+                                }
+                            }
+                        }
+                        break;
+                        }
+                    }
+                    else if(
+                        ev->type
+                        == WA_PROC_STATE)
+                    {
+                        if(pinfolist
+                           != NULL)
+                        {
+                            for(int pi =
+                                    0;
+                                pi
+                                < PROCESSINFOLISTSIZE;
+                                pi++)
+                            {
+                                if(!pinfolist
+                                    ->active
+                                        [pi])
+                                {
+                                    continue;
+                                }
+                                if(strcmp(
+                                       pinfolist
+                                           ->pnamearray
+                                               [pi],
+                                       ev->name)
+                                   != 0)
+                                {
+                                    continue;
+                                }
+                                pid_t fpid =
+                                    pinfolist
+                                        ->PIDarray
+                                            [pi];
+                                char pfn
+                                    [512];
+                                char pdname
+                                    [256];
+                                processinfo_procdirname(
+                                    pdname);
+                                snprintf(
+                                    pfn,
+                                    sizeof(
+                                        pfn),
+                                    "%s/"
+                                    "proc."
+                                    "%d"
+                                    ".shm",
+                                    pdname,
+                                    (int)
+                                        fpid);
+                                int pfd =
+                                    -1;
+                                PROCESSINFO
+                                    *pii =
+                                    processinfo_shm_link(
+                                        pfn,
+                                        &pfd);
+                                if(pii
+                                       != MAP_FAILED
+                                   && pii
+                                       != NULL)
+                                {
+                                    if(pii
+                                        ->loopstat
+                                       == ev
+                                           ->target_state)
+                                    {
+                                        fired
+                                            = 1;
+                                    }
+                                    munmap(
+                                        pii,
+                                        sizeof(
+                                            PROCESSINFO));
+                                    close(
+                                        pfd);
+                                }
+                                else if(
+                                    pfd
+                                    >= 0)
+                                {
+                                    close(
+                                        pfd);
+                                }
+                                break;
+                            }
+                        }
+                    }
+
+                    if(fired)
+                    {
+                        cli_last_retval
+                            = i;
+                        goto wa_cleanup;
+                    }
+                }
+
+                /* Timeout check */
+                if(timeout >= 0.0)
+                {
+                    struct timespec
+                        ts_now;
+                    clock_gettime(
+                        CLOCK_MONOTONIC,
+                        &ts_now);
+                    double elapsed =
+                        (double)(
+                            ts_now.tv_sec
+                            - ts_start
+                                .tv_sec)
+                        + 1e-9
+                        * (double)(
+                            ts_now
+                                .tv_nsec
+                            - ts_start
+                                .tv_nsec);
+                    if(elapsed
+                       >= timeout)
+                    {
+                        cli_last_retval
+                            = 254;
+                        goto wa_cleanup;
+                    }
+                }
+                usleep(1000);
+            }
+        }
+
+wa_cleanup:
+        /* --- close handles --- */
+        for(int i = 0; i < nevents; i++)
+        {
+            if(events[i].img_open)
+            {
+                ImageStreamIO_closeIm(
+                    &events[i].img);
+            }
+            if(events[i].fps_open)
+            {
+                function_parameter_struct_disconnect(
+                    &events[i].fps);
+            }
+        }
+        return 1;
+    }
+
     /* [[ expr ]] — extended test */
     if(starts_with(p, "[[ "))
     {

--- a/src/cli/libmilkscript/CLIcore_script_intercept.c
+++ b/src/cli/libmilkscript/CLIcore_script_intercept.c
@@ -2676,11 +2676,21 @@ int cli_script_intercept(const char *line)
             {
                 tok = strtok_r(
                     NULL, " \t", &sav);
-                if(tok != NULL)
+                if(tok == NULL)
                 {
-                    timeout =
-                        strtod(tok, NULL);
+                    fprintf(stderr,
+                            "ERROR: wait_any: "
+                            "missing timeout "
+                            "value after -t\n");
+                    fprintf(stderr,
+                            "USAGE: wait_any "
+                            "[-t timeout] "
+                            "<events...>\n");
+                    return 255;
                 }
+
+                timeout =
+                    strtod(tok, NULL);
                 tok = strtok_r(
                     NULL, " \t", &sav);
                 continue;


### PR DESCRIPTION
## Summary

Adds `wait_any` to the milk-cli scripting engine — a unified command that blocks until **any one** of multiple heterogeneous engine events fires, replacing polling loops in orchestration scripts.

### Syntax
```bash
wait_any [-t timeout] S:stream F:fps.param<op>val P:proc:STATE
```

### Event types
| Prefix | Fires when | Example |
|--------|-----------|---------|
| `S:<name>` | Stream `cnt0` changes | `S:wfs_cam` |
| `F:<fps>.<p><op><v>` | FPS param comparison | `F:dmcomb.gain>=0.5` |
| `P:<name>:<state>` | Process reaches target loopstat | `P:wfsloop:STOP` |

FPS comparison operators: `=`, `!=`, `>=`, `<=`.

### Return value (`$?`)
- `0..N-1` — index of the event that fired
- `254` — timeout
- `255` — parse error or no events could be opened

### Example
```bash
wait_any -t 60 S:wfs_cam F:dmcomb.abort=1
if [ $? -eq 0 ]; then
    echo "New frame arrived"
elif [ $? -eq 1 ]; then
    echo "Operator requested abort"
fi
```

## Changes

### `CLIcore_script_intercept.c` — core `wait_any` implementation

- New `wait_any` built-in: argument parsing, resource handle setup, polling loop, and return codes.
- `-t` without a following value is now a parse error (returns 255 with usage message) rather than silently continuing.
- Supplying more than `WA_MAX_EVENTS` (16) event tokens is now a parse error: the parser detects overflow after the loop (`tok != NULL` when `nevents == WA_MAX_EVENTS`) and returns 255 with the message `ERROR: wait_any: too many events (max 16)`.
- `WA_MAX_EVENTS` is defined as a block-scoped `enum` constant rather than a file-scoped `#define` to avoid macro name leakage.

### `CLIcore_help_topics.c`

- `wait_any` added to `help-flowcontrol` and `help-milk` topics.

### `docs/cli/scripting.md`

- New "Unified Event Multiplexing" section documenting `wait_any` usage, token formats, and return codes.

### `.agents/skills/milk-script-writer/SKILL.md`

- Quick-reference entry added for script authors.

## Verification

- [ ] Build passes (`/compile-test`)
- [ ] Tests pass (`ctest --output-on-failure`)
- [ ] CLI robustness tests pass (if CLI changed)
- [ ] Documentation updated (README, help, docs/)

## Prompt Summary

User requested Phase 2 of the CLI integration enhancement roadmap: a unified event multiplexing command (`wait_any`) that combines functionality from the existing single-resource wait primitives (`wait -S`, `wait -F`, `procwait`) into one command capable of blocking on multiple events simultaneously. Prefix-token syntax (`S:`, `F:`, `P:`) was chosen over flag-based syntax for unambiguous multi-event parsing. Follow-up feedback requested stricter argument parsing: overflow beyond `WA_MAX_EVENTS` tokens now returns a clear error instead of silently truncating.

## AI Authorship

- **Model:** Antigravity / Copilot
- **User edits:** None — all code authored by agent