### PR TITLE
feat: TrueColor fallback and compiler warnings fixes

### DIFF
--- a/src/CLImain.c
+++ b/src/CLImain.c
@@ -183,7 +183,7 @@ int main(int argc, char *argv[])
             /* 1. Move cursor to bottom row col 1 */
             n = snprintf(esc, sizeof(esc),
                          "\033[%d;1H", r);
-            write(STDOUT_FILENO, esc, n);
+            if(write(STDOUT_FILENO, esc, n) < 0) {}
 
             /* 2. Overwrite entire row with spaces */
             {
@@ -197,8 +197,8 @@ int main(int argc, char *argv[])
                     {
                         chunk = (int) sizeof(spaces);
                     }
-                    write(STDOUT_FILENO, spaces,
-                          chunk);
+                    if(write(STDOUT_FILENO, spaces,
+                          chunk) < 0) {}
                     remain -= chunk;
                 }
             }
@@ -206,12 +206,12 @@ int main(int argc, char *argv[])
             /* 3. Reset scroll region to full */
             n = snprintf(esc, sizeof(esc),
                          "\033[1;%dr", r);
-            write(STDOUT_FILENO, esc, n);
+            if(write(STDOUT_FILENO, esc, n) < 0) {}
 
             /* 4. Position cursor for bash prompt */
             n = snprintf(esc, sizeof(esc),
                          "\033[%d;1H", r - 1);
-            write(STDOUT_FILENO, esc, n);
+            if(write(STDOUT_FILENO, esc, n) < 0) {}
         }
     }
 

--- a/src/cli/CLIcore/termview/termview.c
+++ b/src/cli/CLIcore/termview/termview.c
@@ -212,12 +212,12 @@ static void tv_enter_raw(void)
 
 static void tv_enter_alt_screen(void)
 {
-    write(STDOUT_FILENO, "\033[?1049h\033[?25l\033[?1002h\033[?1006h", 30); // alt screen + hide cursor + mouse track
+    if(write(STDOUT_FILENO, "\033[?1049h\033[?25l\033[?1002h\033[?1006h", 30) < 0) {} // alt screen + hide cursor + mouse track
 }
 
 static void tv_exit_alt_screen(void)
 {
-    (void)write(STDOUT_FILENO, "\033[?1006l\033[?1002l\033[?1049l\033[?25h", 30); // exit alt screen + show cursor + no mouse track
+    if(write(STDOUT_FILENO, "\033[?1006l\033[?1002l\033[?1049l\033[?25h", 30) < 0) {} // exit alt screen + show cursor + no mouse track
 }
 
 static void tv_get_size(unsigned short *rows, unsigned short *cols)
@@ -398,7 +398,7 @@ errno_t termview_screen(const char *imagename, termview_options_t options)
                 memset(prev_screen, 0, screen_size * sizeof(tv_cell_t));
             }
             // Issue a clear screen just in case terminal scrolling messed up the view
-            write(STDOUT_FILENO, "\033[2J\033[H", 7);
+            if(write(STDOUT_FILENO, "\033[2J\033[H", 7) < 0) {}
         }
 
         long target_us = 1000000L / target_fps;
@@ -1197,7 +1197,7 @@ errno_t termview_screen(const char *imagename, termview_options_t options)
         tv_reset(frame_buffer, &fb_pos);
 
         if (fb_pos > 0) {
-            write(STDOUT_FILENO, frame_buffer, fb_pos);
+            if(write(STDOUT_FILENO, frame_buffer, fb_pos) < 0) {}
         }
     }
 

--- a/src/cli/libmilkscript/CLIcore_script_intercept_process.c
+++ b/src/cli/libmilkscript/CLIcore_script_intercept_process.c
@@ -767,8 +767,8 @@ static int cli_assert_cmp(const char *ap)
                 "\033[0m\n",
                 cli_float_digits, v1,
                 cli_cmp_sym(o1ch, o1eq),
-                cli_float_digits,
-                part2, v2,
+                part2,
+                cli_float_digits, v2,
                 cli_cmp_sym(o2ch, o2eq),
                 cli_float_digits, v3);
         }
@@ -782,8 +782,8 @@ static int cli_assert_cmp(const char *ap)
                 "\033[0m\n",
                 cli_float_digits, v1,
                 cli_cmp_sym(o1ch, o1eq),
-                cli_float_digits,
-                part2, v2,
+                part2,
+                cli_float_digits, v2,
                 cli_cmp_sym(o2ch, o2eq),
                 cli_float_digits, v3);
             cli_last_retval = 1;

--- a/src/cli/streamCTRL/streamCTRL_TUI.c
+++ b/src/cli/streamCTRL/streamCTRL_TUI.c
@@ -423,12 +423,12 @@ errno_t streamCTRL_CTRLscreen(void)
     //
 
 
-    // default: use ncurses
+    // default: use TUI
     TUI_set_screenprintmode(SCREENPRINT_NCURSES);
 
     if(getenv("MILK_TUIPRINT_STDIO"))
     {
-        // use stdio instead of ncurses
+        // use stdio instead of TUI
         TUI_set_screenprintmode(SCREENPRINT_STDIO);
     }
 

