### PR TITLE
refactor: flatten cli_expand_env() depth-9 nesting into named helpers

### DIFF
--- a/src/cli/libmilkscript/CLIcore_script_expand_env.c
+++ b/src/cli/libmilkscript/CLIcore_script_expand_env.c
@@ -39,9 +39,8 @@
 
 
 /* ============================================================
- *  Helper
- * ============================================================
- */
+ *  emit_str_local — append a C string to output buffer
+ * ============================================================ */
 
 /**
  * emit_str_local - append a C string to the output buffer
@@ -53,9 +52,9 @@
  * Writes characters until NUL or the buffer is full.
  */
 static void emit_str_local(
-    char *out,
-    int  *opos,
-    int   maxlen,
+    char       *out,
+    int        *opos,
+    int         maxlen,
     const char *s
 )
 {
@@ -67,9 +66,308 @@ static void emit_str_local(
 
 
 /* ============================================================
- *  cli_expand_env
- * ============================================================
+ *  expand_env_array_all — expand ${arr[@]}
+ * ============================================================ */
+
+/**
+ * expand_env_array_all - collect all elements of an array
+ *      or associative array into a space-separated string.
+ * @varname:     Name of the array variable
+ * @is_length:   If non-zero, set *out_val to element count
+ * @out_buf:     Caller buffer (STRINGMAXLEN_CLICMDLINE)
+ * @out_val:     Set to out_buf on success, NULL if not found
+ *
+ * Searches associative arrays first, then indexed arrays.
+ * When @is_length is set, writes the element count into
+ * @out_buf instead of the concatenated values.
  */
+static void expand_env_array_all(
+    const char *varname,
+    int         is_length,
+    char       *out_buf,
+    const char **out_val
+)
+{
+    int elems_count = 0;
+    out_buf[0] = '\0';
+
+    /* Search associative arrays first */
+    for(int a = 0; a < CLI_MAX_ASSOC; a++)
+    {
+        if(!cli_assoc[a].used)
+        {
+            continue;
+        }
+        if(strcmp(cli_assoc[a].name, varname) != 0)
+        {
+            continue;
+        }
+
+        elems_count = cli_assoc[a].nelem;
+        if(!is_length)
+        {
+            for(int e = 0; e < cli_assoc[a].nelem; e++)
+            {
+                if(e > 0)
+                {
+                    strncat(out_buf, " ",
+                            STRINGMAXLEN_CLICMDLINE
+                            - strlen(out_buf) - 1);
+                }
+                strncat(out_buf,
+                        cli_assoc[a].vals[e],
+                        STRINGMAXLEN_CLICMDLINE
+                        - strlen(out_buf) - 1);
+            }
+        }
+        *out_val = out_buf;
+        break;
+    }
+
+    /* Fallback: indexed arrays */
+    if(*out_val == NULL)
+    {
+        for(int a = 0; a < CLI_MAX_ARRAYS; a++)
+        {
+            if(!cli_arrays[a].used)
+            {
+                continue;
+            }
+            if(strcmp(cli_arrays[a].name, varname) != 0)
+            {
+                continue;
+            }
+
+            elems_count = cli_arrays[a].nelem;
+            if(!is_length)
+            {
+                for(int e = 0; e < cli_arrays[a].nelem; e++)
+                {
+                    if(e > 0)
+                    {
+                        strncat(out_buf, " ",
+                                STRINGMAXLEN_CLICMDLINE
+                                - strlen(out_buf) - 1);
+                    }
+                    strncat(out_buf,
+                            cli_arrays[a].elem[e],
+                            STRINGMAXLEN_CLICMDLINE
+                            - strlen(out_buf) - 1);
+                }
+            }
+            *out_val = out_buf;
+            break;
+        }
+    }
+
+    /* When is_length, overwrite buf with the count */
+    if(is_length && *out_val != NULL)
+    {
+        char cnt_buf[32];
+        snprintf(cnt_buf, sizeof(cnt_buf), "%d", elems_count);
+        strncpy(out_buf, cnt_buf,
+                STRINGMAXLEN_CLICMDLINE - 1);
+        out_buf[STRINGMAXLEN_CLICMDLINE - 1] = '\0';
+    }
+}
+
+
+/* ============================================================
+ *  expand_env_array_index — expand ${arr[n]} / ${assoc[key]}
+ * ============================================================ */
+
+/**
+ * expand_env_array_index - look up a single element by index
+ *      or key from a CLI array or associative array.
+ * @varname:   Name of the array variable
+ * @idx_val:   Index string (numeric for arrays, key for assoc)
+ * @out_val:   Set to the element value, or NULL if not found
+ *
+ * Searches associative arrays first (by key), then indexed
+ * arrays (by numeric index).
+ */
+static void expand_env_array_index(
+    const char  *varname,
+    const char  *idx_val,
+    const char **out_val
+)
+{
+    /* Search associative arrays by key */
+    for(int a = 0; a < CLI_MAX_ASSOC; a++)
+    {
+        if(!cli_assoc[a].used)
+        {
+            continue;
+        }
+        if(strcmp(cli_assoc[a].name, varname) != 0)
+        {
+            continue;
+        }
+
+        for(int e = 0; e < cli_assoc[a].nelem; e++)
+        {
+            if(strcmp(cli_assoc[a].keys[e], idx_val) == 0)
+            {
+                *out_val = cli_assoc[a].vals[e];
+                break;
+            }
+        }
+        break; /* found the array, stop outer search */
+    }
+
+    if(*out_val != NULL)
+    {
+        return;
+    }
+
+    /* Fallback: indexed arrays by numeric index */
+    int num_idx = atoi(idx_val);
+    for(int a = 0; a < CLI_MAX_ARRAYS; a++)
+    {
+        if(!cli_arrays[a].used)
+        {
+            continue;
+        }
+        if(strcmp(cli_arrays[a].name, varname) != 0)
+        {
+            continue;
+        }
+
+        if(num_idx >= 0 && num_idx < cli_arrays[a].nelem)
+        {
+            *out_val = cli_arrays[a].elem[num_idx];
+        }
+        break;
+    }
+}
+
+
+/* ============================================================
+ *  apply_modifier — apply :- := :? :+ :off:len modifiers
+ * ============================================================ */
+
+/**
+ * apply_modifier - apply a ${VAR:op:arg} modifier to *val.
+ * @varname:  Variable name (used by := to store defaults)
+ * @mod_op:   Two-char operator string, e.g. ":-", ":="
+ * @mod_arg:  Argument after the operator
+ * @val_buf:  Caller-supplied scratch buffer (size 256)
+ * @val:      Pointer to current value; updated in place
+ *
+ * Supported operators:
+ *   :-  use mod_arg if val is NULL or empty
+ *   :=  same as :- but also stores into the variable
+ *   :?  print error if val is NULL or empty
+ *   :+  use mod_arg if val is set, empty otherwise
+ *   :   substring ${VAR:off} or ${VAR:off:len}
+ */
+static void apply_modifier(
+    const char  *varname,
+    const char  *mod_op,
+    char        *mod_arg,
+    char        *val_buf,
+    const char **val
+)
+{
+    char op = mod_op[1]; /* '-', '=', '?', '+', or '\0' */
+
+    if(op == '-')
+    {
+        if(*val == NULL || (*val)[0] == '\0')
+        {
+            *val = mod_arg;
+        }
+        return;
+    }
+
+    if(op == '=')
+    {
+        if(*val == NULL || (*val)[0] == '\0')
+        {
+            *val = mod_arg;
+            cli_var_set(varname, *val);
+        }
+        return;
+    }
+
+    if(op == '?')
+    {
+        if(*val == NULL || (*val)[0] == '\0')
+        {
+            printf("CLI expand error: %s: %s\n",
+                   varname, mod_arg);
+            *val = "";
+        }
+        return;
+    }
+
+    if(op == '+')
+    {
+        *val = (*val != NULL && (*val)[0] != '\0')
+               ? mod_arg : "";
+        return;
+    }
+
+    /* Plain ':' — substring ${VAR:off} or ${VAR:off:len} */
+    if(*val == NULL)
+    {
+        return;
+    }
+
+    int offset = 0;
+    int length = 255;
+
+    char *colon = strchr(mod_arg, ':');
+    if(colon != NULL)
+    {
+        *colon = '\0';
+        const char *lv = cli_var_lookup(mod_arg);
+        offset = atoi(lv ? lv : mod_arg);
+        const char *rv = cli_var_lookup(colon + 1);
+        length = atoi(rv ? rv : colon + 1);
+    }
+    else
+    {
+        const char *lv = cli_var_lookup(mod_arg);
+        offset = atoi(lv ? lv : mod_arg);
+    }
+
+    int vlen = (int) strlen(*val);
+
+    if(offset < 0)
+    {
+        offset = vlen + offset;
+    }
+    if(offset < 0)
+    {
+        offset = 0;
+    }
+    if(offset > vlen)
+    {
+        offset = vlen;
+    }
+    if(length < 0)
+    {
+        length = vlen - offset + length;
+    }
+    if(length < 0)
+    {
+        length = 0;
+    }
+    if(offset + length > vlen)
+    {
+        length = vlen - offset;
+    }
+
+    strncpy(val_buf, *val + offset, (size_t) length);
+    val_buf[length] = '\0';
+    *val = val_buf;
+}
+
+
+/* ============================================================
+ *  cli_expand_env — public entry point
+ * ============================================================ */
 
 /**
  * @brief Expand $VAR / ${VAR} references in place
@@ -93,500 +391,170 @@ void cli_expand_env(
 {
     char out[STRINGMAXLEN_CLICMDLINE];
     int  opos = 0;
-    int  i = 0;
+    int  i    = 0;
 
-    while(line[i] != '\0'
-          && opos < maxlen - 1)
+    while(line[i] != '\0' && opos < maxlen - 1)
     {
-        if(line[i] == '$')
+        /* ---- Escaped dollar: pass through unchanged ---- */
+        if(line[i] == '\\' && line[i + 1] == '$')
         {
-            /* Skip $((  — let arith handle it */
-            if(line[i + 1] == '('
-               && line[i + 2] == '(')
+            if(opos < maxlen - 1)
             {
                 out[opos++] = line[i++];
-                out[opos++] = line[i++];
-                out[opos++] = line[i++];
-                continue;
             }
-            /* Skip $(  — command substitution */
-            if(line[i + 1] == '(')
+            if(opos < maxlen - 1)
             {
                 out[opos++] = line[i++];
-                out[opos++] = line[i++];
-                continue;
             }
+            continue;
+        }
 
+        /* ---- Non-dollar: copy verbatim ---- */
+        if(line[i] != '$')
+        {
+            out[opos++] = line[i++];
+            continue;
+        }
+
+        /* ---- Dollar sign: begin expansion ---- */
+
+        /* Skip $((  — arithmetic, handled downstream */
+        if(line[i + 1] == '(' && line[i + 2] == '(')
+        {
+            out[opos++] = line[i++];
+            out[opos++] = line[i++];
+            out[opos++] = line[i++];
+            continue;
+        }
+        /* Skip $(  — command substitution, handled downstream */
+        if(line[i + 1] == '(')
+        {
+            out[opos++] = line[i++];
+            out[opos++] = line[i++];
+            continue;
+        }
+
+        i++; /* consume the '$' */
+
+        int has_brace = (line[i] == '{');
+        if(has_brace)
+        {
             i++;
-            int has_brace = 0;
-            if(line[i] == '{')
+        }
+
+        int is_length = (has_brace && line[i] == '#');
+        if(is_length)
+        {
+            i++;
+        }
+
+        /* ${@fps.param} — FPS inline expansion */
+        if(has_brace && line[i] == '@')
+        {
+            i++; /* skip @ */
+            char atbuf[512];
+            int  alen = 0;
+            atbuf[alen++] = '@';
+            while(line[i] != '\0' && line[i] != '}'
+                  && alen < 511)
             {
-                has_brace = 1;
+                atbuf[alen++] = line[i++];
+            }
+            atbuf[alen] = '\0';
+            if(line[i] == '}')
+            {
                 i++;
             }
+            cli_expand_fpsvar(atbuf, (int) sizeof(atbuf));
+            int rlen  = (int) strlen(atbuf);
+            int avail = maxlen - 1 - opos;
+            int clen  = rlen < avail ? rlen : avail;
+            memcpy(out + opos, atbuf, (size_t) clen);
+            opos += clen;
+            continue;
+        }
 
-            int is_length = 0;
-            if(has_brace && line[i] == '#')
+        /* Collect variable name */
+        char varname[256];
+        int  vlen = 0;
+        while(line[i] != '\0' && vlen < 255)
+        {
+            char c = line[i];
+            if(!((c >= 'A' && c <= 'Z')
+                 || (c >= 'a' && c <= 'z')
+                 || (c >= '0' && c <= '9')
+                 || c == '_' || c == '?' || c == '.'))
             {
-                is_length = 1;
+                break;
+            }
+            varname[vlen++] = line[i++];
+            if(c == '?')
+            {
+                break;
+            }
+        }
+        varname[vlen] = '\0';
+
+        /* Optional array index: ${arr[n]} */
+        char index_str[256];
+        int  has_index = 0;
+        if(has_brace && line[i] == '[')
+        {
+            i++;
+            int ilen = 0;
+            while(line[i] != '\0' && line[i] != ']'
+                  && ilen < 255)
+            {
+                index_str[ilen++] = line[i++];
+            }
+            if(line[i] == ']')
+            {
                 i++;
             }
+            index_str[ilen] = '\0';
+            has_index = 1;
+        }
 
-            /* ${@fps.param} — FPS inline */
-            if(has_brace && line[i] == '@')
+        /* Optional modifier: ${VAR:-…} etc. */
+        char mod_op[3]    = {0};
+        char mod_arg[256] = {0};
+        if(has_brace && line[i] == ':')
+        {
+            i++;
+            if(line[i] == '-' || line[i] == '='
+               || line[i] == '?' || line[i] == '+')
             {
-                i++; /* skip @ */
-                char atbuf[512];
-                int  alen = 0;
-                atbuf[alen++] = '@';
-                while(line[i] != '\0'
-                      && line[i] != '}'
-                      && alen < 511)
-                {
-                    atbuf[alen++] = line[i++];
-                }
-                atbuf[alen] = '\0';
-                if(line[i] == '}')
-                {
-                    i++;
-                }
-                cli_expand_fpsvar(
-                    atbuf,
-                    (int) sizeof(atbuf));
-                int rlen = (int) strlen(atbuf);
-                int avail = maxlen - 1 - opos;
-                int clen = rlen < avail
-                           ? rlen : avail;
-                memcpy(out + opos, atbuf,
-                       (size_t) clen);
-                opos += clen;
-                continue;
-            }
-
-            char varname[256];
-            int  vlen = 0;
-
-            while(line[i] != '\0'
-                  && vlen < 255)
-            {
-                char c = line[i];
-                if(!((c >= 'A' && c <= 'Z')
-                     || (c >= 'a' && c <= 'z')
-                     || (c >= '0' && c <= '9')
-                     || c == '_'
-                     || c == '?'
-                     || c == '.'))
-                {
-                    break;
-                }
-                varname[vlen++] = line[i++];
-                if(c == '?')
-                {
-                    break;
-                }
-            }
-            varname[vlen] = '\0';
-
-            char index_str[256];
-            int  has_index = 0;
-            if(has_brace && line[i] == '[')
-            {
-                i++;
-                int ilen = 0;
-                while(line[i] != '\0'
-                      && line[i] != ']'
-                      && ilen < 255)
-                {
-                    index_str[ilen++] =
-                        line[i++];
-                }
-                if(line[i] == ']')
-                {
-                    i++;
-                }
-                index_str[ilen] = '\0';
-                has_index = 1;
-            }
-
-            char mod_op[3]  = {0};
-            char mod_arg[256] = {0};
-            if(has_brace && line[i] == ':')
-            {
-                i++;
-                if(line[i] == '-'
-                   || line[i] == '='
-                   || line[i] == '?'
-                   || line[i] == '+')
-                {
-                    mod_op[0] = ':';
-                    mod_op[1] = line[i++];
-                }
-                else
-                {
-                    mod_op[0] = ':';
-                }
-                int mlen = 0;
-                while(line[i] != '\0'
-                      && line[i] != '}'
-                      && mlen < 255)
-                {
-                    mod_arg[mlen++] = line[i++];
-                }
-                mod_arg[mlen] = '\0';
-            }
-
-            if(has_brace)
-            {
-                if(line[i] == '}')
-                {
-                    i++;
-                }
-                else
-                {
-                    /* Complex: pass through */
-                    out[opos++] = '$';
-                    out[opos++] = '{';
-                    if(is_length)
-                    {
-                        out[opos++] = '#';
-                    }
-                    for(int k = 0;
-                        k < vlen; k++)
-                    {
-                        if(opos < maxlen - 1)
-                        {
-                            out[opos++] =
-                                varname[k];
-                        }
-                    }
-                    continue;
-                }
-            }
-
-            const char *val = NULL;
-            char all_elems[
-                STRINGMAXLEN_CLICMDLINE];
-            all_elems[0] = '\0';
-            int elems_count = 0;
-
-            if(has_index)
-            {
-                const char *idx_val =
-                    cli_var_lookup(index_str);
-                if(idx_val == NULL)
-                {
-                    idx_val = index_str;
-                }
-
-                if(strcmp(idx_val, "@") == 0)
-                {
-                    int is_found = 0;
-                    for(int a = 0;
-                        a < CLI_MAX_ASSOC; a++)
-                    {
-                        if(cli_assoc[a].used
-                           && strcmp(
-                               cli_assoc[a].name,
-                               varname) == 0)
-                        {
-                            elems_count =
-                                cli_assoc[a]
-                                    .nelem;
-                            if(!is_length)
-                            {
-                                for(int e = 0;
-                                    e < cli_assoc[a].nelem;
-                                    e++)
-                                {
-                                    if(e > 0)
-                                    {
-                                        strncat(
-                                            all_elems,
-                                            " ",
-                                            sizeof(all_elems)
-                                            - strlen(all_elems)
-                                            - 1);
-                                    }
-                                    strncat(
-                                        all_elems,
-                                        cli_assoc[a]
-                                            .vals[e],
-                                        sizeof(all_elems)
-                                        - strlen(all_elems)
-                                        - 1);
-                                }
-                            }
-                            is_found = 1;
-                            break;
-                        }
-                    }
-                    if(!is_found)
-                    {
-                        for(int a = 0;
-                            a < CLI_MAX_ARRAYS;
-                            a++)
-                        {
-                            if(cli_arrays[a].used
-                               && strcmp(
-                                   cli_arrays[a]
-                                       .name,
-                                   varname) == 0)
-                            {
-                                elems_count =
-                                    cli_arrays[a]
-                                        .nelem;
-                                if(!is_length)
-                                {
-                                    for(int e = 0;
-                                        e < cli_arrays[a].nelem;
-                                        e++)
-                                    {
-                                        if(e > 0)
-                                        {
-                                            strncat(
-                                                all_elems,
-                                                " ",
-                                                sizeof(all_elems)
-                                                - strlen(all_elems)
-                                                - 1);
-                                        }
-                                        strncat(
-                                            all_elems,
-                                            cli_arrays[a]
-                                                .elem[e],
-                                            sizeof(all_elems)
-                                            - strlen(all_elems)
-                                            - 1);
-                                    }
-                                }
-                                break;
-                            }
-                        }
-                    }
-                    if(is_length)
-                    {
-                        char cnt_buf[32];
-                        snprintf(cnt_buf,
-                                 sizeof(cnt_buf),
-                                 "%d",
-                                 elems_count);
-                        strncpy(all_elems,
-                                cnt_buf,
-                                sizeof(all_elems)
-                                - 1);
-                        is_length = 0;
-                    }
-                    val = all_elems;
-                }
-                else
-                {
-                    int is_found = 0;
-                    for(int a = 0;
-                        a < CLI_MAX_ASSOC; a++)
-                    {
-                        if(cli_assoc[a].used
-                           && strcmp(
-                               cli_assoc[a].name,
-                               varname) == 0)
-                        {
-                            for(int e = 0;
-                                e < cli_assoc[a]
-                                    .nelem;
-                                e++)
-                            {
-                                if(strcmp(
-                                    cli_assoc[a]
-                                        .keys[e],
-                                    idx_val)
-                                   == 0)
-                                {
-                                    val =
-                                        cli_assoc[a]
-                                            .vals[e];
-                                    is_found = 1;
-                                    break;
-                                }
-                            }
-                            break;
-                        }
-                    }
-                    if(!is_found)
-                    {
-                        int num_idx =
-                            atoi(idx_val);
-                        for(int a = 0;
-                            a < CLI_MAX_ARRAYS;
-                            a++)
-                        {
-                            if(cli_arrays[a].used
-                               && strcmp(
-                                   cli_arrays[a]
-                                       .name,
-                                   varname) == 0)
-                            {
-                                if(num_idx >= 0
-                                   && num_idx
-                                      < cli_arrays[a]
-                                            .nelem)
-                                {
-                                    val =
-                                        cli_arrays[a]
-                                            .elem[num_idx];
-                                }
-                                break;
-                            }
-                        }
-                    }
-                }
+                mod_op[0] = ':';
+                mod_op[1] = line[i++];
             }
             else
             {
-                val = cli_var_lookup(varname);
+                mod_op[0] = ':';
             }
-
-            char val_buf[256];
-            val_buf[0] = '\0';
-
-            if(mod_op[0] != '\0')
+            int mlen = 0;
+            while(line[i] != '\0' && line[i] != '}'
+                  && mlen < 255)
             {
-                if(mod_op[1] == '-')
-                {
-                    if(val == NULL
-                       || val[0] == '\0')
-                    {
-                        val = mod_arg;
-                    }
-                }
-                else if(mod_op[1] == '=')
-                {
-                    if(val == NULL
-                       || val[0] == '\0')
-                    {
-                        val = mod_arg;
-                        cli_var_set(varname,
-                                    val);
-                    }
-                }
-                else if(mod_op[1] == '?')
-                {
-                    if(val == NULL
-                       || val[0] == '\0')
-                    {
-                        printf(
-                            "CLI expand "
-                            "error: %s: %s\n",
-                            varname, mod_arg);
-                        val = "";
-                    }
-                }
-                else if(mod_op[1] == '+')
-                {
-                    if(val != NULL
-                       && val[0] != '\0')
-                    {
-                        val = mod_arg;
-                    }
-                    else
-                    {
-                        val = "";
-                    }
-                }
-                else if(mod_op[0] == ':')
-                {
-                    int offset = 0;
-                    int length = 255;
-                    char *colon =
-                        strchr(mod_arg, ':');
-                    if(colon != NULL)
-                    {
-                        *colon = '\0';
-                        const char *lval =
-                            cli_var_lookup(
-                                mod_arg);
-                        offset = atoi(
-                            lval ? lval
-                                 : mod_arg);
-                        const char *rval =
-                            cli_var_lookup(
-                                colon + 1);
-                        length = atoi(
-                            rval ? rval
-                                 : colon + 1);
-                    }
-                    else
-                    {
-                        const char *lval =
-                            cli_var_lookup(
-                                mod_arg);
-                        offset = atoi(
-                            lval ? lval
-                                 : mod_arg);
-                    }
-
-                    if(val != NULL)
-                    {
-                        int v1 =
-                            (int) strlen(val);
-                        if(offset < 0)
-                        {
-                            offset = v1 + offset;
-                        }
-                        if(offset < 0)
-                        {
-                            offset = 0;
-                        }
-                        if(offset > v1)
-                        {
-                            offset = v1;
-                        }
-
-                        if(length < 0)
-                        {
-                            length = v1
-                                     - offset
-                                     + length;
-                        }
-                        if(length < 0)
-                        {
-                            length = 0;
-                        }
-                        if(offset + length > v1)
-                        {
-                            length = v1 - offset;
-                        }
-
-                        strncpy(val_buf,
-                                val + offset,
-                                (size_t) length);
-                        val_buf[length] = '\0';
-                        val = val_buf;
-                    }
-                }
+                mod_arg[mlen++] = line[i++];
             }
+            mod_arg[mlen] = '\0';
+        }
 
-            if(is_length)
+        /* Consume closing brace or emit passthrough */
+        if(has_brace)
+        {
+            if(line[i] == '}')
             {
-                int len = val
-                          ? (int) strlen(val)
-                          : 0;
-                char numstr[32];
-                snprintf(numstr, sizeof(numstr),
-                         "%d", len);
-                emit_str_local(out, &opos,
-                               maxlen, numstr);
-            }
-            else if(val != NULL)
-            {
-                emit_str_local(out, &opos,
-                               maxlen, val);
+                i++;
             }
             else
             {
-                /* Variable not found */
+                /* Complex expression — pass through */
                 out[opos++] = '$';
-                if(has_brace)
+                out[opos++] = '{';
+                if(is_length)
                 {
-                    out[opos++] = '{';
+                    out[opos++] = '#';
                 }
                 for(int k = 0; k < vlen; k++)
                 {
@@ -595,31 +563,86 @@ void cli_expand_env(
                         out[opos++] = varname[k];
                     }
                 }
-                if(has_brace
-                   && opos < maxlen - 1)
-                {
-                    out[opos++] = '}';
-                }
+                continue;
             }
         }
-        else if(line[i] == '\\'
-                && line[i + 1] == '$')
+
+        /* ---- Value lookup ---- */
+        const char *val = NULL;
+        char all_buf[STRINGMAXLEN_CLICMDLINE];
+        all_buf[0] = '\0';
+
+        if(has_index)
         {
-            /* Escaped $: pass both chars */
-            if(opos < maxlen - 1)
+            const char *idx_val = cli_var_lookup(index_str);
+            if(idx_val == NULL)
             {
-                out[opos++] = line[i++];
+                idx_val = index_str;
             }
-            if(opos < maxlen - 1)
+
+            if(strcmp(idx_val, "@") == 0)
             {
-                out[opos++] = line[i++];
+                expand_env_array_all(varname,
+                                     is_length,
+                                     all_buf,
+                                     &val);
+                is_length = 0; /* already handled */
+            }
+            else
+            {
+                expand_env_array_index(varname,
+                                       idx_val,
+                                       &val);
             }
         }
         else
         {
-            out[opos++] = line[i++];
+            val = cli_var_lookup(varname);
+        }
+
+        /* ---- Apply modifier if present ---- */
+        char val_buf[256];
+        val_buf[0] = '\0';
+        if(mod_op[0] != '\0')
+        {
+            apply_modifier(varname, mod_op, mod_arg,
+                           val_buf, &val);
+        }
+
+        /* ---- Emit result ---- */
+        if(is_length)
+        {
+            int   len = val ? (int) strlen(val) : 0;
+            char  numstr[32];
+            snprintf(numstr, sizeof(numstr), "%d", len);
+            emit_str_local(out, &opos, maxlen, numstr);
+        }
+        else if(val != NULL)
+        {
+            emit_str_local(out, &opos, maxlen, val);
+        }
+        else
+        {
+            /* Variable not found — restore literal */
+            out[opos++] = '$';
+            if(has_brace)
+            {
+                out[opos++] = '{';
+            }
+            for(int k = 0; k < vlen; k++)
+            {
+                if(opos < maxlen - 1)
+                {
+                    out[opos++] = varname[k];
+                }
+            }
+            if(has_brace && opos < maxlen - 1)
+            {
+                out[opos++] = '}';
+            }
         }
     }
+
     out[opos] = '\0';
     strncpy(line, out, (size_t) maxlen);
     line[maxlen - 1] = '\0';

--- a/src/cli/libmilkscript/CLIcore_script_expand_env.c
+++ b/src/cli/libmilkscript/CLIcore_script_expand_env.c
@@ -88,8 +88,9 @@ static void expand_env_array_all(
     const char **out_val
 )
 {
+    *out_val    = NULL;
     int elems_count = 0;
-    out_buf[0] = '\0';
+    out_buf[0]  = '\0';
 
     /* Search associative arrays first */
     for(int a = 0; a < CLI_MAX_ASSOC; a++)
@@ -160,8 +161,9 @@ static void expand_env_array_all(
         }
     }
 
-    /* When is_length, overwrite buf with the count */
-    if(is_length && *out_val != NULL)
+    /* When is_length, overwrite buf with the element count.
+     * elems_count is 0 when no array was found, giving "0". */
+    if(is_length)
     {
         char cnt_buf[32];
         snprintf(cnt_buf, sizeof(cnt_buf), "%d", elems_count);
@@ -169,6 +171,11 @@ static void expand_env_array_all(
                 STRINGMAXLEN_CLICMDLINE - 1);
         out_buf[STRINGMAXLEN_CLICMDLINE - 1] = '\0';
     }
+
+    /* Always point out_val at out_buf: empty string when the
+     * array was not found, "0" for is_length on a missing array,
+     * preserving shell-like semantics. */
+    *out_val = out_buf;
 }
 
 
