### PR TITLE
Vd/doc_cleanup

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,9 +10,6 @@ on:
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
-      - 'Doxyfile'
-      - 'src/**/*.h'
-      - 'plugins/**/*.h'
       - '.github/workflows/docs.yml'
   pull_request:
     branches:
@@ -23,9 +20,6 @@ on:
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
-      - 'Doxyfile'
-      - 'src/**/*.h'
-      - 'plugins/**/*.h'
       - '.github/workflows/docs.yml'
 
 jobs:
@@ -60,17 +54,6 @@ jobs:
       - name: Build MkDocs site (lenient)
         if: steps.build_strict.outcome == 'failure'
         run: mkdocs build -d _site
-
-      - name: Install Doxygen
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y doxygen graphviz
-
-      - name: Build Doxygen API reference
-        if: hashFiles('Doxyfile') != ''
-        run: |
-          ( cat Doxyfile; echo "OUTPUT_DIRECTORY=_site/api" ) \
-            | doxygen -
 
       - name: Deploy to GitHub Pages
         if: >-

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Code metrics (dev branch) :
 
 milk-core for **milk** package
 
-> **📖 [Documentation](https://milk-org.github.io/milk/)** · **📚 [API Reference](https://milk-org.github.io/milk/api/html/)** · **🚀 [Getting Started](https://milk-org.github.io/milk/install/compile/)**
+> **📖 [Documentation](https://milk-org.github.io/milk/)** · **🚀 [Getting Started](https://milk-org.github.io/milk/install/compile/)**
 
 ## _Looking for something else?_
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -183,14 +183,6 @@ pillars — **ImageStreamIO**, **FPS**, and
 
     [:octicons-arrow-right-24: Debugging](debugging.md)
 
--   :material-api:{ .lg .middle } **API Reference**
-
-    ---
-
-    Auto-generated Doxygen C API docs with call graphs.
-
-    [:octicons-arrow-right-24: Doxygen API](api/html/index.html)
-
 </div>
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,7 +110,6 @@ nav:
     - Performance Tuning: performance.md
     - PGO & LTO: pgo.md
     - Debugging: debugging.md
-  - API Reference: api/html/index.html
 
 markdown_extensions:
   - abbr


### PR DESCRIPTION
Cleanup the gh-pages branch history.

Disable doxygen, remove stale linkes in md doc to api/html (which was doxygen).

Full clone size trimmed down from 1.3GB+ to 23MB.

Need to propagate the amended github action to upstream branches, which could take a few steps.