--- a/src/cli/streamCTRL/streamCTRL_TUIcompat.h
+++ b/src/cli/streamCTRL/streamCTRL_TUIcompat.h
@@ -64,7 +64,7 @@ static inline void sc_frame_flush(void)
 {
     if(sc_framebuf_pos > 0)
     {
-        (void) write(STDOUT_FILENO, sc_framebuf, (size_t) sc_framebuf_pos);
+        if(write(STDOUT_FILENO, sc_framebuf, (size_t) sc_framebuf_pos) < 0) {}
         sc_framebuf_pos = 0;
     }
 }

--- a/src/cli/streamCTRL/streamCTRL_ansi.h
+++ b/src/cli/streamCTRL/streamCTRL_ansi.h
@@ -101,7 +101,7 @@ static inline void ansi_raw_mode_enter(void)
     }
 
     /* hide cursor and disable line wrap */
-    (void) write(STDOUT_FILENO, "\033[?25l\033[?7l", 11);
+    if(write(STDOUT_FILENO, "\033[?25l\033[?7l", 11) < 0) {}
     ansi__raw_active = 1;
 }
 
@@ -115,9 +115,9 @@ static inline void ansi_raw_mode_exit(void)
         return;
     }
     /* show cursor and enable line wrap */
-    (void) write(STDOUT_FILENO, "\033[?25h\033[?7h", 11);
+    if(write(STDOUT_FILENO, "\033[?25h\033[?7h", 11) < 0) {}
     /* clear screen, home cursor */
-    (void) write(STDOUT_FILENO, "\033[2J\033[H", 7);
+    if(write(STDOUT_FILENO, "\033[2J\033[H", 7) < 0) {}
     tcsetattr(STDIN_FILENO, TCSAFLUSH, &ansi__orig_termios);
     ansi__raw_active = 0;
 }
@@ -157,7 +157,7 @@ static inline void ansi_get_terminal_size(int *rows, int *cols)
 /** ansi_cls - clear entire screen and move cursor to top-left. */
 static inline void ansi_cls(void)
 {
-    (void) write(STDOUT_FILENO, "\033[2J\033[H", 7);
+    if(write(STDOUT_FILENO, "\033[2J\033[H", 7) < 0) {}
 }
 
 /**
@@ -171,7 +171,37 @@ static inline void ansi_pos(int row, int col)
     int  n = snprintf(buf, sizeof(buf), "\033[%d;%dH", row, col);
     if(n > 0)
     {
-        (void) write(STDOUT_FILENO, buf, (size_t) n);
+        if(write(STDOUT_FILENO, buf, (size_t) n) < 0) {}
+    }
+}
+
+/* =========================================================
+ * Terminal capabilities
+ * ========================================================= */
+
+static int ansi__color_level = 0; // 0=uninit, 1=16-color, 2=256-color, 3=TrueColor
+
+static inline void ansi_detect_color_level(void)
+{
+    if (ansi__color_level > 0)
+    {
+        return;
+    }
+
+    const char *term = getenv("TERM");
+    const char *colorterm = getenv("COLORTERM");
+
+    if (colorterm && (strstr(colorterm, "truecolor") || strstr(colorterm, "24bit")))
+    {
+        ansi__color_level = 3;
+    }
+    else if (term && strstr(term, "256color"))
+    {
+        ansi__color_level = 2;
+    }
+    else
+    {
+        ansi__color_level = 1;
     }
 }
 
@@ -191,7 +221,7 @@ static inline void ansi_fg(int r, int g, int b)
     int  n = snprintf(buf, sizeof(buf), "\033[38;2;%d;%d;%dm", r, g, b);
     if(n > 0)
     {
-        (void) write(STDOUT_FILENO, buf, (size_t) n);
+        if(write(STDOUT_FILENO, buf, (size_t) n) < 0) {}
     }
 }
 
