### PR TITLE
refactor: namespace MILK_* op-table macros; fix double-underscore include guards

### DIFF
--- a/src/coremods/COREMOD_arith/image_arith__im__im.c
+++ b/src/coremods/COREMOD_arith/image_arith__im__im.c
@@ -5,7 +5,7 @@
  * Applies a single math function to every pixel of
  * an input image, producing an output image.
  *
- * All call surfaces are generated from the UNARY_OPS
+ * All call surfaces are generated from the MILK_UNARY_OPS
  * X-macro table:
  *
  *  - arith_image_<op>_IMGID(imgin, imgout)
@@ -30,7 +30,7 @@
 #include "image_arith__im__im.h"
 
 
-/* UNARY_OPS table is defined in image_arith__im__im.h */
+/* MILK_UNARY_OPS table is defined in image_arith__im__im.h */
 
 
 
@@ -47,7 +47,7 @@ int arith_image_##op##_IMGID(  \
         imgin, imgout);        \
 }
 
-UNARY_OPS(DEFINE_IMGID)
+MILK_UNARY_OPS(DEFINE_IMGID)
 #undef DEFINE_IMGID
 
 
@@ -68,7 +68,7 @@ int arith_image_##op(                        \
         &imgin, &imgout);                    \
 }
 
-UNARY_OPS(DEFINE_STRING)
+MILK_UNARY_OPS(DEFINE_STRING)
 #undef DEFINE_STRING
 
 
@@ -85,5 +85,5 @@ int arith_image_##op##_inplace(   \
     return 0;                     \
 }
 
-UNARY_OPS(DEFINE_INPLACE)
+MILK_UNARY_OPS(DEFINE_INPLACE)
 #undef DEFINE_INPLACE

--- a/src/coremods/COREMOD_arith/image_arith__im__im.c
+++ b/src/coremods/COREMOD_arith/image_arith__im__im.c
@@ -30,32 +30,8 @@
 #include "image_arith__im__im.h"
 
 
-/* ==========================================================
- * X-macro table: all unary image operations.
- *
- * Columns:  X(op, fptr)
- *   op   — operation suffix
- *   fptr — function-pointer variable from mathfuncs.h
- * ========================================================== */
+/* UNARY_OPS table is defined in image_arith__im__im.h */
 
-#define UNARY_OPS(X) \
-    X(acos,     Pacos)     \
-    X(asin,     Pasin)     \
-    X(atan,     Patan)     \
-    X(ceil,     Pceil)     \
-    X(cos,      Pcos)      \
-    X(cosh,     Pcosh)     \
-    X(exp,      Pexp)      \
-    X(fabs,     Pfabs)     \
-    X(floor,    Pfloor)    \
-    X(ln,       Pln)       \
-    X(log,      Plog)      \
-    X(sqrt,     Psqrt)     \
-    X(sin,      Psin)      \
-    X(sinh,     Psinh)     \
-    X(tan,      Ptan)      \
-    X(tanh,     Ptanh)     \
-    X(positive, Ppositive)
 
 
 /* ----------------------------------------------------------

--- a/src/coremods/COREMOD_arith/image_arith__im__im.h
+++ b/src/coremods/COREMOD_arith/image_arith__im__im.h
@@ -2,9 +2,9 @@
  * @file  image_arith__im__im.h
  * @brief Unary image arithmetic prototypes (image → image).
  *
- * All prototypes are generated from the UNARY_OPS X-macro
+ * All prototypes are generated from the MILK_UNARY_OPS X-macro
  * table.  Adding a new operation requires only one edit:
- * add a row to UNARY_OPS in this header.
+ * add a row to MILK_UNARY_OPS in this header.
  *
  * Three call surfaces per operation:
  *   arith_image_<op>_IMGID(imgin, imgout)
@@ -12,8 +12,8 @@
  *   arith_image_<op>_inplace(name)
  */
 
-#ifndef IMAGE_ARITH__IM__IM_H
-#define IMAGE_ARITH__IM__IM_H
+#ifndef IMAGE_ARITH_IM_IM_H
+#define IMAGE_ARITH_IM_IM_H
 
 #include <libfps/IMGID.h>
 
@@ -28,7 +28,7 @@ double Ppositive(double a);
  *   fptr — function-pointer (from mathfuncs.h)
  * ========================================================== */
 
-#define UNARY_OPS(X) \
+#define MILK_UNARY_OPS(X) \
     X(acos,     Pacos)     \
     X(asin,     Pasin)     \
     X(atan,     Patan)     \
@@ -52,17 +52,17 @@ double Ppositive(double a);
  * Generated prototypes — IMGID, string, and inplace APIs
  * ---------------------------------------------------------- */
 
-#define _DECLARE_UNARY(op, fptr) \
-int arith_image_##op##_IMGID(   \
-    IMGID *imgin,               \
-    IMGID *imgout);             \
-int arith_image_##op(           \
-    const char *ID_name,        \
-    const char *ID_out);        \
-int arith_image_##op##_inplace( \
+#define IMAGE_ARITH_DECLARE_UNARY(op, fptr) \
+int arith_image_##op##_IMGID(               \
+    IMGID *imgin,                           \
+    IMGID *imgout);                         \
+int arith_image_##op(                       \
+    const char *ID_name,                    \
+    const char *ID_out);                    \
+int arith_image_##op##_inplace(             \
     const char *ID_name);
 
-UNARY_OPS(_DECLARE_UNARY)
-#undef _DECLARE_UNARY
+MILK_UNARY_OPS(IMAGE_ARITH_DECLARE_UNARY)
+#undef IMAGE_ARITH_DECLARE_UNARY
 
-#endif /* IMAGE_ARITH__IM__IM_H */
+#endif /* IMAGE_ARITH_IM_IM_H */

--- a/src/coremods/COREMOD_arith/image_arith__im__im.h
+++ b/src/coremods/COREMOD_arith/image_arith__im__im.h
@@ -1,119 +1,68 @@
 /**
- * @file image_arith__im__im.h
- * @brief -------------------------------------------------------------------------
+ * @file  image_arith__im__im.h
+ * @brief Unary image arithmetic prototypes (image → image).
+ *
+ * All prototypes are generated from the UNARY_OPS X-macro
+ * table.  Adding a new operation requires only one edit:
+ * add a row to UNARY_OPS in this header.
+ *
+ * Three call surfaces per operation:
+ *   arith_image_<op>_IMGID(imgin, imgout)
+ *   arith_image_<op>(name_in, name_out)
+ *   arith_image_<op>_inplace(name)
  */
 
-/**
- * @file    image_arith__im__im.h
- *
- */
+#ifndef IMAGE_ARITH__IM__IM_H
+#define IMAGE_ARITH__IM__IM_H
 
 #include <libfps/IMGID.h>
 
 double Ppositive(double a);
 
