### PR TITLE
refactor: migrate COREMOD_memory files (Group A, B) to IMGID API

### DIFF
--- a/src/coremods/COREMOD_memory/create_image.c
+++ b/src/coremods/COREMOD_memory/create_image.c
@@ -30,6 +30,7 @@
 #include "create_image.h"
 #include "delete_image.h"
 #include "image_ID.h"
+#include "COREMOD_memory/imageID.h"
 #include "list_image.h"
 #include "stream_sem.h"
 #include <fps.h>
@@ -57,7 +58,10 @@ errno_t create_image_ID_IMGID(
                      img->mdt->shared,
                      img->mdt->NBkw,
                      img->mdt->CBsize);
-    if(image_ID(img->name, dcimg, dcnimg) == -1)
+    IMGID exist_img = imgid_make_from_name(img->name);
+    resolveIMGID(&exist_img, ERRMODE_NULL, dcimg, dcnimg);
+
+    if(exist_img.ID == -1)
     {
         img->ID = next_avail_image_ID(img->ID);
         ImageStreamIO_createIm(&dcimg[img->ID],
@@ -72,9 +76,7 @@ errno_t create_image_ID_IMGID(
     else
     {
         // Image name already in use — check compatibility
-        img->ID = image_ID(img->name,
-                           dcimg,
-                           dcnimg);
+        img->ID = exist_img.ID;
 
         int mismatch = 0;
 

--- a/src/coremods/COREMOD_memory/create_variable.c
+++ b/src/coremods/COREMOD_memory/create_variable.c
@@ -12,22 +12,20 @@
 #include "libmilkdata/milkdata.h"
 #endif
 #include "image_ID.h"
+#include "COREMOD_memory/imageID.h"
 #include "variable_ID.h"
 
 /* creates floating point variable */
 variableID create_variable_ID(const char *name, double value)
 {
     variableID ID;
-    long       i1, i2;
-
+    long       i2;
 
     ID = -1;
 
-    i1 = image_ID(name, dcimg, dcnimg);
-
     i2 = variable_ID(name);
 
-    if(i1 != -1)
+    if(imgid_exists(name))
     {
         printf(
             "ERROR: cannot create variable \"%s\": name already used as an "
@@ -58,13 +56,12 @@ variableID create_variable_ID(const char *name, double value)
 variableID create_variable_long_ID(const char *name, long value)
 {
     variableID ID;
-    long       i1, i2;
+    long       i2;
 
     ID = -1;
-    i1 = image_ID(name, dcimg, dcnimg);
     i2 = variable_ID(name);
 
-    if(i1 != -1)
+    if(imgid_exists(name))
     {
         printf(
             "ERROR: cannot create variable \"%s\": name already used as an "
@@ -96,13 +93,12 @@ variableID create_variable_long_ID(const char *name, long value)
 variableID create_variable_string_ID(const char *name, const char *value)
 {
     variableID ID;
-    long       i1, i2;
+    long       i2;
 
     ID = -1;
-    i1 = image_ID(name, dcimg, dcnimg);
     i2 = variable_ID(name);
 
-    if(i1 != -1)
+    if(imgid_exists(name))
     {
         printf(
             "ERROR: cannot create variable \"%s\": name already used as an "

--- a/src/coremods/COREMOD_memory/delete_sharedmem_image.c
+++ b/src/coremods/COREMOD_memory/delete_sharedmem_image.c
@@ -57,14 +57,13 @@ static char imname[FUNCTION_PARAMETER_STRMAXLEN]
 errno_t destroy_shared_image_ID(
     const char *__restrict imname)
 {
-    imageID ID;
+    IMGID img = imgid_make_from_name(imname);
+    resolveIMGID(&img, ERRMODE_NULL, dcimg, dcnimg);
 
-    ID = image_ID(
-        imname, dcimg, dcnimg);
-    if((ID != -1)
-        && (dcimg[ID].md[0].shared == 1))
+    if((img.ID != -1)
+        && (img.im->md[0].shared == 1))
     {
-        ImageStreamIO_destroyIm(&dcimg[ID]);
+        ImageStreamIO_destroyIm(img.im);
     }
     else
     {

--- a/src/coremods/COREMOD_memory/image_checksize.c
+++ b/src/coremods/COREMOD_memory/image_checksize.c
@@ -10,26 +10,28 @@
 #include "libmilkdata/milkdata.h"
 #endif
 #include "image_ID.h"
+#include "COREMOD_memory/imageID.h"
 
 //  check only is size > 0
 int check_2Dsize(const char *ID_name, uint32_t xsize, uint32_t ysize)
 {
     int     retval;
-    imageID ID;
+    IMGID img = imgid_make_from_name(ID_name);
+    resolveIMGID(&img, ERRMODE_WARN, dcimg, dcnimg);
+    if(img.ID == -1) return 0;
 
     retval = 1;
-    ID     = image_ID(ID_name, dcimg, dcnimg);
-    if(dcimg[ID].md[0].naxis != 2)
+    if(img.im->md[0].naxis != 2)
     {
         retval = 0;
     }
     if(retval == 1)
     {
-        if((xsize > 0) && (dcimg[ID].md[0].size[0] != xsize))
+        if((xsize > 0) && (img.im->md[0].size[0] != xsize))
         {
             retval = 0;
         }
-        if((ysize > 0) && (dcimg[ID].md[0].size[1] != ysize))
+        if((ysize > 0) && (img.im->md[0].size[1] != ysize))
         {
             retval = 0;
         }
@@ -44,30 +46,31 @@ int check_3Dsize(const char *ID_name,
                  uint32_t    zsize)
 {
     int     retval;
-    imageID ID;
-
+    IMGID img = imgid_make_from_name(ID_name);
+    resolveIMGID(&img, ERRMODE_WARN, dcimg, dcnimg);
+    if(img.ID == -1) return 0;
+    
     retval = 1;
-    ID     = image_ID(ID_name, dcimg, dcnimg);
-    if(dcimg[ID].md[0].naxis != 3)
+    if(img.im->md[0].naxis != 3)
     {
-        /*      printf("Wrong naxis : %ld - should be 3\n",dcimg[ID].md[0].naxis);*/
+        /*      printf("Wrong naxis : %ld - should be 3\n",img.im->md[0].naxis);*/
         retval = 0;
     }
     if(retval == 1)
     {
-        if((xsize > 0) && (dcimg[ID].md[0].size[0] != xsize))
+        if((xsize > 0) && (img.im->md[0].size[0] != xsize))
         {
-            /*	  printf("Wrong xsize : %ld - should be %ld\n",dcimg[ID].md[0].size[0],xsize);*/
+            /*	  printf("Wrong xsize : %ld - should be %ld\n",img.im->md[0].size[0],xsize);*/
             retval = 0;
         }
-        if((ysize > 0) && (dcimg[ID].md[0].size[1] != ysize))
+        if((ysize > 0) && (img.im->md[0].size[1] != ysize))
         {
-            /*	  printf("Wrong ysize : %ld - should be %ld\n",dcimg[ID].md[0].size[1],ysize);*/
+            /*	  printf("Wrong ysize : %ld - should be %ld\n",img.im->md[0].size[1],ysize);*/
             retval = 0;
         }
-        if((zsize > 0) && (dcimg[ID].md[0].size[2] != zsize))
+        if((zsize > 0) && (img.im->md[0].size[2] != zsize))
         {
-            /*	  printf("Wrong zsize : %ld - should be %ld\n",dcimg[ID].md[0].size[2],zsize);*/
+            /*	  printf("Wrong zsize : %ld - should be %ld\n",img.im->md[0].size[2],zsize);*/
             retval = 0;
         }
     }
@@ -81,35 +84,35 @@ int COREMOD_MEMORY_check_2Dsize(const char *IDname,
                                 uint32_t    ysize)
 {
     int     sizeOK = 1; // 1 if size matches
-    imageID ID;
-
-    ID = image_ID(IDname, dcimg, dcnimg);
-    if(dcimg[ID].md[0].naxis != 2)
+    IMGID img = imgid_make_from_name(IDname);
+    resolveIMGID(&img, ERRMODE_WARN, dcimg, dcnimg);
+    if(img.ID == -1) return 0;
+    if(img.im->md[0].naxis != 2)
     {
         printf(
             "WARNING : image %s naxis = %d does not match expected value "
             "2\n",
             IDname,
-            (int) dcimg[ID].md[0].naxis);
+            (int) img.im->md[0].naxis);
         sizeOK = 0;
     }
-    if((xsize > 0) && (dcimg[ID].md[0].size[0] != xsize))
+    if((xsize > 0) && (img.im->md[0].size[0] != xsize))
     {
         printf(
             "WARNING : image %s xsize = %d does not match expected value "
             "%d\n",
             IDname,
-            (int) dcimg[ID].md[0].size[0],
+            (int) img.im->md[0].size[0],
             (int) xsize);
         sizeOK = 0;
     }
-    if((ysize > 0) && (dcimg[ID].md[0].size[1] != ysize))
+    if((ysize > 0) && (img.im->md[0].size[1] != ysize))
     {
         printf(
             "WARNING : image %s ysize = %d does not match expected value "
             "%d\n",
             IDname,
-            (int) dcimg[ID].md[0].size[1],
+            (int) img.im->md[0].size[1],
             (int) ysize);
         sizeOK = 0;
     }
@@ -123,45 +126,45 @@ int COREMOD_MEMORY_check_3Dsize(const char *IDname,
                                 uint32_t    zsize)
 {
     int     sizeOK = 1; // 1 if size matches
-    imageID ID;
-
-    ID = image_ID(IDname, dcimg, dcnimg);
-    if(dcimg[ID].md[0].naxis != 3)
+    IMGID img = imgid_make_from_name(IDname);
+    resolveIMGID(&img, ERRMODE_WARN, dcimg, dcnimg);
+    if(img.ID == -1) return 0;
+    if(img.im->md[0].naxis != 3)
     {
         printf(
             "WARNING : image %s naxis = %d does not match expected value "
             "3\n",
             IDname,
-            (int) dcimg[ID].md[0].naxis);
+            (int) img.im->md[0].naxis);
         sizeOK = 0;
     }
-    if((xsize > 0) && (dcimg[ID].md[0].size[0] != xsize))
+    if((xsize > 0) && (img.im->md[0].size[0] != xsize))
     {
         printf(
             "WARNING : image %s xsize = %d does not match expected value "
             "%d\n",
             IDname,
-            (int) dcimg[ID].md[0].size[0],
+            (int) img.im->md[0].size[0],
             (int) xsize);
         sizeOK = 0;
     }
-    if((ysize > 0) && (dcimg[ID].md[0].size[1] != ysize))
+    if((ysize > 0) && (img.im->md[0].size[1] != ysize))
     {
         printf(
             "WARNING : image %s ysize = %d does not match expected value "
             "%d\n",
             IDname,
-            (int) dcimg[ID].md[0].size[1],
+            (int) img.im->md[0].size[1],
             (int) ysize);
         sizeOK = 0;
     }
-    if((zsize > 0) && (dcimg[ID].md[0].size[2] != zsize))
+    if((zsize > 0) && (img.im->md[0].size[2] != zsize))
     {
         printf(
             "WARNING : image %s zsize = %d does not match expected value "
             "%d\n",
             IDname,
-            (int) dcimg[ID].md[0].size[2],
+            (int) img.im->md[0].size[2],
             (int) zsize);
         sizeOK = 0;
     }

--- a/src/coremods/COREMOD_memory/image_copy.c
+++ b/src/coremods/COREMOD_memory/image_copy.c
@@ -349,7 +349,7 @@ imageID chname_image_ID_IMGID(
 {
     resolveIMGID(imgin, ERRMODE_ABORT, dcimg, dcnimg);
 
-    if((image_ID(new_name, dcimg, dcnimg) == -1) && (variable_ID(new_name) == -1))
+    if((!imgid_exists(new_name)) && (variable_ID(new_name) == -1))
     {
         strcpy(imgin->im->name, new_name);
         strcpy(imgin->name, new_name);

--- a/src/coremods/COREMOD_memory/image_keyword.c
+++ b/src/coremods/COREMOD_memory/image_keyword.c
@@ -224,10 +224,11 @@ long image_write_keyword_L(
     long        value,
     const char *comment)
 {
-    imageID ID;
+    IMGID img = imgid_make_from_name(IDname);
+    resolveIMGID(&img, ERRMODE_ABORT, dcimg, dcnimg);
+    long ID = img.ID;
     long    kw, NBkw, kw0;
 
-    ID   = image_ID(IDname, dcimg, dcnimg);
     NBkw = dcimg[ID].md[0].NBkw;
 
     kw = 0;
@@ -272,12 +273,13 @@ long image_write_keyword_D(
     double      value,
     const char *comment)
 {
-    imageID ID;
+    IMGID img = imgid_make_from_name(IDname);
+    resolveIMGID(&img, ERRMODE_ABORT, dcimg, dcnimg);
+    long ID = img.ID;
     long    kw;
     long    NBkw;
     long    kw0;
 
-    ID   = image_ID(IDname, dcimg, dcnimg);
     NBkw = dcimg[ID].md[0].NBkw;
 
     kw = 0;
@@ -322,12 +324,13 @@ long image_write_keyword_S(
     const char *value,
     const char *comment)
 {
-    imageID ID;
+    IMGID img = imgid_make_from_name(IDname);
+    resolveIMGID(&img, ERRMODE_ABORT, dcimg, dcnimg);
+    long ID = img.ID;
     long    kw;
     long    NBkw;
     long    kw0;
 
-    ID   = image_ID(IDname, dcimg, dcnimg);
     NBkw = dcimg[ID].md[0].NBkw;
 
     kw = 0;
@@ -370,10 +373,10 @@ long image_write_keyword_S(
 imageID image_list_keywords(
     const char *restrict IDname)
 {
-    imageID ID;
+    IMGID img = imgid_make_from_name(IDname);
+    resolveIMGID(&img, ERRMODE_ABORT, dcimg, dcnimg);
+    long ID = img.ID;
     long    kw;
-
-    ID = image_ID(IDname, dcimg, dcnimg);
 
     int kwcnt = 0;
     for(kw = 0;
@@ -433,11 +436,13 @@ long image_read_keyword_D(
     const char *kname,
     double *val)
 {
-    variableID ID;
+    IMGID img = imgid_make_from_name(IDname);
+    resolveIMGID(&img, ERRMODE_NULL, dcimg, dcnimg);
+    if(img.ID == -1) return -1;
+    long ID = img.ID;
     long       kw;
     long       kw0;
-
-    ID  = image_ID(IDname, dcimg, dcnimg);
+    
     kw0 = -1;
     for(kw = 0;
         kw < dcimg[ID].md[0].NBkw;
@@ -471,11 +476,13 @@ long image_read_keyword_L(
     const char *kname,
     long *val)
 {
-    variableID ID;
+    IMGID img = imgid_make_from_name(IDname);
+    resolveIMGID(&img, ERRMODE_NULL, dcimg, dcnimg);
+    if(img.ID == -1) return -1;
+    long ID = img.ID;
     long       kw;
     long       kw0;
-
-    ID  = image_ID(IDname, dcimg, dcnimg);
+    
     kw0 = -1;
     for(kw = 0;
         kw < dcimg[ID].md[0].NBkw;

--- a/src/coremods/COREMOD_memory/image_set_counters.c
+++ b/src/coremods/COREMOD_memory/image_set_counters.c
@@ -23,10 +23,12 @@
 errno_t COREMOD_MEMORY_image_set_status(
     const char *IDname, int status)
 {
-    imageID ID;
-
-    ID = image_ID(IDname, dcimg, dcnimg);
-    dcimg[ID].md[0].status = status;
+    IMGID img = imgid_make_from_name(IDname);
+    resolveIMGID(&img, ERRMODE_WARN, dcimg, dcnimg);
+    if(img.ID != -1)
+    {
+        img.im->md[0].status = status;
+    }
 
     return RETURN_SUCCESS;
 }
@@ -34,10 +36,12 @@ errno_t COREMOD_MEMORY_image_set_status(
 errno_t COREMOD_MEMORY_image_set_cnt0(
     const char *IDname, int cnt0)
 {
-    imageID ID;
-
-    ID = image_ID(IDname, dcimg, dcnimg);
-    dcimg[ID].md[0].cnt0 = cnt0;
+    IMGID img = imgid_make_from_name(IDname);
+    resolveIMGID(&img, ERRMODE_WARN, dcimg, dcnimg);
+    if(img.ID != -1)
+    {
+        img.im->md[0].cnt0 = cnt0;
+    }
 
     return RETURN_SUCCESS;
 }
@@ -45,10 +49,12 @@ errno_t COREMOD_MEMORY_image_set_cnt0(
 errno_t COREMOD_MEMORY_image_set_cnt1(
     const char *IDname, int cnt1)
 {
-    imageID ID;
-
-    ID = image_ID(IDname, dcimg, dcnimg);
-    dcimg[ID].md[0].cnt1 = cnt1;
+    IMGID img = imgid_make_from_name(IDname);
+    resolveIMGID(&img, ERRMODE_WARN, dcimg, dcnimg);
+    if(img.ID != -1)
+    {
+        img.im->md[0].cnt1 = cnt1;
+    }
 
     return RETURN_SUCCESS;
 }

--- a/src/coremods/COREMOD_memory/logshmim_save.c
+++ b/src/coremods/COREMOD_memory/logshmim_save.c
@@ -257,9 +257,11 @@ void *save_telemetry_fits_function(
         fclose(fp);
     }
 
-    tret = image_ID(tmsg->iname,
-                    dcimg,
-                    dcnimg);
+    {
+        IMGID img = imgid_make_from_name(tmsg->iname);
+        resolveIMGID(&img, ERRMODE_NULL, dcimg, dcnimg);
+        tret = img.ID;
+    }
 
     struct timespec tend;
     clock_gettime(CLOCK_MILK, &tend);

--- a/src/coremods/COREMOD_memory/read_shmim_size.c
+++ b/src/coremods/COREMOD_memory/read_shmim_size.c
@@ -79,11 +79,11 @@ imageID read_sharedmem_image_size(
     IMAGE_METADATA *map;
     int             i;
     FILE           *fp;
-    imageID         ID = -1;
 
-    if((ID = image_ID(
-            name, dcimg,
-            dcnimg)) == -1)
+    IMGID img = imgid_make_from_name(name);
+    resolveIMGID(&img, ERRMODE_NULL, dcimg, dcnimg);
+
+    if(img.ID == -1)
     {
         WRITE_FULLFILENAME(
             SM_fname, "%s/%s.im.shm",
@@ -141,19 +141,18 @@ imageID read_sharedmem_image_size(
     {
         fp = fopen(fname, "w");
         for(i = 0;
-             i < dcimg[ID].md[0].naxis;
+             i < img.im->md[0].naxis;
              i++)
         {
             fprintf(
                 fp, "%ld ",
-                (long) dcimg[ID]
-                    .md[0].size[i]);
+                (long) img.im->md[0].size[i]);
         }
         fprintf(fp, "\n");
         fclose(fp);
     }
 
-    return ID;
+    return img.ID;
 }
 
 

--- a/src/coremods/COREMOD_memory/read_shmimall.c
+++ b/src/coremods/COREMOD_memory/read_shmimall.c
@@ -81,10 +81,7 @@ errno_t read_sharedmem_image_all(
     for(int sindex = 0;
          sindex < NBstream; sindex++)
     {
-        imageID ID = image_ID(
-            streaminfo[sindex].sname,
-            dcimg, dcnimg);
-        if(ID == -1)
+        if(!imgid_exists(streaminfo[sindex].sname))
         {
             read_sharedmem_image(
                 streaminfo[sindex].sname,

--- a/src/coremods/COREMOD_memory/saveall.c
+++ b/src/coremods/COREMOD_memory/saveall.c
@@ -326,8 +326,14 @@ errno_t COREMOD_MEMORY_SaveAll_sequ(
     EXECUTE_SYSTEM_COMMAND(
         "mkdir -p %s", dirname);
 
-    IDtrig = image_ID(
-        IDtrig_name, dcimg, dcnimg);
+    {
+        IMGID imgtrig =
+            imgid_make_from_name(IDtrig_name);
+        resolveIMGID(
+            &imgtrig, ERRMODE_NULL,
+            dcimg, dcnimg);
+        IDtrig = imgtrig.ID;
+    }
 
     printf("Creating arrays\n");
     fflush(stdout);

--- a/src/coremods/COREMOD_memory/saveall.c
+++ b/src/coremods/COREMOD_memory/saveall.c
@@ -333,6 +333,16 @@ errno_t COREMOD_MEMORY_SaveAll_sequ(
             &imgtrig, ERRMODE_NULL,
             dcimg, dcnimg);
         IDtrig = imgtrig.ID;
+        if(IDtrig == -1)
+        {
+            fprintf(stderr,
+                    "ERROR: trigger stream \"%s\" not found\n",
+                    IDtrig_name);
+            free(IDarray);
+            free(IDarrayout);
+            free(imsizearray);
+            return RETURN_FAILURE;
+        }
     }
 
     printf("Creating arrays\n");

--- a/src/coremods/COREMOD_memory/shmim_purge.c
+++ b/src/coremods/COREMOD_memory/shmim_purge.c
@@ -98,8 +98,22 @@ errno_t shmim_purge(const char *strfilter)
             imageID fid = read_sharedmem_image(
                 streaminfo[sindex].sname,
                 dcimg, dcnimg);
-            img.ID = fid;
-            img.im = &dcimg[fid];
+            if(fid == -1)
+            {
+                printf("Failed to load stream %s\n",
+                       streaminfo[sindex].sname);
+                continue;
+            }
+
+            resolveIMGID(
+                &img, ERRMODE_NULL,
+                dcimg, dcnimg);
+            if(img.ID == -1 || img.im == NULL)
+            {
+                printf("Failed to resolve stream %s after load\n",
+                       streaminfo[sindex].sname);
+                continue;
+            }
         }
         DEBUG_TRACEPOINT(
             "stream %s loaded ID %ld",

--- a/src/coremods/COREMOD_memory/shmim_purge.c
+++ b/src/coremods/COREMOD_memory/shmim_purge.c
@@ -88,22 +88,26 @@ errno_t shmim_purge(const char *strfilter)
         printf(" STREAM %3d   %s\n",
                sindex,
                streaminfo[sindex].sname);
-        imageID ID = image_ID(
-            streaminfo[sindex].sname,
+        IMGID img = imgid_make_from_name(
+            streaminfo[sindex].sname);
+        resolveIMGID(
+            &img, ERRMODE_NULL,
             dcimg, dcnimg);
-        if(ID == -1)
+        if(img.ID == -1)
         {
-            ID = read_sharedmem_image(
+            imageID fid = read_sharedmem_image(
                 streaminfo[sindex].sname,
                 dcimg, dcnimg);
+            img.ID = fid;
+            img.im = &dcimg[fid];
         }
         DEBUG_TRACEPOINT(
             "stream %s loaded ID %ld",
             streaminfo[sindex].sname,
-            (long) ID);
+            (long) img.ID);
 
         pid_t opid;
-        opid = dcimg[ID].md[0].ownerPID;
+        opid = img.im->md[0].ownerPID;
         DEBUG_TRACEPOINT("owner PID : %ld",
                          (long) opid);
         printf("owner PID : %ld\n",
@@ -120,16 +124,14 @@ errno_t shmim_purge(const char *strfilter)
             {
                 printf("Purging stream %s\n",
                        streaminfo[sindex].sname);
-                ImageStreamIO_destroyIm(
-                    &dcimg[ID]);
+                ImageStreamIO_destroyIm(img.im);
             }
         }
         else
         {
             printf("Purging stream %s\n",
                    streaminfo[sindex].sname);
-            ImageStreamIO_destroyIm(
-                &dcimg[ID]);
+            ImageStreamIO_destroyIm(img.im);
         }
     }
 

--- a/src/coremods/COREMOD_memory/shmim_setowner.c
+++ b/src/coremods/COREMOD_memory/shmim_setowner.c
@@ -23,30 +23,28 @@
 /** @brief set owner to creator */
 imageID shmim_setowner_creator(const char *name)
 {
-    imageID ID;
-
-    ID = image_ID(name, dcimg, dcnimg);
-    if(ID != -1)
+    IMGID img = imgid_make_from_name(name);
+    resolveIMGID(&img, ERRMODE_NULL, dcimg, dcnimg);
+    if(img.ID != -1)
     {
-        dcimg[ID].md[0].ownerPID =
-            dcimg[ID].md[0].creatorPID;
+        img.im->md[0].ownerPID =
+            img.im->md[0].creatorPID;
     }
 
-    return ID;
+    return img.ID;
 }
 
 /** @brief set owner to current PID */
 imageID shmim_setowner_current(const char *name)
 {
-    imageID ID;
-
-    ID = image_ID(name, dcimg, dcnimg);
-    if(ID != -1)
+    IMGID img = imgid_make_from_name(name);
+    resolveIMGID(&img, ERRMODE_NULL, dcimg, dcnimg);
+    if(img.ID != -1)
     {
-        dcimg[ID].md[0].ownerPID = getpid();
+        img.im->md[0].ownerPID = getpid();
     }
 
-    return ID;
+    return img.ID;
 }
 
 /**
@@ -56,15 +54,14 @@ imageID shmim_setowner_current(const char *name)
  */
 imageID shmim_setowner_init(const char *name)
 {
-    imageID ID;
-
-    ID = image_ID(name, dcimg, dcnimg);
-    if(ID != -1)
+    IMGID img = imgid_make_from_name(name);
+    resolveIMGID(&img, ERRMODE_NULL, dcimg, dcnimg);
+    if(img.ID != -1)
     {
-        dcimg[ID].md[0].ownerPID = 1;
+        img.im->md[0].ownerPID = 1;
     }
 
-    return ID;
+    return img.ID;
 }
 
 

--- a/src/coremods/COREMOD_memory/stream_pixmapdecode.c
+++ b/src/coremods/COREMOD_memory/stream_pixmapdecode.c
@@ -163,8 +163,13 @@ imageID COREMOD_MEMORY_PixMapDecode_U(
 
     PROCESSINFO *processinfo;
 
-    IDin  = image_ID(inputstream_name, dcimg, dcnimg);
-    IDmap = image_ID(IDmap_name, dcimg, dcnimg);
+    IMGID img_in = imgid_make_from_name(inputstream_name);
+    resolveIMGID(&img_in, ERRMODE_ABORT, dcimg, dcnimg);
+    IDin = img_in.ID;
+
+    IMGID img_map = imgid_make_from_name(IDmap_name);
+    resolveIMGID(&img_map, ERRMODE_ABORT, dcimg, dcnimg);
+    IDmap = img_map.ID;
     // Size of IDmap is different depending if forward or reverse lookup !
     // Reverse = 0: same size as IDin
     // Reverse = 1: same size as IDout


### PR DESCRIPTION
## Summary

This PR migrates Group A and Group B code in `COREMOD_memory` from the legacy `image_ID()` lookup API to the modern `IMGID` framework (`imgid_make_from_name` and `resolveIMGID`). This is part of an ongoing effort to eliminate raw image array indexing, improve type consistency, and enforce strict stream error-checking protocols.

## Changes

### COREMOD_memory
- **Group A (Trivial Checks)**
  - Migrated `delete_sharedmem_image.c`, `image_copy.c`, `logshmim_save.c`, `read_shmim_size.c`, `read_shmimall.c`, `saveall.c`, and `shmim_purge.c` to use `imgid_exists()` and `resolveIMGID()`.
  
- **Group B (Structure/Loop Updates)**
  - `create_image.c`, `create_variable.c`: replaced ID existence checks with correct boolean `imgid_exists()` and resolution validation. Added missing `COREMOD_memory/imageID.h` to prevent isolated compilation failures.
  - `image_checksize.c`: migrated `check_{2,3}Dsize` macros to `resolveIMGID()`, addressing a silent bug where size checks on broken inputs would result in indexing of `dcimg[-1]`.
  - `stream_pixmapdecode.c`: modern `resolveIMGID` lookups applied mapping configuration with `ERRMODE_ABORT`.
  - `image_keyword.c`, `image_set_counters.c`, `shmim_setowner.c`: eliminated direct `image_ID` calls in query loops and replaced with `IMGID` pointer indirections (`img.im`).

## Verification

- [x] Build passes (`make milkCOREMODmemory`) locally
- [x] Tested the `IMGID` abstractions across sequential loop access components.

## Prompt Summary

The user requested systematically refactoring the `COREMOD_memory` module to replace the legacy `image_ID()` lookup function with the modern `IMGID` API. The chosen approach was to perform an incremental, bisectable file-by-file commit starting from trivial existence checks up to structural iterations.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None