@@ -207,38 +237,66 @@ static inline void ansi_bg(int r, int g, int b)
     int  n = snprintf(buf, sizeof(buf), "\033[48;2;%d;%d;%dm", r, g, b);
     if(n > 0)
     {
-        (void) write(STDOUT_FILENO, buf, (size_t) n);
+        if(write(STDOUT_FILENO, buf, (size_t) n) < 0) {}
+    }
+}
+
+/**
+ * ansi_fg_256 - set 256-color foreground.
+ * @code: 8-bit color code (0-255)
+ */
+static inline void ansi_fg_256(int code)
+{
+    char buf[32];
+    int  n = snprintf(buf, sizeof(buf), "\033[38;5;%dm", code);
+    if(n > 0)
+    {
+        if(write(STDOUT_FILENO, buf, (size_t) n) < 0) {}
+    }
+}
+
+/**
+ * ansi_fg_16 - set 16-color standard foreground.
+ * @code: ANSI standard color code (e.g., 32 for green)
+ */
+static inline void ansi_fg_16(int code)
+{
+    char buf[32];
+    int  n = snprintf(buf, sizeof(buf), "\033[%dm", code);
+    if(n > 0)
+    {
+        if(write(STDOUT_FILENO, buf, (size_t) n) < 0) {}
     }
 }
 
 /** ansi_bold_on - enable bold/bright text attribute. */
 static inline void ansi_bold_on(void)
 {
-    (void) write(STDOUT_FILENO, "\033[1m", 4);
+    if(write(STDOUT_FILENO, "\033[1m", 4) < 0) {}
 }
 
 /** ansi_bold_off - disable bold/bright text attribute. */
 static inline void ansi_bold_off(void)
 {
-    (void) write(STDOUT_FILENO, "\033[22m", 5);
+    if(write(STDOUT_FILENO, "\033[22m", 5) < 0) {}
 }
 
 /** ansi_reverse_on - enable reverse-video attribute. */
 static inline void ansi_reverse_on(void)
 {
-    (void) write(STDOUT_FILENO, "\033[7m", 4);
+    if(write(STDOUT_FILENO, "\033[7m", 4) < 0) {}
 }
 
 /** ansi_reverse_off - disable reverse-video attribute. */
 static inline void ansi_reverse_off(void)
 {
-    (void) write(STDOUT_FILENO, "\033[27m", 5);
+    if(write(STDOUT_FILENO, "\033[27m", 5) < 0) {}
 }
 
 /** ansi_reset - reset all attributes (color + style) to default. */
 static inline void ansi_reset(void)
 {
-    (void) write(STDOUT_FILENO, "\033[0m", 4);
+    if(write(STDOUT_FILENO, "\033[0m", 4) < 0) {}
 }
 
 /* =========================================================
@@ -258,16 +316,52 @@ static inline void ansi_reset(void)
 
 static inline void ansi_setcolor(int idx)
 {
-    switch(idx)
+    ansi_detect_color_level();
+
+    if (ansi__color_level >= 3)
     {
-    case 2:  ansi_fg(80,  220, 80);  break; /* green        */
-    case 3:  ansi_fg(220, 200, 0);   break; /* yellow       */
-    case 4:  ansi_fg(240, 60,  60);  break; /* red          */
-    case 5:  ansi_fg(200, 80,  220); break; /* magenta      */
-    case 7:  ansi_fg(0,   200, 220); break; /* cyan         */
-    case 9:  ansi_fg(255, 140, 0);   break; /* orange       */
-    case 12: ansi_fg(100, 255, 100); break; /* bright-green */
-    default: ansi_reset(); break;
+        /* TrueColor (24-bit) */
+        switch(idx)
+        {
+        case 2:  ansi_fg(80,  220, 80);  break; /* green        */
+        case 3:  ansi_fg(220, 200, 0);   break; /* yellow       */
+        case 4:  ansi_fg(240, 60,  60);  break; /* red          */
+        case 5:  ansi_fg(200, 80,  220); break; /* magenta      */
+        case 7:  ansi_fg(0,   200, 220); break; /* cyan         */
+        case 9:  ansi_fg(255, 140, 0);   break; /* orange       */
+        case 12: ansi_fg(100, 255, 100); break; /* bright-green */
+        default: ansi_reset(); break;
+        }
+    }
+    else if (ansi__color_level == 2)
+    {
+        /* 256-color fallback */
+        switch(idx)
+        {
+        case 2:  ansi_fg_256(114); break; /* green        */
+        case 3:  ansi_fg_256(220); break; /* yellow       */
+        case 4:  ansi_fg_256(203); break; /* red          */
+        case 5:  ansi_fg_256(176); break; /* magenta      */
+        case 7:  ansi_fg_256(44);  break; /* cyan         */
+        case 9:  ansi_fg_256(208); break; /* orange       */
+        case 12: ansi_fg_256(119); break; /* bright-green */
+        default: ansi_reset();     break;
+        }
+    }
+    else
+    {
+        /* 16-color (standard ANSI) fallback */
+        switch(idx)
+        {
+        case 2:  ansi_fg_16(32); break; /* green        */
+        case 3:  ansi_fg_16(33); break; /* yellow       */
+        case 4:  ansi_fg_16(31); break; /* red          */
+        case 5:  ansi_fg_16(35); break; /* magenta      */
+        case 7:  ansi_fg_16(36); break; /* cyan         */
+        case 9:  ansi_fg_16(33); break; /* orange -> yellow */
+        case 12: ansi_fg_16(92); break; /* bright-green */
+        default: ansi_reset();   break;
+        }
     }
 }
 

--- a/src/coremods/COREMOD_memory/logshmim.c
+++ b/src/coremods/COREMOD_memory/logshmim.c
@@ -787,13 +787,7 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
 
                     if(compressON == 0)
                     {
-                        snprintf(
-                            tmsg
-                            ->compress_string,
-                            sizeof(
-                                tmsg
-                                ->compress_string),
-                            "");
+                        tmsg->compress_string[0] = '\0';
                     }
                     else
                     {

--- a/src/engine/libfps/fpsCTRL/fpsCTRL_TUIcompat.h
+++ b/src/engine/libfps/fpsCTRL/fpsCTRL_TUIcompat.h
@@ -73,7 +73,7 @@ static inline void sc_frame_flush(void)
     SC_APPEND("\033[J");
     if(sc_framebuf_pos > 0)
     {
-        (void) write(STDOUT_FILENO, sc_framebuf, (size_t) sc_framebuf_pos);
+        if(write(STDOUT_FILENO, sc_framebuf, (size_t) sc_framebuf_pos) < 0) {}
         sc_framebuf_pos = 0;
     }
 }

--- a/src/engine/libfps/fpsCTRL/fpsCTRL_ansi.h
+++ b/src/engine/libfps/fpsCTRL/fpsCTRL_ansi.h
@@ -102,7 +102,7 @@ static inline void ansi_raw_mode_enter(void)
     }
 
     /* hide cursor and disable line wrap */
