### PR TITLE
feat: actionable resolveIMGID diagnostics + fix standalone 1-step loop exit

### DIFF
--- a/src/coremods/COREMOD_memory/imageID.h
+++ b/src/coremods/COREMOD_memory/imageID.h
@@ -133,25 +133,45 @@ static inline imageID _resolveIMGID_impl(
         {
             if (img->name[0] == '\0')
             {
+                const char *fpskey =
+                    (img->fpskeyword[0] != '\0')
+                    ? img->fpskeyword
+                    : "<unknown — use imgid_setfpskeyword()>";
+
                 fprintf(stderr,
-                        "\n\033[1;31mABORT\033[0m resolveIMGID: "
-                        "stream name is empty or NULL.\n"
-                        "  Called from: %s:%d in %s()\n"
-                        "  A required FPS stream parameter (or hardcoded stream name) has not been configured.\n",
-                        caller_file, caller_line, caller_func);
+                    "\n\033[1;31mABORT\033[0m "
+                    "resolveIMGID: stream name "
+                    "is empty.\n"
+                    "  FPS parameter : %s\n"
+                    "  Called from   : %s:%d"
+                    " in %s()\n"
+                    "  Fix: set the missing "
+                    "parameter, e.g.:\n"
+                    "    milk-fps-set %s"
+                    " <stream_name>\n",
+                    fpskey,
+                    caller_file, caller_line,
+                    caller_func,
+                    fpskey);
                 fflush(stderr);
                 abort();
             }
             else
             {
-                PRINT_ERROR("Cannot resolve image \"%s\"\n", img->name);
+                PRINT_ERROR(
+                    "Cannot resolve image \"%s\"\n",
+                    img->name);
                 abort();
             }
         }
         else if(ERRMODE == ERRMODE_WARN)
         {
-            const char *imgname = (img->name[0] != '\0') ? img->name : "<empty name>";
-            PRINT_WARNING("Cannot resolve image \"%s\"\n", imgname);
+            const char *imgname =
+                (img->name[0] != '\0')
+                ? img->name : "<empty name>";
+            PRINT_WARNING(
+                "Cannot resolve image \"%s\"\n",
+                imgname);
         }
     }
 

--- a/src/coremods/COREMOD_memory/imageID.h
+++ b/src/coremods/COREMOD_memory/imageID.h
@@ -136,23 +136,44 @@ static inline imageID _resolveIMGID_impl(
                 const char *fpskey =
                     (img->fpskeyword[0] != '\0')
                     ? img->fpskeyword
-                    : "<unknown — use imgid_setfpskeyword()>";
+                    : "<unknown>";
 
-                fprintf(stderr,
-                    "\n\033[1;31mABORT\033[0m "
-                    "resolveIMGID: stream name "
-                    "is empty.\n"
-                    "  FPS parameter : %s\n"
-                    "  Called from   : %s:%d"
-                    " in %s()\n"
-                    "  Fix: set the missing "
-                    "parameter, e.g.:\n"
-                    "    milk-fps-set %s"
-                    " <stream_name>\n",
-                    fpskey,
-                    caller_file, caller_line,
-                    caller_func,
-                    fpskey);
+                if(img->fpskeyword[0] != '\0')
+                {
+                    fprintf(stderr,
+                        "\n\033[1;31mABORT\033[0m "
+                        "resolveIMGID: stream name "
+                        "is empty.\n"
+                        "  FPS parameter : %s\n"
+                        "  Called from   : %s:%d"
+                        " in %s()\n"
+                        "  Fix: set the missing "
+                        "parameter, e.g.:\n"
+                        "    milk-fps-set %s"
+                        " <stream_name>\n",
+                        fpskey,
+                        caller_file, caller_line,
+                        caller_func,
+                        fpskey);
+                }
+                else
+                {
+                    fprintf(stderr,
+                        "\n\033[1;31mABORT\033[0m "
+                        "resolveIMGID: stream name "
+                        "is empty.\n"
+                        "  FPS parameter : %s\n"
+                        "  Called from   : %s:%d"
+                        " in %s()\n"
+                        "  Fix: set the missing "
+                        "parameter and tag this "
+                        "IMGID with imgid_setfpskeyword() "
+                        "to enable a specific "
+                        "milk-fps-set suggestion.\n",
+                        fpskey,
+                        caller_file, caller_line,
+                        caller_func);
+                }
                 fflush(stderr);
                 abort();
             }

