### PR TITLE
feat(fpsexec): add -loops/-loopd options with verbose echo

### DIFF
--- a/docs/FPS_Standalone_CMD_Modes.md
+++ b/docs/FPS_Standalone_CMD_Modes.md
@@ -97,7 +97,7 @@ for built-in flags and process control commands. This
 establishes the lifecycle of the shared memory FPS
 segment.
 
-- **Options:**
+- **Options** (placed before the command):
   - `-h`, `--help`: View detailed parameter bindings
     and command help.
   - `-h1`, `--help-oneline`: Print one-line description
@@ -106,9 +106,14 @@ segment.
     dispatch commands isolated from the main terminal.
   - `-n`, `--name <fpsname>`: Override the default FPS
     shared memory name.
+  - `-procinfo`: Enable processinfo entries at fpsinit.
+  - `-loops`: Infinite loop with stream semaphore
+    trigger.
+  - `-loopd <sec>`: Infinite loop with delay trigger
+    (seconds).
   - `-k`, `-d`: Pass keywords and descriptions for
     `fpsinit`.
-- **Commands:**
+- **Commands** (placed last on the command line):
   - `fpsinit`: Create the FPS shared memory segment.
   - `confstart`, `confstep`, `confstop`: Manage the
     configuration loop.

--- a/src/engine/libfps/fps.h
+++ b/src/engine/libfps/fps.h
@@ -621,9 +621,18 @@ int main(int argc, char *argv[]) { \
     } \
     if (show_help || (argc < 2)) { \
         if (show_help_color) { \
-            printf("\n" COLORHEADER "Usage:" COLORRESET " %s " COLOROPTION "[fpsname:]" COLORRESET COLORCOMMAND "<Command>" COLORRESET " " COLOROPTION "[Options]" COLORRESET "\n", argv[0]); \
+            printf("\n" COLORHEADER "Usage:" COLORRESET " %s " COLOROPTION "[Options]" COLORRESET " " COLOROPTION "[fpsname:]" COLORRESET COLORCOMMAND "<Command>" COLORRESET "\n", argv[0]); \
             printf("  Compiled: %s %s\n\n", __DATE__, __TIME__); \
             printf(COLORHEADER "Description:" COLORRESET "\n  Standalone FPS application.\n\n"); \
+            printf(COLORHEADER "Options:" COLORRESET "\n"); \
+            printf("  " COLOROPTION "fpsname:" COLORRESET "           Optional prefix (or use -n) to specify FPS name (default: %s).\n", DEFAULT_FPS_NAME); \
+            printf("  " COLOROPTION "-n, --name FPSNAME" COLORRESET "       Specify FPS name.\n"); \
+            printf("  " COLOROPTION "-k, --keywords KEYWORDS" COLORRESET "  Specify FPS keywords (default: NULL).\n"); \
+            printf("  " COLOROPTION "-d, --description DESC" COLORRESET "   Specify FPS description (default: NULL).\n"); \
+            printf("  " COLOROPTION "-tmux" COLORRESET "                    Auto-create a tmux session and dispatch commands.\n"); \
+            printf("  " COLOROPTION "-procinfo" COLORRESET "                Enable processinfo support (for fpsinit).\n"); \
+            printf("  " COLOROPTION "-h, --help" COLORRESET "               Show this help message (color default).\n"); \
+            printf("  " COLOROPTION "-hnc, --help-no-color" COLORRESET "   Show this help message without color.\n\n"); \
             printf(COLORHEADER "Commands:" COLORRESET "\n"); \
             printf("  " COLORCOMMAND "fpsinit" COLORRESET "    One-time setup: creates the FPS shared memory segment.\n"); \
             printf("  " COLORCOMMAND "fps" COLORRESET "        Print content of the FPS.\n"); \
@@ -635,15 +644,6 @@ int main(int argc, char *argv[]) { \
             printf("  " COLORCOMMAND "runstop" COLORRESET "    Stop the main processing loop.\n"); \
             printf("  " COLORCOMMAND "set" COLORRESET " " COLOROPTION "[args]" COLORRESET "  Set positional arguments in the FPS (use . to skip).\n"); \
             printf("  " COLORCOMMAND "exec" COLORRESET " " COLOROPTION "[args]" COLORRESET " Auto-init + set args + run.\n\n"); \
-            printf(COLORHEADER "Options:" COLORRESET "\n"); \
-            printf("  " COLOROPTION "fpsname:" COLORRESET "           Optional prefix (or use -n) to specify FPS name (default: %s).\n", DEFAULT_FPS_NAME); \
-            printf("  " COLOROPTION "-n, --name FPSNAME" COLORRESET "       Specify FPS name.\n"); \
-            printf("  " COLOROPTION "-k, --keywords KEYWORDS" COLORRESET "  Specify FPS keywords (default: NULL).\n"); \
-            printf("  " COLOROPTION "-d, --description DESC" COLORRESET "   Specify FPS description (default: NULL).\n"); \
-            printf("  " COLOROPTION "-tmux" COLORRESET "                    Auto-create a tmux session and dispatch commands.\n"); \
-            printf("  " COLOROPTION "-procinfo" COLORRESET "                Enable processinfo support (for fpsinit).\n"); \
-            printf("  " COLOROPTION "-h, --help" COLORRESET "               Show this help message (color default).\n"); \
-            printf("  " COLOROPTION "-hnc, --help-no-color" COLORRESET "   Show this help message without color.\n\n"); \
             printf(COLORHEADER "Notes:" COLORRESET "\n"); \
             printf("  Alternate ways to perform these operations once the FPS has been created:\n"); \
             printf("    " COLORCOMMAND "milk-fps-confstart" COLORRESET " <fpsname>\n"); \
@@ -652,9 +652,18 @@ int main(int argc, char *argv[]) { \
             printf("    " COLORCOMMAND "milk-fps-runstop" COLORRESET "   <fpsname>\n"); \
             printf("    " COLORCOMMAND "milk-fps-confstep" COLORRESET "  <fpsname>\n\n"); \
         } else { \
-            printf("\nUsage: %s [fpsname:]<Command> [Options]\n", argv[0]); \
+            printf("\nUsage: %s [Options] [fpsname:]<Command>\n", argv[0]); \
             printf("  Compiled: %s %s\n\n", __DATE__, __TIME__); \
             printf("Description:\n  Standalone FPS application.\n\n"); \
+            printf("Options:\n"); \
+            printf("  fpsname:                 Optional prefix (or use -n) to specify FPS name (default: %s).\n", DEFAULT_FPS_NAME); \
+            printf("  -n, --name FPSNAME       Specify FPS name.\n"); \
+            printf("  -k, --keywords KEYWORDS  Specify FPS keywords (default: NULL).\n"); \
+            printf("  -d, --description DESC   Specify FPS description (default: NULL).\n"); \
+            printf("  -tmux                    Auto-create a tmux session and dispatch commands.\n"); \
+            printf("  -procinfo                Enable processinfo support (for fpsinit).\n"); \
+            printf("  -h, --help               Show this help message (color default).\n"); \
+            printf("  -hnc, --help-no-color    Show this help message without color.\n\n"); \
             printf("Commands:\n"); \
             printf("  fpsinit    One-time setup: creates the FPS shared memory segment.\n"); \
             printf("  fps        Print content of the FPS.\n"); \
@@ -666,15 +675,6 @@ int main(int argc, char *argv[]) { \
             printf("  runstop    Stop the main processing loop.\n"); \
             printf("  set [args] Set positional arguments in the FPS (use . to skip).\n"); \
             printf("  exec [args] Auto-init + set args + run.\n\n"); \
-            printf("Options:\n"); \
-            printf("  fpsname:                 Optional prefix (or use -n) to specify FPS name (default: %s).\n", DEFAULT_FPS_NAME); \
-            printf("  -n, --name FPSNAME       Specify FPS name.\n"); \
-            printf("  -k, --keywords KEYWORDS  Specify FPS keywords (default: NULL).\n"); \
-            printf("  -d, --description DESC   Specify FPS description (default: NULL).\n"); \
-            printf("  -tmux                    Auto-create a tmux session and dispatch commands.\n"); \
-            printf("  -procinfo                Enable processinfo support (for fpsinit).\n"); \
-            printf("  -h, --help               Show this help message (color default).\n"); \
-            printf("  -hnc, --help-no-color    Show this help message without color.\n\n"); \
             printf("Notes:\n"); \
             printf("  Alternate ways to perform these operations once the FPS has been created:\n"); \
             printf("    milk-fps-confstart <fpsname>\n"); \
@@ -803,13 +803,13 @@ int main(int argc, char *argv[]) { \
                 function_parameter_struct_disconnect(&fps); \
             } \
             char run_arg[512] = ""; \
-            if (strcmp(fps_name, DEFAULT_FPS_NAME) != 0) { \
-                snprintf(run_arg, sizeof(run_arg), " %s:runstart", fps_name); \
-            } else { \
-                snprintf(run_arg, sizeof(run_arg), " runstart"); \
-            } \
             if (use_procinfo) { \
                 strncat(run_arg, " -procinfo", sizeof(run_arg) - strlen(run_arg) - 1); \
+            } \
+            if (strcmp(fps_name, DEFAULT_FPS_NAME) != 0) { \
+                { size_t _l = strlen(run_arg); snprintf(run_arg + _l, sizeof(run_arg) - _l, " %s:runstart", fps_name); } \
+            } else { \
+                strncat(run_arg, " runstart", sizeof(run_arg) - strlen(run_arg) - 1); \
             } \
             functionparameter_FPS_tmux_send_dispatch(fps_name, "runstart", path, run_arg); \
             return 0; \
@@ -1215,6 +1215,7 @@ int main(int argc, char *argv[]) { \
     int use_tmux = 0; \
     int use_procinfo = 0; \
     int use_loop = 0; \
+    double loop_delay = -1.0; \
     int show_help = 0; \
     int show_h1 = 0; \
     int show_help_color = 1; \
@@ -1260,11 +1261,31 @@ int main(int argc, char *argv[]) { \
                    "--procinfo") == 0) { \
             use_procinfo = 1; \
         } else if (strcmp(argv[i], \
-                   "-loop") == 0 || \
+                   "-loops") == 0 || \
             strcmp(argv[i], \
-                   "--loop") == 0) { \
+                   "--loops") == 0) { \
             use_loop = 1; \
             use_procinfo = 1; \
+        } else if (strcmp(argv[i], \
+                    "-loopd") == 0 || \
+            strcmp(argv[i], \
+                    "--loopd") == 0) { \
+            use_loop = 2; \
+            use_procinfo = 1; \
+            /* Consume next arg as delay only if \
+             * it looks numeric (digit, '.', '-').\
+             * Otherwise use delay=0. */ \
+            if (i + 1 < argc) { \
+                char c0 = argv[i + 1][0]; \
+                if ((c0 >= '0' && c0 <= '9') \
+                    || c0 == '.' || c0 == '-') {\
+                    loop_delay = atof(argv[++i]);\
+                } else { \
+                    loop_delay = 0.0; \
+                } \
+            } else { \
+                loop_delay = 0.0; \
+            } \
         } else if ((strcmp(argv[i], "-k") == 0 ||\
             strcmp(argv[i], \
                    "--keywords") == 0) \
@@ -1330,24 +1351,68 @@ int main(int argc, char *argv[]) { \
         if (show_help_color) { \
             printf("\n" COLORHEADER "Usage:" \
                    COLORRESET " %s " \
+                   COLOROPTION "[Options]" \
+                   COLORRESET " " \
                    COLOROPTION "[fpsname:]" \
                    COLORRESET COLORCOMMAND \
-                   "<Command>" COLORRESET " " \
-                   COLOROPTION "[Options]" \
-                   COLORRESET "\n", argv[0]); \
+                   "<Command>" COLORRESET \
+                   "\n", argv[0]); \
             printf("  Compiled: %s %s\n\n", \
                    __DATE__, __TIME__); \
             printf(COLORHEADER "Description:" \
                    COLORRESET "\n  %s\n\n", \
                    (APP_INFO).description); \
         } else { \
-            printf("\nUsage: %s [fpsname:]" \
-                   "<Command> [Options]\n", \
+            printf("\nUsage: %s [Options]" \
+                   " [fpsname:]<Command>\n", \
                    argv[0]); \
             printf("  Compiled: %s %s\n\n", \
                    __DATE__, __TIME__); \
             printf("Description:\n  %s\n\n", \
                    (APP_INFO).description); \
+        } \
+        if (show_help_color) \
+            printf(COLORHEADER "Options:" \
+                   COLORRESET "\n"); \
+        else printf("Options:\n"); \
+        if (show_help_color) { \
+            printf("  " COLOROPTION "-tmux" \
+                   COLORRESET \
+                   "       Run inside " \
+                   "tmux session.\n"); \
+            printf("  " COLOROPTION "-procinfo" \
+                   COLORRESET \
+                   "   Enable " \
+                   "processinfo.\n"); \
+            printf("  " COLOROPTION "-loops" \
+                   COLORRESET \
+                   "      Infinite loop," \
+                   " stream semaphore" \
+                   " trigger.\n"); \
+            printf("  " COLOROPTION \
+                   "-loopd SEC" \
+                   COLORRESET \
+                   " Infinite loop," \
+                   " delay trigger" \
+                   " (seconds).\n"); \
+            printf("  " COLOROPTION \
+                   "-n NAME" \
+                   COLORRESET \
+                   "   Set FPS instance" \
+                   " name.\n\n"); \
+        } else { \
+            printf("  -tmux       Run inside" \
+                   " tmux session.\n"); \
+            printf("  -procinfo   Enable" \
+                   " processinfo.\n"); \
+            printf("  -loops      Infinite loop," \
+                   " stream semaphore" \
+                   " trigger.\n"); \
+            printf("  -loopd SEC  Infinite loop," \
+                   " delay trigger" \
+                   " (seconds).\n"); \
+            printf("  -n NAME     Set FPS" \
+                   " instance name.\n\n"); \
         } \
         if (show_help_color) \
             printf(COLORHEADER "Commands:" \
@@ -1397,26 +1462,6 @@ int main(int argc, char *argv[]) { \
                    COLORRESET \
                    " Auto-init + set" \
                    " args + run.\n\n"); \
-            printf(COLORHEADER "Options:" \
-                   COLORRESET "\n"); \
-            printf("  " COLOROPTION "-tmux" \
-                   COLORRESET \
-                   "       Run inside " \
-                   "tmux session.\n"); \
-            printf("  " COLOROPTION "-procinfo" \
-                   COLORRESET \
-                   "   Enable " \
-                   "processinfo.\n"); \
-            printf("  " COLOROPTION "-loop" \
-                   COLORRESET \
-                   "       Enable procinfo +" \
-                   " semaphore trigger +" \
-                   " infinite loop.\n"); \
-            printf("  " COLOROPTION \
-                   "-n NAME" \
-                   COLORRESET \
-                   "   Set FPS instance" \
-                   " name.\n\n"); \
         } else { \
             printf("  fpsinit    Create the " \
                    "FPS.\n"); \
@@ -1438,17 +1483,6 @@ int main(int argc, char *argv[]) { \
                    " args (. to skip).\n"); \
             printf("  exec [args] Auto-init +" \
                    " set args + run.\n\n"); \
-            printf("Options:\n"); \
-            printf("  -tmux       Run inside" \
-                   " tmux session.\n"); \
-            printf("  -procinfo   Enable" \
-                   " processinfo.\n"); \
-            printf("  -loop       Enable" \
-                   " procinfo + semaphore" \
-                   " trigger +" \
-                   " infinite loop.\n"); \
-            printf("  -n NAME     Set FPS" \
-                   " instance name.\n\n"); \
         } \
         int col_kw_w = 7; \
         int col_tp_w = 4; \
@@ -1653,35 +1687,47 @@ int main(int argc, char *argv[]) { \
                         &fs_, farg_, \
                         my_bindings_, \
                         nb_bindings_); \
-                    if (use_loop) { \
+                    if (use_loop == 1) { \
                         fps_loop_override_trigger(\
                             &fs_, my_bindings_, \
                             nb_bindings_); \
+                    } else if (use_loop == 2) { \
+                        fps_loop_override_delay(\
+                            &fs_, loop_delay); \
                     } \
                     function_parameter_struct_disconnect(\
                         &fs_); \
                 } \
             } \
             char run_arg[512] = ""; \
-            if (strcmp(fps_name, \
-                      (APP_INFO).fps_name) != 0)\
-            { \
-                snprintf(run_arg, \
-                         sizeof(run_arg), \
-                         " %s:runstart", \
-                         fps_name); \
-            } else { \
-                snprintf(run_arg, \
-                         sizeof(run_arg), \
-                         " runstart"); \
-            } \
             if (use_procinfo) { \
                 strncat(run_arg, " -procinfo", \
                         sizeof(run_arg) \
                         - strlen(run_arg) - 1); \
             } \
-            if (use_loop) { \
-                strncat(run_arg, " -loop", \
+            if (use_loop == 1) { \
+                strncat(run_arg, " -loops", \
+                        sizeof(run_arg) \
+                        - strlen(run_arg) - 1); \
+            } else if (use_loop == 2) { \
+                char _ld[64]; \
+                snprintf(_ld, sizeof(_ld), \
+                         " -loopd %.6f", \
+                         loop_delay); \
+                strncat(run_arg, _ld, \
+                        sizeof(run_arg) \
+                        - strlen(run_arg) - 1); \
+            } \
+            if (strcmp(fps_name, \
+                      (APP_INFO).fps_name) != 0)\
+            { \
+                { size_t _l = strlen(run_arg); \
+                  snprintf(run_arg + _l, \
+                           sizeof(run_arg) - _l,\
+                           " %s:runstart", \
+                           fps_name); } \
+            } else { \
+                strncat(run_arg, " runstart", \
                         sizeof(run_arg) \
                         - strlen(run_arg) - 1); \
             } \
@@ -1693,21 +1739,93 @@ int main(int argc, char *argv[]) { \
         if (functionparameter_FPS_tmux_send_dispatch( \
                 fps_name, command, path, \
                 name_arg) == 0) { \
+            if (strcmp(command, "fpsinit") == 0) { \
+                fps_generic_init(fps_name, \
+                    (FPS_APP_INFO *)&(APP_INFO), \
+                    my_bindings_, nb_bindings_, \
+                    use_procinfo); \
+                if (use_loop == 1 \
+                    && !fps_check_has_trigger_binding(\
+                        my_bindings_, \
+                        nb_bindings_)) { \
+                    fprintf(stderr, \
+                        "\033[1;33mWARNING" \
+                        "\033[0m [-loops] No" \
+                        " trigger stream" \
+                        " binding found \xe2\x80\x94" \
+                        " semaphore trigger" \
+                        " will not be" \
+                        " configured.\n" \
+                        "  Flag a stream" \
+                        " parameter with" \
+                        " FPFLAG_TRIGGER" \
+                        "_STREAM.\n"); \
+                } \
+                /* Apply -loops/-loopd overrides */ \
+                if (use_loop) { \
+                    FUNCTION_PARAMETER_STRUCT fp_; \
+                    if (function_parameter_struct_connect(\
+                            fps_name, &fp_, \
+                            FPSCONNECT_SIMPLE) != -1)\
+                    { \
+                        if (use_loop == 1) { \
+                            fps_loop_override_trigger(\
+                                &fp_, my_bindings_,\
+                                nb_bindings_); \
+                        } else if (use_loop == 2) {\
+                            fps_loop_override_delay(\
+                                &fp_, loop_delay);\
+                        } \
+                        function_parameter_struct_disconnect(\
+                            &fp_); \
+                    } \
+                } \
+            } \
             return 0; \
-        } \
-        if (strcmp(command, "fpsinit") == 0) { \
-            fps_generic_init(fps_name, \
-                (FPS_APP_INFO *)&(APP_INFO), \
-                my_bindings_, nb_bindings_, \
-                use_procinfo); \
         } \
         return 0; \
     } \
     if (strcmp(command, "fpsinit") == 0) { \
-        return fps_generic_init(fps_name, \
+        int rc_ = fps_generic_init(fps_name, \
             (FPS_APP_INFO *)&(APP_INFO), \
             my_bindings_, nb_bindings_, \
             use_procinfo); \
+        if (use_loop == 1 \
+            && !fps_check_has_trigger_binding(\
+                my_bindings_, \
+                nb_bindings_)) { \
+            fprintf(stderr, \
+                "\033[1;33mWARNING" \
+                "\033[0m [-loops] No" \
+                " trigger stream" \
+                " binding found \xe2\x80\x94" \
+                " semaphore trigger" \
+                " will not be" \
+                " configured.\n" \
+                "  Flag a stream" \
+                " parameter with" \
+                " FPFLAG_TRIGGER" \
+                "_STREAM.\n"); \
+        } \
+        /* Apply -loops/-loopd overrides */ \
+        if (use_loop && rc_ == 0) { \
+            FUNCTION_PARAMETER_STRUCT fp_; \
+            if (function_parameter_struct_connect(\
+                    fps_name, &fp_, \
+                    FPSCONNECT_SIMPLE) != -1) {\
+                if (use_loop == 1) { \
+                    fps_loop_override_trigger(\
+                        &fp_, my_bindings_, \
+                        nb_bindings_); \
+                } else if (use_loop == 2) { \
+                    fps_loop_override_delay( \
+                        &fp_, loop_delay); \
+                } \
+                function_parameter_struct_disconnect(\
+                    &fp_); \
+            } \
+        } \
+        return rc_; \
     } else if (strcmp(command, \
                       "confstart") == 0) { \
         return fps_generic_conf_cb( \
@@ -1772,8 +1890,8 @@ int main(int argc, char *argv[]) { \
                 } \
             } \
         } \
-        /* Apply -loop overrides before run */ \
-        if (use_loop) { \
+        /* Apply -loops/-loopd overrides */ \
+        if (use_loop == 1) { \
             FUNCTION_PARAMETER_STRUCT fps_lp_; \
             if (function_parameter_struct_connect(\
                     fps_name, &fps_lp_, \
@@ -1781,6 +1899,16 @@ int main(int argc, char *argv[]) { \
                 fps_loop_override_trigger( \
                     &fps_lp_, my_bindings_, \
                     nb_bindings_); \
+                function_parameter_struct_disconnect(\
+                    &fps_lp_); \
+            } \
+        } else if (use_loop == 2) { \
+            FUNCTION_PARAMETER_STRUCT fps_lp_; \
+            if (function_parameter_struct_connect(\
+                    fps_name, &fps_lp_, \
+                    FPSCONNECT_SIMPLE) != -1) { \
+                fps_loop_override_delay( \
+                    &fps_lp_, loop_delay); \
                 function_parameter_struct_disconnect(\
                     &fps_lp_); \
             } \
@@ -1792,8 +1920,8 @@ int main(int argc, char *argv[]) { \
     } else if (strcmp(command, \
                       "runstart") == 0 || \
                strcmp(command, "run") == 0) { \
-        /* Apply -loop overrides before run */ \
-        if (use_loop) { \
+        /* Apply -loops/-loopd overrides */ \
+        if (use_loop == 1) { \
             FUNCTION_PARAMETER_STRUCT fps_lp_; \
             if (function_parameter_struct_connect(\
                     fps_name, &fps_lp_, \
@@ -1801,6 +1929,16 @@ int main(int argc, char *argv[]) { \
                 fps_loop_override_trigger( \
                     &fps_lp_, my_bindings_, \
                     nb_bindings_); \
+                function_parameter_struct_disconnect(\
+                    &fps_lp_); \
+            } \
+        } else if (use_loop == 2) { \
+            FUNCTION_PARAMETER_STRUCT fps_lp_; \
+            if (function_parameter_struct_connect(\
+                    fps_name, &fps_lp_, \
+                    FPSCONNECT_SIMPLE) != -1) { \
+                fps_loop_override_delay( \
+                    &fps_lp_, loop_delay); \
                 function_parameter_struct_disconnect(\
                     &fps_lp_); \
             } \

--- a/src/engine/libfps/fps_lifecycle.c
+++ b/src/engine/libfps/fps_lifecycle.c
@@ -8,6 +8,7 @@
  */
 
 #include <stdio.h>
+#include <inttypes.h>
 
 
 #ifndef FPS_STANDALONE
@@ -182,6 +183,31 @@ int fps_generic_init(
 }
 
 
+/**
+ * @brief Check if bindings have a trigger stream.
+ *
+ * @param bindings  Parameter bindings array
+ * @param nb_b      Number of bindings
+ * @return          1 if trigger stream found
+ */
+int fps_check_has_trigger_binding(
+    FPS_CLI_BINDING *bindings,
+    int              nb_b
+)
+{
+    for (int i = 0; i < nb_b; i++) {
+        if ((bindings[i].fpflag
+             & FPFLAG_TRIGGER_STREAM)
+            && (bindings[i].type
+                == FPTYPE_STREAMNAME))
+        {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+
 void fps_loop_override_trigger(
     FUNCTION_PARAMETER_STRUCT *fps,
     FPS_CLI_BINDING           *bindings,
@@ -228,16 +254,18 @@ void fps_loop_override_trigger(
         }
     }
 
-    /* Force trigger mode and loop count */
-    functionparameter_SetParamValue_INT64(
-        fps, ".procinfo.triggermode",
-        PROCESSINFO_TRIGGERMODE_SEMAPHORE);
+    printf("\033[33m-loops\033[0m"
+           " Stream semaphore trigger\n");
 
+    /* Force loop count and enable */
     functionparameter_SetParamValue_INT64(
         fps, ".procinfo.loopcntMax", -1);
+    printf("  .procinfo.loopcntMax  = -1"
+           " (infinite)\n");
 
     functionparameter_SetParamValue_ONOFF(
         fps, ".procinfo.enabled", 1);
+    printf("  .procinfo.enabled     = ON\n");
 
     if (trigger_name != NULL
         && trigger_name[0] != '\0')
@@ -245,7 +273,78 @@ void fps_loop_override_trigger(
         functionparameter_SetParamValue_STRING(
             fps, ".procinfo.triggersname",
             trigger_name);
+        printf("  .procinfo.triggersname"
+               " = %s\n", trigger_name);
+
+        functionparameter_SetParamValue_INT64(
+            fps, ".procinfo.triggermode",
+            PROCESSINFO_TRIGGERMODE_SEMAPHORE);
+        printf("  .procinfo.triggermode "
+               " = %d (SEMAPHORE)\n",
+               PROCESSINFO_TRIGGERMODE_SEMAPHORE);
     }
+    else
+    {
+        fprintf(stderr,
+                "\033[1;33mWARNING\033[0m"
+                " [-loops] No trigger stream"
+                " found — semaphore trigger"
+                " not configured.\n"
+                "  Loop will use delay mode."
+                " To fix, flag a stream"
+                " parameter with"
+                " FPFLAG_TRIGGER_STREAM.\n");
+
+        functionparameter_SetParamValue_INT64(
+            fps, ".procinfo.triggermode",
+            PROCESSINFO_TRIGGERMODE_DELAY);
+        printf("  .procinfo.triggermode "
+               " = %d (DELAY)\n",
+               PROCESSINFO_TRIGGERMODE_DELAY);
+    }
+}
+
+
+/**
+ * @brief Force delay-loop settings for -loopd mode.
+ *
+ * Sets triggermode=DELAY, loopcntMax=-1, enabled=ON,
+ * and triggerdelay to the specified seconds value.
+ *
+ * @param fps       Connected FPS
+ * @param delay_sec Delay between iterations (seconds)
+ */
+void fps_loop_override_delay(
+    FUNCTION_PARAMETER_STRUCT *fps,
+    double                     delay_sec
+)
+{
+    printf("\033[33m-loopd\033[0m"
+           " Delay loop (%.6f sec)\n",
+           delay_sec);
+
+    functionparameter_SetParamValue_INT64(
+        fps, ".procinfo.loopcntMax", -1);
+    printf("  .procinfo.loopcntMax  = -1"
+           " (infinite)\n");
+
+    functionparameter_SetParamValue_ONOFF(
+        fps, ".procinfo.enabled", 1);
+    printf("  .procinfo.enabled     = ON\n");
+
+    functionparameter_SetParamValue_INT64(
+        fps, ".procinfo.triggermode",
+        PROCESSINFO_TRIGGERMODE_DELAY);
+    printf("  .procinfo.triggermode "
+           " = %d (DELAY)\n",
+           PROCESSINFO_TRIGGERMODE_DELAY);
+
+    functionparameter_SetParamValue_TIMESPEC(
+        fps, ".procinfo.triggerdelay",
+        (float) delay_sec);
+    printf("  .procinfo.triggerdelay"
+           " = %.6f sec\n",
+           delay_sec);
 }
 
 

--- a/src/engine/libfps/fps_lifecycle.h
+++ b/src/engine/libfps/fps_lifecycle.h
@@ -41,7 +41,7 @@ int fps_generic_init(
 
 
 /**
- * @brief Force trigger settings for -loop mode.
+ * @brief Force trigger settings for -loops mode.
  *
  * Scans bindings for FPFLAG_TRIGGER_STREAM. Sets
  * triggermode=SEMAPHORE, loopcntMax=-1, enabled=ON.
@@ -55,6 +55,21 @@ void fps_loop_override_trigger(
     FUNCTION_PARAMETER_STRUCT *fps,
     FPS_CLI_BINDING           *bindings,
     int                        nb_b
+);
+
+
+/**
+ * @brief Force delay-loop settings for -loopd mode.
+ *
+ * Sets triggermode=DELAY, loopcntMax=-1, enabled=ON,
+ * and writes the delay value to .procinfo.triggerdelay.
+ *
+ * @param fps       Connected FPS
+ * @param delay_sec Delay between iterations (seconds)
+ */
+void fps_loop_override_delay(
+    FUNCTION_PARAMETER_STRUCT *fps,
+    double                     delay_sec
 );
 
 
@@ -132,6 +147,22 @@ int fps_generic_runstop(const char *fps_name);
  * @return          0 on success
  */
 int fps_generic_confstop(const char *fps_name);
+
+
+/**
+ * @brief Check if bindings contain a trigger stream.
+ *
+ * Returns 1 if at least one binding has
+ * FPFLAG_TRIGGER_STREAM set, 0 otherwise.
+ *
+ * @param bindings  Parameter bindings array
+ * @param nb_b      Number of bindings
+ * @return          1 if trigger stream found
+ */
+int fps_check_has_trigger_binding(
+    FPS_CLI_BINDING *bindings,
+    int              nb_b
+);
 
 
 #endif /* FPS_LIFECYCLE_H */

--- a/src/engine/libfps/milk-fpsexec-help.c
+++ b/src/engine/libfps/milk-fpsexec-help.c
@@ -60,9 +60,10 @@ int main(int argc, char *argv[])
     /* ---- Usage ---- */
     printf(C_HDR "General Usage\n" C_RST);
     printf(
-        "  $ " C_CMD "<executable> " C_FPS
-        "[fpsname:]" C_CMD "<command>"
-        " [options]\n" C_RST
+        "  $ " C_CMD "<executable> " C_RST
+        "[options] "
+        C_FPS "[fpsname:]" C_CMD "<command>"
+        "\n" C_RST
         "\n"
         "  If no " C_FPS "fpsname:" C_RST
         " prefix is given, a default name"
@@ -70,6 +71,28 @@ int main(int argc, char *argv[])
         "  Run " C_CMD "<executable> -h" C_RST
         " for command-specific help and"
         " parameters.\n\n");
+
+    /* ---- Options ---- */
+    printf(C_HDR "Common Options\n" C_RST);
+    printf(
+        "  " C_FPS "fpsname:" C_RST
+        "         Name prefix for the FPS\n"
+        "  " C_CMD "-n, --name" C_RST
+        "      Specify FPS name\n"
+        "  " C_CMD "-tmux" C_RST
+        "           Run inside a tmux"
+        " session\n"
+        "  " C_CMD "-procinfo" C_RST
+        "       Enable process monitoring"
+        " (for fpsinit)\n"
+        "  " C_CMD "-loops" C_RST
+        "         Infinite loop, stream"
+        " semaphore trigger\n"
+        "  " C_CMD "-loopd SEC" C_RST
+        "     Infinite loop, delay"
+        " trigger (seconds)\n"
+        "  " C_CMD "-h" C_RST
+        "              Show help message\n\n");
 
     /* ---- Commands ---- */
     printf(C_HDR "Commands\n" C_RST);
@@ -95,22 +118,6 @@ int main(int argc, char *argv[])
         "      Stop main processing loop\n"
         "  " C_CMD "exec" C_RST
         "         Auto-init + run\n\n");
-
-    /* ---- Options ---- */
-    printf(C_HDR "Common Options\n" C_RST);
-    printf(
-        "  " C_FPS "fpsname:" C_RST
-        "         Name prefix for the FPS\n"
-        "  " C_CMD "-n, --name" C_RST
-        "      Specify FPS name\n"
-        "  " C_CMD "-tmux" C_RST
-        "           Run inside a tmux"
-        " session\n"
-        "  " C_CMD "-procinfo" C_RST
-        "       Enable process monitoring"
-        " (for fpsinit)\n"
-        "  " C_CMD "-h" C_RST
-        "              Show help message\n\n");
 
     /* ---- Workflow ---- */
     printf(C_HDR "Typical Workflow\n" C_RST);
@@ -167,17 +174,20 @@ int main(int argc, char *argv[])
         " to auto-create a tmux session"
         " and dispatch commands:\n"
         "    $ " C_CMD
-        "milk-fpsexec-clitest " C_FPS
+        "milk-fpsexec-clitest "
+        C_CMD "-tmux " C_FPS
         "myfps00" C_CMD
-        ":fpsinit -tmux\n" C_RST
+        ":fpsinit\n" C_RST
         "    $ " C_CMD
-        "milk-fpsexec-clitest " C_FPS
+        "milk-fpsexec-clitest "
+        C_CMD "-tmux " C_FPS
         "myfps00" C_CMD
-        ":confstart -tmux\n" C_RST
+        ":confstart\n" C_RST
         "    $ " C_CMD
-        "milk-fpsexec-clitest " C_FPS
+        "milk-fpsexec-clitest "
+        C_CMD "-tmux " C_FPS
         "myfps00" C_CMD
-        ":runstart -tmux\n" C_RST
+        ":runstart\n" C_RST
         "\n");
 
     /* ---- Alternate tools ---- */


### PR DESCRIPTION
## Summary

Implements the `-loops` (stream semaphore trigger) and `-loopd <sec>` (delay trigger) command-line options for all fpsexec standalone binaries, replacing the old `-loop` flag. Adds verbose output echoing every FPS parameter set, and fixes an argument parsing bug where `-loopd` consumed subcommands as delay values.

## Changes

### Argument Parsing & Macros (`fps.h`)
- Rename `-loop` to `-loops` for stream semaphore trigger mode
- Add `-loopd <sec>` with numeric validation — if the next argument isn't numeric, it's treated as a subcommand (not consumed as the delay)
- Apply loop overrides during `fpsinit` (not just `run`/`exec`)
- Reorder help output: Options before Commands; update usage line to `[Options] [fpsname:]<Command>`

### Loop Override Functions (`fps_lifecycle.c`, `fps_lifecycle.h`)
- Add `fps_loop_override_delay()` for delay-triggered loops
- Add `fps_check_has_trigger_binding()` utility
- Add verbose printf echo to both override functions showing the option used and every FPS parameter set (loopcntMax, enabled, triggermode, triggersname, triggerdelay)
- Warning message when `-loops` is used but no trigger stream binding exists

### Help & Documentation
- `milk-fpsexec-help.c`: Add `-loops`/`-loopd` to common options; fix tmux examples to place `-tmux` before the command
- `FPS_Standalone_CMD_Modes.md`: Document new options

## Verification

- [x] Build passes
- [x] `-loopd 0.1 fpsinit` correctly creates FPS and echoes delay parameters
- [x] `-loops fpsinit` correctly warns about missing trigger and echoes fallback
- [x] `-loopd 0.5 exec` correctly applies delay and echoes parameters before run
- [x] `-loopd fpsinit` (no numeric arg) correctly treats `fpsinit` as subcommand

## Prompt Summary

User requested renaming `-loop` to `-loops` and adding `-loopd <delay>` for time-based delay loops. Follow-up requests: fix argument parsing bug where `-loopd fpsinit` consumed `fpsinit` as the delay value; add verbose echo of all parameters set by loop overrides; ensure overrides also apply during `fpsinit` (not just `run`/`exec`).

## AI Authorship

- **Model**: Antigravity
- **User edits**: None