### PR TITLE
docs: remove ncurses dependency references across documentation

### DIFF
--- a/docs/cli/scripting.md
+++ b/docs/cli/scripting.md
@@ -27,7 +27,7 @@ You can execute a milk script file in several ways:
 
 - **Shebang**: Use `#!/usr/bin/env milk-script` as the first line.
   The standalone `milk-script` binary runs the file
-  non-interactively with no readline/ncurses dependency.
+  non-interactively with no readline dependency.
 - **Command line**: Run `milk-cli -s script.milk` from a shell.
 - **Interactive**: Use the `source` (or `.`) command from within
   an active `milk-cli` session.

--- a/docs/dependency_graph.md
+++ b/docs/dependency_graph.md
@@ -26,7 +26,6 @@
 ```mermaid
 graph TD
     CFITSIO["cfitsio"]:::ext
-    NCURSES["ncurses"]:::ext
     READLINE["readline"]:::ext
 
     subgraph engine ["Engine Tier — POSIX only"]
@@ -36,10 +35,6 @@ graph TD
         MILKDATA["milkdata"]:::core
     end
 
-    MILKTUI["milkTUI"]:::core
-
-    PITUI["milkprocessinfoTUI"]:::fw
-    FPSTUI["milkfpsTUI"]:::fw
     FPSCLI["milkfpsCLI"]:::fw
     FPSSTANDALONE["milkfpsStandalone"]:::fw
 
@@ -66,9 +61,6 @@ graph TD
     FPS --> PROCINFO
     MILKDATA --> FPS
     MILKDATA --> PROCINFO
-    MILKTUI --> ISIO
-    MILKTUI --> NCURSES
-
     IOFITS --> FPS
     IOFITS --> CFITSIO
     ARITH --> FPS
@@ -78,10 +70,6 @@ graph TD
     MEMORY -.->|USE_CFITSIO| CFITSIO
     TOOLS --> FPS
 
-    PITUI --> PROCINFO
-    PITUI --> MILKTUI
-    FPSTUI --> FPS
-    FPSTUI --> MILKTUI
     FPSCLI --> FPS
     FPSCLI --> CLICORE
     FPSSTANDALONE --> FPS
@@ -94,16 +82,11 @@ graph TD
     CLICORE --> FPS
     CLICORE --> MILKDATA
     CLICORE --> PROCINFO
-    CLICORE --> MILKTUI
-    CLICORE --> FPSTUI
-    CLICORE --> PITUI
     CLICORE --> READLINE
-    CLICORE --> NCURSES
     CLICORE -.->|USE_CFITSIO| CFITSIO
 
-    FPSCTRL --> FPSTUI
     FPSCTRL --> CLICORE
-    PROCCTRL --> PITUI
+    PROCCTRL --> CLICORE
     STREAMCTRL --> CLICORE
     STREAMCTRL --> ISIO
     MILKEXE --> FPSSTANDALONE
@@ -354,12 +337,9 @@ COREMOD_iofits ── Core+FITS           ← USE_CFITSIO
 
 | Target | Links to | Optional |
 |--------|----------|----------|
-| milkTUI | ImageStreamIO, ncurses | |
-| milkprocessinfoTUI | milkprocessinfo, milkTUI, ncurses | |
-| milkfpsTUI | milkfps, milkTUI, ncurses | |
 | milkfpsStandalone | milkfps, milkdata | |
 | milkfpsCLI | milkfps, CLIcore | |
-| CLIcore | COREMODarith, COREMODmemory, COREMODtools, milkfps, milkdata, milkprocessinfo, milkTUI, milkfpsTUI, milkprocessinfoTUI, readline, ncurses | COREMODiofits (USE_CFITSIO), cfitsio (USE_CFITSIO), OpenMP |
+| CLIcore | COREMODarith, COREMODmemory, COREMODtools, milkfps, milkdata, milkprocessinfo, readline | COREMODiofits (USE_CFITSIO), cfitsio (USE_CFITSIO), OpenMP |
 
 </details>
 
@@ -440,15 +420,15 @@ COREMOD_iofits ── Core+FITS           ← USE_CFITSIO
 | Target | Links to |
 |--------|----------|
 | milk-cli | CLIcore + all module libs |
-| milk-fpsCTRL | milkfpsTUI, milkfps, milkprocessinfo, ImageStreamIO, CLIcore, ncurses |
-| milk-procCTRL | milkprocessinfoTUI |
+| milk-fpsCTRL | milkfps, milkprocessinfo, ImageStreamIO, CLIcore |
+| milk-procCTRL | milkprocessinfo, ImageStreamIO |
 | milk-streamCTRL | CLIcore, ImageStreamIO |
 | milk-fps-list/search/info/rm | milkfps, milkfpsStandalone, milkdata, milkprocessinfo, ImageStreamIO |
 | milk-fps-set/track | milkfps, milkfpsStandalone, milkdata, milkprocessinfo, ImageStreamIO |
 | milk-fps-conf*/run* | milkfps, milkfpsStandalone, milkdata, milkprocessinfo, ImageStreamIO |
 | milk-fps-valkey | milkfps, milkprocessinfo, ImageStreamIO, valkey |
 | stream-monproc-runner | milkinfo, CLIcore, ImageStreamIO |
-| stream-monproc-disp | milkinfo, CLIcore, ImageStreamIO, ncurses |
+| stream-monproc-disp | milkdata, milkfps, ImageStreamIO |
 
 </details>
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -34,7 +34,7 @@ running `milk`.
     See [Build Tiers](install/build_tiers.md) and
     [Compile Instructions](install/compile.md) for details.
 
-??? faq "Build fails with missing readline/ncurses"
+??? faq "Build fails with missing readline"
 
     ```text
     fatal error: readline/readline.h: No such file or directory