--- a/src/coremods/COREMOD_memory/imageID.h
+++ b/src/coremods/COREMOD_memory/imageID.h
@@ -93,7 +93,12 @@ static inline imageID RegisterIMGID(
  * ERRMODE_FAIL : error
  * ERRMODE_ABORT : abort
  */
-static inline imageID resolveIMGID(
+#define resolveIMGID(...) _resolveIMGID_impl(__FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+
+static inline imageID _resolveIMGID_impl(
+    const char *caller_file,
+    int caller_line,
+    const char *caller_func,
     IMGID *img,
     int ERRMODE,
     IMAGE *imagearray __attribute__((unused)),
@@ -124,18 +129,28 @@ static inline imageID resolveIMGID(
     //
     if(img->ID == -1)
     {
-        const char *imgname =
-            (img->name[0] != '\0')
-            ? img->name
-            : "<empty name — FPS stream parameter not set>";
-
         if((ERRMODE == ERRMODE_FAIL) || (ERRMODE == ERRMODE_ABORT))
         {
-            PRINT_ERROR("Cannot resolve image \"%s\"\n", imgname);
-            abort();
+            if (img->name[0] == '\0')
+            {
+                fprintf(stderr,
+                        "\n\033[1;31mABORT\033[0m resolveIMGID: "
+                        "stream name is empty or NULL.\n"
+                        "  Called from: %s:%d in %s()\n"
+                        "  A required FPS stream parameter (or hardcoded stream name) has not been configured.\n",
+                        caller_file, caller_line, caller_func);
+                fflush(stderr);
+                abort();
+            }
+            else
+            {
+                PRINT_ERROR("Cannot resolve image \"%s\"\n", img->name);
+                abort();
+            }
         }
         else if(ERRMODE == ERRMODE_WARN)
         {
+            const char *imgname = (img->name[0] != '\0') ? img->name : "<empty name>";
             PRINT_WARNING("Cannot resolve image \"%s\"\n", imgname);
         }
     }

--- a/src/engine/libfps/IMGID.h
+++ b/src/engine/libfps/IMGID.h
@@ -13,6 +13,7 @@
 
 #include "ImageStreamIO/ImageStreamIO.h"
 #include "fps_streamname_parse.h"
+#include "fps_types.h"
 #include "imgid_slice.h"
 
 
@@ -29,6 +30,16 @@ typedef int errno_t;
 #endif
 
 #define IMGID_NB_KEYWO_MAX 10
+
+/* Buffer for a full FPS parameter key, e.g.
+ * "mfilt-00.inmval": FPS name (STRINGMAXLEN_FPS_NAME)
+ * plus dotted keyword suffix
+ * (FUNCTION_PARAMETER_KEYWORD_STRMAXLEN).
+ * See fps_types.h for the component limits.
+ */
+#define IMGID_FPSKEYWORD_STRMAXLEN \
+    (STRINGMAXLEN_FPS_NAME + \
+     FUNCTION_PARAMETER_KEYWORD_STRMAXLEN)
 
 #define IMGID_CONNECT_NOCHECK      0
 #define IMGID_CONNECT_CHECK_FAIL   1
@@ -98,7 +109,7 @@ typedef struct
     // FPS parameter key that sourced this stream name.
     // Set by imgid_setfpskeyword(); empty if not from FPS.
     // Used by resolveIMGID to produce actionable errors.
-    char fpskeyword[128];
+    char fpskeyword[IMGID_FPSKEYWORD_STRMAXLEN];
 
 } IMGID;
 

--- a/src/engine/libfps/IMGID.h
+++ b/src/engine/libfps/IMGID.h
@@ -95,6 +95,11 @@ typedef struct
     uint64_t    slice_last_cnt0;  // source frame counter
     int         slice_shared;    // 1 if @S: requested
 
+    // FPS parameter key that sourced this stream name.
+    // Set by imgid_setfpskeyword(); empty if not from FPS.
+    // Used by resolveIMGID to produce actionable errors.
+    char fpskeyword[128];
+
 } IMGID;
 
 
@@ -135,6 +140,8 @@ static inline IMGID imgid_make()
     img.slice_im       = NULL;
     img.slice_last_cnt0 = 0;
     img.slice_shared   = 0;
+
+    img.fpskeyword[0] = '\0';
 
     return img;
 }
@@ -334,6 +341,47 @@ static inline IMGID imgid_make_from_name(CONST_WORD name)
     return img;
 }
 
