### PR TITLE
feat(fpsCTRL): dim non-selected hierarchy entries in TUI

### DIFF
--- a/src/engine/libfps/fpsCTRL/fpsCTRL_FPSdisplay.c
+++ b/src/engine/libfps/fpsCTRL/fpsCTRL_FPSdisplay.c
@@ -439,6 +439,29 @@ errno_t fpsCTRL_FPSdisplay(
             for(level = 0; level < fpsCTRLvar->currentlevel; level ++)
             {
                 int c_idx = child_index[level];
+
+                /* Determine if this row is the selected
+                 * node in the chain for this level. */
+                int is_chain_node = 0;
+                if(c_idx >= 0
+                    && c_idx < keywnode[nodechain[level]].NBchild)
+                {
+                    int v1 = keywnode[nodechain[level]]
+                        .child[c_idx];
+                    int v2 = nodechain[level + 1];
+                    if(v1 == v2)
+                    {
+                        is_chain_node = 1;
+                    }
+                }
+
+                /* Fade non-selected entries so the
+                 * active chain stands out. */
+                if(!is_chain_node)
+                {
+                    screenprint_setdim();
+                }
+
                 if(level == 0)
                 {
                     if(c_idx >= 0 && c_idx < keywnode[nodechain[0]].NBchild)
@@ -459,9 +482,7 @@ errno_t fpsCTRL_FPSdisplay(
                     int knodeindex = keywnode[nodechain[level]].child[c_idx];
 
                     // toggle highlight if node is in the chain
-                    int v1 = keywnode[nodechain[level]].child[c_idx];
-                    int v2 = nodechain[level + 1];
-                    if(v1 == v2)
+                    if(is_chain_node)
                     {
                         snode = 1;
                         screenprint_setreverse();
@@ -495,6 +516,7 @@ errno_t fpsCTRL_FPSdisplay(
                 {
                     TUI_printfw("%*s ", max_kw_width[level], " ");
                     TUI_printfw("  ");
+                    screenprint_setnormal();
                 }
             }
 

--- a/src/engine/libfps/fpsCTRL/fpsCTRL_TUIcompat.h
+++ b/src/engine/libfps/fpsCTRL/fpsCTRL_TUIcompat.h
@@ -263,10 +263,13 @@ static inline void screenprint_setcolor(int idx)
     }
 }
 
+/** Reset fg+bg colors to default, preserving other attrs
+ *  (bold, dim, reverse, blink).  Use screenprint_setnormal()
+ *  for a full attribute reset. */
 static inline void screenprint_unsetcolor(int idx)
 {
     (void) idx;
-    SC_APPEND("\033[0m");
+    SC_APPEND("\033[39;49m");
 }
 
 /** Reset only the background color (preserve fg attrs). */


### PR DESCRIPTION
## Summary

Improves visual hierarchy in `milk-fpsCTRL` by dimming non-selected root entries when navigating into a branch, making the active selection chain immediately visible.

## Changes

### fpsCTRL TUI (`src/engine/libfps/fpsCTRL/`)
- **fpsCTRL_FPSdisplay.c**: Compute `is_chain_node` per row and apply `screenprint_setdim()` on non-selected entries; clear dim at row end with `screenprint_setnormal()`
- **fpsCTRL_TUIcompat.h**: Change `screenprint_unsetcolor()` from full ANSI reset (`\033[0m`) to color-only reset (`\033[39;49m`), preserving dim/bold/reverse attributes across color cycles

## Verification

- [x] Build passes
- [x] Visual inspection in `milk-fpsCTRL` — dimming applies to all columns including PID and name

## Prompt Summary

User requested fading non-selected FPS root entries when navigating deep into the keyword tree. Initial implementation only faded the first two columns; a follow-up fix to `screenprint_unsetcolor()` ensured dim persists across color resets so PID/name columns are also faded.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None