-/* ------------------------------------------------------------------------- */
-/* image  -> image                                                           */
-/* ------------------------------------------------------------------------- */
+
+/* ==========================================================
+ * X-macro table: all unary image operations.
+ *
+ * X(op, fptr)
+ *   op   — operation suffix
+ *   fptr — function-pointer (from mathfuncs.h)
+ * ========================================================== */
+
+#define UNARY_OPS(X) \
+    X(acos,     Pacos)     \
+    X(asin,     Pasin)     \
+    X(atan,     Patan)     \
+    X(ceil,     Pceil)     \
+    X(cos,      Pcos)      \
+    X(cosh,     Pcosh)     \
+    X(exp,      Pexp)      \
+    X(fabs,     Pfabs)     \
+    X(floor,    Pfloor)    \
+    X(ln,       Pln)       \
+    X(log,      Plog)      \
+    X(sqrt,     Psqrt)     \
+    X(sin,      Psin)      \
+    X(sinh,     Psinh)     \
+    X(tan,      Ptan)      \
+    X(tanh,     Ptanh)     \
+    X(positive, Ppositive)
 
 
+/* ----------------------------------------------------------
+ * Generated prototypes — IMGID, string, and inplace APIs
+ * ---------------------------------------------------------- */
 
+#define _DECLARE_UNARY(op, fptr) \
+int arith_image_##op##_IMGID(   \
+    IMGID *imgin,               \
+    IMGID *imgout);             \
+int arith_image_##op(           \
+    const char *ID_name,        \
+    const char *ID_out);        \
+int arith_image_##op##_inplace( \
+    const char *ID_name);
 
+UNARY_OPS(_DECLARE_UNARY)
+#undef _DECLARE_UNARY
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-int arith_image_acos(const char *ID_name, const char *ID_out);
-int arith_image_acos_IMGID(IMGID *imgin, IMGID *imgout);
-
-int arith_image_asin(const char *ID_name, const char *ID_out);
-int arith_image_asin_IMGID(IMGID *imgin, IMGID *imgout);
-
-int arith_image_atan(const char *ID_name, const char *ID_out);
-int arith_image_atan_IMGID(IMGID *imgin, IMGID *imgout);
-
-int arith_image_ceil(const char *ID_name, const char *ID_out);
-int arith_image_ceil_IMGID(IMGID *imgin, IMGID *imgout);
-
-int arith_image_cos(const char *ID_name, const char *ID_out);
-int arith_image_cos_IMGID(IMGID *imgin, IMGID *imgout);
-
-int arith_image_cosh(const char *ID_name, const char *ID_out);
-int arith_image_cosh_IMGID(IMGID *imgin, IMGID *imgout);
-
-int arith_image_exp(const char *ID_name, const char *ID_out);
-int arith_image_exp_IMGID(IMGID *imgin, IMGID *imgout);
-
-int arith_image_fabs(const char *ID_name, const char *ID_out);
-int arith_image_fabs_IMGID(IMGID *imgin, IMGID *imgout);
-
-int arith_image_floor(const char *ID_name, const char *ID_out);
-int arith_image_floor_IMGID(IMGID *imgin, IMGID *imgout);
-
-int arith_image_ln(const char *ID_name, const char *ID_out);
-int arith_image_ln_IMGID(IMGID *imgin, IMGID *imgout);
-
-int arith_image_log(const char *ID_name, const char *ID_out);
-int arith_image_log_IMGID(IMGID *imgin, IMGID *imgout);
-
-int arith_image_sqrt(const char *ID_name, const char *ID_out);
-int arith_image_sqrt_IMGID(IMGID *imgin, IMGID *imgout);
-
-int arith_image_sin(const char *ID_name, const char *ID_out);
-int arith_image_sin_IMGID(IMGID *imgin, IMGID *imgout);
-
-int arith_image_sinh(const char *ID_name, const char *ID_out);
-int arith_image_sinh_IMGID(IMGID *imgin, IMGID *imgout);
-
-int arith_image_tan(const char *ID_name, const char *ID_out);
-int arith_image_tan_IMGID(IMGID *imgin, IMGID *imgout);
-
-int arith_image_tanh(const char *ID_name, const char *ID_out);
-int arith_image_tanh_IMGID(IMGID *imgin, IMGID *imgout);
-
-int arith_image_positive(const char *ID_name, const char *ID_out);
-int arith_image_positive_IMGID(IMGID *imgin, IMGID *imgout);
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-int arith_image_acos_inplace(const char *ID_name);
-int arith_image_asin_inplace(const char *ID_name);
-int arith_image_atan_inplace(const char *ID_name);
-int arith_image_ceil_inplace(const char *ID_name);
-int arith_image_cos_inplace(const char *ID_name);
-int arith_image_cosh_inplace(const char *ID_name);
-int arith_image_exp_inplace(const char *ID_name);
-int arith_image_fabs_inplace(const char *ID_name);
-int arith_image_floor_inplace(const char *ID_name);
-int arith_image_ln_inplace(const char *ID_name);
-int arith_image_log_inplace(const char *ID_name);
-int arith_image_sqrt_inplace(const char *ID_name);
-int arith_image_sin_inplace(const char *ID_name);
-int arith_image_sinh_inplace(const char *ID_name);
-int arith_image_tan_inplace(const char *ID_name);
-int arith_image_tanh_inplace(const char *ID_name);
+#endif /* IMAGE_ARITH__IM__IM_H */

--- a/src/coremods/COREMOD_arith/image_arith__im_f__im.c
+++ b/src/coremods/COREMOD_arith/image_arith__im_f__im.c
@@ -27,7 +27,7 @@
 #include "image_arith__im_f__im.h"
 
 
-/* CST_OPS_* tables are defined in image_arith__im_f__im.h */
+/* MILK_CST_OPS_* tables are defined in image_arith__im_f__im.h */
 
 
 
@@ -46,8 +46,8 @@ int arith_image_cst##op##_IMGID(  \
         imgin, f1, imgout);       \
 }
 
-CST_OPS_OPT_FULL(DEFINE_IMGID_OPT)
-CST_OPS_OPT_NOIP(DEFINE_IMGID_OPT)
+MILK_CST_OPS_OPT_FULL(DEFINE_IMGID_OPT)
+MILK_CST_OPS_OPT_NOIP(DEFINE_IMGID_OPT)
 #undef DEFINE_IMGID_OPT
 
 
@@ -65,7 +65,7 @@ int arith_image_cst##op##_IMGID(    \
         imgin, f1, imgout, &fptr);  \
 }
 