-    (void) write(STDOUT_FILENO, "\033[?25l\033[?7l", 11);
+    if(write(STDOUT_FILENO, "\033[?25l\033[?7l", 11) < 0) {}
     ansi__raw_active = 1;
 }
 
@@ -116,9 +116,9 @@ static inline void ansi_raw_mode_exit(void)
         return;
     }
     /* show cursor and enable line wrap */
-    (void) write(STDOUT_FILENO, "\033[?25h\033[?7h", 11);
+    if(write(STDOUT_FILENO, "\033[?25h\033[?7h", 11) < 0) {}
     /* clear screen, home cursor */
-    (void) write(STDOUT_FILENO, "\033[2J\033[H", 7);
+    if(write(STDOUT_FILENO, "\033[2J\033[H", 7) < 0) {}
     tcsetattr(STDIN_FILENO, TCSAFLUSH, &ansi__orig_termios);
     ansi__raw_active = 0;
 }
@@ -158,7 +158,7 @@ static inline void ansi_get_terminal_size(int *rows, int *cols)
 /** ansi_cls - clear entire screen and move cursor to top-left. */
 static inline void ansi_cls(void)
 {
-    (void) write(STDOUT_FILENO, "\033[2J\033[H", 7);
+    if(write(STDOUT_FILENO, "\033[2J\033[H", 7) < 0) {}
 }
 
 /**
@@ -172,7 +172,37 @@ static inline void ansi_pos(int row, int col)
     int  n = snprintf(buf, sizeof(buf), "\033[%d;%dH", row, col);
     if(n > 0)
     {
-        (void) write(STDOUT_FILENO, buf, (size_t) n);
+        if(write(STDOUT_FILENO, buf, (size_t) n) < 0) {}
+    }
+}
+
+/* =========================================================
+ * Terminal capabilities
+ * ========================================================= */
+
+static int ansi__color_level = 0; // 0=uninit, 1=16-color, 2=256-color, 3=TrueColor
+
+static inline void ansi_detect_color_level(void)
+{
+    if (ansi__color_level > 0)
+    {
+        return;
+    }
+
+    const char *term = getenv("TERM");
+    const char *colorterm = getenv("COLORTERM");
+
+    if (colorterm && (strstr(colorterm, "truecolor") || strstr(colorterm, "24bit")))
+    {
+        ansi__color_level = 3;
+    }
+    else if (term && strstr(term, "256color"))
+    {
+        ansi__color_level = 2;
+    }
+    else
+    {
+        ansi__color_level = 1;
     }
 }
 
@@ -192,7 +222,7 @@ static inline void ansi_fg(int r, int g, int b)
     int  n = snprintf(buf, sizeof(buf), "\033[38;2;%d;%d;%dm", r, g, b);
     if(n > 0)
     {
-        (void) write(STDOUT_FILENO, buf, (size_t) n);
+        if(write(STDOUT_FILENO, buf, (size_t) n) < 0) {}
     }
 }
 
