### PR TITLE
feat: stabilize CLI history expansion and implement readline builtins

### DIFF
--- a/src/cli/CLIcore/CLIcore/CLIcore_UI_completion.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI_completion.c
@@ -178,22 +178,7 @@ void rl_cb_linehandler(char *linein)
             STRINGMAXLEN_CLICMDLINE - 1);
     data.CLIcmdline[STRINGMAXLEN_CLICMDLINE - 1] = '\0';
 
-    /* Record raw prompt in readline history
-     * and structured log BEFORE any expansion
-     * or alias resolution.  This means up-arrow
-     * recalls exactly what the user typed. */
-    if(linein[0] != '\0')
-    {
-        add_history(linein);
-        cli_history_log_prompt(linein);
-        if(data.autocomplete_history)
-        {
-            append_history(
-                1, CLI_history_file());
-            history_truncate_file(
-                CLI_history_file(), 10000);
-        }
-    }
+    /* We will add to history AFTER backslash continuation and history expansion */
 
     /* Handle backslash line continuation:
      * temporarily switch to blocking readline
@@ -233,6 +218,33 @@ void rl_cb_linehandler(char *linein)
             }
             free(cont);
             len = strlen(data.CLIcmdline);
+        }
+    }
+
+    /* Expand history (!! and !$) now that the full line is assembled */
+    cli_history_expand();
+    
+    if(data.CLIcmdline[0] == '\0')
+    {
+        /* Expansion error. Exit loop and prevent execution. */
+        free(linein);
+        return;
+    }
+
+    /* Record expanded prompt in readline history
+     * and structured log BEFORE alias resolution.
+     * This ensures up-arrow recalls the expanded command,
+     * consistent with native bash behavior. */
+    if(data.CLIcmdline[0] != '\0')
+    {
+        add_history(data.CLIcmdline);
+        cli_history_log_prompt(data.CLIcmdline);
+        if(data.autocomplete_history)
+        {
+            append_history(
+                1, CLI_history_file());
+            history_truncate_file(
+                CLI_history_file(), 10000);
         }
     }
 

--- a/src/cli/CLIcore/CLIcore/CLIcore_UI_completion_tab.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI_completion_tab.c
@@ -879,8 +879,22 @@ CLI_completion(
         }
     }
 
-    matches = rl_completion_matches(
-        (char *) text, &CLI_generator);
+    if(data.CLImatchMode == CLICOMPLETIONMODE_FILES)
+    {
+        /* Use standard readline filename completion */
+        matches = rl_completion_matches(
+            (char *) text, (rl_compentry_func_t *) rl_filename_completion_function);
+    }
+    else
+    {
+        /* Use custom generator for commands, images, fps parameters, etc. */
+        matches = rl_completion_matches(
+            (char *) text, &CLI_generator);
+    }
+
+    /* Prevent readline from falling back to default filename completion 
+     * when our custom generators return NULL. */
+    rl_attempted_completion_over = 1;
 
     /* Reset append char to default space */
     if(data.CLImatchMode

--- a/src/cli/CLIcore/CLIcore/CLIcore_UI_hintarea.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI_hintarea.c
@@ -504,6 +504,20 @@ void CLI_redisplay(void)
         ghost_chars_on_line = 0;
     }
 