-CST_OPS_FPTR_FULL(DEFINE_IMGID_FPTR)
+MILK_CST_OPS_FPTR_FULL(DEFINE_IMGID_FPTR)
 #undef DEFINE_IMGID_FPTR
 
 
@@ -107,9 +107,9 @@ int arith_image_cst##op(                     \
     return ret;                              \
 }
 
-CST_OPS_OPT_FULL(DEFINE_CST_STRING)
-CST_OPS_FPTR_FULL(DEFINE_CST_STRING)
-CST_OPS_OPT_NOIP(DEFINE_CST_STRING)
+MILK_CST_OPS_OPT_FULL(DEFINE_CST_STRING)
+MILK_CST_OPS_FPTR_FULL(DEFINE_CST_STRING)
+MILK_CST_OPS_OPT_NOIP(DEFINE_CST_STRING)
 #undef DEFINE_CST_STRING
 
 

--- a/src/coremods/COREMOD_arith/image_arith__im_f__im.c
+++ b/src/coremods/COREMOD_arith/image_arith__im_f__im.c
@@ -27,62 +27,9 @@
 #include "image_arith__im_f__im.h"
 
 
-/* ==========================================================
- * X-macro operation tables.
- *
- * Table groups used below:
- *   - CST_OPS_OPT_FULL  : optimized-dispatch ops with
- *                         inplace variants
- *   - CST_OPS_FPTR_FULL : function-pointer-dispatch ops with
- *                         inplace variants
- *   - CST_OPS_OPT_NOIP  : optimized-dispatch ops without
- *                         inplace variants
- *
- * All tables use the form:
- *   X(op, dispatch)
- *
- * For optimized-dispatch tables, the 2nd column is a
- * placeholder token kept for a consistent X-macro shape and
- * is not used by the optimized wrapper macros.
- *
- * For function-pointer tables, the 2nd column is the
- * function-pointer variable passed to the generic dispatcher.
- * ========================================================== */
+/* CST_OPS_* tables are defined in image_arith__im_f__im.h */
 
-/**
- * Ops dispatched to optimized (macro-stamped) IMGID
- * functions AND that have inplace variants.
- */
-#define CST_OPS_OPT_FULL(X) \
-    X(add,    optimized)     \
-    X(sub,    optimized)     \
-    X(mult,   optimized)     \
-    X(div,    optimized)     \
-    X(pow,    optimized)     \
-    X(testlt, optimized)     \
-    X(testmt, optimized)
 
-/**
- * Ops dispatched via function-pointer AND that have
- * inplace variants.
- */
-#define CST_OPS_FPTR_FULL(X) \
-    X(fmod,   Pfmod)         \
-    X(subm,   Psubm)         \
-    X(div1,   Pdiv1)         \
-    X(maxv,   Pmaxv)         \
-    X(minv,   Pminv)
-
-/**
- * Ops dispatched to optimized IMGID, NO inplace variants.
- */
-#define CST_OPS_OPT_NOIP(X) \
-    X(teste,  optimized)     \
-    X(testne, optimized)     \
-    X(testle, optimized)     \
-    X(testge, optimized)     \
-    X(and,    optimized)     \
-    X(or,     optimized)
 
 
 /* ----------------------------------------------------------

--- a/src/coremods/COREMOD_arith/image_arith__im_f__im.h
+++ b/src/coremods/COREMOD_arith/image_arith__im_f__im.h
@@ -12,8 +12,8 @@
  *   arith_image_cst<op>_inplace(name, f1)   [FULL ops only]
  */
 
-#ifndef IMAGE_ARITH__IM_F__IM_H
-#define IMAGE_ARITH__IM_F__IM_H
+#ifndef IMAGE_ARITH_IM_F_IM_H
+#define IMAGE_ARITH_IM_F_IM_H
 
 #include <libfps/IMGID.h>
 
@@ -21,45 +21,45 @@
 /* ==========================================================
  * X-macro operation tables.
  *
- * CST_OPS_OPT_FULL  — optimized dispatch, with inplace
- * CST_OPS_FPTR_FULL — function-pointer dispatch, with inplace
- * CST_OPS_OPT_NOIP  — optimized dispatch, no inplace
+ * MILK_CST_OPS_OPT_FULL  — optimized dispatch, with inplace
+ * MILK_CST_OPS_FPTR_FULL — function-pointer dispatch, with inplace
+ * MILK_CST_OPS_OPT_NOIP  — optimized dispatch, no inplace
  *
  * X(op, tag_or_fptr)
  * ========================================================== */
 
 /** Optimized dispatch + inplace variants */
-#define CST_OPS_OPT_FULL(X) \
-    X(add,    optimized)     \
-    X(sub,    optimized)     \
-    X(mult,   optimized)     \
-    X(div,    optimized)     \
-    X(pow,    optimized)     \
-    X(testlt, optimized)     \
+#define MILK_CST_OPS_OPT_FULL(X) \
+    X(add,    optimized)          \
+    X(sub,    optimized)          \
+    X(mult,   optimized)          \
+    X(div,    optimized)          \
+    X(pow,    optimized)          \
+    X(testlt, optimized)          \
     X(testmt, optimized)
 
 /** Function-pointer dispatch + inplace variants */
-#define CST_OPS_FPTR_FULL(X) \
-    X(fmod,   Pfmod)         \
-    X(subm,   Psubm)         \
-    X(div1,   Pdiv1)         \
-    X(maxv,   Pmaxv)         \
+#define MILK_CST_OPS_FPTR_FULL(X) \
+    X(fmod,   Pfmod)               \
+    X(subm,   Psubm)               \
+    X(div1,   Pdiv1)               \
+    X(maxv,   Pmaxv)               \
     X(minv,   Pminv)
 
 /** Optimized dispatch, no inplace variant */
-#define CST_OPS_OPT_NOIP(X) \
-    X(teste,  optimized)     \
-    X(testne, optimized)     \
-    X(testle, optimized)     \
-    X(testge, optimized)     \
-    X(and,    optimized)     \
+#define MILK_CST_OPS_OPT_NOIP(X) \
+    X(teste,  optimized)          \
+    X(testne, optimized)          \
+    X(testle, optimized)          \
+    X(testge, optimized)          \
+    X(and,    optimized)          \
     X(or,     optimized)
 
 /** Expand all three tables for macros that apply to all */