@@ -208,38 +238,66 @@ static inline void ansi_bg(int r, int g, int b)
     int  n = snprintf(buf, sizeof(buf), "\033[48;2;%d;%d;%dm", r, g, b);
     if(n > 0)
     {
-        (void) write(STDOUT_FILENO, buf, (size_t) n);
+        if(write(STDOUT_FILENO, buf, (size_t) n) < 0) {}
+    }
+}
+
+/**
+ * ansi_fg_256 - set 256-color foreground.
+ * @code: 8-bit color code (0-255)
+ */
+static inline void ansi_fg_256(int code)
+{
+    char buf[32];
+    int  n = snprintf(buf, sizeof(buf), "\033[38;5;%dm", code);
+    if(n > 0)
+    {
+        if(write(STDOUT_FILENO, buf, (size_t) n) < 0) {}
+    }
+}
+
+/**
+ * ansi_fg_16 - set 16-color standard foreground.
+ * @code: ANSI standard color code (e.g., 32 for green)
+ */
+static inline void ansi_fg_16(int code)
+{
+    char buf[32];
+    int  n = snprintf(buf, sizeof(buf), "\033[%dm", code);
+    if(n > 0)
+    {
+        if(write(STDOUT_FILENO, buf, (size_t) n) < 0) {}
     }
 }
 
 /** ansi_bold_on - enable bold/bright text attribute. */
 static inline void ansi_bold_on(void)
 {
-    (void) write(STDOUT_FILENO, "\033[1m", 4);
+    if(write(STDOUT_FILENO, "\033[1m", 4) < 0) {}
 }
 
 /** ansi_bold_off - disable bold/bright text attribute. */
 static inline void ansi_bold_off(void)
 {
-    (void) write(STDOUT_FILENO, "\033[22m", 5);
+    if(write(STDOUT_FILENO, "\033[22m", 5) < 0) {}
 }
 
 /** ansi_reverse_on - enable reverse-video attribute. */
 static inline void ansi_reverse_on(void)
 {
-    (void) write(STDOUT_FILENO, "\033[7m", 4);
+    if(write(STDOUT_FILENO, "\033[7m", 4) < 0) {}
 }
 
 /** ansi_reverse_off - disable reverse-video attribute. */
 static inline void ansi_reverse_off(void)
 {
-    (void) write(STDOUT_FILENO, "\033[27m", 5);
+    if(write(STDOUT_FILENO, "\033[27m", 5) < 0) {}
 }
 
 /** ansi_reset - reset all attributes (color + style) to default. */
 static inline void ansi_reset(void)
 {
-    (void) write(STDOUT_FILENO, "\033[0m", 4);
+    if(write(STDOUT_FILENO, "\033[0m", 4) < 0) {}
 }
 
 /* =========================================================
@@ -259,16 +317,52 @@ static inline void ansi_reset(void)
 
 static inline void ansi_setcolor(int idx)
 {
-    switch(idx)
+    ansi_detect_color_level();
+
+    if (ansi__color_level >= 3)
     {
-    case 2:  ansi_fg(80,  220, 80);  break; /* green        */
-    case 3:  ansi_fg(220, 200, 0);   break; /* yellow       */
-    case 4:  ansi_fg(240, 60,  60);  break; /* red          */
-    case 5:  ansi_fg(200, 80,  220); break; /* magenta      */
-    case 7:  ansi_fg(0,   200, 220); break; /* cyan         */
-    case 9:  ansi_fg(255, 140, 0);   break; /* orange       */
-    case 12: ansi_fg(100, 255, 100); break; /* bright-green */
-    default: ansi_reset(); break;
+        /* TrueColor (24-bit) */
+        switch(idx)
+        {
+        case 2:  ansi_fg(80,  220, 80);  break; /* green        */
+        case 3:  ansi_fg(220, 200, 0);   break; /* yellow       */
+        case 4:  ansi_fg(240, 60,  60);  break; /* red          */
+        case 5:  ansi_fg(200, 80,  220); break; /* magenta      */
+        case 7:  ansi_fg(0,   200, 220); break; /* cyan         */
+        case 9:  ansi_fg(255, 140, 0);   break; /* orange       */
+        case 12: ansi_fg(100, 255, 100); break; /* bright-green */
+        default: ansi_reset(); break;
+        }
+    }
+    else if (ansi__color_level == 2)
+    {
+        /* 256-color fallback */
+        switch(idx)
+        {
+        case 2:  ansi_fg_256(114); break; /* green        */
+        case 3:  ansi_fg_256(220); break; /* yellow       */
+        case 4:  ansi_fg_256(203); break; /* red          */
+        case 5:  ansi_fg_256(176); break; /* magenta      */
+        case 7:  ansi_fg_256(44);  break; /* cyan         */
+        case 9:  ansi_fg_256(208); break; /* orange       */
+        case 12: ansi_fg_256(119); break; /* bright-green */
+        default: ansi_reset();     break;
+        }
+    }
+    else
+    {
+        /* 16-color (standard ANSI) fallback */
+        switch(idx)
+        {
+        case 2:  ansi_fg_16(32); break; /* green        */
+        case 3:  ansi_fg_16(33); break; /* yellow       */
+        case 4:  ansi_fg_16(31); break; /* red          */
+        case 5:  ansi_fg_16(35); break; /* magenta      */
+        case 7:  ansi_fg_16(36); break; /* cyan         */
+        case 9:  ansi_fg_16(33); break; /* orange -> yellow */
+        case 12: ansi_fg_16(92); break; /* bright-green */
+        default: ansi_reset();   break;
+        }
     }
 }
 

--- a/src/engine/libfps/fpsCTRL/milk-fpsCTRL.c
+++ b/src/engine/libfps/fpsCTRL/milk-fpsCTRL.c
@@ -31,8 +31,8 @@ void fpsCTRL_crash_handler(int sig)
      */
     static const char reset_seq[] =
         "\033[?1049l\033[?25h\033[0m\n";
-    (void) write(STDERR_FILENO,
-                 reset_seq, sizeof(reset_seq) - 1);
+    if(write(STDERR_FILENO,
+                 reset_seq, sizeof(reset_seq) - 1) < 0) {}
                  
     if (ansi__raw_active) {
         tcsetattr(STDIN_FILENO, TCSAFLUSH, &ansi__orig_termios);
@@ -67,8 +67,8 @@ void print_usage(const char *progname) {
         "Quiet mode (suppress "
         "TUI output)\n");
     printf("  -s, --stdio       "
-        "Use stdio instead of "
-        "ncurses\n");
+        "Use stdio line-by-line "
+        "display instead of TUI\n");
     printf("  -h, --help        "
         "Show this help message\n");
     printf("\n");