@@ -44,7 +44,7 @@ running `milk`.
 
     === "Install headers"
         ```bash
-        sudo apt-get install libreadline-dev libncurses5-dev
+        sudo apt-get install libreadline-dev
         ```
 
     === "Build standalone-only (No CLI)"

--- a/docs/includes/abbreviations.md
+++ b/docs/includes/abbreviations.md
@@ -1,7 +1,7 @@
 *[FPS]: Function Processing System — shared-memory parameter management
 *[SHM]: Shared Memory (/dev/shm)
 *[AO]: Adaptive Optics
-*[TUI]: Text User Interface (ncurses-based)
+*[TUI]: Text User Interface (ANSI escape sequences)
 *[CLI]: Command Line Interface
 *[IMGID]: Image ID — milk's stream reference structure
 *[LTO]: Link-Time Optimization

--- a/docs/install/build_tiers.md
+++ b/docs/install/build_tiers.md
@@ -13,7 +13,7 @@
 ┌─────────────────────────────────────────────────────┐
 │  Full Build (default)                               │
 │  CLI (milk-cli) + plugins + example module          │
-│  Optional: readline, ncurses, GSL, CUDA             │
+│  Optional: readline, GSL, CUDA                      │
 │                                                     │
 │  ┌───────────────────────────────────────────────┐  │
 │  │  Core + FITS                                  │  │
@@ -45,7 +45,6 @@
 | `USE_COREMODS` | ON | Build core modules (COREMOD_*) |
 | `USE_CFITSIO` | ON | Build FITS I/O (requires cfitsio) |
 | `USE_CLI` | ON | Build interactive CLI (`milk-cli`) |
-| `USE_NCURSES` | ON | Enable ncurses / TUI screens |
 | `USE_READLINE` | ON | Enable readline for CLI input |
 | `USE_GSL` | ON | Enable GSL for plugins |
 

--- a/docs/install/compile.md
+++ b/docs/install/compile.md
@@ -67,7 +67,6 @@ $ sudo mount /milk/shm
     |------------|-------------|---------|---------|
     | **cfitsio** | `USE_CFITSIO` | ON | FITS file I/O (`COREMOD_iofits`) |
     | **readline** | `USE_READLINE` | ON | Interactive CLI line editing |
