### PR TITLE
feat: add fpslist --json and milkquery unified introspection

### DIFF
--- a/.agents/skills/milk-script-writer/SKILL.md
+++ b/.agents/skills/milk-script-writer/SKILL.md
@@ -316,6 +316,8 @@ Params: `$1`..`$9`, `shift [N]`,
 fpsset fpsname param val # Write (command)
 fpsdump fpsname          # Dump all params
 fpsdump --json fpsname   # Dump as JSON object
+fpslist                  # List FPS instances
+fpslist --json           # List as JSON array
 waitfor_fps name 10      # Wait up to 10s
 wait -F name p=v 5       # Wait for param=val
 ```
@@ -373,6 +375,15 @@ wait_any [-t T] S:stream F:fps.p=v P:proc:STATE
 wait_any -t 10 S:cam F:dmcomb.gain>=0.5
 wait_any -t -1 P:wfsloop:STOP P:wfsloop:CRASHED
 # $? = 0..N-1 (event), 254 (timeout), 255 (error)
+```
+
+### System Snapshot
+
+```bash
+milkquery                    # Full JSON snapshot
+milkquery --fps [pattern]    # FPS only
+milkquery --streams [pat]    # Streams only
+milkquery --procs            # Processes only
 ```
 
 ### I/O

--- a/docs/cli/scripting.md
+++ b/docs/cli/scripting.md
@@ -146,6 +146,27 @@ elif [ $? -eq 1 ]; then
 fi
 ```
 
+### System Snapshot (`milkquery`)
+
+The `milkquery` command emits a unified JSON object containing FPS instances, shared-memory streams, and active processes in one call:
+
+```bash
+milkquery                     # Full snapshot
+milkquery --fps [pattern]     # FPS instances only
+milkquery --streams [pattern] # Streams only
+milkquery --procs             # Active processes only
+```
+
+Output is a JSON object with top-level keys `"fps"`, `"streams"`, and `"processes"`, each containing an array of entries. When a filter flag is used, only the requested section(s) appear.
+
+Individual list commands also support `--json`:
+
+```bash
+fpslist --json [pattern]      # Same as milkquery --fps
+streamlist --json [pattern]   # Same as milkquery --streams
+proclist --json               # Same as milkquery --procs
+```
+
 ### FPS Parameter Expansion
 
 You can effortlessly read FPS (Function Processing System) parameters directly into bash variables using the native `@fpsname.param` syntax:

--- a/src/cli/CLIcore/CLIcore.c
+++ b/src/cli/CLIcore/CLIcore.c
@@ -1731,8 +1731,8 @@ void runCLI_cmd_init()
         __FILE__,
         cli_cmd_fpslist,
         "list live FPS instances",
-        "[pattern]",
-        "fpslist dm*",
+        "[--json] [pattern]",
+        "fpslist --json dm*",
         "cli_cmd_fpslist()");
 
     RegisterCLIcommand(
@@ -1761,6 +1761,16 @@ void runCLI_cmd_init()
         "[-l] [--json]",
         "proclist -l",
         "cli_cmd_proclist()");
+
+    RegisterCLIcommand(
+        "milkquery",
+        __FILE__,
+        cli_cmd_milkquery,
+        "unified JSON system snapshot",
+        "[--fps [pat]] [--streams [pat]]"
+        " [--procs]",
+        "milkquery --fps dm*",
+        "cli_cmd_milkquery()");
 
     RegisterCLIcommand(
         "defer",

--- a/src/cli/libmilkscript/CLIcore_help_topics.c
+++ b/src/cli/libmilkscript/CLIcore_help_topics.c
@@ -623,10 +623,14 @@ void help_topic_milk(void)
     printf(C_HDR "Introspection (JSON):\n" C_RST);
     printf("  " C_CMD "fpsdump --json <fps>" C_RST
            "  FPS params as JSON\n");
+    printf("  " C_CMD "fpslist --json      " C_RST
+           "  FPS instances as JSON\n");
     printf("  " C_CMD "streamlist --json   " C_RST
            "  Streams as JSON\n");
     printf("  " C_CMD "proclist --json     " C_RST
            "  Processes as JSON\n");
+    printf("  " C_CMD "milkquery           " C_RST
+           "  Unified system snapshot\n");
     printf("\n");
     printf(C_HDR "FPS Parameters:\n" C_RST);
     printf("  " C_CMD "@fpsname.param   " C_RST

--- a/src/cli/libmilkscript/CLIcore_script.h
+++ b/src/cli/libmilkscript/CLIcore_script.h
@@ -153,6 +153,9 @@ errno_t cli_cmd_streamlist(void);
 /** proclist — list active processes */
 errno_t cli_cmd_proclist(void);
 
+/** milkquery — unified JSON system snapshot */
+errno_t cli_cmd_milkquery(void);
+
 /** defer — push cleanup command to stack */
 errno_t cli_cmd_defer(void);
 

--- a/src/cli/libmilkscript/CLIcore_script_builtin.c
+++ b/src/cli/libmilkscript/CLIcore_script_builtin.c
@@ -817,6 +817,11 @@ errno_t cli_cmd_printf(void)
 #include "fps_disconnect.h"
 #include "fps_shmdirname.h"
 
+/* Forward declaration — defined below in the
+ * JSON helpers section */
+static void json_escape_str(
+    char *buf, size_t bufsz, const char *src);
+
 /**
  * @brief fpslist command — list live FPS instances
  *
@@ -824,28 +829,164 @@ errno_t cli_cmd_printf(void)
  * connects to each, and prints a summary table
  * showing name, status and description.
  *
- * Usage: fpslist [pattern]
+ * Usage: fpslist [--json] [pattern]
+ *   --json  JSON array of FPS metadata
  *
  * An optional glob pattern (e.g. "dm*") limits
  * output to matching FPS names.
  */
-errno_t cli_cmd_fpslist(void)
+
+/**
+ * emit_fps_json_body - emit FPS entries as JSON
+ * @pat:    optional glob pattern (NULL = all)
+ * @indent: number of spaces for indentation
+ *
+ * Emits the JSON array body (without outer [ ])
+ * for all matching FPS instances. Used by both
+ * fpslist --json and milkquery.
+ *
+ * Returns the number of entries emitted.
+ */
+static int emit_fps_json_body(
+    const char *pat, int indent)
 {
     char shmdname[STRINGMAXLEN_SHMDIRNAME];
     function_parameter_struct_shmdirname(
         shmdname);
 
-    /* Optional glob pattern from $1
-     * (cmdNBarg includes the command itself,
-     *  so >= 2 means one argument was given) */
-    const char *pat = NULL;
-    if(data.cmdNBarg >= 2)
+    DIR *d = opendir(shmdname);
+    if(d == NULL)
     {
-        pat =
-            data.cmdargtoken[1].val.string;
+        return 0;
     }
 
-    /* Header */
+    char pad[32];
+    {
+        int n = indent;
+        if(n >= (int) sizeof(pad))
+        {
+            n = (int) sizeof(pad) - 1;
+        }
+        memset(pad, ' ', (size_t) n);
+        pad[n] = '\0';
+    }
+
+    int count = 0;
+    struct dirent *de;
+    while((de = readdir(d)) != NULL)
+    {
+        char *sfx = strstr(de->d_name,
+                           ".fps.shm");
+        if(sfx == NULL)
+        {
+            continue;
+        }
+
+        char fpsname[STRINGMAXLEN_FPS_NAME];
+        size_t nlen = (size_t)(sfx
+                               - de->d_name);
+        if(nlen >= sizeof(fpsname))
+        {
+            continue;
+        }
+        strncpy(fpsname, de->d_name, nlen);
+        fpsname[nlen] = '\0';
+
+        if(pat != NULL
+           && fnmatch(pat, fpsname, 0) != 0)
+        {
+            continue;
+        }
+
+        FUNCTION_PARAMETER_STRUCT fps;
+        fps.SMfd = -1;
+        int rc =
+            function_parameter_struct_connect(
+                fpsname, &fps,
+                FPSCONNECT_SIMPLE);
+        if(rc == -1 || fps.md == NULL)
+        {
+            continue;
+        }
+
+        uint32_t st = fps.md->status;
+        const char *ststr = "IDLE";
+        if(st
+           & FUNCTION_PARAMETER_STRUCT_STATUS_RUN)
+        {
+            ststr = "RUN";
+        }
+        else if(
+            st
+            & FUNCTION_PARAMETER_STRUCT_STATUS_CONF)
+        {
+            ststr = "CONF_ON";
+        }
+
+        char nesc[STRINGMAXLEN_FPS_NAME];
+        char desc_esc[512];
+        json_escape_str(nesc,
+                        sizeof(nesc),
+                        fpsname);
+        json_escape_str(desc_esc,
+                        sizeof(desc_esc),
+                        fps.md->description);
+
+        if(count > 0)
+        {
+            printf(",\n");
+        }
+        printf("%s{\n", pad);
+        printf("%s  \"name\": \"%s\",\n",
+               pad, nesc);
+        printf("%s  \"status\": \"%s\",\n",
+               pad, ststr);
+        printf("%s  \"description\": \"%s\"\n",
+               pad, desc_esc);
+        printf("%s}", pad);
+
+        count++;
+
+        function_parameter_struct_disconnect(
+            &fps);
+    }
+    closedir(d);
+    return count;
+}
+
+
+errno_t cli_cmd_fpslist(void)
+{
+    int jsonmode = 0;
+    const char *pat = NULL;
+
+    for(int a = 1; a < data.cmdNBarg; a++)
+    {
+        const char *tok =
+            data.cmdargtoken[a].val.string;
+        if(strcmp(tok, "--json") == 0)
+        {
+            jsonmode = 1;
+        }
+        else
+        {
+            pat = tok;
+        }
+    }
+
+    if(jsonmode)
+    {
+        printf("[\n");
+        emit_fps_json_body(pat, 2);
+        printf("\n]\n");
+        return RETURN_SUCCESS;
+    }
+
+    /* Table mode (default) */
+    char shmdname[STRINGMAXLEN_SHMDIRNAME];
+    function_parameter_struct_shmdirname(
+        shmdname);
+
     printf("%-24s %-12s %s\n",
            "FPS NAME", "STATUS",
            "DESCRIPTION");
@@ -867,7 +1008,6 @@ errno_t cli_cmd_fpslist(void)
 
     while((de = readdir(d)) != NULL)
     {
-        /* Only process *.fps.shm files */
         char *sfx = strstr(de->d_name,
                            ".fps.shm");
         if(sfx == NULL)
@@ -875,7 +1015,6 @@ errno_t cli_cmd_fpslist(void)
             continue;
         }
 
-        /* Extract FPS name */
         char fpsname[STRINGMAXLEN_FPS_NAME];
         size_t nlen = (size_t)(sfx
                                - de->d_name);
@@ -886,14 +1025,12 @@ errno_t cli_cmd_fpslist(void)
         strncpy(fpsname, de->d_name, nlen);
         fpsname[nlen] = '\0';
 
-        /* Apply glob filter when provided */
         if(pat != NULL
            && fnmatch(pat, fpsname, 0) != 0)
         {
             continue;
         }
 
-        /* Connect to FPS */
         FUNCTION_PARAMETER_STRUCT fps;
         fps.SMfd = -1;
         int rc =
@@ -908,17 +1045,17 @@ errno_t cli_cmd_fpslist(void)
             continue;
         }
 
-        /* Build status string */
         uint32_t st = fps.md->status;
-        /* longest value: "CONF_ON\0" = 8 */
         char ststr[16];
-        if(st & FUNCTION_PARAMETER_STRUCT_STATUS_RUN)
+        if(st
+           & FUNCTION_PARAMETER_STRUCT_STATUS_RUN)
         {
             strncpy(ststr, "RUN",
                     sizeof(ststr) - 1);
         }
-        else if(st
-                & FUNCTION_PARAMETER_STRUCT_STATUS_CONF)
+        else if(
+            st
+            & FUNCTION_PARAMETER_STRUCT_STATUS_CONF)
         {
             strncpy(ststr, "CONF_ON",
                     sizeof(ststr) - 1);
@@ -1589,6 +1726,356 @@ errno_t cli_cmd_proclist(void)
 
     if(jsonmode) { printf("\n]\n"); }
 
+    return RETURN_SUCCESS;
+}
+
+/* ============================================================
+ *  JSON body helpers for milkquery
+ * ============================================================
+ */
+
+/**
+ * emit_streams_json_body - emit stream entries
+ * @pat:    optional glob pattern (NULL = all)
+ * @indent: indentation spaces
+ *
+ * Returns number of entries emitted.
+ */
+static int emit_streams_json_body(
+    const char *pat, int indent)
+{
+    char pad[32];
+    {
+        int n = indent;
+        if(n >= (int) sizeof(pad))
+        {
+            n = (int) sizeof(pad) - 1;
+        }
+        memset(pad, ' ', (size_t) n);
+        pad[n] = '\0';
+    }
+
+    DIR *d = opendir(dcshmdir);
+    if(d == NULL)
+    {
+        return 0;
+    }
+
+    int count = 0;
+    struct dirent *de;
+    while((de = readdir(d)) != NULL)
+    {
+        char *sfx = strstr(de->d_name,
+                           ".im.shm");
+        if(sfx == NULL)
+        {
+            continue;
+        }
+        if(strstr(de->d_name,
+                  ".fps.shm") != NULL)
+        {
+            continue;
+        }
+
+        char sname[256];
+        size_t nlen = (size_t)(sfx
+                               - de->d_name);
+        if(nlen >= sizeof(sname))
+        {
+            continue;
+        }
+        strncpy(sname, de->d_name, nlen);
+        sname[nlen] = '\0';
+
+        if(pat != NULL
+           && fnmatch(pat, sname, 0) != 0)
+        {
+            continue;
+        }
+
+        IMAGE img;
+        memset(&img, 0, sizeof(IMAGE));
+        errno_t sret =
+            ImageStreamIO_openIm(&img, sname);
+        if(sret != IMAGESTREAMIO_SUCCESS
+           || img.md == NULL)
+        {
+            continue;
+        }
+
+        char nesc[256];
+        char tesc[64];
+        json_escape_str(nesc,
+                        sizeof(nesc), sname);
+        json_escape_str(tesc,
+                        sizeof(tesc),
+                        ImageStreamIO_typename(
+                            img.md->datatype));
+
+        if(count > 0)
+        {
+            printf(",\n");
+        }
+        printf("%s{\n", pad);
+        printf("%s  \"name\": \"%s\",\n",
+               pad, nesc);
+        printf("%s  \"naxis\": %u,\n",
+               pad, img.md->naxis);
+        printf("%s  \"size\": [", pad);
+        for(int ax = 0;
+            ax < img.md->naxis; ax++)
+        {
+            if(ax > 0)
+            {
+                printf(", ");
+            }
+            printf("%u", img.md->size[ax]);
+        }
+        printf("],\n");
+        printf("%s  \"type\": \"%s\",\n",
+               pad, tesc);
+        printf("%s  \"cnt0\": %lu\n",
+               pad,
+               (unsigned long) img.md->cnt0);
+        printf("%s}", pad);
+
+        count++;
+        ImageStreamIO_closeIm(&img);
+    }
+    closedir(d);
+    return count;
+}
+
+/**
+ * emit_procs_json_body - emit process entries
+ * @indent: indentation spaces
+ *
+ * Returns number of entries emitted.
+ */
+static int emit_procs_json_body(int indent)
+{
+    if(pinfolist == NULL)
+    {
+        return 0;
+    }
+
+    char pad[32];
+    {
+        int n = indent;
+        if(n >= (int) sizeof(pad))
+        {
+            n = (int) sizeof(pad) - 1;
+        }
+        memset(pad, ' ', (size_t) n);
+        pad[n] = '\0';
+    }
+
+    int count = 0;
+    for(int pi = 0;
+        pi < PROCESSINFOLISTSIZE; pi++)
+    {
+        if(!pinfolist->active[pi])
+        {
+            continue;
+        }
+
+        pid_t fpid =
+            pinfolist->PIDarray[pi];
+        const char *state = "UNKNOWN";
+        double freq = 0.0;
+
+        if(fpid > 0)
+        {
+            char pfn[512];
+            char pdname[256];
+            processinfo_procdirname(pdname);
+            snprintf(pfn, sizeof(pfn),
+                     "%s/proc.%d.shm",
+                     pdname, (int) fpid);
+            int pfd = -1;
+            PROCESSINFO *pi_shm =
+                processinfo_shm_link(
+                    pfn, &pfd);
+            if(pi_shm != MAP_FAILED
+               && pi_shm != NULL)
+            {
+                switch(pi_shm->CTRLval)
+                {
+                case PROCESSINFO_CTRLVAL_RUN:
+                    state = "ACTIVE";
+                    break;
+                case PROCESSINFO_CTRLVAL_PAUSE:
+                    state = "PAUSED";
+                    break;
+                case PROCESSINFO_CTRLVAL_EXIT:
+                    state = "STOPPED";
+                    break;
+                default:
+                    state = "OTHER";
+                    break;
+                }
+                if(pi_shm
+                       ->dtmedian_iter_ns
+                   > 0)
+                {
+                    freq =
+                        1.0e9
+                        / (double) pi_shm
+                              ->dtmedian_iter_ns;
+                }
+                munmap(pi_shm,
+                       sizeof(PROCESSINFO));
+                close(pfd);
+            }
+            else if(pfd >= 0)
+            {
+                close(pfd);
+            }
+        }
+
+        char nesc[256];
+        char sesc[64];
+        json_escape_str(nesc,
+                        sizeof(nesc),
+                        pinfolist
+                            ->pnamearray[pi]);
+        json_escape_str(sesc,
+                        sizeof(sesc), state);
+
+        if(count > 0)
+        {
+            printf(",\n");
+        }
+        printf("%s{\n", pad);
+        printf("%s  \"name\": \"%s\",\n",
+               pad, nesc);
+        printf("%s  \"state\": \"%s\",\n",
+               pad, sesc);
+        printf("%s  \"pid\": %d,\n",
+               pad, (int) fpid);
+        printf("%s  \"freq_hz\": %g\n",
+               pad, freq);
+        printf("%s}", pad);
+        count++;
+    }
+    return count;
+}
+
+
+/* ============================================================
+ *  milkquery — unified system snapshot
+ * ============================================================
+ */
+
+/**
+ * @brief milkquery — unified JSON snapshot
+ *
+ * Emits a single JSON object containing FPS,
+ * stream, and process arrays.
+ *
+ * Usage: milkquery [--fps [pat]]
+ *                  [--streams [pat]]
+ *                  [--procs]
+ *
+ * With no flags, all three sections are emitted.
+ */
+errno_t cli_cmd_milkquery(void)
+{
+    int do_fps = 0;
+    int do_streams = 0;
+    int do_procs = 0;
+    const char *fps_pat = NULL;
+    const char *stream_pat = NULL;
+
+    /* Parse flags */
+    for(int a = 1; a < data.cmdNBarg; a++)
+    {
+        const char *tok =
+            data.cmdargtoken[a].val.string;
+        if(strcmp(tok, "--fps") == 0)
+        {
+            do_fps = 1;
+            /* Next arg might be pattern */
+            if(a + 1 < data.cmdNBarg
+               && data.cmdargtoken[a + 1]
+                          .val.string[0]
+                      != '-')
+            {
+                fps_pat =
+                    data.cmdargtoken[a + 1]
+                        .val.string;
+                a++;
+            }
+        }
+        else if(strcmp(tok, "--streams") == 0)
+        {
+            do_streams = 1;
+            if(a + 1 < data.cmdNBarg
+               && data.cmdargtoken[a + 1]
+                          .val.string[0]
+                      != '-')
+            {
+                stream_pat =
+                    data.cmdargtoken[a + 1]
+                        .val.string;
+                a++;
+            }
+        }
+        else if(strcmp(tok, "--procs") == 0)
+        {
+            do_procs = 1;
+        }
+    }
+
+    /* Default: all sections */
+    if(!do_fps && !do_streams && !do_procs)
+    {
+        do_fps = 1;
+        do_streams = 1;
+        do_procs = 1;
+    }
+
+    printf("{\n");
+    int need_comma = 0;
+
+    if(do_fps)
+    {
+        if(need_comma)
+        {
+            printf(",\n");
+        }
+        printf("  \"fps\": [\n");
+        emit_fps_json_body(fps_pat, 4);
+        printf("\n  ]");
+        need_comma = 1;
+    }
+
+    if(do_streams)
+    {
+        if(need_comma)
+        {
+            printf(",\n");
+        }
+        printf("  \"streams\": [\n");
+        emit_streams_json_body(
+            stream_pat, 4);
+        printf("\n  ]");
+        need_comma = 1;
+    }
+
+    if(do_procs)
+    {
+        if(need_comma)
+        {
+            printf(",\n");
+        }
+        printf("  \"processes\": [\n");
+        emit_procs_json_body(4);
+        printf("\n  ]");
+        need_comma = 1;
+    }
+
+    printf("\n}\n");
     return RETURN_SUCCESS;
 }
 

--- a/src/cli/libmilkscript/CLIcore_script_builtin.c
+++ b/src/cli/libmilkscript/CLIcore_script_builtin.c
@@ -2031,6 +2031,18 @@ errno_t cli_cmd_milkquery(void)
         {
             do_procs = 1;
         }
+        else
+        {
+            fprintf(
+                stderr,
+                "milkquery: unknown argument '%s'\n",
+                tok);
+            fprintf(
+                stderr,
+                "usage: milkquery [--fps [pattern]]"
+                " [--streams [pattern]] [--procs]\n");
+            return RETURN_FAILURE;
+        }
     }
 
     /* Default: all sections */

--- a/src/cli/libmilkscript/CLIcore_script_builtin.c
+++ b/src/cli/libmilkscript/CLIcore_script_builtin.c
@@ -1805,12 +1805,18 @@ static int emit_streams_json_body(
 
         char nesc[256];
         char tesc[64];
+        const char *dtype_name =
+            ImageStreamIO_typename(
+                img.md->datatype);
+        if(dtype_name == NULL)
+        {
+            dtype_name = "?";
+        }
         json_escape_str(nesc,
                         sizeof(nesc), sname);
         json_escape_str(tesc,
                         sizeof(tesc),
-                        ImageStreamIO_typename(
-                            img.md->datatype));
+                        dtype_name);
 
         if(count > 0)
         {

--- a/src/cli/libmilkscript/CLIcore_script_builtin.c
+++ b/src/cli/libmilkscript/CLIcore_script_builtin.c
@@ -912,15 +912,15 @@ static int emit_fps_json_body(
         uint32_t st = fps.md->status;
         const char *ststr = "IDLE";
         if(st
-           & FUNCTION_PARAMETER_STRUCT_STATUS_RUN)
+           & FUNCTION_PARAMETER_STRUCT_STATUS_CONF)
         {
-            ststr = "RUN";
+            ststr = "CONF_ON";
         }
         else if(
             st
-            & FUNCTION_PARAMETER_STRUCT_STATUS_CONF)
+            & FUNCTION_PARAMETER_STRUCT_STATUS_RUN)
         {
-            ststr = "CONF_ON";
+            ststr = "RUN";
         }
 
         char nesc[STRINGMAXLEN_FPS_NAME];

--- a/tests/cli/cli_robustness_tests.milk
+++ b/tests/cli/cli_robustness_tests.milk
@@ -1661,3 +1661,39 @@ proclist --json
 #DESC: proclist with -l and --json
 #EXPECT:OK
 proclist -l --json
+
+#DESC: fpslist --json (no FPS required)
+#EXPECT:OK
+fpslist --json
+
+#DESC: fpslist --json with nonexistent pattern
+#EXPECT:OK
+fpslist --json _nonexist_*
+
+#DESC: milkquery default (full snapshot, no FPS/streams/procs required)
+#EXPECT:OK
+milkquery
+
+#DESC: milkquery --fps only
+#EXPECT:OK
+milkquery --fps
+
+#DESC: milkquery --fps with nonexistent pattern
+#EXPECT:OK
+milkquery --fps _nonexist_*
+
+#DESC: milkquery --streams only
+#EXPECT:OK
+milkquery --streams
+
+#DESC: milkquery --procs only
+#EXPECT:OK
+milkquery --procs
+
+#DESC: milkquery --fps --streams --procs combined
+#EXPECT:OK
+milkquery --fps --streams --procs
+
+#DESC: milkquery unknown argument returns error
+#EXPECT:ERR
+milkquery foo


### PR DESCRIPTION
## Summary

Completes the JSON introspection surface for the milk-cli environment by adding `--json` support to `fpslist` and introducing `milkquery` — a unified command that emits a full system snapshot in one call. Also fixes correctness issues in status priority, null-safety, and error handling identified during review.

### `fpslist --json`

```bash
fpslist --json [pattern]
```

Outputs a JSON array of FPS instances with `name`, `status`, and `description` fields. Mirrors the existing `--json` support in `streamlist` and `proclist`.

### `milkquery`

```bash
milkquery                     # Full snapshot
milkquery --fps [pattern]     # FPS section only
milkquery --streams [pattern] # Streams section only
milkquery --procs             # Processes section only
```

Emits a single JSON object with `"fps"`, `"streams"`, and `"processes"` arrays. Section filters select which arrays to include. Unknown arguments return a usage error.

## Changes

### `CLIcore_script_builtin.c`

- `emit_fps/streams/procs_json_body()` helpers + `cli_cmd_milkquery()`
- Fixed CONF/RUN status priority in `emit_fps_json_body()` to check `CONF` before `RUN`, matching existing codebase semantics
- Added NULL guard for `ImageStreamIO_typename()` return value before passing to `json_escape_str()`
- `milkquery` now returns `RETURN_FAILURE` on unknown arguments instead of silently ignoring them

### Other files

- `CLIcore_script.h` — `cli_cmd_milkquery` declaration
- `CLIcore.c` — Registration + fpslist help update
- `CLIcore_help_topics.c` — help-milk introspection section
- `docs/cli/scripting.md` — milkquery documentation
- `milk-script-writer/SKILL.md` — Quick reference
- `tests/cli/cli_robustness_tests.milk` — Added test blocks for `fpslist --json` and `milkquery` (default, section filters, and unknown-arg error case)

## Verification

- [ ] Build passes (`/compile-test`)
- [ ] Tests pass (`ctest --output-on-failure`)
- [ ] CLI robustness tests pass (if CLI changed)
- [ ] Documentation updated (README, help, docs/)

## Prompt Summary

User requested Phase 4 of the CLI integration roadmap: completing JSON introspection by adding `--json` to `fpslist` and creating `milkquery` to unify all three introspection commands into a single system snapshot. Long flags (`--fps`, `--streams`, `--procs`) were chosen for readability. Follow-up review feedback addressed CONF/RUN status priority, null-safety for stream type names, unknown-argument error handling, and CLI robustness test coverage.

## AI Authorship

- **Model:** Antigravity
- **User edits:** None