### PR TITLE
docs: fix help consistency across CLI, FPS, and procinfo sources

### DIFF
--- a/docs/FPS_Standalone_CMD_Modes.md
+++ b/docs/FPS_Standalone_CMD_Modes.md
@@ -118,6 +118,10 @@ segment.
   - `confstart`, `confstep`, `confstop`: Manage the
     configuration loop.
   - `runstart`, `runstop`: Manage the execution loop.
+  - `fps`: Print content of the FPS.
+  - `fpslist`: List all FPS instances matching this
+    executable.
+  - `exec`: Auto-init + set args + run (one-shot).
 
 </details>
 

--- a/docs/cli/CLIcore.md
+++ b/docs/cli/CLIcore.md
@@ -43,7 +43,6 @@ available:
 | `-e`, `--errorexit` | Exit on command error |
 | `-Z`, `--idle` | Only run process when X is idle |
 | `--listimf` | Write image list to `imlist.txt` |
-| `-m`, `--mmon=TTY` | Open memory monitor on tty device |
 | `-n`, `--pname=NAME` | Rename process |
 | `-p`, `--priority=PR` | Set RT priority (0–99, higher = higher) |
 | `-f`, `--fifoflag` | Enable fifo input; auto-generate fifo path |

--- a/src/cli/CLIcore/doc/help.txt
+++ b/src/cli/CLIcore/doc/help.txt
@@ -38,10 +38,6 @@ COMMAND LINE OPTIONS
   -s, --startup=STARTUPFILE
 	execute specified script on startup
 	requires the -f or -F option, as the script is loaded into fifo
-  -m, --mmon=STREAM
-	Set memory monitor stream
-  -E, --echo-input
-	Echo each input line (colored)
   -A, --autocomplete
 	Enable autocomplete preview
   --no-autocomplete

--- a/src/cli/CLIcore/milk-cli-help-synchro.c
+++ b/src/cli/CLIcore/milk-cli-help-synchro.c
@@ -72,8 +72,8 @@ void print_milk_synchro_help(void)
     printf("  - " C_NOTE "DELAY (4):" C_RST "     Executes on a fixed timer.\n");
     printf("  - " C_NOTE "CNT2 (5):" C_RST "      Reserved trigger mode.\n");
     printf("\n");
-    printf("  You define " C_CMD "triggerstreamname" C_RST " to select the stream, and\n");
-    printf("  " C_CMD "semindexrequested" C_RST " (typically 0) to bind the process.\n");
+    printf("  You define " C_CMD "procinfo.triggersname" C_RST " to select the stream, and\n");
+    printf("  " C_CMD "procinfo.semindexrequested" C_RST " (typically 0) to bind the process.\n");
     printf("\n");
 
     printf(C_TITLE "========================================================\n" C_RST);

--- a/src/engine/libprocessinfo/milk-procinfo-help.c
+++ b/src/engine/libprocessinfo/milk-procinfo-help.c
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
     printf("                          0: IMMEDIATE (Continuous loop)\n");
     printf("                          3: SEMAPHORE (Stream semWait trigger)\n");
     printf("                          4: DELAY (Throttle with timer delay)\n");
-    printf("  " C_BOLD "procinfo.timersname" C_RST "   (Alias triggersname) The stream to wait on.\n");
+    printf("  " C_BOLD "procinfo.triggersname" C_RST " The stream to wait on.\n");
     printf("\n");
 
     printf(C_HDR "Example:\n" C_RST);


### PR DESCRIPTION
## Summary

Systematic audit of all 6 help cross-reference groups (CLI options, FPS management, processinfo, streams, fpsexec one-liners, per-module) found 7 inconsistencies. All fixes were verified against the actual source code implementation before being applied.

## Changes

### Stale CLI flags removed
- **`doc/help.txt`**: Removed `-m, --mmon=STREAM` and `-E, --echo-input` — both absent from `CLIcore.c` getopt (`"hvic:d:oen:p:fF:s:A"`). `-E` only exists in `milk-script`.
- **`docs/cli/CLIcore.md`**: Removed `-m, --mmon=TTY` row from the options table.

### Missing fpsexec commands documented
- **`docs/FPS_Standalone_CMD_Modes.md`**: Added `fps`, `fpslist`, and `exec` to the standalone commands list — all three are implemented in `fps.h` V2 macros and documented in `milk-fpsexec-help.c` but were missing from the markdown reference.

### Incorrect parameter names fixed
- **`milk-procinfo-help.c`**: Changed `procinfo.timersname (Alias triggersname)` → `procinfo.triggersname`. The `timersname` parameter does not exist; `fps_processinfo_entries.c` defines `.procinfo.triggersname`.
- **`milk-cli-help-synchro.c`**: Replaced bare C struct field names (`triggerstreamname`, `semindexrequested`) with the actual FPS parameter names users interact with (`procinfo.triggersname`, `procinfo.semindexrequested`).

## Testing
- Build: 0 errors, 0 warnings on modified targets
- Tests: 38/38 passed
- Visual verification: `milk-procinfo-help` and `milk-cli-help-synchro` output confirmed correct

## Prompt Summary
User requested `/audit-help-consistency` workflow. Audit identified 7 cross-source inconsistencies verified against `CLIcore.c` getopt implementation, `fps.h` V2 macros, and `fps_processinfo_entries.c` parameter definitions.

## AI Authorship
- **Model**: Antigravity
- **User edits**: None — all changes authored by the agent