-    | **ncurses** | `USE_NCURSES` | ON | TUI screens (fpsCTRL, procCTRL, streamCTRL) |
     | **GSL** | `USE_GSL` | ON | Numerical routines in plugins |
     | **fftw3** | — | auto | FFT (used by some plugins) |
     | **openMP** | — | auto | Parallel processing |
@@ -82,14 +81,14 @@ $ sudo mount /milk/shm
     === "Ubuntu / Debian"
         ```bash
         sudo apt-get install \
-            libcfitsio-dev libreadline-dev libncurses5-dev \
+            libcfitsio-dev libreadline-dev \
             libfftw3-dev libgsl-dev
         ```
 
     === "CentOS / RHEL / Fedora"
         ```bash
         sudo yum install \
-            cfitsio-devel readline-devel ncurses-devel \
+            cfitsio-devel readline-devel \
             fftw3-devel gsl-devel
         ```
 

--- a/docs/pgo.md
+++ b/docs/pgo.md
@@ -737,9 +737,8 @@ library installation is needed on the target.
 | `CMAKE_EXE_LINKER_FLAGS` | `-static` | Tells the linker to produce a static binary |
 | `USE_STATIC_LTO` | `ON` | Builds `.a` archives; required by `-static` |
 | `USE_CFITSIO` | `OFF` | System cfitsio is glibc-linked; incompatible with musl static |
-| `USE_CLI` | `OFF` | CLI requires ncurses/readline dynamic libs |
-| `USE_NCURSES` | `OFF` | ncurses has no musl static variant by default |
-| `USE_READLINE` | `OFF` | Same as ncurses |
+| `USE_CLI` | `OFF` | CLI requires readline dynamic libs |
+| `USE_READLINE` | `OFF` | readline has no musl static variant by default |
 | `USE_OPENBLAS` | `OFF` | System OpenBLAS is glibc-linked |
 | `BUILD_SHARED_LIBS` | `OFF` | Prevents cmake from building `.so` targets that would fail the static link |
 | `-D_GNU_SOURCE` (C flag) | set | Exposes `cpu_set_t`, `pthread_setaffinity_np` and other POSIX extensions in musl |
@@ -777,7 +776,6 @@ impact.
 |---------|--------------------|----|
 | CFITSIO support | ✓ | ✗ (glibc-only) |
 | OpenBLAS/MKL | ✓ | ✗ |
-| ncurses TUI | ✓ | ✗ |
 | Dynamic library deps | 3 (libc family) | **0** |
 | Deploy without runtime | ✗ | **✓** |
 | Binary portability | Same glibc version | Any Linux x86-64 |


### PR DESCRIPTION
## Summary

This PR finalizes the removal of the `ncurses` dependency from the documentation, reflecting its removal from the codebase in favor of direct ANSI escape sequences. All build tier tables, dependency graphs, installation commands, FAQs, and capability matrices have been updated to represent the zero-ncurses architecture.

## Changes

### Documentation
- `docs/dependency_graph.md`: Purged references to `milkTUI`, `milkfpsTUI`, `milkprocessinfoTUI`, and external `NCURSES` dependencies. Updated linking profiles for standalone utilities.
- `docs/install/build_tiers.md`: Removed `ncurses` from optional dependencies and `USE_NCURSES` from CMake options.
- `docs/install/compile.md`: Removed `libncurses5-dev` and `ncurses-devel` from OS-specific installation commands.
- `docs/faq.md`: Removed `ncurses` from the troubleshooting steps for missing packages.
- `docs/includes/abbreviations.md`: Redefined `[TUI]` to "Text User Interface (ANSI escape sequences)" instead of "ncurses-based".
- `docs/cli/scripting.md`: Updated scripting context to mention only the absence of the readline dependency.
- `docs/pgo.md`: Dropped the ncurses comparison row in the static build capabilities matrix.

## Verification

- [x] Documentation review completed to ensure internal consistency.
- [ ] Build passes (`/compile-test`)

## Prompt Summary

The user requested to finalize the documentation cleanup following the removal of `ncurses` as a project dependency. The objective was to update all documentation—including build tiers, dependency graphs, installation guides, and FAQs—to accurately reflect the new build architecture without `ncurses` and `USE_NCURSES`.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None