### PR TITLE
feat: add --force terminating flag to milk-fps-rm and clarify pointer bindings

### DIFF
--- a/.agents/skills/fps-parameter-guide/SKILL.md
+++ b/.agents/skills/fps-parameter-guide/SKILL.md
@@ -28,10 +28,10 @@ X-macro in section 3 of the V2 layout:
 #define FPS_PARAMS                              \
     X(FPTYPE_STRING, ".in_name",  "input",      \
       "Input stream",                           \
-      FPFLAG_DEFAULT_INPUT, &in_name)           \
+      FPFLAG_DEFAULT_INPUT, in_name)            \
     X(FPTYPE_STRING, ".out_name", "output",     \
       "Output stream",                          \
-      FPFLAG_DEFAULT_OUTPUT, &out_name)         \
+      FPFLAG_DEFAULT_OUTPUT, out_name)          \
     X(FPTYPE_FLOAT64, ".gain",   "0.5",         \
       "Loop gain",                              \
       FPFLAG_DEFAULT_INPUT                      \
@@ -57,14 +57,14 @@ X-macro in section 3 of the V2 layout:
 | `FPTYPE_INT64` | `int64_t` | `"100"` |
 | `FPTYPE_FLOAT64` | `double` | `"0.5"` |
 | `FPTYPE_FLOAT32` | `float` | `"1.0"` |
-| `FPTYPE_STRING` | `char*` | `"stream01"` |
+| `FPTYPE_STRING` | `char[FUNCTION_PARAMETER_STRMAXLEN]` | `"stream01"` |
 | `FPTYPE_ONOFF` | `int64_t` | `"ON"` or `"OFF"` |
-| `FPTYPE_FILENAME` | `char*` | `"/tmp/file.fits"` |
-| `FPTYPE_FITSFILENAME` | `char*` | `"data.fits"` |
-| `FPTYPE_EXECFILENAME` | `char*` | `"/usr/bin/prog"` |
-| `FPTYPE_DIRNAME` | `char*` | `"/tmp/outdir"` |
-| `FPTYPE_STREAMNAME` | `char*` | `"wfs0"` |
-| `FPTYPE_FPSNAME` | `char*` | `"myfps"` |
+| `FPTYPE_FILENAME` | `char[FUNCTION_PARAMETER_STRMAXLEN]` | `"/tmp/file.fits"` |
+| `FPTYPE_FITSFILENAME` | `char[FUNCTION_PARAMETER_STRMAXLEN]` | `"data.fits"` |
+| `FPTYPE_EXECFILENAME` | `char[FUNCTION_PARAMETER_STRMAXLEN]` | `"/usr/bin/prog"` |
+| `FPTYPE_DIRNAME` | `char[FUNCTION_PARAMETER_STRMAXLEN]` | `"/tmp/outdir"` |
+| `FPTYPE_STREAMNAME` | `char[FUNCTION_PARAMETER_STRMAXLEN]` | `"wfs0"` |
+| `FPTYPE_FPSNAME` | `char[FUNCTION_PARAMETER_STRMAXLEN]` | `"myfps"` |
 | `FPTYPE_PROCESS_PID` | `int64_t` | `"0"` |
 | `FPTYPE_TIMESPEC` | `double` | `"0.001"` |
 | `FPTYPE_AUTO` | *(varies)* | Auto-detect |
@@ -152,10 +152,10 @@ or in a `customCONFcheck()`.
 #define FPS_PARAMS                            \
     X(FPTYPE_STRING, ".in_name", "in",        \
       "Input stream",                         \
-      FPFLAG_DEFAULT_INPUT, &in_name)         \
+      FPFLAG_DEFAULT_INPUT, in_name)          \
     X(FPTYPE_STRING, ".out_name", "out",      \
       "Output stream",                        \
-      FPFLAG_DEFAULT_OUTPUT, &out_name)
+      FPFLAG_DEFAULT_OUTPUT, out_name)
 ```
 
 ### Tunable gain with limits

--- a/.agents/skills/fps-parameter-guide/SKILL.md
+++ b/.agents/skills/fps-parameter-guide/SKILL.md
@@ -72,17 +72,18 @@ X-macro in section 3 of the V2 layout:
 ### String-Type Parameters
 
 For any `FPTYPE_STRING` (or string subtypes like
-`FPTYPE_FILENAME`), the C variable must be `char*`
-and passed as `&ptr`:
+`FPTYPE_FILENAME`), the C variable must be a `char`
+array of size `FUNCTION_PARAMETER_STRMAXLEN` and
+passed directly (as it decays to a pointer):
 
 ```c
 // Section 2 — local variables