--- a/src/engine/libprocessinfo/procCTRL/procCTRL_TUI.c
+++ b/src/engine/libprocessinfo/procCTRL/procCTRL_TUI.c
@@ -180,7 +180,7 @@ errno_t processinfo_CTRLscreen()
         char response = 'n';
         if (scanf(" %c", &response) == 1 && (response == 'y' || response == 'Y')) {
             printf("Launching milk-procCTRL-scan...\n");
-            system("tmux new-session -d -s milk-procCTRL-scan 'milk-procCTRL-scan'");
+            if(system("tmux new-session -d -s milk-procCTRL-scan 'milk-procCTRL-scan'") < 0) {}
             sleep(1);
             if (system("pgrep \"milk-procCTRL-s\" > /dev/null") != 0) {
                 fprintf(stderr, "ERROR: Failed to launch milk-procCTRL-scan daemon.\n");
@@ -718,13 +718,13 @@ errno_t processinfo_CTRLscreen()
                         if (procinfoproc->col_visible[m][2]) {
                             if (procinfoproc->selected_col == 2) screenprint_setcolor(10);
                             if (pinfolist->active[pindex] == 1) {
-                                screenprint_setcolor(6); TUI_printfw("% -10s ", "ACTIVE"); screenprint_unsetcolor(6);
+                                screenprint_setcolor(6); TUI_printfw("%-10s ", "ACTIVE"); screenprint_unsetcolor(6);
                             } else if (pinfolist->active[pindex] == 2) {
-                                screenprint_setcolor(7); TUI_printfw("% -10s ", "STOPPED"); screenprint_unsetcolor(7);
+                                screenprint_setcolor(7); TUI_printfw("%-10s ", "STOPPED"); screenprint_unsetcolor(7);
                             } else if (pinfolist->active[pindex] == 3) {
-                                screenprint_setcolor(8); TUI_printfw("% -10s ", "CRASHED"); screenprint_unsetcolor(8);
+                                screenprint_setcolor(8); TUI_printfw("%-10s ", "CRASHED"); screenprint_unsetcolor(8);
                             } else {
-                                TUI_printfw("% -10s ", "OFF");
+                                TUI_printfw("%-10s ", "OFF");
                             }
                             if (procinfoproc->selected_col == 2) screenprint_unsetcolor(10);
                         }
@@ -765,7 +765,7 @@ errno_t processinfo_CTRLscreen()
                             // 5: pname
                             if (procinfoproc->col_visible[m][5]) {
                                 if (procinfoproc->selected_col == 5) screenprint_setcolor(10);
-                                TUI_printfw("% -25s ", pinfolist->pnamearray[pindex]);
+                                TUI_printfw("%-25s ", pinfolist->pnamearray[pindex]);
                                 if (procinfoproc->selected_col == 5) screenprint_unsetcolor(10);
                             }
 
@@ -799,7 +799,7 @@ errno_t processinfo_CTRLscreen()
                             // 8: msg
                             if (procinfoproc->col_visible[m][8]) {
                                 if (procinfoproc->selected_col == 8) screenprint_setcolor(10);
-                                TUI_printfw("% -30s ", desc); 
+                                TUI_printfw("%-30s ", desc); 
                                 if (procinfoproc->selected_col == 8) screenprint_unsetcolor(10);
                             }
                         }
@@ -807,7 +807,7 @@ errno_t processinfo_CTRLscreen()
                             // 4: pname
                             if (procinfoproc->col_visible[m][4]) {
                                 if (procinfoproc->selected_col == 4) screenprint_setcolor(10);
-                                TUI_printfw("% -25s ", pinfolist->pnamearray[pindex]);
+                                TUI_printfw("%-25s ", pinfolist->pnamearray[pindex]);
                                 if (procinfoproc->selected_col == 4) screenprint_unsetcolor(10);
                             }
                             // 5: prio
@@ -839,7 +839,7 @@ errno_t processinfo_CTRLscreen()
                             // 4: pname
                             if (procinfoproc->col_visible[m][4]) {
                                 if (procinfoproc->selected_col == 4) screenprint_setcolor(10);
-                                TUI_printfw("% -25s ", pinfolist->pnamearray[pindex]);
+                                TUI_printfw("%-25s ", pinfolist->pnamearray[pindex]);
                                 if (procinfoproc->selected_col == 4) screenprint_unsetcolor(10);
                             }
                             // 5: tmode
@@ -877,7 +877,7 @@ errno_t processinfo_CTRLscreen()
                             // 4: pname
                             if (procinfoproc->col_visible[m][4]) {
                                 if (procinfoproc->selected_col == 4) screenprint_setcolor(10);
-                                TUI_printfw("% -25s ", pinfolist->pnamearray[pindex]);
+                                TUI_printfw("%-25s ", pinfolist->pnamearray[pindex]);
                                 if (procinfoproc->selected_col == 4) screenprint_unsetcolor(10);
                             }
                             if (scan_shm->pinfodisp[pindex].MeasureTiming) {
@@ -912,7 +912,7 @@ errno_t processinfo_CTRLscreen()
                             // 4: pname
                             if (procinfoproc->col_visible[m][4]) {
                                 if (procinfoproc->selected_col == 4) screenprint_setcolor(10);
-                                TUI_printfw("% -25s ", pinfolist->pnamearray[pindex]);
+                                TUI_printfw("%-25s ", pinfolist->pnamearray[pindex]);
                                 if (procinfoproc->selected_col == 4) screenprint_unsetcolor(10);
                             }
                             // 5: RT

--- a/src/engine/libprocessinfo/procCTRL/procCTRL_TUIcompat.h
+++ b/src/engine/libprocessinfo/procCTRL/procCTRL_TUIcompat.h
@@ -64,7 +64,7 @@ static inline void sc_frame_flush(void)
 {
     if(sc_framebuf_pos > 0)
     {
-        (void) write(STDOUT_FILENO, sc_framebuf, (size_t) sc_framebuf_pos);
+        if(write(STDOUT_FILENO, sc_framebuf, (size_t) sc_framebuf_pos) < 0) {}
         sc_framebuf_pos = 0;
     }
 }

--- a/src/engine/libprocessinfo/procCTRL/procCTRL_ansi.h
+++ b/src/engine/libprocessinfo/procCTRL/procCTRL_ansi.h
@@ -101,7 +101,7 @@ static inline void ansi_raw_mode_enter(void)
     }
 
     /* hide cursor and disable line wrap */
-    (void) write(STDOUT_FILENO, "\033[?25l\033[?7l", 11);
+    if(write(STDOUT_FILENO, "\033[?25l\033[?7l", 11) < 0) {}
     ansi__raw_active = 1;
 }
 
