### PR TITLE
feat: streamCTRL TUI enhancements and FPS stability fixes

### DIFF
--- a/plugins/milk-extra-src/info/stream_monproc.c
+++ b/plugins/milk-extra-src/info/stream_monproc.c
@@ -38,20 +38,27 @@ static FPS_APP_INFO FPS_app_info = {
  * 2.  LOCAL PARAMETER VARIABLES
  * ============================================================= */
 
-static char * inimname = NULL;
-static uint64_t * tbinflag = NULL;
-static uint32_t * cbbuffersize = NULL;
-
+static char inimname[FUNCTION_PARAMETER_STRMAXLEN] = "";
+static uint64_t tbinflag = 1;
+static uint32_t cbbuffersize = 100;
 
 /* ================================================================
  * 3.  UNIFIED PARAMETER TABLE (X-Macro)
  * ============================================================= */
 
 #define FPS_PARAMS(X) \
-    X(".in_name", &inimname, \
+    X(".in_name", inimname, \
       FPTYPE_STREAMNAME, 1, \
       FPFLAG_DEFAULT_INPUT, \
-      "input image")
+      "input image") \
+    X(".tbinflag", &tbinflag, \
+      FPTYPE_UINT64, 0, \
+      FPFLAG_DEFAULT_INPUT, \
+      "Time binning flag (bitmask)") \
+    X(".cbbufsize", &cbbuffersize, \
+      FPTYPE_UINT32, 0, \
+      FPFLAG_DEFAULT_INPUT, \
+      "Circular buffer size")
 
 
 /* ================================================================
@@ -549,7 +556,7 @@ errno_t stream_monitor_run(
 static MILK_HOT errno_t compute_function()
 {
     // Wrapper for CLI mode
-    return stream_monitor_run(inimname, *tbinflag, *cbbuffersize, 0, 0);
+    return stream_monitor_run(inimname, tbinflag, cbbuffersize, 0, 0);
 }
 
 

--- a/plugins/milk-extra-src/info/stream_monproc_shm.c
+++ b/plugins/milk-extra-src/info/stream_monproc_shm.c
@@ -22,7 +22,9 @@ STREAM_MON_STRUCT* stream_monitor_connect(const char *streamname, int create)
     int fd;
     STREAM_MON_STRUCT *smon = NULL;
 
-    snprintf(shmname, sizeof(shmname), "%s/%s.mon.shm", milk_data.shmdir, streamname);
+    // Fallback to /milk/shm if milk_data.shmdir is empty
+    const char *dir = (milk_data.shmdir[0] != '\0') ? milk_data.shmdir : "/milk/shm";
+    snprintf(shmname, sizeof(shmname), "%s/%s.mon.shm", dir, streamname);
 
     int flags = O_RDWR;
     if (create) {

--- a/scripts/milk-fpslist-addentry
+++ b/scripts/milk-fpslist-addentry
@@ -2,7 +2,14 @@
 
 # Early-exit help flags
 case "${1-}" in
-    -h1|--help-oneline) echo "add an FPS entry to the fpslist tracking file"; exit 0 ;;
+    -h1|--help-oneline)
+        if [ -n "${fpsdescr-}" ]; then
+            echo "Register FPS process: ${fpsdescr}"
+        else
+            echo "add an FPS entry to the fpslist tracking file"
+        fi
+        exit 0
+        ;;
     -h|--help)
         echo "Usage: milk-fpslist-addentry  -- sourced by cacao-fpslistadd to register an FPS"
         exit 0 ;;

--- a/src/cli/streamCTRL/streamCTRL_TUI.c
+++ b/src/cli/streamCTRL/streamCTRL_TUI.c
@@ -23,6 +23,7 @@ typedef int errno_t;
 #include <stdio.h>
 #include <time.h>
 #include <unistd.h>
+#include <math.h>
 
 #include "streamCTRL_defs.h"
 #include "streamCTRL_ansi.h"
@@ -41,6 +42,50 @@ typedef int errno_t;
 #include "streamCTRL_print_trace.h"
 #include "streamCTRL_scan.h"
 #include "streamCTRL_utilfuncs.h"
+
+static inline void streamCTRL_set_sem_color(int val) {
+    if (val == 0) {
+        screenprint_setcolor(2); // green
+    } else if (val >= 10) {
+        screenprint_setcolor(4); // red
+    } else {
+        ansi_detect_color_level();
+        if (ansi__color_level >= 3) {
+            int r = 150 + (val - 1) * (255 - 150) / 9;
+            int g = 100 - (val - 1) * 100 / 9;
+            int b = 0;
+            SC_APPEND("\033[38;2;%d;%d;%dm", r, g, b);
+        } else if (ansi__color_level == 2) {
+            if (val < 4) SC_APPEND("\033[38;5;130m");
+            else if (val < 7) SC_APPEND("\033[38;5;166m");
+            else SC_APPEND("\033[38;5;196m");
+        } else {
+            screenprint_setcolor(3);
+        }
+    }
+}
+
+static inline void streamCTRL_set_wave_bg(int i, double t_sec, double frequ) {
+    ansi_detect_color_level();
+    if (ansi__color_level < 2) return;
+    
+    double f = frequ;
+    if (f < 1.0) f = 1.0;
+    if (f > 10000.0) f = 10000.0;
+    double speed = log10(f) + 1.0;
+    
+    double phase = t_sec * speed * 0.5 - i * 0.8;
+    int intensity = (int)(60.0 * (1.0 + sin(phase)));
+    
+    if (ansi__color_level >= 3) {
+        SC_APPEND("\033[48;2;0;%d;%dm", intensity/2, intensity + 50);
+    } else if (ansi__color_level == 2) {
+        int color_base = 17;
+        if (intensity > 90) color_base = 21;
+        else if (intensity > 45) color_base = 19;
+        SC_APPEND("\033[48;5;%dm", color_base);
+    }
+}
 
 
 
@@ -370,7 +415,7 @@ errno_t streamCTRL_CTRLscreen(void)
     // display
     int DispName_NBchar = 36;
     int DispSize_NBchar = 20;
-    int Dispcnt0_NBchar = 10;
+    int Dispcnt0_NBchar = 16;
     int Dispfreq_NBchar = 8;
     int DispPID_NBchar  = 8;
 
@@ -712,7 +757,7 @@ errno_t streamCTRL_CTRLscreen(void)
 
             // attron(A_BOLD);
 
-            TUI_printfw("%*s  %-*s  %-*s  %*s   %*s %*s %*s %8s",
+            TUI_printfw("%*s  %-*s  %-*s  %*s   %*s %*s %*s",
                         9,
                         "inode",
                         DispName_NBchar,
@@ -726,8 +771,7 @@ errno_t streamCTRL_CTRLscreen(void)
                         DispPID_NBchar,
                         "ownPID",
                         Dispfreq_NBchar,
-                        "   frequ ",
-                        "#sem");
+                        "   frequ ");
 
             switch(sTUIparam.DisplayMode)
             {
@@ -770,13 +814,28 @@ errno_t streamCTRL_CTRLscreen(void)
 
             // SORT
 
-            // default : no sorting
-            for(int dindex = 0; dindex < sTUIparam.NBsindex; dindex++)
+            // build active streams array
+            sTUIparam.NBsindex = 0;
+            for(int sindex = 0; sindex < streaminfoproc.NBstream; sindex++)
             {
-                sTUIparam.ssindex[dindex] = dindex;
+                if(streaminfo[sindex].erased == 1) continue;
+                imageID ID = streaminfo[sindex].ID;
+                if(streamCTRLimages[ID].used == 0) continue;
+
+                sTUIparam.ssindex[sTUIparam.NBsindex] = sindex;
+                sTUIparam.NBsindex++;
             }
 
             DEBUG_TRACEPOINT(" ");
+
+            // compute dynamic lengths
+            int max_name_len = 10;
+            for(int dindex = 0; dindex < sTUIparam.NBsindex; dindex++)
+            {
+                int len = strlen(streaminfo[sTUIparam.ssindex[dindex]].sname);
+                if (len > max_name_len) max_name_len = len;
+            }
+            DispName_NBchar = max_name_len + 2;
 
             if(sTUIparam.SORTING == 1)  // alphabetical sorting
             {
@@ -927,20 +986,7 @@ errno_t streamCTRL_CTRLscreen(void)
                 int sindex = sTUIparam.ssindex[dindex];
                 ID     = streaminfo[sindex].ID;
 
-                if(streaminfo[sindex].erased == 1)
-                {
-                    continue;
-                }
-
-
-                while((streamCTRLimages[streaminfo[sindex].ID].used == 0) &&
-                        (dindex < sTUIparam.NBsindex))
-                {
-                    // skip this entry, as it is no longer in use
-                    dindex++;
-                    sindex = sTUIparam.ssindex[dindex];
-                    ID     = streaminfo[sindex].ID;
-                }
+                // Stream is guaranteed active and not erased
 
 
                 int downstreammin = NO_DOWNSTREAM_INDEX;
@@ -1284,7 +1330,7 @@ errno_t streamCTRL_CTRLscreen(void)
 
                         if(streamCTRLimages[streaminfo[sindex].ID].md == NULL)
                         {
-                            snprintf(string, stringlen, "???");
+                            snprintf(string, stringlen, " %*s ", Dispcnt0_NBchar, "???");
                         }
                         else
                         {
@@ -1295,15 +1341,28 @@ errno_t streamCTRL_CTRLscreen(void)
                                      Dispcnt0_NBchar,
                                      streamCTRLimages[ID].md[0].cnt0);
                         }
+                        
                         if(streaminfo[sindex].deltacnt0 == 0)
                         {
                             TUI_printfw("%s", string);
                         }
                         else
                         {
+                            struct timespec ts;
+                            clock_gettime(CLOCK_MONOTONIC, &ts);
+                            double t_sec = ts.tv_sec + ts.tv_nsec * 1e-9;
+                            
+                            int len_cnt = strlen(string);
                             screenprint_setcolor(2);
-                            TUI_printfw("%s", string);
-                            screenprint_unsetcolor(2);
+                            for(int c_idx = 0; c_idx < len_cnt; c_idx++) {
+                                streamCTRL_set_wave_bg(c_idx, t_sec, streaminfo[sindex].updatevalue);
+                                TUI_printfw("%c", string[c_idx]);
+                            }
+                            SC_APPEND("\033[0m");
+                            
+                            if((dindex == sTUIparam.dindexSelected) && (sTUIparam.DisplayDetailLevel == 0)) {
+                                screenprint_setreverse();
+                            }
                         }
 
                         // creatorPID
@@ -1339,6 +1398,7 @@ errno_t streamCTRL_CTRLscreen(void)
                         if(streamCTRLimages[streaminfo[sindex].ID].md == NULL)
                         {
                             snprintf(string, stringlen, "???");
+                            TUI_printfw("%s", string);
                         }
                         else
                         {
@@ -1347,8 +1407,19 @@ errno_t streamCTRL_CTRLscreen(void)
                                      " %*.2f Hz",
                                      Dispfreq_NBchar,
                                      streaminfo[sindex].updatevalue);
+                            
+                            double f = streaminfo[sindex].updatevalue;
+                            int f_color = 0;
+                            if (f == 0.0) f_color = 0;
+                            else if (f < 1.0) f_color = 4;
+                            else if (f < 10.0) f_color = 3;
+                            else if (f < 100.0) f_color = 2;
+                            else f_color = 12;
+                            
+                            screenprint_setcolor(f_color);
+                            TUI_printfw("%s", string);
+                            screenprint_unsetcolor(f_color);
                         }
-                        TUI_printfw("%s", string);
                     }
 
                     DEBUG_TRACEPOINT(" ");
@@ -1358,7 +1429,6 @@ errno_t streamCTRL_CTRLscreen(void)
                         if((sTUIparam.DisplayMode == DISPLAY_MODE_SUMMARY) &&
                                 (DisplayFlag == 1)) // sem vals
                         {
-
                             snprintf(string,
                                      stringlen,
                                      " %3d sems ",
@@ -1373,17 +1443,19 @@ errno_t streamCTRL_CTRLscreen(void)
                             for(s = 0; s < max_s; s++)
                             {
                                 int semval = ImageStreamIO_semvalue(streamCTRLimages + ID, s);
-                                if (s == 0) {
-                                    snprintf(string, stringlen, "%02d", semval);
-                                } else {
-                                    snprintf(string, stringlen, ":%02d", semval);
+                                if (s > 0) {
+                                    TUI_printfw(":");
                                 }
+                                streamCTRL_set_sem_color(semval);
+                                snprintf(string, stringlen, "%02d", semval);
                                 TUI_printfw("%s", string);
+                                screenprint_unsetcolor(0);
                             }
                         }
                     }
 
                     DEBUG_TRACEPOINT(" ");
+
                     if(streamCTRLimages[streaminfo[sindex].ID].md != NULL)
                     {
                         if((sTUIparam.DisplayMode == DISPLAY_MODE_WRITE) &&

--- a/src/cli/streamCTRL/streamCTRL_TUIcompat.h
+++ b/src/cli/streamCTRL/streamCTRL_TUIcompat.h
@@ -300,8 +300,8 @@ static inline void TUI_clearscreen(
     sc_term_cols = c;
     if(wrow) *wrow = (short unsigned int) r;
     if(wcol) *wcol = (short unsigned int) c;
-    /* Move to top-left of screen without erasing — we overwrite line by line */
-    SC_APPEND("\033[H");
+    /* Reset attributes and move to top-left of screen */
+    SC_APPEND("\033[0m\033[H");
     sc_cursor_row = 1;
     sc_cursor_col = 0;
 }

