### PR TITLE
fix: expose strmonproc FPS parameters in CLI arguments

### DIFF
--- a/plugins/milk-extra-src/info/stream_monproc.c
+++ b/plugins/milk-extra-src/info/stream_monproc.c
@@ -52,13 +52,14 @@ static uint32_t cbbuffersize = 100;
       FPFLAG_DEFAULT_INPUT, \
       "input image") \
     X(".tbinflag", &tbinflag, \
-      FPTYPE_UINT64, 0, \
+      FPTYPE_UINT64, 1, \
       FPFLAG_DEFAULT_INPUT, \
       "Time binning flag (bitmask)") \
     X(".cbbufsize", &cbbuffersize, \
-      FPTYPE_UINT32, 0, \
+      FPTYPE_UINT32, 1, \
       FPFLAG_DEFAULT_INPUT, \
       "Circular buffer size")
+
 
 
 /* ================================================================


### PR DESCRIPTION
## Summary
This PR exposes the hidden `tbinflag` and `cbbufsize` parameters in the `milk-fpsexec-info-strmonproc` CLI interface. Previously, these parameters were marked as secondary in the X-macro definition, preventing them from being passed as standard positional arguments and leading to corrupted parameter assignments (such as `.in_name` receiving the string `"tbinflag"`) when incorrectly invoked.

## Changes

### milk-extra-src/info (stream_monproc)
- Set `is_primary = 1` for both `.tbinflag` and `.cbbufsize` in the `FPS_PARAMS` X-macro.
- This change ensures they receive valid CLI indices (`1` and `2`) and can be safely set via standard CLI syntax: `milk-fpsexec-info-strmonproc exec <in_name> <tbinflag> <cbbufsize>`.

## Verification
- [x] Build passes (`/compile-test`)
- [x] Tested `-h` output to confirm parameters are now properly listed with their assigned `Idx` indices.
- [x] Tested positional assignment via `exec` to verify values route correctly without corrupting `.in_name`.

## Prompt Summary
The user noticed that `tbinflag` and `cbbufsize` were missing their indices (`-`) in the help menu and asked how to set them. Investigation revealed that attempting to set them positionally when they were non-primary resulted in the engine mistakenly writing `"tbinflag"` into the `.in_name` parameter in shared memory. This fix makes them primary parameters to restore predictable CLI behavior.

## AI Authorship
- **Model**: Antigravity
- **User edits**: None