@@ -192,6 +199,8 @@ static void expand_env_array_index(
     const char **out_val
 )
 {
+    *out_val = NULL;
+
     /* Search associative arrays by key */
     for(int a = 0; a < CLI_MAX_ASSOC; a++)
     {
@@ -248,11 +257,12 @@ static void expand_env_array_index(
 
 /**
  * apply_modifier - apply a ${VAR:op:arg} modifier to *val.
- * @varname:  Variable name (used by := to store defaults)
- * @mod_op:   Two-char operator string, e.g. ":-", ":="
- * @mod_arg:  Argument after the operator
- * @val_buf:  Caller-supplied scratch buffer (size 256)
- * @val:      Pointer to current value; updated in place
+ * @varname:      Variable name (used by := to store defaults)
+ * @mod_op:       Two-char operator string, e.g. ":-", ":="
+ * @mod_arg:      Argument after the operator
+ * @val_buf:      Caller-supplied scratch buffer
+ * @val_buf_size: Size of @val_buf in bytes
+ * @val:          Pointer to current value; updated in place
  *
  * Supported operators:
  *   :-  use mod_arg if val is NULL or empty
@@ -266,6 +276,7 @@ static void apply_modifier(
     const char  *mod_op,
     char        *mod_arg,
     char        *val_buf,
+    int          val_buf_size,
     const char **val
 )
 {
@@ -357,6 +368,11 @@ static void apply_modifier(
     if(offset + length > vlen)
     {
         length = vlen - offset;
+    }
+    /* Clamp to val_buf capacity to prevent overflow */
+    if(length > val_buf_size - 1)
+    {
+        length = val_buf_size - 1;
     }
 
     strncpy(val_buf, *val + offset, (size_t) length);
@@ -606,7 +622,8 @@ void cli_expand_env(
         if(mod_op[0] != '\0')
         {
             apply_modifier(varname, mod_op, mod_arg,
-                           val_buf, &val);
+                           val_buf, (int) sizeof(val_buf),
+                           &val);
         }
 
         /* ---- Emit result ---- */


### PR DESCRIPTION
## Summary

`cli_expand_env()` in `CLIcore_script_expand_env.c` had the deepest nesting in the entire CLI codebase (depth 9, 512 lines). Three distinct logical blocks were buried inside deeply nested braces, making the function very difficult to read and reason about. This PR extracts those blocks into named helpers and fixes correctness bugs identified in code review.

## Changes

### Helper extraction

Three `static` helper functions were extracted from the monolithic body of `cli_expand_env()`:

| New function | Responsibility |
|---|---|
| `expand_env_array_all()` | Build space-joined string for `${arr[@]}` from indexed or associative arrays |
| `expand_env_array_index()` | Look up a single element by key (`${assoc[key]}`) or index (`${arr[n]}`) |
| `apply_modifier()` | Apply `:-` `:=` `:?` `:+` `:off:len` modifiers to the resolved value |

The main `cli_expand_env()` loop was also restructured with early-continue guard clauses, converting the deep nesting into flat, readable sequential logic.

**Result:** Maximum nesting depth 9 → 3. Function length 512 → ~220 lines. No new files or public API changes.

### Bug fixes (code review feedback)

- **`expand_env_array_all()`** — `*out_val` was left as `NULL` when the named array was not found, causing `${missing[@]}` and `${#missing[@]}` to fall through to a literal passthrough instead of expanding to `""` / `"0"` (shell semantics). Fixed by initializing `*out_val = NULL` at the top and unconditionally pointing it to `out_buf` at the end; the `is_length` block now writes `"0"` for missing arrays.

- **`expand_env_array_index()`** — relied on the caller having pre-initialized the output pointer; a stale non-`NULL` value would skip the lookup via the early-return guard. Fixed by adding `*out_val = NULL` at function entry.

- **`apply_modifier()`** — `length` was derived from `atoi()` of user input and could exceed the 256-byte `val_buf` scratch buffer (CLI variables allow up to `CLI_VAR_VALLEN=512` chars), making the `strncpy` write out-of-bounds. Fixed by adding a `val_buf_size` parameter and clamping `length` to `val_buf_size - 1` before the copy.

## Verification

- [x] Build passes (`/compile-test`)
- [x] Tests pass (`ctest --output-on-failure`)
- [x] CLI robustness tests pass (276/276 with no regressions)
- [ ] Documentation updated (README, help, docs/)

## Prompt Summary

The user asked to identify the worst-offending functions by line count and nesting depth across the CLI layer, then chose to proceed with Strategy A (extract sub-functions) starting with `cli_expand_env` as the deepest function in the codebase (depth 9). Follow-up code review identified three correctness/safety bugs in the extracted helpers, which were subsequently fixed.

## AI Authorship

- **Model**: Antigravity / Claude
- **User edits**: None