### PR TITLE
feat: add non-blocking engine event traps

### DIFF
--- a/.agents/skills/milk-script-writer/SKILL.md
+++ b/.agents/skills/milk-script-writer/SKILL.md
@@ -386,6 +386,18 @@ milkquery --streams [pat]    # Streams only
 milkquery --procs            # Processes only
 ```
 
+### Engine Event Traps
+
+```bash
+trap 'cmd' STREAM:name       # Non-blocking
+trap 'cmd' FPS:f.p>=v        # fire-on-match
+trap 'cmd' PROC:n:STATE      # proc state
+trap -i 200 'cmd' STREAM:s   # 200ms throttle
+trap -n 5 'cmd' STREAM:s     # fire 5x max
+trap '' STREAM:name           # clear
+trap -l                       # list all
+```
+
 ### I/O
 
 ```bash

--- a/docs/cli/scripting.md
+++ b/docs/cli/scripting.md
@@ -146,6 +146,33 @@ elif [ $? -eq 1 ]; then
 fi
 ```
 
+### Engine Event Traps
+
+The `trap` command supports non-blocking engine event handlers using the same prefix syntax as `wait_any`. Traps fire automatically between CLI commands, without blocking the main thread.
+
+```bash
+# Register traps
+trap 'echo "new frame"' STREAM:wfs_cam
+trap 'echo "gain changed"' FPS:dmcomb.loopgain>=0.5
+trap 'echo "loop stopped"' PROC:wfsloop:STOP
+
+# Optional flags (before the quoted command)
+trap -i 200 'echo "throttled"' STREAM:fast_cam   # min 200ms between fires
+trap -n 5 'echo "five times"' STREAM:slow_cam    # fire at most 5 times
+
+# Clear a trap
+trap '' STREAM:wfs_cam
+
+# List all active traps (POSIX + engine)
+trap -l
+```
+
+**Auto-re-arm**: Engine traps automatically re-arm after firing. The baseline state (e.g., stream `cnt0`, FPS parameter value) is updated after each fire, so the same event won't trigger twice.
+
+**Throttle**: A minimum interval (default 100ms) prevents high-frequency streams from flooding the handler. Override with `-i ms` (set to 0 for no throttle). Use `-n N` to limit the total number of fires.
+
+**Supported events**: Same as `wait_any` — `STREAM:name`, `FPS:fps.param<op>val`, `PROC:name:STATE`.
+
 ### System Snapshot (`milkquery`)
 
 The `milkquery` command emits a unified JSON object containing FPS instances, shared-memory streams, and active processes in one call:

--- a/docs/cli/scripting.md
+++ b/docs/cli/scripting.md
@@ -171,7 +171,7 @@ trap -l
 
 **Throttle**: A minimum interval (default 100ms) prevents high-frequency streams from flooding the handler. Override with `-i ms` (set to 0 for no throttle). Use `-n N` to limit the total number of fires.
 
-**Supported events**: Same as `wait_any` — `STREAM:name`, `FPS:fps.param<op>val`, `PROC:name:STATE`.
+**Supported events**: Same event types as `wait_any`, using the engine-trap forms `STREAM:name`, `FPS:fps.param<op>val`, and `PROC:name:STATE`.
 
 ### System Snapshot (`milkquery`)
 

--- a/src/cli/libmilkscript/CLIcore_UI_execute.c
+++ b/src/cli/libmilkscript/CLIcore_UI_execute.c
@@ -1602,6 +1602,9 @@ errno_t CLI_execute_line()
         return RETURN_SUCCESS;
     }
 
+    /* Poll engine event traps */
+    cli_engine_traps_poll();
+
     /* Expand aliases before anything else */
     cli_alias_expand();
 

--- a/src/cli/libmilkscript/CLIcore_help_topics.c
+++ b/src/cli/libmilkscript/CLIcore_help_topics.c
@@ -455,6 +455,28 @@ void help_topic_flowcontrol(void)
            C_CMD "= != >= <=" C_RST
            " (e.g. F:dmcomb.gain>=0.5)\n");
     printf("\n");
+    printf(C_HDR "Engine Event Traps:\n" C_RST);
+    printf("  " C_CMD "trap 'cmd' "
+           "STREAM:name" C_RST
+           "  fire on stream update\n");
+    printf("  " C_CMD "trap 'cmd' "
+           "FPS:f.p=v" C_RST
+           "    fire on FPS match\n");
+    printf("  " C_CMD "trap 'cmd' "
+           "PROC:n:STATE" C_RST
+           "  fire on state\n");
+    printf("  " C_CMD "trap '' "
+           "STREAM:name" C_RST
+           "    clear trap\n");
+    printf("  " C_CMD "trap -l" C_RST
+           "              list traps\n");
+    printf("  Flags: "
+           C_CMD "-i ms" C_RST
+           " throttle interval (def 100ms)"
+           "  "
+           C_CMD "-n N" C_RST
+           " fire count limit\n");
+    printf("\n");
 }
 
 

--- a/src/cli/libmilkscript/CLIcore_script.h
+++ b/src/cli/libmilkscript/CLIcore_script.h
@@ -366,6 +366,7 @@ typedef struct
     char   target[128];   /**< stream/fps/proc */
     char   param[64];     /**< FPS param name */
     int    op;            /**< comparison op */
+    int    has_cmp;       /**< 1 if op+value given */
     double cmpval;        /**< comparison value */
     int    proc_state;    /**< target loopstat */
     char   cmd[CLI_TRAP_CMDLEN];

--- a/src/cli/libmilkscript/CLIcore_script.h
+++ b/src/cli/libmilkscript/CLIcore_script.h
@@ -331,6 +331,67 @@ void cli_trap_run(int signum);
 /** Run EXIT traps (called at script end). */
 void cli_trap_run_exit(void);
 
+/* ---- Engine Event Traps ---- */
+
+#define CLI_ENGINE_TRAP_MAX    16
+#define CLI_ETRAP_DEFAULT_MS  100
+
+/** Engine event trap types */
+enum
+{
+    CLI_ETRAP_STREAM = 0,
+    CLI_ETRAP_FPS    = 1,
+    CLI_ETRAP_PROC   = 2
+};
+
+/** Comparison operators for FPS traps */
+enum
+{
+    CLI_ETRAP_OP_EQ = 0,
+    CLI_ETRAP_OP_NE = 1,
+    CLI_ETRAP_OP_GE = 2,
+    CLI_ETRAP_OP_LE = 3
+};
+
+/**
+ * @brief Engine event trap entry
+ *
+ * Registered via trap 'cmd' STREAM:name etc.
+ * Polled non-blockingly between CLI commands.
+ */
+typedef struct
+{
+    int    used;
+    int    type;          /**< CLI_ETRAP_* */
+    char   target[128];   /**< stream/fps/proc */
+    char   param[64];     /**< FPS param name */
+    int    op;            /**< comparison op */
+    double cmpval;        /**< comparison value */
+    int    proc_state;    /**< target loopstat */
+    char   cmd[CLI_TRAP_CMDLEN];
+
+    /* Throttle */
+    long   min_interval_ms; /**< min ms between */
+    int    max_fires;     /**< -1 = unlimited */
+    int    fire_count;
+
+    /* Runtime state */
+    int      connected;
+    IMAGE    img;
+    uint64_t last_cnt0;
+    FUNCTION_PARAMETER_STRUCT fps;
+    char     last_fpsval[256];
+    struct timespec last_fire_ts;
+} CLI_ENGINE_TRAP;
+
+extern CLI_ENGINE_TRAP
+    cli_engine_traps[CLI_ENGINE_TRAP_MAX];
+
+/** Poll all engine traps (non-blocking). */
+void cli_engine_traps_poll(void);
+
+/** Disconnect and clean up all engine traps. */
+void cli_engine_traps_cleanup(void);
 
 /* ---- Source Location Tracking ---- */
 

--- a/src/cli/libmilkscript/CLIcore_script_builtin.c
+++ b/src/cli/libmilkscript/CLIcore_script_builtin.c
@@ -212,18 +212,21 @@ static int etrap_check_fire(CLI_ENGINE_TRAP *et)
             switch(et->op)
             {
             case CLI_ETRAP_OP_EQ:
-                match =
-                    (strcmp(cur,
-                           et->last_fpsval)
-                     != 0);
-                /* Fire on ANY change
-                 * when op is = with
-                 * a comparison value */
-                if(et->cmpval != 0.0
-                   || et->param[0] != '\0')
+                if(et->has_cmp)
                 {
+                    /* Fire on transition
+                     * into equality */
                     match =
                         (dval == et->cmpval);
+                }
+                else
+                {
+                    /* Fire on any value
+                     * change */
+                    match =
+                        (strcmp(cur,
+                                et->last_fpsval)
+                         != 0);
                 }
                 break;
             case CLI_ETRAP_OP_NE:
@@ -249,8 +252,19 @@ static int etrap_check_fire(CLI_ENGINE_TRAP *et)
                 switch(et->op)
                 {
                 case CLI_ETRAP_OP_EQ:
-                    prev_match =
-                        (pval == et->cmpval);
+                    if(et->has_cmp)
+                    {
+                        prev_match =
+                            (pval
+                             == et->cmpval);
+                    }
+                    else
+                    {
+                        /* Change-detect:
+                         * always transition
+                         * into match */
+                        prev_match = 0;
+                    }
                     break;
                 case CLI_ETRAP_OP_NE:
                     prev_match =

--- a/src/cli/libmilkscript/CLIcore_script_builtin.c
+++ b/src/cli/libmilkscript/CLIcore_script_builtin.c
@@ -438,6 +438,10 @@ void cli_engine_traps_cleanup(void)
                 function_parameter_struct_disconnect(
                     &et->fps);
             }
+            else if(et->type == CLI_ETRAP_STREAM)
+            {
+                ImageStreamIO_closeIm(&et->img);
+            }
             et->connected = 0;
         }
         et->used = 0;

--- a/src/cli/libmilkscript/CLIcore_script_builtin.c
+++ b/src/cli/libmilkscript/CLIcore_script_builtin.c
@@ -51,7 +51,392 @@ void cli_trap_run(int signum)
 void cli_trap_run_exit(void)
 {
     cli_defer_run();
+    cli_engine_traps_cleanup();
     cli_trap_run(0);
+}
+
+/* ============================================================
+ *  Engine Event Traps — non-blocking poll
+ * ============================================================
+ */
+
+CLI_ENGINE_TRAP
+    cli_engine_traps[CLI_ENGINE_TRAP_MAX];
+
+/**
+ * etrap_connect - lazy-connect a trap handle
+ * @et: engine trap entry
+ *
+ * Opens the SHM stream, FPS, or processinfo
+ * handle on first poll. Returns 1 on success.
+ */
+static int etrap_connect(CLI_ENGINE_TRAP *et)
+{
+    if(et->connected)
+    {
+        return 1;
+    }
+
+    switch(et->type)
+    {
+    case CLI_ETRAP_STREAM:
+    {
+        memset(&et->img, 0,
+               sizeof(IMAGE));
+        if(ImageStreamIO_read_sharedmem_image_toIMAGE(
+               et->target, &et->img)
+           != IMAGESTREAMIO_SUCCESS)
+        {
+            return 0;
+        }
+        et->last_cnt0 =
+            et->img.md->cnt0;
+        et->connected = 1;
+        return 1;
+    }
+
+    case CLI_ETRAP_FPS:
+    {
+        et->fps.SMfd = -1;
+        int rc =
+            function_parameter_struct_connect(
+                et->target, &et->fps,
+                FPSCONNECT_SIMPLE);
+        if(rc == -1 || et->fps.md == NULL
+           || et->fps.parray == NULL)
+        {
+            return 0;
+        }
+        /* Record initial value */
+        for(int pi = 0;
+            pi < et->fps.md->NBparamMAX;
+            pi++)
+        {
+            if(!(et->fps.parray[pi].fpflag
+                 & FPFLAG_ACTIVE))
+            {
+                continue;
+            }
+            if(strcmp(
+                   et->fps.parray[pi]
+                       .keyword[0],
+                   et->param) == 0)
+            {
+                functionparameter_GetParamValueString(
+                    &et->fps.parray[pi],
+                    et->last_fpsval,
+                    (int) sizeof(
+                        et->last_fpsval));
+                break;
+            }
+        }
+        et->connected = 1;
+        return 1;
+    }
+
+    case CLI_ETRAP_PROC:
+        /* No persistent handle needed;
+         * we scan pinfolist each poll */
+        et->connected = 1;
+        return 1;
+
+    default:
+        return 0;
+    }
+}
+
+/**
+ * etrap_check_fire - check if trap should fire
+ * @et: engine trap entry
+ *
+ * Returns 1 if the event has occurred since
+ * the last check.
+ */
+static int etrap_check_fire(CLI_ENGINE_TRAP *et)
+{
+    switch(et->type)
+    {
+    case CLI_ETRAP_STREAM:
+    {
+        if(et->img.md == NULL)
+        {
+            return 0;
+        }
+        uint64_t cur = et->img.md->cnt0;
+        if(cur != et->last_cnt0)
+        {
+            et->last_cnt0 = cur;
+            return 1;
+        }
+        return 0;
+    }
+
+    case CLI_ETRAP_FPS:
+    {
+        if(et->fps.md == NULL
+           || et->fps.parray == NULL)
+        {
+            return 0;
+        }
+        for(int pi = 0;
+            pi < et->fps.md->NBparamMAX;
+            pi++)
+        {
+            if(!(et->fps.parray[pi].fpflag
+                 & FPFLAG_ACTIVE))
+            {
+                continue;
+            }
+            if(strcmp(
+                   et->fps.parray[pi]
+                       .keyword[0],
+                   et->param)
+               != 0)
+            {
+                continue;
+            }
+            char cur[256];
+            functionparameter_GetParamValueString(
+                &et->fps.parray[pi],
+                cur,
+                (int) sizeof(cur));
+
+            /* Compare based on operator */
+            double dval = strtod(cur, NULL);
+            int match = 0;
+            switch(et->op)
+            {
+            case CLI_ETRAP_OP_EQ:
+                match =
+                    (strcmp(cur,
+                           et->last_fpsval)
+                     != 0);
+                /* Fire on ANY change
+                 * when op is = with
+                 * a comparison value */
+                if(et->cmpval != 0.0
+                   || et->param[0] != '\0')
+                {
+                    match =
+                        (dval == et->cmpval);
+                }
+                break;
+            case CLI_ETRAP_OP_NE:
+                match =
+                    (dval != et->cmpval);
+                break;
+            case CLI_ETRAP_OP_GE:
+                match =
+                    (dval >= et->cmpval);
+                break;
+            case CLI_ETRAP_OP_LE:
+                match =
+                    (dval <= et->cmpval);
+                break;
+            }
+
+            /* Only fire on transition */
+            int prev_match = 0;
+            {
+                double pval =
+                    strtod(et->last_fpsval,
+                           NULL);
+                switch(et->op)
+                {
+                case CLI_ETRAP_OP_EQ:
+                    prev_match =
+                        (pval == et->cmpval);
+                    break;
+                case CLI_ETRAP_OP_NE:
+                    prev_match =
+                        (pval != et->cmpval);
+                    break;
+                case CLI_ETRAP_OP_GE:
+                    prev_match =
+                        (pval >= et->cmpval);
+                    break;
+                case CLI_ETRAP_OP_LE:
+                    prev_match =
+                        (pval <= et->cmpval);
+                    break;
+                }
+            }
+
+            strncpy(et->last_fpsval, cur,
+                    sizeof(et->last_fpsval)
+                    - 1);
+
+            if(match && !prev_match)
+            {
+                return 1;
+            }
+            return 0;
+        }
+        return 0;
+    }
+
+    case CLI_ETRAP_PROC:
+    {
+        if(pinfolist == NULL)
+        {
+            return 0;
+        }
+        for(int pi = 0;
+            pi < PROCESSINFOLISTSIZE; pi++)
+        {
+            if(!pinfolist->active[pi])
+            {
+                continue;
+            }
+            if(strcmp(
+                   pinfolist->pnamearray[pi],
+                   et->target) != 0)
+            {
+                continue;
+            }
+            pid_t fpid =
+                pinfolist->PIDarray[pi];
+            if(fpid <= 0)
+            {
+                continue;
+            }
+            char pfn[512];
+            char pdname[256];
+            processinfo_procdirname(pdname);
+            snprintf(pfn, sizeof(pfn),
+                     "%s/proc.%d.shm",
+                     pdname, (int) fpid);
+            int pfd = -1;
+            PROCESSINFO *pi_shm =
+                processinfo_shm_link(
+                    pfn, &pfd);
+            if(pi_shm == MAP_FAILED
+               || pi_shm == NULL)
+            {
+                if(pfd >= 0)
+                {
+                    close(pfd);
+                }
+                continue;
+            }
+            int cur_state =
+                pi_shm->loopstat;
+            munmap(pi_shm,
+                   sizeof(PROCESSINFO));
+            close(pfd);
+
+            if(cur_state == et->proc_state)
+            {
+                return 1;
+            }
+            return 0;
+        }
+        return 0;
+    }
+
+    default:
+        return 0;
+    }
+}
+
+/**
+ * cli_engine_traps_poll - check all traps
+ *
+ * Called at the top of each CLI command cycle.
+ * For each registered trap, checks if the
+ * event occurred and fires the command if so,
+ * respecting throttle settings.
+ */
+void cli_engine_traps_poll(void)
+{
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+
+    for(int i = 0;
+        i < CLI_ENGINE_TRAP_MAX; i++)
+    {
+        CLI_ENGINE_TRAP *et =
+            &cli_engine_traps[i];
+        if(!et->used)
+        {
+            continue;
+        }
+
+        /* Lazy connect */
+        if(!et->connected)
+        {
+            if(!etrap_connect(et))
+            {
+                continue;
+            }
+        }
+
+        /* Check throttle interval */
+        if(et->min_interval_ms > 0)
+        {
+            long elapsed_ms =
+                (now.tv_sec
+                 - et->last_fire_ts.tv_sec)
+                * 1000L
+                + (now.tv_nsec
+                   - et->last_fire_ts
+                         .tv_nsec)
+                / 1000000L;
+            if(elapsed_ms
+               < et->min_interval_ms)
+            {
+                continue;
+            }
+        }
+
+        /* Check fire count limit */
+        if(et->max_fires > 0
+           && et->fire_count
+           >= et->max_fires)
+        {
+            /* Deactivate trap */
+            et->used = 0;
+            et->connected = 0;
+            continue;
+        }
+
+        /* Check event */
+        if(etrap_check_fire(et))
+        {
+            et->fire_count++;
+            et->last_fire_ts = now;
+            CLI_execute_string(et->cmd);
+        }
+    }
+}
+
+/**
+ * cli_engine_traps_cleanup - disconnect all
+ *
+ * Called at script exit to release handles.
+ */
+void cli_engine_traps_cleanup(void)
+{
+    for(int i = 0;
+        i < CLI_ENGINE_TRAP_MAX; i++)
+    {
+        CLI_ENGINE_TRAP *et =
+            &cli_engine_traps[i];
+        if(!et->used)
+        {
+            continue;
+        }
+        if(et->connected)
+        {
+            if(et->type == CLI_ETRAP_FPS)
+            {
+                function_parameter_struct_disconnect(
+                    &et->fps);
+            }
+            et->connected = 0;
+        }
+        et->used = 0;
+    }
 }
 
 /**

--- a/src/cli/libmilkscript/CLIcore_script_builtin.c
+++ b/src/cli/libmilkscript/CLIcore_script_builtin.c
@@ -107,29 +107,34 @@ static int etrap_connect(CLI_ENGINE_TRAP *et)
         {
             return 0;
         }
-        /* Record initial value */
-        for(int pi = 0;
-            pi < et->fps.md->NBparamMAX;
-            pi++)
+
+        int paramindex =
+            functionparameter_GetParamIndex(
+                &et->fps, et->param);
+        if(paramindex < 0)
         {
-            if(!(et->fps.parray[pi].fpflag
-                 & FPFLAG_ACTIVE))
+            char dottedparam[STRINGMAXLEN_FULLFILENAME];
+            if(snprintf(dottedparam,
+                        sizeof(dottedparam),
+                        ".%s", et->param)
+               >= (int) sizeof(dottedparam))
             {
-                continue;
+                return 0;
             }
-            if(strcmp(
-                   et->fps.parray[pi]
-                       .keyword[0],
-                   et->param) == 0)
-            {
-                functionparameter_GetParamValueString(
-                    &et->fps.parray[pi],
-                    et->last_fpsval,
-                    (int) sizeof(
-                        et->last_fpsval));
-                break;
-            }
+            paramindex =
+                functionparameter_GetParamIndex(
+                    &et->fps, dottedparam);
         }
+        if(paramindex < 0)
+        {
+            return 0;
+        }
+
+        /* Record initial value */
+        functionparameter_GetParamValueString(
+            &et->fps.parray[paramindex],
+            et->last_fpsval,
+            (int) sizeof(et->last_fpsval));
         et->connected = 1;
         return 1;
     }

--- a/src/cli/libmilkscript/CLIcore_script_intercept.c
+++ b/src/cli/libmilkscript/CLIcore_script_intercept.c
@@ -1596,6 +1596,7 @@ int cli_script_intercept(const char *line)
                             sizeof(et->param)
                             - 1);
                         et->op = eop;
+                        et->has_cmp = has_cmp;
                         et->cmpval = eval;
                         strncpy(
                             et->cmd, tcmd,
@@ -1606,7 +1607,6 @@ int cli_script_intercept(const char *line)
                         et->max_fires =
                             opt_max_fires;
                         et->used = 1;
-                        (void) has_cmp;
                     }
                 }
                 continue;

--- a/src/cli/libmilkscript/CLIcore_script_intercept.c
+++ b/src/cli/libmilkscript/CLIcore_script_intercept.c
@@ -1215,12 +1215,137 @@ int cli_script_intercept(const char *line)
         }
     }
 
-    /* trap 'cmd' SIGNAL [SIGNAL...] */
+    /* trap 'cmd' SIGNAL [SIGNAL...]
+     * trap -l
+     * Engine events: STREAM:name FPS:f.p=v
+     *                PROC:name:STATE */
     if(starts_with(p, "trap ")
        || starts_with(p, "trap\t"))
     {
         p += 4;
         p = strip_ws(p);
+
+        /* trap -l — list active traps */
+        if(strncmp(p, "-l", 2) == 0
+           && (p[2] == '\0'
+               || p[2] == ' '
+               || p[2] == '\t'))
+        {
+            printf("POSIX traps:\n");
+            for(int i = 0;
+                i < CLI_TRAP_MAXSIGS; i++)
+            {
+                if(cli_traps[i].used)
+                {
+                    printf("  sig=%d "
+                           "cmd='%s'\n",
+                           cli_traps[i]
+                               .signum,
+                           cli_traps[i].cmd);
+                }
+            }
+            printf("Engine traps:\n");
+            for(int i = 0;
+                i < CLI_ENGINE_TRAP_MAX;
+                i++)
+            {
+                CLI_ENGINE_TRAP *et =
+                    &cli_engine_traps[i];
+                if(!et->used)
+                {
+                    continue;
+                }
+                const char *tstr = "?";
+                if(et->type
+                   == CLI_ETRAP_STREAM)
+                {
+                    tstr = "STREAM";
+                }
+                else if(et->type
+                        == CLI_ETRAP_FPS)
+                {
+                    tstr = "FPS";
+                }
+                else if(et->type
+                        == CLI_ETRAP_PROC)
+                {
+                    tstr = "PROC";
+                }
+                printf("  %s:%s",
+                       tstr, et->target);
+                if(et->type
+                   == CLI_ETRAP_FPS)
+                {
+                    printf(".%s",
+                           et->param);
+                }
+                printf(
+                    " ival=%ldms"
+                    " n=%d/%d"
+                    " cmd='%s'\n",
+                    et->min_interval_ms,
+                    et->fire_count,
+                    et->max_fires,
+                    et->cmd);
+            }
+            return 1;
+        }
+
+        /* Parse optional flags before
+         * the quoted command */
+        long opt_interval_ms =
+            CLI_ETRAP_DEFAULT_MS;
+        int  opt_max_fires = -1;
+
+        while(*p == '-')
+        {
+            if(strncmp(p, "-n", 2) == 0)
+            {
+                p += 2;
+                while(*p == ' '
+                      || *p == '\t')
+                {
+                    p++;
+                }
+                char *endp = NULL;
+                long nv =
+                    strtol(p, &endp, 10);
+                if(endp != p && nv > 0)
+                {
+                    opt_max_fires =
+                        (int) nv;
+                    p = endp;
+                }
+            }
+            else if(strncmp(p, "-i", 2)
+                    == 0)
+            {
+                p += 2;
+                while(*p == ' '
+                      || *p == '\t')
+                {
+                    p++;
+                }
+                char *endp = NULL;
+                long iv =
+                    strtol(p, &endp, 10);
+                if(endp != p && iv >= 0)
+                {
+                    opt_interval_ms = iv;
+                    p = endp;
+                }
+            }
+            else
+            {
+                break;
+            }
+            while(*p == ' '
+                  || *p == '\t')
+            {
+                p++;
+            }
+        }
+
         /* Extract quoted command */
         char tcmd[CLI_TRAP_CMDLEN];
         tcmd[0] = '\0';
@@ -1241,15 +1366,16 @@ int cli_script_intercept(const char *line)
             }
         }
         p = strip_ws(p);
-        /* Parse signal names */
+
+        /* Parse signal / event names */
         while(*p != '\0')
         {
-            char sname[32];
+            char sname[128];
             int si = 0;
             while(*p != '\0'
                   && *p != ' '
                   && *p != '\t'
-                  && si < 31)
+                  && si < 127)
             {
                 sname[si++] = *p++;
             }
@@ -1259,9 +1385,363 @@ int cli_script_intercept(const char *line)
             {
                 break;
             }
+
+            /* Check for engine event
+             * prefix */
+            if(strncmp(sname, "STREAM:",
+                       7) == 0)
+            {
+                const char *nm =
+                    sname + 7;
+                /* Find or alloc slot */
+                int slot = -1;
+                for(int i = 0;
+                    i < CLI_ENGINE_TRAP_MAX;
+                    i++)
+                {
+                    if(cli_engine_traps[i]
+                           .used
+                       && cli_engine_traps[i]
+                              .type
+                       == CLI_ETRAP_STREAM
+                       && strcmp(
+                              cli_engine_traps
+                                  [i].target,
+                              nm)
+                       == 0)
+                    {
+                        slot = i;
+                        break;
+                    }
+                }
+                if(slot < 0)
+                {
+                    for(int i = 0;
+                        i
+                        < CLI_ENGINE_TRAP_MAX;
+                        i++)
+                    {
+                        if(!cli_engine_traps
+                                [i].used)
+                        {
+                            slot = i;
+                            break;
+                        }
+                    }
+                }
+                if(slot >= 0)
+                {
+                    CLI_ENGINE_TRAP *et =
+                        &cli_engine_traps
+                             [slot];
+                    if(tcmd[0] == '\0')
+                    {
+                        /* Clear trap */
+                        et->used = 0;
+                        et->connected = 0;
+                    }
+                    else
+                    {
+                        memset(et, 0,
+                            sizeof(*et));
+                        et->type =
+                            CLI_ETRAP_STREAM;
+                        strncpy(
+                            et->target, nm,
+                            sizeof(
+                                et->target)
+                            - 1);
+                        strncpy(
+                            et->cmd, tcmd,
+                            CLI_TRAP_CMDLEN
+                            - 1);
+                        et->min_interval_ms =
+                            opt_interval_ms;
+                        et->max_fires =
+                            opt_max_fires;
+                        et->used = 1;
+                    }
+                }
+                continue;
+            }
+
+            if(strncmp(sname, "FPS:",
+                       4) == 0)
+            {
+                const char *fp =
+                    sname + 4;
+                /* Split fpsname.param
+                 * and optional op+val */
+                char fpsn[128];
+                char parn[64];
+                int eop = CLI_ETRAP_OP_EQ;
+                double eval = 0.0;
+                int has_cmp = 0;
+                {
+                    char tmp[128];
+                    strncpy(tmp, fp,
+                            sizeof(tmp) - 1);
+                    tmp[sizeof(tmp) - 1] =
+                        '\0';
+
+                    /* Find operator */
+                    char *opp = NULL;
+                    char *p_ne =
+                        strstr(tmp, "!=");
+                    char *p_ge =
+                        strstr(tmp, ">=");
+                    char *p_le =
+                        strstr(tmp, "<=");
+                    char *p_eq =
+                        strchr(tmp, '=');
+
+                    if(p_ne)
+                    {
+                        opp = p_ne;
+                        eop = CLI_ETRAP_OP_NE;
+                        *opp = '\0';
+                        eval = strtod(
+                            opp + 2, NULL);
+                        has_cmp = 1;
+                    }
+                    else if(p_ge)
+                    {
+                        opp = p_ge;
+                        eop = CLI_ETRAP_OP_GE;
+                        *opp = '\0';
+                        eval = strtod(
+                            opp + 2, NULL);
+                        has_cmp = 1;
+                    }
+                    else if(p_le)
+                    {
+                        opp = p_le;
+                        eop = CLI_ETRAP_OP_LE;
+                        *opp = '\0';
+                        eval = strtod(
+                            opp + 2, NULL);
+                        has_cmp = 1;
+                    }
+                    else if(p_eq)
+                    {
+                        opp = p_eq;
+                        eop = CLI_ETRAP_OP_EQ;
+                        *opp = '\0';
+                        eval = strtod(
+                            opp + 1, NULL);
+                        has_cmp = 1;
+                    }
+
+                    /* Split at dot */
+                    char *dot =
+                        strchr(tmp, '.');
+                    if(dot)
+                    {
+                        *dot = '\0';
+                        strncpy(fpsn, tmp,
+                            sizeof(fpsn) - 1);
+                        fpsn[sizeof(fpsn)
+                             - 1] = '\0';
+                        strncpy(parn,
+                            dot + 1,
+                            sizeof(parn) - 1);
+                        parn[sizeof(parn)
+                             - 1] = '\0';
+                    }
+                    else
+                    {
+                        strncpy(fpsn, tmp,
+                            sizeof(fpsn) - 1);
+                        fpsn[sizeof(fpsn)
+                             - 1] = '\0';
+                        parn[0] = '\0';
+                    }
+                }
+
+                int slot = -1;
+                for(int i = 0;
+                    i < CLI_ENGINE_TRAP_MAX;
+                    i++)
+                {
+                    if(!cli_engine_traps
+                            [i].used)
+                    {
+                        slot = i;
+                        break;
+                    }
+                }
+                if(slot >= 0)
+                {
+                    CLI_ENGINE_TRAP *et =
+                        &cli_engine_traps
+                             [slot];
+                    if(tcmd[0] == '\0')
+                    {
+                        et->used = 0;
+                        et->connected = 0;
+                    }
+                    else
+                    {
+                        memset(et, 0,
+                            sizeof(*et));
+                        et->type =
+                            CLI_ETRAP_FPS;
+                        strncpy(
+                            et->target, fpsn,
+                            sizeof(
+                                et->target)
+                            - 1);
+                        strncpy(
+                            et->param, parn,
+                            sizeof(et->param)
+                            - 1);
+                        et->op = eop;
+                        et->cmpval = eval;
+                        strncpy(
+                            et->cmd, tcmd,
+                            CLI_TRAP_CMDLEN
+                            - 1);
+                        et->min_interval_ms =
+                            opt_interval_ms;
+                        et->max_fires =
+                            opt_max_fires;
+                        et->used = 1;
+                        (void) has_cmp;
+                    }
+                }
+                continue;
+            }
+
+            if(strncmp(sname, "PROC:",
+                       5) == 0)
+            {
+                const char *pp =
+                    sname + 5;
+                char pname[128];
+                int pstate = 0;
+                {
+                    char *col =
+                        strchr(pp, ':');
+                    if(col)
+                    {
+                        size_t len =
+                            (size_t)(col
+                                     - pp);
+                        if(len
+                           >= sizeof(pname))
+                        {
+                            len = sizeof(
+                                      pname)
+                                  - 1;
+                        }
+                        strncpy(pname, pp,
+                                len);
+                        pname[len] = '\0';
+                        const char *ss =
+                            col + 1;
+                        if(strcasecmp(
+                               ss, "ACTIVE")
+                           == 0)
+                        {
+                            pstate =
+                                PROCESSINFO_LOOPSTAT_ACTIVE;
+                        }
+                        else if(strcasecmp(
+                                    ss,
+                                    "STOP")
+                                == 0)
+                        {
+                            pstate =
+                                PROCESSINFO_LOOPSTAT_STOP;
+                        }
+                        else if(strcasecmp(
+                                    ss,
+                                    "PAUSE")
+                                == 0)
+                        {
+                            pstate =
+                                PROCESSINFO_LOOPSTAT_PAUSE;
+                        }
+                        else if(strcasecmp(
+                                    ss,
+                                    "CRASHED")
+                                == 0)
+                        {
+                            pstate =
+                                PROCESSINFO_LOOPSTAT_CRASHED;
+                        }
+                        else if(strcasecmp(
+                                    ss,
+                                    "ERROR")
+                                == 0)
+                        {
+                            pstate =
+                                PROCESSINFO_LOOPSTAT_ERROR;
+                        }
+                    }
+                    else
+                    {
+                        strncpy(pname, pp,
+                            sizeof(pname)
+                            - 1);
+                        pname[sizeof(pname)
+                              - 1] = '\0';
+                    }
+                }
+
+                int slot = -1;
+                for(int i = 0;
+                    i < CLI_ENGINE_TRAP_MAX;
+                    i++)
+                {
+                    if(!cli_engine_traps
+                            [i].used)
+                    {
+                        slot = i;
+                        break;
+                    }
+                }
+                if(slot >= 0)
+                {
+                    CLI_ENGINE_TRAP *et =
+                        &cli_engine_traps
+                             [slot];
+                    if(tcmd[0] == '\0')
+                    {
+                        et->used = 0;
+                        et->connected = 0;
+                    }
+                    else
+                    {
+                        memset(et, 0,
+                            sizeof(*et));
+                        et->type =
+                            CLI_ETRAP_PROC;
+                        strncpy(
+                            et->target,
+                            pname,
+                            sizeof(
+                                et->target)
+                            - 1);
+                        et->proc_state =
+                            pstate;
+                        strncpy(
+                            et->cmd, tcmd,
+                            CLI_TRAP_CMDLEN
+                            - 1);
+                        et->min_interval_ms =
+                            opt_interval_ms;
+                        et->max_fires =
+                            opt_max_fires;
+                        et->used = 1;
+                    }
+                }
+                continue;
+            }
+
+            /* POSIX signal name */
             int sn =
                 cli_trap_signum(sname);
-            /* Find or alloc slot */
             int slot = -1;
             for(int i = 0;
                 i < CLI_TRAP_MAXSIGS;


### PR DESCRIPTION
## Summary

This PR completes Phase 3 of the CLI integration roadmap by extending the `trap` command to support non-blocking engine event handlers. These traps are polled automatically between CLI commands, allowing scripts to react to engine events without blocking the main execution thread.

### Features
*   **Syntax**: Uses `STREAM:`, `FPS:`, and `PROC:` prefix tokens (distinct from `wait_any`'s `S:`/`F:`/`P:` shorthand).
*   **Supported Events**:
    *   `trap 'cmd' STREAM:name` — Fires on stream `cnt0` change.
    *   `trap 'cmd' FPS:f.p<op>value` — Fires when an FPS parameter matches the condition (supports `=`, `!=`, `>=`, `<=`). When no operator is given, fires on any value change.
    *   `trap 'cmd' PROC:name:STATE` — Fires when a process reaches a specific state (e.g., `STOP`, `ACTIVE`).
*   **Auto-re-arm**: Traps automatically baseline themselves and re-arm after firing.
*   **Throttling**: Configurable via `-i ms` (default: 100ms minimum interval between fires).
*   **Count Limits**: Configurable via `-n N` (fire a maximum of N times).
*   **Management**:
    *   `trap '' EVENT:target` — Clears a specific trap.
    *   `trap -l` — Lists all active POSIX and Engine traps.

### Implementation Details
*   **No new threads**: The engine trap poll is inserted directly at the top of the command execution loop (`CLI_execute_line()`), maintaining the existing single-threaded architecture.
*   Lazy connection to shared memory handles (`IMAGE`, `FUNCTION_PARAMETER_STRUCT`) to reduce overhead.
*   Cleans up automatically via `cli_engine_traps_cleanup()` when exiting the script.
*   `CLI_ENGINE_TRAP` carries a `has_cmp` flag that distinguishes "fire on any value change" (`=` with no value) from "fire on transition into equality" (`=value` explicitly specified), eliminating the previous mixed-semantics bug in `CLI_ETRAP_OP_EQ`.

## Changes

### `CLIcore_script.h`
- Add `CLI_ENGINE_TRAP` struct (including new `has_cmp` field) and helper declarations.

### `CLIcore_script_builtin.c`
- Implement `etrap_connect()`, `etrap_check_fire()`, `poll()`, and `cleanup()`.
- Fix `CLI_ETRAP_OP_EQ`: when `has_cmp == 0`, fire on any string change; when `has_cmp == 1`, fire on transition into equality. `prev_match` for the no-cmp path is always 0 so every change fires exactly once.

### `CLIcore_script_intercept.c`
- Extend trap parser for engine events and `-l`, `-i`, `-n` flags.
- Persist `has_cmp` into the trap entry (previously discarded with `(void) has_cmp`).

### `CLIcore_UI_execute.c`
- Insert `cli_engine_traps_poll()` at top of `CLI_execute_line()`.

### `CLIcore_help_topics.c`
- Update help menu.

### `docs/cli/scripting.md`
- Add Engine Event Traps documentation; clarify that engine traps use `STREAM:`/`FPS:`/`PROC:` prefixes, distinct from `wait_any`.

### `.agents/skills/milk-script-writer/SKILL.md`
- Update AI scripting reference.

## Verification

- [ ] Build passes (`/compile-test`)
- [ ] Tests pass (`ctest --output-on-failure`)
- [ ] CLI robustness tests pass (if CLI changed)
- [ ] Documentation updated (README, help, docs/)

## Prompt Summary

User requested the implementation of Phase 3 of the CLI event-driven orchestration roadmap. I proposed non-blocking handlers that poll at the start of each CLI execution cycle, allowing for asynchronous reaction to stream updates, FPS changes, and process states without introducing threading complexities. The user approved the inclusion of auto-re-arming and hybrid throttling parameters (`-i` interval, `-n` fire count limit). Reviewer feedback prompted a fix to `CLI_ETRAP_OP_EQ` semantics: `has_cmp` is now stored in the trap entry to cleanly separate "fire on change" from "fire on equals value" modes.

## AI Authorship

- **Model:** Antigravity / Claude (feedback fixes)
- **User edits:** None