-#define CST_OPS_ALL(X)    \
-    CST_OPS_OPT_FULL(X)   \
-    CST_OPS_FPTR_FULL(X)  \
-    CST_OPS_OPT_NOIP(X)
+#define MILK_CST_OPS_ALL(X)      \
+    MILK_CST_OPS_OPT_FULL(X)     \
+    MILK_CST_OPS_FPTR_FULL(X)    \
+    MILK_CST_OPS_OPT_NOIP(X)
 
 
 /* ----------------------------------------------------------
@@ -76,7 +76,7 @@ int arith_image_cst##op(                 \
     double f1,                           \
     const char *ID_out);
 
-CST_OPS_ALL(IMAGE_ARITH_DECLARE_CST)
+MILK_CST_OPS_ALL(IMAGE_ARITH_DECLARE_CST)
 #undef IMAGE_ARITH_DECLARE_CST
 
 
@@ -89,8 +89,8 @@ int arith_image_cst##op##_inplace(               \
     const char *ID_name,                         \
     double f1);
 
-CST_OPS_OPT_FULL(IMAGE_ARITH_DECLARE_CST_INPLACE)
-CST_OPS_FPTR_FULL(IMAGE_ARITH_DECLARE_CST_INPLACE)
+MILK_CST_OPS_OPT_FULL(IMAGE_ARITH_DECLARE_CST_INPLACE)
+MILK_CST_OPS_FPTR_FULL(IMAGE_ARITH_DECLARE_CST_INPLACE)
 #undef IMAGE_ARITH_DECLARE_CST_INPLACE
 
-#endif /* IMAGE_ARITH__IM_F__IM_H */
+#endif /* IMAGE_ARITH_IM_F_IM_H */

--- a/src/coremods/COREMOD_arith/image_arith__im_f__im.h
+++ b/src/coremods/COREMOD_arith/image_arith__im_f__im.h
@@ -66,31 +66,31 @@
  * Generated prototypes — IMGID and string APIs (all ops)
  * ---------------------------------------------------------- */
 
-#define _DECLARE_CST(op, tag) \
-int arith_image_cst##op##_IMGID( \
-    IMGID *imgin,                \
-    double f1,                   \
-    IMGID *imgout);              \
-int arith_image_cst##op(         \
-    const char *ID_name,         \
-    double f1,                   \
+#define IMAGE_ARITH_DECLARE_CST(op, tag) \
+int arith_image_cst##op##_IMGID(         \
+    IMGID *imgin,                        \
+    double f1,                           \
+    IMGID *imgout);                      \
+int arith_image_cst##op(                 \
+    const char *ID_name,                 \
+    double f1,                           \
     const char *ID_out);
 
-CST_OPS_ALL(_DECLARE_CST)
-#undef _DECLARE_CST
+CST_OPS_ALL(IMAGE_ARITH_DECLARE_CST)
+#undef IMAGE_ARITH_DECLARE_CST
 
 
 /* ----------------------------------------------------------
  * Generated prototypes — inplace API (FULL ops only)
  * ---------------------------------------------------------- */
 
-#define _DECLARE_CST_INPLACE(op, tag) \
-int arith_image_cst##op##_inplace(    \
-    const char *ID_name,              \
+#define IMAGE_ARITH_DECLARE_CST_INPLACE(op, tag) \
+int arith_image_cst##op##_inplace(               \
+    const char *ID_name,                         \
     double f1);
 
-CST_OPS_OPT_FULL(_DECLARE_CST_INPLACE)
-CST_OPS_FPTR_FULL(_DECLARE_CST_INPLACE)
-#undef _DECLARE_CST_INPLACE
+CST_OPS_OPT_FULL(IMAGE_ARITH_DECLARE_CST_INPLACE)
+CST_OPS_FPTR_FULL(IMAGE_ARITH_DECLARE_CST_INPLACE)
+#undef IMAGE_ARITH_DECLARE_CST_INPLACE
 
 #endif /* IMAGE_ARITH__IM_F__IM_H */

--- a/src/coremods/COREMOD_arith/image_arith__im_f__im.h
+++ b/src/coremods/COREMOD_arith/image_arith__im_f__im.h
@@ -1,104 +1,96 @@
 /**
- * @file image_arith__im_f__im.h
- * @brief Image arith  im f  im module
+ * @file  image_arith__im_f__im.h
+ * @brief Image + scalar arithmetic prototypes (img,float → img).
+ *
+ * All prototypes are generated from X-macro op tables.
+ * Adding a new operation requires only one edit:
+ * add a row to the appropriate table below.
+ *
+ * Three call surfaces per operation:
+ *   arith_image_cst<op>_IMGID(imgin, f1, imgout)
+ *   arith_image_cst<op>(name, f1, name_out)
+ *   arith_image_cst<op>_inplace(name, f1)   [FULL ops only]
  */
 
-/**
- * @file    image_arith__im_f__im.h
- *
- */
+#ifndef IMAGE_ARITH__IM_F__IM_H
+#define IMAGE_ARITH__IM_F__IM_H
 
 #include <libfps/IMGID.h>
 
-int arith_image_cstfmod(const char *ID_name, double f1, const char *ID_out);
-int arith_image_cstfmod_IMGID(IMGID *imgin, double f1, IMGID *imgout);
 
-int arith_image_cstadd(const char *ID_name, double f1, const char *ID_out);
-int arith_image_cstadd_IMGID(IMGID *imgin, double f1, IMGID *imgout);
+/* ==========================================================
+ * X-macro operation tables.
+ *
+ * CST_OPS_OPT_FULL  — optimized dispatch, with inplace
+ * CST_OPS_FPTR_FULL — function-pointer dispatch, with inplace
+ * CST_OPS_OPT_NOIP  — optimized dispatch, no inplace
+ *
+ * X(op, tag_or_fptr)
+ * ========================================================== */
 
-int arith_image_cstsub(const char *ID_name, double f1, const char *ID_out);
-int arith_image_cstsub_IMGID(IMGID *imgin, double f1, IMGID *imgout);
+/** Optimized dispatch + inplace variants */
+#define CST_OPS_OPT_FULL(X) \
+    X(add,    optimized)     \
+    X(sub,    optimized)     \
+    X(mult,   optimized)     \
+    X(div,    optimized)     \
+    X(pow,    optimized)     \
+    X(testlt, optimized)     \
+    X(testmt, optimized)
 
-int arith_image_cstsubm(const char *ID_name, double f1, const char *ID_out);
-int arith_image_cstsubm_IMGID(IMGID *imgin, double f1, IMGID *imgout);
+/** Function-pointer dispatch + inplace variants */
+#define CST_OPS_FPTR_FULL(X) \
+    X(fmod,   Pfmod)         \
+    X(subm,   Psubm)         \
+    X(div1,   Pdiv1)         \
+    X(maxv,   Pmaxv)         \
+    X(minv,   Pminv)
 
-int arith_image_cstmult(const char *ID_name, double f1, const char *ID_out);
-int arith_image_cstmult_IMGID(IMGID *imgin, double f1, IMGID *imgout);
+/** Optimized dispatch, no inplace variant */
+#define CST_OPS_OPT_NOIP(X) \
+    X(teste,  optimized)     \
+    X(testne, optimized)     \
+    X(testle, optimized)     \
+    X(testge, optimized)     \
+    X(and,    optimized)     \
+    X(or,     optimized)
 
