### PR TITLE
fix: sync CLI args before trigger stream override in standalone executables

### DIFF
--- a/src/engine/libfps/fps.h
+++ b/src/engine/libfps/fps.h
@@ -1761,13 +1761,17 @@ int main(int argc, char *argv[]) { \
                         " FPFLAG_TRIGGER" \
                         "_STREAM.\n"); \
                 } \
-                /* Apply -loops/-loopd overrides */ \
+                /* Sync CLI args + apply overrides */\
                 if (use_loop) { \
                     FUNCTION_PARAMETER_STRUCT fp_; \
                     if (function_parameter_struct_connect(\
                             fps_name, &fp_, \
                             FPSCONNECT_SIMPLE) != -1)\
                     { \
+                        fps_process_cli_and_sync( \
+                            &fp_, farg_, \
+                            my_bindings_, \
+                            nb_bindings_); \
                         if (use_loop == 1) { \
                             fps_loop_override_trigger(\
                                 &fp_, my_bindings_,\
@@ -1807,12 +1811,16 @@ int main(int argc, char *argv[]) { \
                 " FPFLAG_TRIGGER" \
                 "_STREAM.\n"); \
         } \
-        /* Apply -loops/-loopd overrides */ \
+        /* Sync CLI args into FPS before \
+         * applying loop overrides. */ \
         if (use_loop && rc_ == 0) { \
             FUNCTION_PARAMETER_STRUCT fp_; \
             if (function_parameter_struct_connect(\
                     fps_name, &fp_, \
                     FPSCONNECT_SIMPLE) != -1) {\
+                fps_process_cli_and_sync( \
+                    &fp_, farg_, \
+                    my_bindings_, nb_bindings_);\
                 if (use_loop == 1) { \
                     fps_loop_override_trigger(\
                         &fp_, my_bindings_, \
@@ -1890,6 +1898,21 @@ int main(int argc, char *argv[]) { \
                 } \
             } \
         } \
+        /* Sync CLI args into FPS before \
+         * applying loop overrides, so that \
+         * trigger stream names are available. */ \
+        { \
+            FUNCTION_PARAMETER_STRUCT fps_sync_; \
+            if (function_parameter_struct_connect(\
+                    fps_name, &fps_sync_, \
+                    FPSCONNECT_SIMPLE) != -1) { \
+                fps_process_cli_and_sync( \
+                    &fps_sync_, farg_, \
+                    my_bindings_, nb_bindings_);\
+                function_parameter_struct_disconnect(\
+                    &fps_sync_); \
+            } \
+        } \
         /* Apply -loops/-loopd overrides */ \
         if (use_loop == 1) { \
             FUNCTION_PARAMETER_STRUCT fps_lp_; \
@@ -1920,6 +1943,20 @@ int main(int argc, char *argv[]) { \
     } else if (strcmp(command, \
                       "runstart") == 0 || \
                strcmp(command, "run") == 0) { \
+        /* Sync CLI args into FPS before \
+         * applying loop overrides. */ \
+        { \
+            FUNCTION_PARAMETER_STRUCT fps_sync_; \
+            if (function_parameter_struct_connect(\
+                    fps_name, &fps_sync_, \
+                    FPSCONNECT_SIMPLE) != -1) { \
+                fps_process_cli_and_sync( \
+                    &fps_sync_, farg_, \
+                    my_bindings_, nb_bindings_);\
+                function_parameter_struct_disconnect(\
+                    &fps_sync_); \
+            } \
+        } \
         /* Apply -loops/-loopd overrides */ \
         if (use_loop == 1) { \
             FUNCTION_PARAMETER_STRUCT fps_lp_; \

--- a/src/engine/libfps/fps_lifecycle.c
+++ b/src/engine/libfps/fps_lifecycle.c
@@ -214,31 +214,78 @@ void fps_loop_override_trigger(
     int                        nb_b
 )
 {
-    /* Find trigger stream from bindings */
+    /*
+     * Find trigger stream from bindings.
+     * First try the local C variable (ptr).
+     * If empty (CLI sync hasn't run yet),
+     * read from FPS shared memory instead.
+     */
     const char *trigger_name = NULL;
+    char trigger_kw[FUNCTION_PARAMETER_STRMAXLEN]
+        = "";
+    char current_ts[FUNCTION_PARAMETER_STRMAXLEN]
+        = "";
+
     for (int i = 0; i < nb_b; i++) {
         if ((bindings[i].fpflag
              & FPFLAG_TRIGGER_STREAM)
             && (bindings[i].type
                 == FPTYPE_STREAMNAME))
         {
-            trigger_name =
+            /* Try local variable first */
+            const char *local =
                 (const char *) bindings[i].ptr;
+            if (local != NULL
+                && local[0] != '\0')
+            {
+                trigger_name = local;
+            }
+            else
+            {
+                /*
+                 * Local var empty — CLI sync
+                 * hasn't populated it yet.
+                 * Read from FPS shared memory.
+                 */
+                strncpy(
+                    trigger_kw,
+                    bindings[i].fpskeyword,
+                    sizeof(trigger_kw) - 1);
+            }
             break;
         }
     }
 
     /*
-     * If no trigger stream found in bindings,
-     * try to read the current value of the
-     * .procinfo.triggersname parameter.
+     * Read trigger name from FPS if local var
+     * was empty but we found the binding keyword.
      */
-    char current_ts[FUNCTION_PARAMETER_STRMAXLEN]
-        = "";
+    if (trigger_name == NULL
+        && trigger_kw[0] != '\0')
+    {
+        long pidx =
+            functionparameter_GetParamIndex(
+                fps, trigger_kw);
+        if (pidx >= 0) {
+            strncpy(
+                current_ts,
+                functionparameter_GetParamPtr_STRING(
+                    fps, trigger_kw),
+                sizeof(current_ts) - 1);
+            if (current_ts[0] != '\0') {
+                trigger_name = current_ts;
+            }
+        }
+    }
+
+    /*
+     * If still no trigger stream, try
+     * .procinfo.triggersname as last resort.
+     */
     if (trigger_name == NULL
         || trigger_name[0] == '\0')
     {
-        int pidx =
+        long pidx =
             functionparameter_GetParamIndex(
                 fps, ".procinfo.triggersname");
         if (pidx >= 0) {


### PR DESCRIPTION
## Problem

When running standalone FPS executables with `-loops` (e.g., `milk-fpsexec-info-strmonproc -procinfo -loops run:exec earth 63 40`), the semaphore trigger stream was not being correctly initialized. The output showed:

```
WARNING [-loops] No trigger stream found — semaphore trigger not configured.
  .procinfo.triggermode  = 4 (DELAY)
```

Despite the trigger binding being correctly defined with `FPFLAG_DEFAULT_TRIGGER_STREAM` in the source, the trigger stream name was empty at the time the override function was called.

## Root Cause

In `_FPS_MAIN_STANDALONE_V2_IMPL` (`fps.h`), the `exec`, `runstart`/`run`, and `fpsinit` command paths called `fps_loop_override_trigger()` **before** `fps_process_cli_and_sync()` had written the CLI arguments (e.g., stream name `"earth"`) into FPS shared memory.

The override function found the correct trigger binding, but the stream name stored in the local C variable (`inimname`) was still `""` (its static initializer), and the FPS parameter `.in_name` had not been populated either.

## Fix

- **`fps.h`**: Add `fps_process_cli_and_sync()` calls before `fps_loop_override_trigger()`/`fps_loop_override_delay()` in all 4 affected code paths (exec, runstart/run, fpsinit direct, fpsinit tmux dispatch).
- **`fps_lifecycle.c`**: Improve `fps_loop_override_trigger()` to read the trigger stream name from FPS shared memory when the local C variable is empty (defense-in-depth). Remove debug printf statements.

## After Fix

```
FPS run exec -> NEW
-loops Stream semaphore trigger
  .procinfo.triggersname = earth
  .procinfo.triggermode  = 3 (SEMAPHORE)
  stream [run.procinfo.triggersname] "earth" -> FOUND (ID 0)
  stream [run.in_name] "earth" [RUN-REQUIRED] -> FOUND (ID 0)
```

## Prompt Summary

User reported that `-loops` was not triggering SEMAPHORE mode in standalone fpsexec binaries. Debugging revealed that `fps_loop_override_trigger` was called before CLI arguments had been synced to FPS shared memory, so the trigger stream name was always empty.

## AI Authorship
- **Model**: Antigravity
- **User edits**: No direct user edits to source code.