@@ -115,9 +115,9 @@ static inline void ansi_raw_mode_exit(void)
         return;
     }
     /* show cursor and enable line wrap */
-    (void) write(STDOUT_FILENO, "\033[?25h\033[?7h", 11);
+    if(write(STDOUT_FILENO, "\033[?25h\033[?7h", 11) < 0) {}
     /* clear screen, home cursor */
-    (void) write(STDOUT_FILENO, "\033[2J\033[H", 7);
+    if(write(STDOUT_FILENO, "\033[2J\033[H", 7) < 0) {}
     tcsetattr(STDIN_FILENO, TCSAFLUSH, &ansi__orig_termios);
     ansi__raw_active = 0;
 }
@@ -157,7 +157,7 @@ static inline void ansi_get_terminal_size(int *rows, int *cols)
 /** ansi_cls - clear entire screen and move cursor to top-left. */
 static inline void ansi_cls(void)
 {
-    (void) write(STDOUT_FILENO, "\033[2J\033[H", 7);
+    if(write(STDOUT_FILENO, "\033[2J\033[H", 7) < 0) {}
 }
 
 /**
@@ -171,7 +171,37 @@ static inline void ansi_pos(int row, int col)
     int  n = snprintf(buf, sizeof(buf), "\033[%d;%dH", row, col);
     if(n > 0)
     {
-        (void) write(STDOUT_FILENO, buf, (size_t) n);
+        if(write(STDOUT_FILENO, buf, (size_t) n) < 0) {}
+    }
+}
+
+/* =========================================================
+ * Terminal capabilities
+ * ========================================================= */
+
+static int ansi__color_level = 0; // 0=uninit, 1=16-color, 2=256-color, 3=TrueColor
+
+static inline void ansi_detect_color_level(void)
+{
+    if (ansi__color_level > 0)
+    {
+        return;
+    }
+
+    const char *term = getenv("TERM");
+    const char *colorterm = getenv("COLORTERM");
+
+    if (colorterm && (strstr(colorterm, "truecolor") || strstr(colorterm, "24bit")))
+    {
+        ansi__color_level = 3;
+    }
+    else if (term && strstr(term, "256color"))
+    {
+        ansi__color_level = 2;
+    }
+    else
+    {
+        ansi__color_level = 1;
     }
 }
 
@@ -191,7 +221,7 @@ static inline void ansi_fg(int r, int g, int b)
     int  n = snprintf(buf, sizeof(buf), "\033[38;2;%d;%d;%dm", r, g, b);
     if(n > 0)
     {
-        (void) write(STDOUT_FILENO, buf, (size_t) n);
+        if(write(STDOUT_FILENO, buf, (size_t) n) < 0) {}
     }
 }
 