-int arith_image_cstdiv(const char *ID_name, double f1, const char *ID_out);
-int arith_image_cstdiv_IMGID(IMGID *imgin, double f1, IMGID *imgout);
-
-int arith_image_cstdiv1(const char *ID_name, double f1, const char *ID_out);
-int arith_image_cstdiv1_IMGID(IMGID *imgin, double f1, IMGID *imgout);
-
-int arith_image_cstpow(const char *ID_name, double f1, const char *ID_out);
-int arith_image_cstpow_IMGID(IMGID *imgin, double f1, IMGID *imgout);
-
-int arith_image_cstmaxv(const char *ID_name, double f1, const char *ID_out);
-int arith_image_cstmaxv_IMGID(IMGID *imgin, double f1, IMGID *imgout);
-
-int arith_image_cstminv(const char *ID_name, double f1, const char *ID_out);
-int arith_image_cstminv_IMGID(IMGID *imgin, double f1, IMGID *imgout);
-
-int arith_image_csttestlt(const char *ID_name, double f1, const char *ID_out);
-int arith_image_csttestlt_IMGID(IMGID *imgin, double f1, IMGID *imgout);
-
-int arith_image_csttestmt(const char *ID_name, double f1, const char *ID_out);
-int arith_image_csttestmt_IMGID(IMGID *imgin, double f1, IMGID *imgout);
-
-int arith_image_cstteste(const char *ID_name, double f1, const char *ID_out);
-int arith_image_cstteste_IMGID(IMGID *imgin, double f1, IMGID *imgout);
-int arith_image_csttestne(const char *ID_name, double f1, const char *ID_out);
-int arith_image_csttestne_IMGID(IMGID *imgin, double f1, IMGID *imgout);
-int arith_image_csttestle(const char *ID_name, double f1, const char *ID_out);
-int arith_image_csttestle_IMGID(IMGID *imgin, double f1, IMGID *imgout);
-int arith_image_csttestge(const char *ID_name, double f1, const char *ID_out);
-int arith_image_csttestge_IMGID(IMGID *imgin, double f1, IMGID *imgout);
-int arith_image_cstand(const char *ID_name, double f1, const char *ID_out);
-int arith_image_cstand_IMGID(IMGID *imgin, double f1, IMGID *imgout);
-int arith_image_cstor(const char *ID_name, double f1, const char *ID_out);
-int arith_image_cstor_IMGID(IMGID *imgin, double f1, IMGID *imgout);
-
-int arith_image_cstfmod_inplace(const char *ID_name, double f1);
-
-int arith_image_cstadd_inplace(const char *ID_name, double f1);
-
-int arith_image_cstsub_inplace(const char *ID_name, double f1);
-
-int arith_image_cstmult_inplace(const char *ID_name, double f1);
-
-int arith_image_cstdiv_inplace(const char *ID_name, double f1);
-
-int arith_image_cstdiv1_inplace(const char *ID_name, double f1);
-
-int arith_image_cstpow_inplace(const char *ID_name, double f1);
-
-int arith_image_cstmaxv_inplace(const char *ID_name, double f1);
-
-int arith_image_cstminv_inplace(const char *ID_name, double f1);
-
-int arith_image_csttestlt_inplace(const char *ID_name, double f1);
-
-int arith_image_csttestmt_inplace(const char *ID_name, double f1);
+/** Expand all three tables for macros that apply to all */
+#define CST_OPS_ALL(X)    \
+    CST_OPS_OPT_FULL(X)   \
+    CST_OPS_FPTR_FULL(X)  \
+    CST_OPS_OPT_NOIP(X)
 
 
+/* ----------------------------------------------------------
+ * Generated prototypes — IMGID and string APIs (all ops)
+ * ---------------------------------------------------------- */
+
+#define _DECLARE_CST(op, tag) \
+int arith_image_cst##op##_IMGID( \
+    IMGID *imgin,                \
+    double f1,                   \
+    IMGID *imgout);              \
+int arith_image_cst##op(         \
+    const char *ID_name,         \
+    double f1,                   \
+    const char *ID_out);
+
+CST_OPS_ALL(_DECLARE_CST)
+#undef _DECLARE_CST
 
 
+/* ----------------------------------------------------------
+ * Generated prototypes — inplace API (FULL ops only)
+ * ---------------------------------------------------------- */
 
+#define _DECLARE_CST_INPLACE(op, tag) \
+int arith_image_cst##op##_inplace(    \
+    const char *ID_name,              \
+    double f1);
 
+CST_OPS_OPT_FULL(_DECLARE_CST_INPLACE)
+CST_OPS_FPTR_FULL(_DECLARE_CST_INPLACE)
+#undef _DECLARE_CST_INPLACE
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+#endif /* IMAGE_ARITH__IM_F__IM_H */

--- a/src/coremods/COREMOD_arith/image_arith__im_f_f__im.h
+++ b/src/coremods/COREMOD_arith/image_arith__im_f_f__im.h
@@ -3,8 +3,8 @@
  * @brief Image arithmetic: image + float + float → image
  */
 
-#ifndef IMAGE_ARITH__IM_F_F__IM_H
-#define IMAGE_ARITH__IM_F_F__IM_H
+#ifndef IMAGE_ARITH_IM_F_F_IM_H
+#define IMAGE_ARITH_IM_F_F_IM_H
 
 #include <libfps/IMGID.h>
 
@@ -28,4 +28,4 @@ int arith_image_trunc_inplace(const char *ID_name,
                               double f1,
                               double f2);
 
-#endif /* IMAGE_ARITH__IM_F_F__IM_H */
+#endif /* IMAGE_ARITH_IM_F_F_IM_H */

--- a/src/coremods/COREMOD_arith/image_arith__im_f_f__im.h
+++ b/src/coremods/COREMOD_arith/image_arith__im_f_f__im.h
@@ -1,11 +1,10 @@
 /**
- * @file image_arith__im_f_f__im.h
- * @brief Image arith  im f f  im module
+ * @file  image_arith__im_f_f__im.h
+ * @brief Image arithmetic: image + float + float → image
  */
 
-/**
- * @file    image_arith__im_f_f__im.h
- */
+#ifndef IMAGE_ARITH__IM_F_F__IM_H
+#define IMAGE_ARITH__IM_F_F__IM_H
 
 #include <libfps/IMGID.h>
 
@@ -25,4 +24,8 @@ int arith_image_trunc_IMGID(IMGID  *imgin,
                             double  f2,
                             IMGID  *imgout);
 