--- a/src/cli/streamCTRL/streamCTRL_ansi.h
+++ b/src/cli/streamCTRL/streamCTRL_ansi.h
@@ -116,8 +116,8 @@ static inline void ansi_raw_mode_exit(void)
     }
     /* show cursor and enable line wrap */
     if(write(STDOUT_FILENO, "\033[?25h\033[?7h", 11) < 0) {}
-    /* clear screen, home cursor */
-    if(write(STDOUT_FILENO, "\033[2J\033[H", 7) < 0) {}
+    /* clear screen, reset attributes, home cursor */
+    if(write(STDOUT_FILENO, "\033[0m\033[2J\033[H", 11) < 0) {}
     tcsetattr(STDIN_FILENO, TCSAFLUSH, &ansi__orig_termios);
     ansi__raw_active = 0;
 }

--- a/src/engine/libfps/fps.h
+++ b/src/engine/libfps/fps.h
@@ -1153,6 +1153,15 @@ int main(int argc, char *argv[]) { \
     CONFCHECK_FN) \
 int main(int argc, char *argv[]) { \
     MILK_EMBED_BUILD_TAG(); \
+    for (int _i = 1; _i < argc; _i++) { \
+        if (strcmp(argv[_i], "-h1") == 0 || \
+            strcmp(argv[_i], \
+                   "--help-oneline") == 0) { \
+            printf("%s\n", \
+                   (APP_INFO).description); \
+            return 0; \
+        } \
+    } \
     milk_data_init(); \
     extern void milkfps_set_image_array( \
         IMAGE *imarray, long nb_max); \


### PR DESCRIPTION
## Summary

This PR introduces visual ergonomic improvements to the `milk-streamCTRL` terminal interface and resolves a critical buffer overflow segmentation fault in the standalone stream monitor process (`milk-fpsexec-info-strmonproc`).

## Changes

### CLI & TUI Enhancements (`streamCTRL`)
- **Visual Wave Animation:** Improved the `cnt0` update frequency animation (wave effect) to be wider and move at a slower, normalized rate for better legibility.
- **Frequency Coloring:** Corrected a logic flaw where an update frequency of `0.0 Hz` mapped to a red/white terminal color, restoring it to the standard terminal foreground.
- **Inline Semaphores:** Restored semaphore counts to the summary view using a space-efficient inline format (`%02d:%02d`) that avoids the vertical overhead of an explicit column header.
- **ANSI Attribute Resetting:** Hardened `streamCTRL_TUIcompat.h` and `streamCTRL_ansi.h` screen-clearing and line-drawing primitives to explicitly reset text formatting (`\033[0m`) upon application startup and exit to prevent trailing attribute leakage into the terminal prompt.

### Standalone Executable Stability (`info-strmonproc` & `fps.h`)
- **Parameter Buffer Fix:** Resolved a `SIGSEGV` in `milk-fpsexec-info-strmonproc` during execution by converting FPS string parameter assignments from null pointers to explicit size buffers (`char inimname[FUNCTION_PARAMETER_STRMAXLEN]`). This eliminates a severe buffer overflow that crashed the FPS engine's initialization lifecycle.
- **SHM Directory Fallback:** Fixed a permission denial error in the `info-strmonproc` shared memory constructor caused by uninitialized standalone CLI data pointers. `stream_monproc_shm.c` now safely falls back to `/milk/shm` without root escalation attempts if `milk_data.shmdir` is empty.
- **One-Line Help Hardening:** Adjusted the built-in standalone FPS macro (`FPS_MAIN_STANDALONE_V2` in `fps.h`) and `milk-fpslist-addentry` to consistently parse and provide `-h1`/`--help-oneline` tracking descriptors for automated registry utilities.

## Verification

- [x] Build passes (`make && make install`)
- [x] `milk-streamCTRL` TUI rendering and color mapping verified manually on live streams.
- [x] `milk-fpsexec-info-strmonproc exec earth` tested successfully; segmentation fault resolved and `earth.mon.shm` generates with correct permissions.

## Prompt Summary

The user requested improvements to the `milk-streamCTRL` terminal interface, notably modifying the visual spacing of the stream frequency animation wave, fixing a red text leak when frequency is zero, and compactly restoring the view of connected stream semaphores without extra headers. Additionally, the user identified a `SIGSEGV` when running the standalone `milk-fpsexec-info-strmonproc` utility, which was traced to an FPS parameter binding bug and uninitialized shared memory paths in the V2 standalone engine.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None