### PR TITLE
fix: resolve milk-fpsCTRL segmentation fault when FPS are removed

### DIFF
--- a/src/engine/libfps/fpsCTRL/fpsCTRL_TUI.c
+++ b/src/engine/libfps/fpsCTRL/fpsCTRL_TUI.c
@@ -492,6 +492,18 @@ errno_t functionparameter_CTRLscreen(
             } else if (fpsCTRLvar.NBfps == 0) {
                 fpsCTRLvar.fpsindexSelected = 0;
             }
+
+            // Clamping node indices to the keyword array bounds
+            if (fpsCTRLvar.nodeSelected >= fpsCTRLvar.NBkwn && fpsCTRLvar.NBkwn > 0) {
+                fpsCTRLvar.nodeSelected = fpsCTRLvar.NBkwn - 1;
+            } else if (fpsCTRLvar.NBkwn == 0) {
+                fpsCTRLvar.nodeSelected = 0;
+            }
+            if (fpsCTRLvar.directorynodeSelected >= fpsCTRLvar.NBkwn && fpsCTRLvar.NBkwn > 0) {
+                fpsCTRLvar.directorynodeSelected = 0; // fallback to ROOT
+            } else if (fpsCTRLvar.NBkwn == 0) {
+                fpsCTRLvar.directorynodeSelected = 0;
+            }
         }
         
         int NBtaskLaunched = 0;
@@ -605,7 +617,7 @@ errno_t functionparameter_CTRLscreen(
                 }
                 TUI_printfw("\n");
 
-                if (fpsCTRLvar.NBfps > 0)
+                if (fpsCTRLvar.NBfps > 0 && fpsarray[fpsCTRLvar.fpsindexSelected].md != NULL)
                 {
                     TUI_printfw("    FPS keywords     :  %s\n", fpsarray[fpsCTRLvar.fpsindexSelected].md->keywordarray);
                 }

--- a/src/engine/libfps/fps_scan.c
+++ b/src/engine/libfps/fps_scan.c
@@ -4,6 +4,8 @@
  */
 
 #include <dirent.h>
+#include <string.h>
+
 #include <libgen.h>   // basename
 #include <sys/stat.h> // fstat
 
@@ -54,7 +56,7 @@ errno_t functionparameter_scan_fps(
 
     for(int kindex = 0; kindex < NB_KEYWNODE_MAX; kindex++)
     {
-        keywnode[kindex].NBchild = 0;
+        memset(&keywnode[kindex], 0, sizeof(KEYWORD_TREE_NODE));
     }
 
 

--- a/src/engine/libfps/fps_scan.c
+++ b/src/engine/libfps/fps_scan.c
@@ -54,10 +54,7 @@ errno_t functionparameter_scan_fps(
     static char shmdname[STRINGMAXLEN_SHMDIRNAME] = {0};
 
 
-    for(int kindex = 0; kindex < NB_KEYWNODE_MAX; kindex++)
-    {
-        memset(&keywnode[kindex], 0, sizeof(KEYWORD_TREE_NODE));
-    }
+    memset(keywnode, 0, NB_KEYWNODE_MAX * sizeof(*keywnode));
 
 
     // scan filesystem for fps entries


### PR DESCRIPTION
## Summary

Resolves a segmentation fault in `milk-fpsCTRL` that reliably triggered when FPS instances were removed from shared memory while the TUI was active. The fix guarantees robust UI state boundary synchronization following rescan phases down to zero active FPS files.

## Changes

### `libfps`
- Modified `fps_scan.c` to fully zero-initialize the `KEYWORD_TREE_NODE` array in `functionparameter_scan_fps()` using `memset()`, preventing UI string-parsing components from attempting to process garbage metadata from previously allocated frames.
- Modified `fpsCTRL_TUI.c` by inserting explicit bounding limits on user-selection pointer indices (`nodeSelected` and `directorynodeSelected`) which re-clamp the UI cursor inside the bounds of the newly reduced keyword tree counts. 
- Guarded the fast-path memory formatting dereferences natively with direct `fpsarray[...].md != NULL` verification.

## Verification

- [x] Build passes (`/compile-test`)
- [x] Tested manually by connecting dummy modules into `milk-fpsCTRL` and aggressively wiping shared memory resources, confirming stable reset functionality without SIGSEGV occurrences.

## Prompt Summary

The user observed `milk-fpsCTRL` segfaulting when instances were forcefully dropped from the system (e.g. `milk-fps-rm -a`). The task was to isolate the memory drift without redesigning the core FPS array scanning engine. This PR zeroes stale tree nodes and clamps selection variables during active lifecycle updates.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None