-int arith_image_trunc_inplace(const char *ID_name, double f1, double f2);
+int arith_image_trunc_inplace(const char *ID_name,
+                              double f1,
+                              double f2);
+
+#endif /* IMAGE_ARITH__IM_F_F__IM_H */

--- a/src/coremods/COREMOD_arith/image_arith__im_im__im.c
+++ b/src/coremods/COREMOD_arith/image_arith__im_im__im.c
@@ -32,49 +32,9 @@
 #include "image_arith__im_im__im.h"
 
 
-/* ==========================================================
- * X-macro operation tables.
- *
- * BINARY_OPS_FULL — ops with all 4 call surfaces
- *   (IMGID, string, inplace, inplace_byID)
- *
- * BINARY_OPS_NOIP — ops with IMGID + string only
- *   (no inplace variants exist in the public API)
- *
- * Both tables use the same X(op, fptr) shape so they can be
- * expanded by the shared non-inplace generators below.
- *
- * Column: X(op, fptr)
- *   op   — operation suffix
- *   fptr — function-pointer used only for inplace dispatch
- *          generation from BINARY_OPS_FULL; ignored for
- *          BINARY_OPS_NOIP entries
- * ========================================================== */
+/* BINARY_OPS_* tables are defined in image_arith__im_im__im.h */
 
-#define BINARY_OPS_FULL(X) \
-    X(fmod,   Pfmod)       \
-    X(pow,    Ppow)        \
-    X(add,    Padd)        \
-    X(sub,    Psub)        \
-    X(mult,   Pmult)       \
-    X(div,    Pdiv)        \
-    X(minv,   Pminv)       \
-    X(maxv,   Pmaxv)       \
-    X(testlt, Ptestlt)     \
-    X(testmt, Ptestmt)
 
-#define BINARY_OPS_NOIP(X) \
-    X(teste,  Pteste)      \
-    X(testne, Ptestne)     \
-    X(testle, Ptestle)     \
-    X(testge, Ptestge)     \
-    X(and,    Pand)        \
-    X(or,     Por)
-
-/** Expand both tables for macros that apply to all */
-#define BINARY_OPS_ALL(X) \
-    BINARY_OPS_FULL(X)    \
-    BINARY_OPS_NOIP(X)
 
 
 /* ----------------------------------------------------------

--- a/src/coremods/COREMOD_arith/image_arith__im_im__im.c
+++ b/src/coremods/COREMOD_arith/image_arith__im_im__im.c
@@ -32,7 +32,7 @@
 #include "image_arith__im_im__im.h"
 
 
-/* BINARY_OPS_* tables are defined in image_arith__im_im__im.h */
+/* MILK_BINARY_OPS_* tables are defined in image_arith__im_im__im.h */
 
 
 
@@ -54,7 +54,7 @@ int arith_image_##op##_IMGID( \
         imgin1, imgin2, imgout);              \
 }
 
-BINARY_OPS_ALL(DEFINE_IMGID)
+MILK_BINARY_OPS_ALL(DEFINE_IMGID)
 #undef DEFINE_IMGID
 
 
@@ -104,7 +104,7 @@ int arith_image_##op(                        \
     return ret;                              \
 }
 
-BINARY_OPS_ALL(DEFINE_STRING)
+MILK_BINARY_OPS_ALL(DEFINE_STRING)
 #undef DEFINE_STRING
 
 
@@ -113,7 +113,7 @@ BINARY_OPS_ALL(DEFINE_STRING)
  *
  * Uses function-pointer dispatch via
  * arith_image_function_2_1_inplace().
- * Only generated for BINARY_OPS_FULL operations.
+ * Only generated for MILK_BINARY_OPS_FULL operations.
  * ---------------------------------------------------------- */
 
 #define DEFINE_INPLACE(op, fptr) \
@@ -126,7 +126,7 @@ int arith_image_##op##_inplace(              \
     return 0;                                \
 }
 
-BINARY_OPS_FULL(DEFINE_INPLACE)
+MILK_BINARY_OPS_FULL(DEFINE_INPLACE)
 #undef DEFINE_INPLACE
 
 
@@ -134,7 +134,7 @@ BINARY_OPS_FULL(DEFINE_INPLACE)
  * 4. In-place-by-ID wrappers  (ID,ID → ID1 modified)
  *
  * Legacy API using raw image slot indices.
- * Only generated for BINARY_OPS_FULL operations.
+ * Only generated for MILK_BINARY_OPS_FULL operations.
  * ---------------------------------------------------------- */
 
 

--- a/src/coremods/COREMOD_arith/image_arith__im_im__im.h
+++ b/src/coremods/COREMOD_arith/image_arith__im_im__im.h
@@ -6,7 +6,7 @@
  * Adding a new operation requires only one edit:
  * add a row to the appropriate table below.
  *
- * Up to four call surfaces per operation:
+ * Up to three call surfaces per operation:
  *   arith_image_<op>_IMGID(in1, in2, out)
  *   arith_image_<op>(name1, name2, name_out)
  *   arith_image_<op>_inplace(name1, name2)  [FULL ops only]

--- a/src/coremods/COREMOD_arith/image_arith__im_im__im.h
+++ b/src/coremods/COREMOD_arith/image_arith__im_im__im.h
@@ -1,108 +1,92 @@
 /**
- * @file image_arith__im_im__im.h
- * @brief -------------------------------------------------------------------------
+ * @file  image_arith__im_im__im.h
+ * @brief Binary image×image arithmetic prototypes (img,img → img).
+ *
+ * All prototypes are generated from X-macro op tables.
+ * Adding a new operation requires only one edit:
+ * add a row to the appropriate table below.
+ *
+ * Up to four call surfaces per operation:
+ *   arith_image_<op>_IMGID(in1, in2, out)
+ *   arith_image_<op>(name1, name2, name_out)
+ *   arith_image_<op>_inplace(name1, name2)  [FULL ops only]
  */
 
-/**
- * @file    image_arith__im__im.h
- *
- */
+#ifndef IMAGE_ARITH__IM_IM__IM_H
+#define IMAGE_ARITH__IM_IM__IM_H
 
 #include <libfps/IMGID.h>
 
 double Ptrunc(double a, double b, double c);
 