+#if RL_READLINE_VERSION >= 0x0600
+    /* If incremental search (Ctrl-R) is active, fall back 
+     * entirely to readline's built-in redisplay to avoid 
+     * corrupting the search prompt. */
+    if(RL_ISSTATE(RL_STATE_ISEARCH) || RL_ISSTATE(RL_STATE_NSEARCH))
+    {
+        rl_redisplay_function = NULL;
+        rl_redisplay();
+        fflush(stdout);
+        rl_redisplay_function = CLI_redisplay;
+        return;
+    }
+#endif
+
     /* Default or syntax-highlighted redisplay */
     rl_redisplay_function = NULL;
     if(data.syntax_highlight

--- a/src/cli/CLIcore/CLIcore/CLIcore_UI_history_cmds.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI_history_cmds.c
@@ -42,119 +42,39 @@
 void cli_history_expand(void)
 {
 #ifdef USE_READLINE
-    char *line = data.CLIcmdline;
+    char *expanded_str = NULL;
+    int result = history_expand(data.CLIcmdline, &expanded_str);
 
-    /* Quick check: must start with '!' */
-    if(line[0] != '!')
+    if(result < 0 || result == 2)
     {
-        return;
-    }
-
-    /* !! — replay last command */
-    if(line[1] == '!')
-    {
-        HIST_ENTRY *prev = history_get(
-            history_length);
-        if(prev != NULL)
+        /* -1: Error (expanded_str contains error msg)
+         *  2: Display only, don't execute
+         */
+        if(expanded_str != NULL)
         {
-            char suffix[
-                STRINGMAXLEN_CLICMDLINE];
-            suffix[0] = '\0';
-            if(line[2] != '\0')
-            {
-                strncpy(suffix, line + 2,
-                        STRINGMAXLEN_CLICMDLINE
-                        - 1);
-                suffix[
-                    STRINGMAXLEN_CLICMDLINE - 1]
-                    = '\0';
-            }
-            char expanded[
-                STRINGMAXLEN_CLICMDLINE * 2];
-            snprintf(expanded,
-                     sizeof(expanded),
-                     "%s%s",
-                     prev->line, suffix);
-            strncpy(data.CLIcmdline,
-                    expanded,
-                    STRINGMAXLEN_CLICMDLINE - 1);
-            data.CLIcmdline[
-                STRINGMAXLEN_CLICMDLINE - 1]
-                = '\0';
+            printf("%s\n", expanded_str);
+            free(expanded_str);
+        }
+        data.CLIcmdline[0] = '\0'; /* Prevent execution */
+    }
+    else if(result == 1)
+    {
+        /* 1: Expansion took place */
+        if(expanded_str != NULL)
+        {
+            strncpy(data.CLIcmdline, expanded_str, STRINGMAXLEN_CLICMDLINE - 1);
+            data.CLIcmdline[STRINGMAXLEN_CLICMDLINE - 1] = '\0';
             printf(">> %s\n", data.CLIcmdline);
+            free(expanded_str);
         }
-        return;
     }
-
-    /* !$ — last argument of previous command */
-    if(line[1] == '$')
+    else
     {
-        if(data.last_argument[0] != '\0')
+        /* 0: No expansion took place */
+        if(expanded_str != NULL)
         {
-            char rest[
-                STRINGMAXLEN_CLICMDLINE];
-            strncpy(rest, line + 2,
-                    STRINGMAXLEN_CLICMDLINE - 1);
-            rest[
-                STRINGMAXLEN_CLICMDLINE - 1]
-                = '\0';
-            char expanded[
-                STRINGMAXLEN_CLICMDLINE * 2];
-            snprintf(expanded,
-                     sizeof(expanded),
-                     "%s%s",
-                     data.last_argument, rest);
-            strncpy(data.CLIcmdline,
-                    expanded,
-                    STRINGMAXLEN_CLICMDLINE - 1);
-            data.CLIcmdline[
-                STRINGMAXLEN_CLICMDLINE - 1]
-                = '\0';
-            printf(">> %s\n", data.CLIcmdline);
+            free(expanded_str);
         }
-        return;
-    }
-
-    /* !<prefix> — last command starting with it */
-    {
-        const char *prefix = line + 1;
-        size_t plen = strlen(prefix);
-        /* Trim trailing spaces from prefix */
-        while(plen > 0
-                && prefix[plen - 1] == ' ')
-        {
-            plen--;
-        }
-        if(plen == 0)
-        {
-            return;
-        }
-        HIST_ENTRY **hist = history_list();
-        if(hist == NULL)
-        {
-            return;
-        }
-        int hlen = history_length;
-        for(int i = hlen - 1; i >= 0; i--)
-        {
-            if(strncmp(hist[i]->line,
-                       prefix, plen) == 0)
-            {
-                strncpy(data.CLIcmdline,
-                        hist[i]->line,
-                        STRINGMAXLEN_CLICMDLINE
-                        - 1);
-                data.CLIcmdline[
-                    STRINGMAXLEN_CLICMDLINE - 1]
-                    = '\0';
-                printf(">> %s\n",
-                       data.CLIcmdline);
-                return;
-            }
-        }
-        printf("!%.*s: event not found\n",
-               (int) plen, prefix);
-        data.CLIcmdline[0] = '\0';
     }
 #endif
 }

--- a/src/cli/libmilkscript/CLIcore_UI_execute.c
+++ b/src/cli/libmilkscript/CLIcore_UI_execute.c
@@ -123,14 +123,8 @@ errno_t CLI_execute_line()
         }
     }
 
-    /* Expand history (!! and !$) first */
-    cli_history_expand();
-    if(data.CLIcmdline[0] == '\0')
-    {
-        free(thetime);
-        DEBUG_TRACE_FEXIT();
-        return RETURN_SUCCESS;
-    }
+    /* History expansion (!! and !$) has already been performed
+     * by rl_cb_linehandler() before calling CLI_execute_line. */
 
     /* Poll engine event traps */
     cli_engine_traps_poll();

