### PR TITLE
fix: suppress spurious SHM warnings in TUI

### DIFF
--- a/src/engine/libfps/fpsCTRL/fpsCTRL_FPSdisplay.c
+++ b/src/engine/libfps/fpsCTRL/fpsCTRL_FPSdisplay.c
@@ -8,6 +8,7 @@
 #include <math.h>
 #include <ncurses.h>
 #include <time.h>
+#include <unistd.h>
 #include <sys/stat.h>
 
 #include "fps.h"
@@ -243,7 +244,18 @@ errno_t fpsCTRL_FPSdisplay(
             {
                 IMAGE tmpimg;
                 FPS_STREAMNAME_PARSED sp_sum = fps_streamname_parse(fpsarray[fpsidx].parray[pidx].val.string[0]);
-                if (ImageStreamIO_openIm(&tmpimg, sp_sum.name) == IMAGESTREAMIO_SUCCESS)
+                char shmpath_sum[STRINGMAXLEN_FILE_NAME];
+                int shm_sum_ok =
+                    (ImageStreamIO_filename(
+                         shmpath_sum,
+                         sizeof(shmpath_sum),
+                         sp_sum.name)
+                     == IMAGESTREAMIO_SUCCESS)
+                    && (access(shmpath_sum, F_OK) == 0);
+                if (shm_sum_ok
+                    && ImageStreamIO_openIm(
+                           &tmpimg, sp_sum.name)
+                        == IMAGESTREAMIO_SUCCESS)
                 {
                     char stream_info[256];
                     char size_str[64];

--- a/src/engine/libfps/fps_loadmemstream_lite.c
+++ b/src/engine/libfps/fps_loadmemstream_lite.c
@@ -173,10 +173,20 @@ imageID COREMOD_IOFITS_LoadMemStream(
     {
         /*
          * No image array (pure library context).
-         * Let ImageStreamIO resolve the SHM path so this
-         * stays consistent with MILK_SHM_DIR and fallback
-         * directory logic.
+         * Just check SHM existence.
          */
+        char shmpath_lib[STRINGMAXLEN_FILE_NAME];
+        if (ImageStreamIO_filename(shmpath_lib, sizeof(shmpath_lib), name) != IMAGESTREAMIO_SUCCESS || access(shmpath_lib, F_OK) != 0)
+        {
+            if (sp.must_exist)
+            {
+                 printf("@E modifier: \"%s\" "
+                        "not found in SHM\n",
+                        name);
+            }
+            return -1;
+        }
+
         IMAGE tmpimg;
         if (ImageStreamIO_openIm(&tmpimg, name)
             == IMAGESTREAMIO_SUCCESS)

--- a/src/engine/libfps/fps_loadmemstream_lite.c
+++ b/src/engine/libfps/fps_loadmemstream_lite.c
@@ -124,15 +124,26 @@ imageID COREMOD_IOFITS_LoadMemStream(
 
         if (imarray != NULL)
         {
-            IMAGE tmpimg;
-            if (ImageStreamIO_openIm(
-                    &tmpimg, name)
-                == IMAGESTREAMIO_SUCCESS)
+            char shmpath_n[512];
+            snprintf(shmpath_n,
+                     sizeof(shmpath_n),
+                     "/milk/shm/%s.im.shm",
+                     name);
+            if (access(shmpath_n, F_OK) == 0)
             {
-                ImageStreamIO_closeIm(&tmpimg);
-                printf("@N modifier: \"%s\" "
-                       "exists in SHM\n", name);
-                return -1;
+                IMAGE tmpimg;
+                if (ImageStreamIO_openIm(
+                        &tmpimg, name)
+                    == IMAGESTREAMIO_SUCCESS)
+                {
+                    ImageStreamIO_closeIm(
+                        &tmpimg);
+                    printf(
+                        "@N modifier: \"%s\" "
+                        "exists in SHM\n",
+                        name);
+                    return -1;
+                }
             }
         }
     }
@@ -163,17 +174,26 @@ imageID COREMOD_IOFITS_LoadMemStream(
          * No image array (pure library context).
          * Just check SHM existence.
          */
+        char shmpath_lib[512];
+        snprintf(shmpath_lib,
+                 sizeof(shmpath_lib),
+                 "/milk/shm/%s.im.shm", name);
+        if (access(shmpath_lib, F_OK) != 0)
+        {
+            if (sp.must_exist)
+            {
+                printf("@E modifier: \"%s\" "
+                       "not found in SHM\n",
+                       name);
+            }
+            return -1;
+        }
         IMAGE tmpimg;
         if (ImageStreamIO_openIm(&tmpimg, name)
             == IMAGESTREAMIO_SUCCESS)
         {
             *imLOC = STREAM_LOAD_SOURCE_SHAREMEM;
             ImageStreamIO_closeIm(&tmpimg);
-
-            if (sp.must_exist == 0)
-            {
-                return 0;
-            }
             return 0;
         }
         if (sp.must_exist)

--- a/src/engine/libfps/fps_loadmemstream_lite.c
+++ b/src/engine/libfps/fps_loadmemstream_lite.c
@@ -125,11 +125,12 @@ imageID COREMOD_IOFITS_LoadMemStream(
         if (imarray != NULL)
         {
             char shmpath_n[512];
-            snprintf(shmpath_n,
-                     sizeof(shmpath_n),
-                     "/milk/shm/%s.im.shm",
-                     name);
-            if (access(shmpath_n, F_OK) == 0)
+            if (ImageStreamIO_filename(
+                        shmpath_n,
+                        sizeof(shmpath_n),
+                        name)
+                    == IMAGESTREAMIO_SUCCESS &&
+                access(shmpath_n, F_OK) == 0)
             {
                 IMAGE tmpimg;
                 if (ImageStreamIO_openIm(

--- a/src/engine/libfps/fps_loadmemstream_lite.c
+++ b/src/engine/libfps/fps_loadmemstream_lite.c
@@ -173,22 +173,10 @@ imageID COREMOD_IOFITS_LoadMemStream(
     {
         /*
          * No image array (pure library context).
-         * Just check SHM existence.
+         * Let ImageStreamIO resolve the SHM path so this
+         * stays consistent with MILK_SHM_DIR and fallback
+         * directory logic.
          */
-        char shmpath_lib[512];
-        snprintf(shmpath_lib,
-                 sizeof(shmpath_lib),
-                 "/milk/shm/%s.im.shm", name);
-        if (access(shmpath_lib, F_OK) != 0)
-        {
-            if (sp.must_exist)
-            {
-                printf("@E modifier: \"%s\" "
-                       "not found in SHM\n",
-                       name);
-            }
-            return -1;
-        }
         IMAGE tmpimg;
         if (ImageStreamIO_openIm(&tmpimg, name)
             == IMAGESTREAMIO_SUCCESS)

--- a/src/engine/libfps/fps_print_info.c
+++ b/src/engine/libfps/fps_print_info.c
@@ -162,27 +162,20 @@ int function_parameter_print_info(
                 char shmpath_pi[STRINGMAXLEN_FILE_NAME];
                 int shm_ok = 0;
                 IMAGE tmpimg;
-                FPS_STREAMNAME fps_streamname;
+                FPS_STREAMNAME_PARSED sp = fps_streamname_parse(fps->parray[pindex].val.string[0]);
 
-                if (fps_streamname_parse(
-                        fps->parray[pindex].val.string[0],
-                        &fps_streamname)
-                    == 0)
-                {
+                if (!sp.error) {
                     shm_ok =
                         (ImageStreamIO_filename(
                              shmpath_pi,
                              sizeof(shmpath_pi),
-                             fps_streamname.name)
+                             sp.name)
                          == IMAGESTREAMIO_SUCCESS)
-                        && (access(shmpath_pi,
-                                   F_OK) == 0);
+                        && (access(shmpath_pi, F_OK) == 0);
                 }
 
                 if (shm_ok
-                    && ImageStreamIO_openIm(
-                           &tmpimg,
-                           fps_streamname.name)
+                    && ImageStreamIO_openIm(&tmpimg, sp.name)
                         == IMAGESTREAMIO_SUCCESS)
                 {
                     const char* dtype_str = ImageStreamIO_typename(tmpimg.md->datatype);

--- a/src/engine/libfps/fps_print_info.c
+++ b/src/engine/libfps/fps_print_info.c
@@ -160,21 +160,29 @@ int function_parameter_print_info(
 
             if (show_info && fps->parray[pindex].type == FPTYPE_STREAMNAME) {
                 char shmpath_pi[STRINGMAXLEN_FILE_NAME];
-                int shm_ok =
-                    (ImageStreamIO_filename(
-                         shmpath_pi,
-                         sizeof(shmpath_pi),
-                         fps->parray[pindex]
-                             .val.string[0])
-                     == IMAGESTREAMIO_SUCCESS)
-                    && (access(shmpath_pi,
-                               F_OK) == 0);
+                int shm_ok = 0;
                 IMAGE tmpimg;
+                FPS_STREAMNAME fps_streamname;
+
+                if (fps_streamname_parse(
+                        fps->parray[pindex].val.string[0],
+                        &fps_streamname)
+                    == 0)
+                {
+                    shm_ok =
+                        (ImageStreamIO_filename(
+                             shmpath_pi,
+                             sizeof(shmpath_pi),
+                             fps_streamname.name)
+                         == IMAGESTREAMIO_SUCCESS)
+                        && (access(shmpath_pi,
+                                   F_OK) == 0);
+                }
+
                 if (shm_ok
                     && ImageStreamIO_openIm(
                            &tmpimg,
-                           fps->parray[pindex]
-                               .val.string[0])
+                           fps_streamname.name)
                         == IMAGESTREAMIO_SUCCESS)
                 {
                     const char* dtype_str = ImageStreamIO_typename(tmpimg.md->datatype);

--- a/src/engine/libfps/fps_print_info.c
+++ b/src/engine/libfps/fps_print_info.c
@@ -6,10 +6,12 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include "fps.h"
 #include "fps_print_info.h"
 #include "fps_printparameter_valuestring.h"
+#include "ImageStreamIO/ImageStreamIO.h"
 
 #define C_TITLE  "\033[1;36m"
 #define C_HDR    "\033[1;35m"
@@ -157,8 +159,24 @@ int function_parameter_print_info(
                    fps->parray[pindex].description);
 
             if (show_info && fps->parray[pindex].type == FPTYPE_STREAMNAME) {
+                char shmpath_pi[STRINGMAXLEN_FILE_NAME];
+                int shm_ok =
+                    (ImageStreamIO_filename(
+                         shmpath_pi,
+                         sizeof(shmpath_pi),
+                         fps->parray[pindex]
+                             .val.string[0])
+                     == IMAGESTREAMIO_SUCCESS)
+                    && (access(shmpath_pi,
+                               F_OK) == 0);
                 IMAGE tmpimg;
-                if (ImageStreamIO_openIm(&tmpimg, fps->parray[pindex].val.string[0]) == IMAGESTREAMIO_SUCCESS) {
+                if (shm_ok
+                    && ImageStreamIO_openIm(
+                           &tmpimg,
+                           fps->parray[pindex]
+                               .val.string[0])
+                        == IMAGESTREAMIO_SUCCESS)
+                {
                     const char* dtype_str = ImageStreamIO_typename(tmpimg.md->datatype);
                     char size_str[64];
                     if (tmpimg.md->naxis == 1) snprintf(size_str, 64, "%u", tmpimg.md->size[0]);

--- a/src/engine/libfps/fps_printparameter_valuestring.c
+++ b/src/engine/libfps/fps_printparameter_valuestring.c
@@ -8,6 +8,30 @@
 #include "ImageStreamIO/ImageStreamIO.h"
 
 #include <unistd.h>
+#include <string.h>
+
+static void fps_printparameter_bare_stream_name(
+    const char *streamspec,
+    char *streamname,
+    size_t streamname_size
+)
+{
+    const char *basename = streamspec;
+
+    if((streamspec != NULL) &&
+            (streamspec[0] == '@') &&
+            (streamspec[1] != '\0') &&
+            (streamspec[2] == ':'))
+    {
+        basename = streamspec + 3;
+    }
+
+    if(streamname_size > 0)
+    {
+        strncpy(streamname, basename, streamname_size - 1);
+        streamname[streamname_size - 1] = '\0';
+    }
+}
 
 errno_t functionparameter_PrintParameter_ValueString(
     FUNCTION_PARAMETER *fpsentry,
@@ -190,14 +214,18 @@ errno_t functionparameter_GetParamValueString(
             {
                 int _slen = snprintf(outstring, stringmaxlen, "%s", fpsentry->val.string[0]);
                 if (_slen >= 0) {
+                    char stream_name_pv[STRINGMAXLEN_FILE_NAME];
+                    fps_printparameter_bare_stream_name(
+                        fpsentry->val.string[0],
+                        stream_name_pv,
+                        sizeof(stream_name_pv));
                     char shmpath_pv[
                         STRINGMAXLEN_FILE_NAME];
                     int shm_ok =
                         (ImageStreamIO_filename(
                              shmpath_pv,
                              sizeof(shmpath_pv),
-                             fpsentry->val
-                                 .string[0])
+                             stream_name_pv)
                          == IMAGESTREAMIO_SUCCESS)
                         && (access(shmpath_pv,
                                    F_OK) == 0);
@@ -205,8 +233,7 @@ errno_t functionparameter_GetParamValueString(
                     if (shm_ok
                         && ImageStreamIO_openIm(
                                &tmpimg,
-                               fpsentry->val
-                                   .string[0])
+                               stream_name_pv)
                             == IMAGESTREAMIO_SUCCESS)
                     {
                         const char* type_str = ImageStreamIO_typename(tmpimg.md->datatype);

--- a/src/engine/libfps/fps_printparameter_valuestring.c
+++ b/src/engine/libfps/fps_printparameter_valuestring.c
@@ -7,6 +7,8 @@
 #include "fps_internal.h"
 #include "ImageStreamIO/ImageStreamIO.h"
 
+#include <unistd.h>
+
 errno_t functionparameter_PrintParameter_ValueString(
     FUNCTION_PARAMETER *fpsentry,
     char *outstring,
@@ -188,8 +190,25 @@ errno_t functionparameter_GetParamValueString(
             {
                 int _slen = snprintf(outstring, stringmaxlen, "%s", fpsentry->val.string[0]);
                 if (_slen >= 0) {
+                    char shmpath_pv[
+                        STRINGMAXLEN_FILE_NAME];
+                    int shm_ok =
+                        (ImageStreamIO_filename(
+                             shmpath_pv,
+                             sizeof(shmpath_pv),
+                             fpsentry->val
+                                 .string[0])
+                         == IMAGESTREAMIO_SUCCESS)
+                        && (access(shmpath_pv,
+                                   F_OK) == 0);
                     IMAGE tmpimg;
-                    if (ImageStreamIO_openIm(&tmpimg, fpsentry->val.string[0]) == IMAGESTREAMIO_SUCCESS) {
+                    if (shm_ok
+                        && ImageStreamIO_openIm(
+                               &tmpimg,
+                               fpsentry->val
+                                   .string[0])
+                            == IMAGESTREAMIO_SUCCESS)
+                    {
                         const char* type_str = ImageStreamIO_typename(tmpimg.md->datatype);
                         
                         char size_str[64];


### PR DESCRIPTION
## Summary
Added `access()` pre-checks using `ImageStreamIO_filename()` before calling `ImageStreamIO_openIm()` across the FPS and TUI read routines. This prevents spurious ANSI-colored warning messages printed to `stderr` from polluting the `ncurses` display when checking the parameters for uninitialized or missing streams.

## Changes

### libfps
- **fpsCTRL_FPSdisplay.c**: Guarded stream summary `openIm` call from within the TUI stream display tab.
- **fps_printparameter_valuestring.c**: Guarded `functionparameter_GetParamValueString` stream probe.
- **fps_print_info.c**: Guarded stream info detail printing routine.
- **fps_loadmemstream_lite.c**: Guarded `@N:` modifier check and pure-library stream load paths.

## Verification
- [x] Build passes (`/compile-test`)
- [x] Verified `milk-fpsCTRL` TUI stream display no longer corrupts terminal output when listing parameters holding missing stream names.

## Prompt Summary
The user asked to eliminate spurious "cannot open shm" error messages that were polluting the `milk-fpsCTRL` TUI when pointing entries to missing streams. This suppression was done by implementing pre-check mechanisms with `access(F_OK)` to verify stream file physical existence before trying to open it over `ImageStreamIO_openIm()`, keeping the TUI clean and completely bypassing the internal warning string.

## AI Authorship
- **Model**: Antigravity
- **User edits**: None