-/* ------------------------------------------------------------------------- */
-/* predefined functions    image, image  -> image                                                    */
-/* ------------------------------------------------------------------------- */
+
+/* ==========================================================
+ * X-macro operation tables.
+ *
+ * BINARY_OPS_FULL — ops with all call surfaces
+ *   (IMGID, string, inplace)
+ *
+ * BINARY_OPS_NOIP — ops with IMGID + string only
+ *   (no inplace variants in the public API)
+ *
+ * X(op, fptr)
+ *   op   — operation suffix
+ *   fptr — function-pointer (for inplace dispatch)
+ * ========================================================== */
+
+#define BINARY_OPS_FULL(X) \
+    X(fmod,   Pfmod)       \
+    X(pow,    Ppow)        \
+    X(add,    Padd)        \
+    X(sub,    Psub)        \
+    X(mult,   Pmult)       \
+    X(div,    Pdiv)        \
+    X(minv,   Pminv)       \
+    X(maxv,   Pmaxv)       \
+    X(testlt, Ptestlt)     \
+    X(testmt, Ptestmt)
+
+#define BINARY_OPS_NOIP(X) \
+    X(teste,  Pteste)      \
+    X(testne, Ptestne)     \
+    X(testle, Ptestle)     \
+    X(testge, Ptestge)     \
+    X(and,    Pand)        \
+    X(or,     Por)
+
+#define BINARY_OPS_ALL(X) \
+    BINARY_OPS_FULL(X)    \
+    BINARY_OPS_NOIP(X)
 
 
+/* ----------------------------------------------------------
+ * Generated prototypes — IMGID and string APIs (all ops)
+ * ---------------------------------------------------------- */
+
+#define _DECLARE_BINARY(op, fptr)   \
+int arith_image_##op##_IMGID(       \
+    IMGID *imgin1,                  \
+    IMGID *imgin2,                  \
+    IMGID *imgout);                 \
+int arith_image_##op(               \
+    const char *ID1_name,           \
+    const char *ID2_name,           \
+    const char *ID_out);
+
+BINARY_OPS_ALL(_DECLARE_BINARY)
+#undef _DECLARE_BINARY
 
 
+/* ----------------------------------------------------------
+ * Generated prototypes — inplace API (FULL ops only)
+ * ---------------------------------------------------------- */
 
+#define _DECLARE_BINARY_INPLACE(op, fptr) \
+int arith_image_##op##_inplace(           \
+    const char *ID1_name,                 \
+    const char *ID2_name);
 
+BINARY_OPS_FULL(_DECLARE_BINARY_INPLACE)
+#undef _DECLARE_BINARY_INPLACE
 
-
-
-
-int arith_image_fmod(const char *ID1_name,
-                     const char *ID2_name,
-                     const char *ID_out);
-int arith_image_fmod_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
-
-int arith_image_pow(const char *ID1_name,
-                    const char *ID2_name,
-                    const char *ID_out);
-int arith_image_pow_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
-
-int arith_image_add(const char *ID1_name,
-                    const char *ID2_name,
-                    const char *ID_out);
-int arith_image_add_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
-
-int arith_image_sub(const char *ID1_name,
-                    const char *ID2_name,
-                    const char *ID_out);
-int arith_image_sub_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
-
-int arith_image_mult(const char *ID1_name,
-                     const char *ID2_name,
-                     const char *ID_out);
-int arith_image_mult_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
-
-int arith_image_div(const char *ID1_name,
-                    const char *ID2_name,
-                    const char *ID_out);
-int arith_image_div_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
-
-int arith_image_minv(const char *ID1_name,
-                     const char *ID2_name,
-                     const char *ID_out);
-int arith_image_minv_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
-
-int arith_image_maxv(const char *ID1_name,
-                     const char *ID2_name,
-                     const char *ID_out);
-int arith_image_maxv_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
-
-int arith_image_testlt(const char *ID1_name,
-                       const char *ID2_name,
-                       const char *ID_out);
-int arith_image_testlt_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
-
-int arith_image_testmt(const char *ID1_name,
-                       const char *ID2_name,
-                       const char *ID_out);
-int arith_image_testmt_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
-
-int arith_image_teste(const char *ID1_name, const char *ID2_name, const char *ID_out);
-int arith_image_teste_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
-int arith_image_testne(const char *ID1_name, const char *ID2_name, const char *ID_out);
-int arith_image_testne_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
-int arith_image_testle(const char *ID1_name, const char *ID2_name, const char *ID_out);
-int arith_image_testle_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
-int arith_image_testge(const char *ID1_name, const char *ID2_name, const char *ID_out);
-int arith_image_testge_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
-int arith_image_and(const char *ID1_name, const char *ID2_name, const char *ID_out);
-int arith_image_and_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
-int arith_image_or(const char *ID1_name, const char *ID2_name, const char *ID_out);
-int arith_image_or_IMGID(IMGID *imgin1, IMGID *imgin2, IMGID *imgout);
-
-
-
-
-
-
-
-
-
-
-int arith_image_fmod_inplace(const char *ID1_name,
-                             const char *ID2_name); // ID1 is output
-int arith_image_pow_inplace(const char *ID1_name, const char *ID2_name);
-int arith_image_add_inplace(const char *ID1_name, const char *ID2_name);
-int arith_image_sub_inplace(const char *ID1_name, const char *ID2_name);
-int arith_image_mult_inplace(const char *ID1_name, const char *ID2_name);
-int arith_image_div_inplace(const char *ID1_name, const char *ID2_name);
-int arith_image_minv_inplace(const char *ID1_name, const char *ID2_name);
-int arith_image_maxv_inplace(const char *ID1_name, const char *ID2_name);
+#endif /* IMAGE_ARITH__IM_IM__IM_H */

--- a/src/coremods/COREMOD_arith/image_arith__im_im__im.h
+++ b/src/coremods/COREMOD_arith/image_arith__im_im__im.h
@@ -12,8 +12,8 @@
  *   arith_image_<op>_inplace(name1, name2)  [FULL ops only]
  */
 
-#ifndef IMAGE_ARITH__IM_IM__IM_H
-#define IMAGE_ARITH__IM_IM__IM_H
+#ifndef IMAGE_ARITH_IM_IM_IM_H
+#define IMAGE_ARITH_IM_IM_IM_H
 
 #include <libfps/IMGID.h>
 
@@ -23,10 +23,10 @@ double Ptrunc(double a, double b, double c);
 /* ==========================================================
  * X-macro operation tables.
  *
- * BINARY_OPS_FULL — ops with all call surfaces
+ * MILK_BINARY_OPS_FULL — ops with all call surfaces
  *   (IMGID, string, inplace)
  *
- * BINARY_OPS_NOIP — ops with IMGID + string only
+ * MILK_BINARY_OPS_NOIP — ops with IMGID + string only
  *   (no inplace variants in the public API)
  *
  * X(op, fptr)
@@ -34,29 +34,29 @@ double Ptrunc(double a, double b, double c);
  *   fptr — function-pointer (for inplace dispatch)
  * ========================================================== */
 