--- a/tests/cli/cli_robustness_tests.milk
+++ b/tests/cli/cli_robustness_tests.milk
@@ -824,7 +824,7 @@ unset _ac_test
 
 #DESC: Remove temp redirect file
 #EXPECT:OK
-!rm -f /tmp/_clitest_redir.txt
+! rm -f /tmp/_clitest_redir.txt
 
 #DESC: Defer command evaluation
 #EXPECT:OK
@@ -884,7 +884,7 @@ echo $PATH
 #DESC: Outward env sync: local var exported to spawned shell
 #EXPECT:OK
 BDIR_SYNC_VAR="hello_frommilk"
-!test "$BDIR_SYNC_VAR" = "hello_frommilk"
+! test "$BDIR_SYNC_VAR" = "hello_frommilk"
 
 # ============================================
 # SECTION 21: Command Substitution in Variables
@@ -893,7 +893,7 @@ BDIR_SYNC_VAR="hello_frommilk"
 #DESC: Assign a subshell output to a variable
 #EXPECT:OK
 test_subshell_var=$(echo "success_from_subshell")
-!test "$test_subshell_var" = "success_from_subshell"
+! test "$test_subshell_var" = "success_from_subshell"
 
 # ============================================
 # SECTION 22: Advanced Variable Expansions
@@ -1195,7 +1195,7 @@ savehistory
 
 #DESC: Clean up savehistory temp
 #EXPECT:OK
-!rm -f /tmp/_clitest_hist.txt
+! rm -f /tmp/_clitest_hist.txt
 
 # ============================================
 # SECTION 39: History Commands
@@ -1251,11 +1251,11 @@ on_update
 
 #DESC: Shell bypass with valid command
 #EXPECT:OK
-!echo shell_bypass_test
+! echo shell_bypass_test
 
 #DESC: Shell bypass with nonexistent command
 #EXPECT:ERR
-!nonexistent_cmd_xyz_456
+! nonexistent_cmd_xyz_456
 
 # ============================================
 # SECTION 43: include_once Idempotency
@@ -1263,10 +1263,10 @@ on_update
 
 #DESC: include_once same file twice (no error)
 #EXPECT:OK
-!echo "echo sourced_once" > /tmp/_clitest_inc.milk
+! echo "echo sourced_once" > /tmp/_clitest_inc.milk
 include_once /tmp/_clitest_inc.milk
 include_once /tmp/_clitest_inc.milk
-!rm -f /tmp/_clitest_inc.milk
+! rm -f /tmp/_clitest_inc.milk
 
 # ============================================
 # SECTION 44: Edge Cases


### PR DESCRIPTION
## Summary

This PR resolves a regression with history expansion (`!!`, `!$`) in the interactive CLI, and adds native support for GNU Readline's built-in filename completion and reverse incremental search (`Ctrl-R`).

## Changes

### CLIcore
- **History Expansion:** Refactored `CLIcore_UI_history_cmds.c` to use GNU Readline's native `history_expand()` engine. Fixed an ordering issue in `CLIcore_UI_completion.c` so expansion runs *before* adding the line to history, solving the recursive `!!: event not found` bug.
- **Filename Completion:** Configured `CLIcore_UI_completion_tab.c` to route file argument completions to standard `rl_filename_completion_function`, and prevented spurious file fallbacks for variables by setting `rl_attempted_completion_over = 1`.
- **Incremental Search:** Updated `CLI_redisplay` in `CLIcore_UI_hintarea.c` to bypass custom highlighting when Readline is in `RL_STATE_ISEARCH` (via `Ctrl-R`), ensuring the `(reverse-i-search)` prompt renders correctly.

### Tests
- Updated `cli_robustness_tests.milk` to use the explicit `! cmd` syntax for shell bypass commands.

## Verification

- [x] Build passes (`/compile-test`)
- [x] Tests pass (CLI robustness test suite passed with 307/307 success)
- [x] Interactively verified `!!`, `TAB` filename completion, and `Ctrl-R` in an interactive shell.

## Prompt Summary

The user requested a fix for the CLI history expansion bug where `!!` returned an "event not found" error due to incorrect ordering of operations, requiring an explicit bypass character (`! `) for shell commands. The user also requested the implementation of built-in filename completion and reverse incremental search (`Ctrl-R`), which were similarly intercepted by custom completion and redisplay logic.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None