+
+/**
+ * @brief Tag an IMGID with its originating FPS key.
+ *
+ * When resolveIMGID fails, this key is printed in the
+ * error message so the user knows which
+ * milk-fps-set command to run.
+ *
+ * @param img      IMGID to tag
+ * @param fpsname  FPS instance name (e.g. "mfilt-00")
+ * @param key      Parameter suffix  (e.g. ".inmval")
+ */
+static inline void imgid_setfpskeyword(
+    IMGID      *img,
+    const char *fpsname,
+    const char *key
+)
+{
+    snprintf(img->fpskeyword,
+             sizeof(img->fpskeyword),
+             "%s%s", fpsname, key);
+}
+
+
+/**
+ * @brief Create IMGID from a stream name and tag it
+ *        with the FPS key that provided the name.
+ *
+ * Convenience wrapper combining imgid_make_from_name
+ * and imgid_setfpskeyword.
+ */
+static inline IMGID imgid_make_from_fpskey(
+    CONST_WORD  name,
+    const char *fpsname,
+    const char *key
+)
+{
+    IMGID img = imgid_make_from_name(name);
+    imgid_setfpskeyword(&img, fpsname, key);
+    return img;
+}
 
 
 

--- a/src/engine/libfps/fps_procinfo_macros.h
+++ b/src/engine/libfps/fps_procinfo_macros.h
@@ -226,6 +226,9 @@ typedef struct
         triggertimeout.tv_nsec = 0;      \
     if (dcfpsptr != NULL)               \
     {                                    \
+        CLIcmddata.cmdsettings->flags   \
+            |= (dcfpsptr->cmdset.flags  \
+                & CLICMDFLAG_PROCINFO); \
         CLIcmddata.cmdsettings->        \
             RT_priority =                \
             dcfpsptr->cmdset.RT_priority;\


### PR DESCRIPTION
## Summary

Two related improvements to the FPS V2 standalone executable infrastructure, discovered while debugging runtime crashes in `cacao-fpsexec-dmcomb` and `cacao-fpsexec-mfilt`:

### 1. Actionable `resolveIMGID` abort diagnostics

When `resolveIMGID` aborts because a stream name is empty (unconfigured FPS parameter), the error message now identifies the exact FPS parameter key and suggests the fix command:

**Before:**
```
ABORT resolveIMGID: stream name is empty or NULL.
```

**After:**
```
ABORT resolveIMGID: stream name is empty.
  FPS parameter : mfilt-00.inmval
  Called from   : modalfilter.c:764 in compute_function()
  Fix: set the missing parameter, e.g.:
    milk-fps-set mfilt-00.inmval <stream_name>
```

### 2. Fix: standalone V2 compute loop exits after 1 step

The standalone version of `INSERT_STD_PROCINFO_COMPUTEFUNC_INIT` in `fps_procinfo_macros.h` was missing the line that ORs `CLICMDFLAG_PROCINFO` from `dcfpsptr->cmdset.flags` into `CLIcmddata.cmdsettings->flags`. Without this, the loop macro never saw the PROCINFO flag, hit the `else` branch which sets `processloopOK=0`, and exited after exactly 1 iteration — regardless of `procinfo.loopcntMax`. The CLI version (`CLIcore_utils.h`) already had this line.

## Changes

### `src/engine/libfps/IMGID.h`
- Add `fpskeyword[128]` field to `IMGID` struct
- Initialize field in `imgid_make()`
- Add `imgid_setfpskeyword()` helper to tag an IMGID with its FPS key
- Add `imgid_make_from_fpskey()` convenience constructor

### `src/coremods/COREMOD_memory/imageID.h`
- Update `resolveIMGID` abort path to print the FPS parameter key
- Include suggested `milk-fps-set` fix command in the message
- Add caller file/line/function context to the abort output

### `src/engine/libfps/fps_procinfo_macros.h`
- Add missing `CLICMDFLAG_PROCINFO` flag OR from FPS cmdset, matching the CLI version

## Companion change (cacao)

Already pushed to `cacao:framework-dev`:
- `AOloopControl/modalfilter.c`: Updated `compute_function()` to use `imgid_make_from_fpskey()` as a demonstration of the new diagnostic tagging

## Verification
- [x] Build passes (`make -j`)
- [x] 38/38 ctests pass
- [x] Verified standalone dmcomb was running only 1 step (now fixed)

## Prompt Summary

The user reported that `milk-fpsCTRL` TUI was polluted by "cannot open shm" errors (addressed in PR #239), then discovered that standalone V2 executables would crash with unhelpful abort messages when FPS stream parameters were unconfigured, and separately that `cacao-fpsexec-dmcomb` would exit after 1 step despite `loopcntMax=-1`. The diagnostic enhancement and loop fix address both issues.

## AI Authorship
- **Model**: Antigravity
- **User edits**: None