@@ -207,38 +237,66 @@ static inline void ansi_bg(int r, int g, int b)
     int  n = snprintf(buf, sizeof(buf), "\033[48;2;%d;%d;%dm", r, g, b);
     if(n > 0)
     {
-        (void) write(STDOUT_FILENO, buf, (size_t) n);
+        if(write(STDOUT_FILENO, buf, (size_t) n) < 0) {}
+    }
+}
+
+/**
+ * ansi_fg_256 - set 256-color foreground.
+ * @code: 8-bit color code (0-255)
+ */
+static inline void ansi_fg_256(int code)
+{
+    char buf[32];
+    int  n = snprintf(buf, sizeof(buf), "\033[38;5;%dm", code);
+    if(n > 0)
+    {
+        if(write(STDOUT_FILENO, buf, (size_t) n) < 0) {}
+    }
+}
+
+/**
+ * ansi_fg_16 - set 16-color standard foreground.
+ * @code: ANSI standard color code (e.g., 32 for green)
+ */
+static inline void ansi_fg_16(int code)
+{
+    char buf[32];
+    int  n = snprintf(buf, sizeof(buf), "\033[%dm", code);
+    if(n > 0)
+    {
+        if(write(STDOUT_FILENO, buf, (size_t) n) < 0) {}
     }
 }
 
 /** ansi_bold_on - enable bold/bright text attribute. */
 static inline void ansi_bold_on(void)
 {
-    (void) write(STDOUT_FILENO, "\033[1m", 4);
+    if(write(STDOUT_FILENO, "\033[1m", 4) < 0) {}
 }
 
 /** ansi_bold_off - disable bold/bright text attribute. */
 static inline void ansi_bold_off(void)
 {
-    (void) write(STDOUT_FILENO, "\033[22m", 5);
+    if(write(STDOUT_FILENO, "\033[22m", 5) < 0) {}
 }
 
 /** ansi_reverse_on - enable reverse-video attribute. */
 static inline void ansi_reverse_on(void)
 {
-    (void) write(STDOUT_FILENO, "\033[7m", 4);
+    if(write(STDOUT_FILENO, "\033[7m", 4) < 0) {}
 }
 
 /** ansi_reverse_off - disable reverse-video attribute. */
 static inline void ansi_reverse_off(void)
 {
-    (void) write(STDOUT_FILENO, "\033[27m", 5);
+    if(write(STDOUT_FILENO, "\033[27m", 5) < 0) {}
 }
 
 /** ansi_reset - reset all attributes (color + style) to default. */
 static inline void ansi_reset(void)
 {
-    (void) write(STDOUT_FILENO, "\033[0m", 4);
+    if(write(STDOUT_FILENO, "\033[0m", 4) < 0) {}
 }
 
 /* =========================================================
@@ -258,16 +316,52 @@ static inline void ansi_reset(void)
 
 static inline void ansi_setcolor(int idx)
 {
-    switch(idx)
+    ansi_detect_color_level();
+
+    if (ansi__color_level >= 3)
     {
-    case 2:  ansi_fg(80,  220, 80);  break; /* green        */
-    case 3:  ansi_fg(220, 200, 0);   break; /* yellow       */
-    case 4:  ansi_fg(240, 60,  60);  break; /* red          */
-    case 5:  ansi_fg(200, 80,  220); break; /* magenta      */
-    case 7:  ansi_fg(0,   200, 220); break; /* cyan         */
-    case 9:  ansi_fg(255, 140, 0);   break; /* orange       */
-    case 12: ansi_fg(100, 255, 100); break; /* bright-green */
-    default: ansi_reset(); break;
+        /* TrueColor (24-bit) */
+        switch(idx)
+        {
+        case 2:  ansi_fg(80,  220, 80);  break; /* green        */
+        case 3:  ansi_fg(220, 200, 0);   break; /* yellow       */
+        case 4:  ansi_fg(240, 60,  60);  break; /* red          */
+        case 5:  ansi_fg(200, 80,  220); break; /* magenta      */
+        case 7:  ansi_fg(0,   200, 220); break; /* cyan         */
+        case 9:  ansi_fg(255, 140, 0);   break; /* orange       */
+        case 12: ansi_fg(100, 255, 100); break; /* bright-green */
+        default: ansi_reset(); break;
+        }
+    }
+    else if (ansi__color_level == 2)
+    {
+        /* 256-color fallback */
+        switch(idx)
+        {
+        case 2:  ansi_fg_256(114); break; /* green        */
+        case 3:  ansi_fg_256(220); break; /* yellow       */
+        case 4:  ansi_fg_256(203); break; /* red          */
+        case 5:  ansi_fg_256(176); break; /* magenta      */
+        case 7:  ansi_fg_256(44);  break; /* cyan         */
+        case 9:  ansi_fg_256(208); break; /* orange       */
+        case 12: ansi_fg_256(119); break; /* bright-green */
+        default: ansi_reset();     break;
+        }
+    }
+    else
+    {
+        /* 16-color (standard ANSI) fallback */
+        switch(idx)
+        {
+        case 2:  ansi_fg_16(32); break; /* green        */
+        case 3:  ansi_fg_16(33); break; /* yellow       */
+        case 4:  ansi_fg_16(31); break; /* red          */
+        case 5:  ansi_fg_16(35); break; /* magenta      */
+        case 7:  ansi_fg_16(36); break; /* cyan         */
+        case 9:  ansi_fg_16(33); break; /* orange -> yellow */
+        case 12: ansi_fg_16(92); break; /* bright-green */
+        default: ansi_reset();   break;
+        }
     }
 }
 


### PR DESCRIPTION
### Prompt Summary
The user requested two main architectural improvements across the standalone utilities (`milk-streamCTRL`, `milk-fpsCTRL`, and `milk-procCTRL`):
1. **TrueColor Fallback**: A robust, capability-aware fallback system for legacy terminals that do not support TrueColor (24-bit), dynamically detecting the environment and mapping standard UI colors to 256-color or standard 16-color ANSI code equivalents to prevent rendering garbage text on unsupported systems.
2. **Warning Eradication**: Complete elimination of warnings in `CLImain.c`, `termview.c`, `CLIcore_script_intercept_process.c`, and the various `ansi.h` primitives, specifically addressing missing `write()` and `system()` return checks and invalid format string attributes.
3. **Help Update**: Fixes to the `-s` / `--stdio` flag description to accurately reflect that it enables standard I/O line-by-line output rather than referencing the removed `ncurses` dependency.

### Changes Made
* **`*_ansi.h` Updates**: Implemented capability detection via `ansi_detect_color_level()` checking the `COLORTERM` and `TERM` environment variables, routing palette calls via `ansi_fg_256(code)` and `ansi_fg_16(code)`.
* **Warning Fixes**: Addressed `warn_unused_result` for legacy file descriptors, `system()` wrappers, and `write()` sequences. Corrected invalid `%` format string specifiers and removed empty formatting strings causing GCC complaints.
* **StreamCTRL / fpsCTRL / procCTRL**: Removed outdated code comments referencing `ncurses` and updated command-line help flags (`--stdio`) for the standalone binaries.

### Testing Done
- Successfully compiled the codebase (`make -j`) with no warnings for the modified sections.
- Verified terminal capability fallback in `milk-fpsCTRL` by simulating restricted terminal capabilities (`COLORTERM="" TERM="xterm"`), confirming successful translation to legacy ANSI codes.

### AI Authorship
* **Model(s) used**: Antigravity
* **User edits**: The user directed the architecture changes and provided context around the removal of `ncurses`.