-#define BINARY_OPS_FULL(X) \
-    X(fmod,   Pfmod)       \
-    X(pow,    Ppow)        \
-    X(add,    Padd)        \
-    X(sub,    Psub)        \
-    X(mult,   Pmult)       \
-    X(div,    Pdiv)        \
-    X(minv,   Pminv)       \
-    X(maxv,   Pmaxv)       \
-    X(testlt, Ptestlt)     \
+#define MILK_BINARY_OPS_FULL(X) \
+    X(fmod,   Pfmod)            \
+    X(pow,    Ppow)             \
+    X(add,    Padd)             \
+    X(sub,    Psub)             \
+    X(mult,   Pmult)            \
+    X(div,    Pdiv)             \
+    X(minv,   Pminv)            \
+    X(maxv,   Pmaxv)            \
+    X(testlt, Ptestlt)          \
     X(testmt, Ptestmt)
 
-#define BINARY_OPS_NOIP(X) \
-    X(teste,  Pteste)      \
-    X(testne, Ptestne)     \
-    X(testle, Ptestle)     \
-    X(testge, Ptestge)     \
-    X(and,    Pand)        \
+#define MILK_BINARY_OPS_NOIP(X) \
+    X(teste,  Pteste)           \
+    X(testne, Ptestne)          \
+    X(testle, Ptestle)          \
+    X(testge, Ptestge)          \
+    X(and,    Pand)             \
     X(or,     Por)
 
-#define BINARY_OPS_ALL(X) \
-    BINARY_OPS_FULL(X)    \
-    BINARY_OPS_NOIP(X)
+#define MILK_BINARY_OPS_ALL(X)  \
+    MILK_BINARY_OPS_FULL(X)     \
+    MILK_BINARY_OPS_NOIP(X)
 
 
 /* ----------------------------------------------------------
@@ -73,7 +73,7 @@ int arith_image_##op(                 \
     const char *ID2_name,             \
     const char *ID_out);
 
-BINARY_OPS_ALL(MILK_DECLARE_BINARY)
+MILK_BINARY_OPS_ALL(MILK_DECLARE_BINARY)
 #undef MILK_DECLARE_BINARY
 
 
@@ -86,7 +86,7 @@ int arith_image_##op##_inplace(               \
     const char *ID1_name,                     \
     const char *ID2_name);
 
-BINARY_OPS_FULL(MILK_DECLARE_BINARY_INPLACE)
+MILK_BINARY_OPS_FULL(MILK_DECLARE_BINARY_INPLACE)
 #undef MILK_DECLARE_BINARY_INPLACE
 
-#endif /* IMAGE_ARITH__IM_IM__IM_H */
+#endif /* IMAGE_ARITH_IM_IM_IM_H */

--- a/src/coremods/COREMOD_arith/image_arith__im_im__im.h
+++ b/src/coremods/COREMOD_arith/image_arith__im_im__im.h
@@ -63,30 +63,30 @@ double Ptrunc(double a, double b, double c);
  * Generated prototypes — IMGID and string APIs (all ops)
  * ---------------------------------------------------------- */
 
-#define _DECLARE_BINARY(op, fptr)   \
-int arith_image_##op##_IMGID(       \
-    IMGID *imgin1,                  \
-    IMGID *imgin2,                  \
-    IMGID *imgout);                 \
-int arith_image_##op(               \
-    const char *ID1_name,           \
-    const char *ID2_name,           \
+#define MILK_DECLARE_BINARY(op, fptr) \
+int arith_image_##op##_IMGID(         \
+    IMGID *imgin1,                    \
+    IMGID *imgin2,                    \
+    IMGID *imgout);                   \
+int arith_image_##op(                 \
+    const char *ID1_name,             \
+    const char *ID2_name,             \
     const char *ID_out);
 
-BINARY_OPS_ALL(_DECLARE_BINARY)
-#undef _DECLARE_BINARY
+BINARY_OPS_ALL(MILK_DECLARE_BINARY)
+#undef MILK_DECLARE_BINARY
 
 
 /* ----------------------------------------------------------
  * Generated prototypes — inplace API (FULL ops only)
  * ---------------------------------------------------------- */
 
-#define _DECLARE_BINARY_INPLACE(op, fptr) \
-int arith_image_##op##_inplace(           \
-    const char *ID1_name,                 \
+#define MILK_DECLARE_BINARY_INPLACE(op, fptr) \
+int arith_image_##op##_inplace(               \
+    const char *ID1_name,                     \
     const char *ID2_name);
 
-BINARY_OPS_FULL(_DECLARE_BINARY_INPLACE)
-#undef _DECLARE_BINARY_INPLACE
+BINARY_OPS_FULL(MILK_DECLARE_BINARY_INPLACE)
+#undef MILK_DECLARE_BINARY_INPLACE
 
 #endif /* IMAGE_ARITH__IM_IM__IM_H */


### PR DESCRIPTION
## Summary

Addresses reviewer feedback on the X-macro headers refactor: namespaces all public op-table macros under `MILK_` / `IMAGE_ARITH_` prefixes and removes double-underscore include guards (reserved identifiers in C).

## Changes

### `src/coremods/COREMOD_arith/`

**`image_arith__im_im__im.h` / `.c`**
- `BINARY_OPS_FULL/NOIP/ALL` → `MILK_BINARY_OPS_FULL/NOIP/ALL`
- Include guard: `IMAGE_ARITH__IM_IM__IM_H` → `IMAGE_ARITH_IM_IM_IM_H`

**`image_arith__im__im.h` / `.c`**
- `UNARY_OPS` → `MILK_UNARY_OPS`
- `_DECLARE_UNARY` (reserved) → `IMAGE_ARITH_DECLARE_UNARY`
- Include guard: `IMAGE_ARITH__IM__IM_H` → `IMAGE_ARITH_IM_IM_H`

**`image_arith__im_f__im.h` / `.c`**
- `CST_OPS_OPT_FULL/FPTR_FULL/OPT_NOIP/ALL` → `MILK_CST_OPS_*`
- Include guard: `IMAGE_ARITH__IM_F__IM_H` → `IMAGE_ARITH_IM_F_IM_H`

**`image_arith__im_f_f__im.h`**
- Include guard: `IMAGE_ARITH__IM_F_F__IM_H` → `IMAGE_ARITH_IM_F_F_IM_H`

## Verification

- [x] Build passes (`/compile-test`)
- [ ] Tests pass (`ctest --output-on-failure`)
- [ ] CLI robustness tests pass (if CLI changed)
- [ ] Documentation updated (README, help, docs/)

## Prompt Summary

Reviewer flagged: (1) generic op-table macro names leaking into every translation unit that includes these headers, (2) `_DECLARE_*` macro names starting with underscore+uppercase (reserved), (3) include guards using double underscores (also reserved). All three classes of issue fixed consistently across all four affected headers.

## AI Authorship

- **Model**: Claude Sonnet 4.5
- **User edits**: None