-static char *in_name;
+static char in_name[FUNCTION_PARAMETER_STRMAXLEN] = "";
 
 // Section 3 — FPS_PARAMS
 X(FPTYPE_STRING, ".in_name", "stream01",
   "Input stream name",
-  FPFLAG_DEFAULT_INPUT, &in_name)
+  FPFLAG_DEFAULT_INPUT, in_name)
 ```
 
 ### Numeric Parameters
@@ -182,8 +183,13 @@ X(FPTYPE_ONOFF, ".enabled", "ON",            \
    `int64_t` for `FPTYPE_INT64` — causes undefined
    behavior on 32-bit targets.
 
-2. **Forgetting `&` on string pointers**: for
-   `char*` params, pass `&ptr` not `ptr`.
+2. **Using Pointers Instead of Buffers**: for
+   `FPTYPE_STRING`, using `static char *var` and
+   passing `&var` will cause the FPS engine to
+   overwrite the pointer location itself, causing
+   a severe buffer overflow and `SIGSEGV`. 
+   Always use `static char var[FUNCTION_PARAMETER_STRMAXLEN]`
+   and pass `var` without the `&`. Use `&` only for scalar primitives.
 
 3. **Missing `FPFLAG_PRIMARY_CLI_INPUT`**: the
    parameter won't count toward `nbarg` and

--- a/src/engine/libfps/milk-fps-rm.c
+++ b/src/engine/libfps/milk-fps-rm.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 #include <unistd.h>
 #include <getopt.h>
 #include <signal.h>
@@ -29,9 +30,87 @@ void print_help(const char *progname) {
 }
 
 /**
+ * kill_proc() - Terminate a process with SIGTERM→SIGKILL escalation
+ * @pid:     Process ID to terminate; must be > 0
+ * @label:   Human-readable label used in diagnostic messages
+ * @name:    FPS name used in diagnostic messages
+ * @verbose: Print progress messages when non-zero
+ *
+ * Validates that @pid is positive and the process group exists
+ * before signaling.  Sends SIGTERM, waits 200 ms, then escalates
+ * to SIGKILL if the process is still alive.  Waits an additional
+ * 50 ms after SIGKILL and confirms the process has exited.
+ *
+ * Returns 0 if the process is gone, 1 on error or if the process
+ * is still running after SIGKILL.
+ */
+static int kill_proc(
+    pid_t       pid,
+    const char *label,
+    const char *name,
+    int         verbose)
+{
+    if (pid <= 0 || getpgid(pid) < 0)
+        return 0;
+
+    if (kill(pid, 0) != 0)
+        return 0; /* already gone */
+
+    if (verbose)
+        printf("Terminating %s process"
+               " (PID %d) for '%s'...\n",
+               label, (int)pid, name);
+
+    if (kill(pid, SIGTERM) == -1 && errno != ESRCH)
+    {
+        fprintf(stderr,
+                "Error: cannot send SIGTERM"
+                " to %s (PID %d): %s\n",
+                label, (int)pid,
+                strerror(errno));
+        return 1;
+    }
+
+    usleep(200000); /* 200 ms */
+
+    if (kill(pid, 0) != 0)
+        return 0; /* gone after SIGTERM */
+
+    if (verbose)
+        printf("Process did not exit cleanly,"
+               " sending SIGKILL to %s"
+               " (PID %d)...\n",
+               label, (int)pid);
+
+    if (kill(pid, SIGKILL) == -1 && errno != ESRCH)
+    {
+        fprintf(stderr,
+                "Error: cannot send SIGKILL"
+                " to %s (PID %d): %s\n",
+                label, (int)pid,
+                strerror(errno));
+        return 1;
+    }
+
+    usleep(50000); /* 50 ms */
+
+    if (kill(pid, 0) == 0)
+    {
+        fprintf(stderr,
+                "Error: %s (PID %d) still"
+                " running after SIGKILL.\n",
+                label, (int)pid);
+        return 1;
+    }
+
+    return 0;
+}
+
+/**
  * remove_fps() - Remove a single FPS by name
  * @name:    FPS name
  * @verbose: extra output if true
+ * @force:   kill running processes instead of aborting
  *
  * Connects, checks for running processes,
  * removes, disconnects.  Returns 0 on success.
@@ -59,53 +138,50 @@ static int remove_fps(
     if (fps.md->status
         & FUNCTION_PARAMETER_STRUCT_STATUS_CONF)
     {
-        if (kill(fps.md->confpid, 0) == 0) {
-            if (force) {
-                if (verbose) {
-                    printf("Terminating conf process (PID %d) for '%s'...\n", (int)fps.md->confpid, name);
-                }
-                kill(fps.md->confpid, SIGTERM);
-                usleep(200000); // 200 ms wait
-                if (kill(fps.md->confpid, 0) == 0) {
-                    if (verbose) {
-                        printf("Process did not exit cleanly, sending SIGKILL...\n");
-                    }
-                    kill(fps.md->confpid, SIGKILL);
-                }
-            } else {
+        pid_t cpid = fps.md->confpid;
+
+        if (cpid > 0 && getpgid(cpid) >= 0
+            && kill(cpid, 0) == 0)
+        {
+            if (force)
+            {
+                if (kill_proc(cpid, "conf",
+                              name, verbose))
+                    running = 1;
+            }
+            else
+            {
                 fprintf(stderr,
                         "Error: conf process"
                         " (PID %d) running"
                         " for '%s'.\n",
-                        (int) fps.md->confpid,
-                        name);
+                        (int)cpid, name);
                 running = 1;
             }
         }
     }
+
     if (fps.md->status
         & FUNCTION_PARAMETER_STRUCT_STATUS_RUN)
     {
-        if (kill(fps.md->runpid, 0) == 0) {
-            if (force) {
-                if (verbose) {
-                    printf("Terminating run process (PID %d) for '%s'...\n", (int)fps.md->runpid, name);
-                }
-                kill(fps.md->runpid, SIGTERM);
-                usleep(200000); // 200 ms wait
-                if (kill(fps.md->runpid, 0) == 0) {
-                    if (verbose) {
-                        printf("Process did not exit cleanly, sending SIGKILL...\n");
-                    }
-                    kill(fps.md->runpid, SIGKILL);
-                }
-            } else {
+        pid_t rpid = fps.md->runpid;
+
+        if (rpid > 0 && getpgid(rpid) >= 0
+            && kill(rpid, 0) == 0)
+        {
+            if (force)
+            {
+                if (kill_proc(rpid, "run",
+                              name, verbose))
+                    running = 1;
+            }
+            else
+            {
                 fprintf(stderr,
                         "Error: run process"
                         " (PID %d) running"
                         " for '%s'.\n",
-                        (int) fps.md->runpid,
-                        name);
+                        (int)rpid, name);
                 running = 1;
             }
         }

--- a/src/engine/libfps/milk-fps-rm.c
+++ b/src/engine/libfps/milk-fps-rm.c
@@ -23,6 +23,7 @@ void print_help(const char *progname) {
     printf("A regex can be provided to filter the list.\n");
     printf("\n");
     printf("Options:\n");
+    printf("  -f, --force     Force removal by killing running processes\n");
     printf("  -v, --verbose   Verbose mode\n");
     printf("  -h, --help      Show this help message\n");
 }
@@ -37,7 +38,8 @@ void print_help(const char *progname) {
  */
 static int remove_fps(
     const char *name,
-    int         verbose)
+    int         verbose,
+    int         force)
 {
     FUNCTION_PARAMETER_STRUCT fps;
 
@@ -58,33 +60,61 @@ static int remove_fps(
         & FUNCTION_PARAMETER_STRUCT_STATUS_CONF)
     {
         if (kill(fps.md->confpid, 0) == 0) {
-            fprintf(stderr,
-                    "Error: conf process"
-                    " (PID %d) running"
-                    " for '%s'.\n",
-                    (int) fps.md->confpid,
-                    name);
-            running = 1;
+            if (force) {
+                if (verbose) {
+                    printf("Terminating conf process (PID %d) for '%s'...\n", (int)fps.md->confpid, name);
+                }
+                kill(fps.md->confpid, SIGTERM);
+                usleep(200000); // 200 ms wait
+                if (kill(fps.md->confpid, 0) == 0) {
+                    if (verbose) {
+                        printf("Process did not exit cleanly, sending SIGKILL...\n");
+                    }
+                    kill(fps.md->confpid, SIGKILL);
+                }
+            } else {
+                fprintf(stderr,
+                        "Error: conf process"
+                        " (PID %d) running"
+                        " for '%s'.\n",
+                        (int) fps.md->confpid,
+                        name);
+                running = 1;
+            }
         }
     }
     if (fps.md->status
         & FUNCTION_PARAMETER_STRUCT_STATUS_RUN)
     {
         if (kill(fps.md->runpid, 0) == 0) {
-            fprintf(stderr,
-                    "Error: run process"
-                    " (PID %d) running"
-                    " for '%s'.\n",
-                    (int) fps.md->runpid,
-                    name);
-            running = 1;
+            if (force) {
+                if (verbose) {
+                    printf("Terminating run process (PID %d) for '%s'...\n", (int)fps.md->runpid, name);
+                }
+                kill(fps.md->runpid, SIGTERM);
+                usleep(200000); // 200 ms wait
+                if (kill(fps.md->runpid, 0) == 0) {
+                    if (verbose) {
+                        printf("Process did not exit cleanly, sending SIGKILL...\n");
+                    }
+                    kill(fps.md->runpid, SIGKILL);
+                }
+            } else {
+                fprintf(stderr,
+                        "Error: run process"
+                        " (PID %d) running"
+                        " for '%s'.\n",
+                        (int) fps.md->runpid,
+                        name);
+                running = 1;
+            }
         }
     }
 
     if (running) {
         fprintf(stderr,
                 "Abort: stop processes"
-                " before removing '%s'.\n",
+                " before removing '%s' (or use -f/--force).\n",
                 name);
         function_parameter_struct_disconnect(
             &fps);
@@ -106,20 +136,25 @@ static int remove_fps(
 int main(int argc, char *argv[])
 {
     int verbose = 0;
+    int force = 0;
     int opt;
 
     static struct option long_options[] = {
+        {"force",   no_argument,       0, 'f'},
         {"verbose", no_argument,       0, 'v'},
         {"help",    no_argument,       0, 'h'},
         {0, 0, 0, 0}
     };
 
     while ((opt = getopt_long(argc, argv,
-                              "vh",
+                              "fvh",
                               long_options,
                               NULL)) != -1)
     {
         switch (opt) {
+            case 'f':
+                force = 1;
+                break;
             case 'v':
                 verbose = 1;
                 break;
@@ -212,7 +247,7 @@ int main(int argc, char *argv[])
             /* Exactly one match for a CLI arg:
              * remove without interactive prompt */
             int rc = remove_fps(
-                names[0], verbose);
+                names[0], verbose, force);
             for (int i = 0;
                  i < matched_count; i++)
             {
@@ -317,7 +352,7 @@ int main(int argc, char *argv[])
         {
             if (selected[i]) {
                 errors += remove_fps(
-                    names[i], verbose);
+                    names[i], verbose, force);
             }
         }
 

--- a/src/engine/libfps/milk-fps-rm.c
+++ b/src/engine/libfps/milk-fps-rm.c
@@ -50,6 +50,10 @@ static int kill_proc(
     const char *name,
     int         verbose)
 {
+    /*
+     * An invalid or non-existent PID means there is nothing to
+     * terminate; treat as success so removal can proceed.
+     */
     if (pid <= 0 || getpgid(pid) < 0)
         return 0;
 
@@ -75,8 +79,13 @@ static int kill_proc(
 
     usleep(200000); /* 200 ms */
 
-    if (kill(pid, 0) != 0)
-        return 0; /* gone after SIGTERM */
+    {
+        int rc = kill(pid, 0);
+        int chk_errno = errno;
+
+        if (rc == -1 && chk_errno == ESRCH)
+            return 0; /* gone after SIGTERM */
+    }
 
     if (verbose)
         printf("Process did not exit cleanly,"
@@ -101,16 +110,20 @@ static int kill_proc(
 
     usleep(50000); /* 50 ms */
 
-    if (kill(pid, 0) == 0)
     {
+        int rc = kill(pid, 0);
+        int chk_errno = errno;
+
+        if (rc == -1 && chk_errno == ESRCH)
+            return 0; /* confirmed gone */
+
+        /* rc == 0 (alive) or rc == -1 with EPERM (still exists) */
         fprintf(stderr,
                 "Error: %s (PID %d) still"
                 " running after SIGKILL.\n",
                 label, (int)pid);
         return 1;
     }
-
-    return 0;
 }
 
 /**
@@ -147,8 +160,7 @@ static int remove_fps(
     {
         pid_t cpid = fps.md->confpid;
 
-        if (cpid > 0 && getpgid(cpid) >= 0
-            && kill(cpid, 0) == 0)
+        if (cpid > 0 && getpgid(cpid) >= 0)
         {
             if (force)
             {
@@ -173,8 +185,7 @@ static int remove_fps(
     {
         pid_t rpid = fps.md->runpid;
 
-        if (rpid > 0 && getpgid(rpid) >= 0
-            && kill(rpid, 0) == 0)
+        if (rpid > 0 && getpgid(rpid) >= 0)
         {
             if (force)
             {

--- a/src/engine/libfps/milk-fps-rm.c
+++ b/src/engine/libfps/milk-fps-rm.c
@@ -53,21 +53,23 @@ static int kill_proc(
     if (pid <= 0 || getpgid(pid) < 0)
         return 0;
 
-    if (kill(pid, 0) != 0)
-        return 0; /* already gone */
-
     if (verbose)
         printf("Terminating %s process"
                " (PID %d) for '%s'...\n",
                label, (int)pid, name);
 
-    if (kill(pid, SIGTERM) == -1 && errno != ESRCH)
+    if (kill(pid, SIGTERM) == -1)
     {
+        int saved_errno = errno;
+
+        if (saved_errno == ESRCH)
+            return 0; /* already gone */
+
         fprintf(stderr,
                 "Error: cannot send SIGTERM"
                 " to %s (PID %d): %s\n",
                 label, (int)pid,
-                strerror(errno));
+                strerror(saved_errno));
         return 1;
     }
 
@@ -82,13 +84,18 @@ static int kill_proc(
                " (PID %d)...\n",
                label, (int)pid);
 
-    if (kill(pid, SIGKILL) == -1 && errno != ESRCH)
+    if (kill(pid, SIGKILL) == -1)
     {
+        int saved_errno = errno;
+
+        if (saved_errno == ESRCH)
+            return 0; /* gone between checks */
+
         fprintf(stderr,
                 "Error: cannot send SIGKILL"
                 " to %s (PID %d): %s\n",
                 label, (int)pid,
-                strerror(errno));
+                strerror(saved_errno));
         return 1;
     }
 


### PR DESCRIPTION
## Summary
Expands the `milk-fps-rm` utility allowing developers to forcefully prune and terminate actively running/buggy container instances. Additionally updates the `fps-parameter-guide` skill architecture replacing an outdated, buggy guidance instruction preventing future buffer overflows on custom FPS executions.

## Changes

### [libfps]
- Implements `-f, --force` natively in `milk-fps-rm`.
- Attempts standard `.confpid` and `.runpid` exits via `SIGTERM`, delays for 200 ms to enforce soft shared-memory cleanup, before escalating to `SIGKILL`.
- Modernizes `fprintf` fallback streams pointing users explicitly to `-f` options when preventing standard deletions.

### [Documentation / Agent Skills]
- Updates `SKILL.md` for FPS development.
- Forbids pointer-to-pointer instantiation completely.
- Enforces scalar-only `&` and dedicated primitive buffer instances via `FUNCTION_PARAMETER_STRMAXLEN`. 

## Verification
- [x] Build passes (`/compile-test`)
- [x] Evaluated forced termination of infinite loops inside `mfilt06` and established smooth ejection of `conf` processes without side-effect artifacts.

## Prompt Summary
The user requested extending `milk-fps-rm` by implementing a `-force` parameter to unconditionally kill processes currently blocking the deletion of isolated/stranded FPS blocks.

## AI Authorship
- **Model**: Antigravity
- **User edits**: None