### PR TITLE
perf: add MILK_RESTRICT, MILK_ASSUME_ALIGNED, and fix uint32 overflow in coremods

### DIFF
--- a/src/coremods/COREMOD_arith/image_cropmask.c
+++ b/src/coremods/COREMOD_arith/image_cropmask.c
@@ -109,6 +109,7 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
             const float *__restrict imgmask_row = &imgmask.im->array.F[jj * crop_xsize];
             float *__restrict imgout_row        = &imgout.im->array.F[jj * crop_xsize];
 
+            MILK_IVDEP
             for(uint32_t ii = 0; ii < crop_xsize; ii++)
             {
                 imgout_row[ii] = imgmask_row[ii] * imgin_row[ii];

--- a/src/coremods/COREMOD_arith/image_pixremap.c
+++ b/src/coremods/COREMOD_arith/image_pixremap.c
@@ -95,8 +95,7 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
     // build mapping table
     //
     uint64_t nbpix = 0;
-        MILK_IVDEP
-    for(uint64_t ii = 0; ii < xsize*ysize; ii++)
+    for(uint64_t ii = 0; ii < (uint64_t)xsize*ysize; ii++)
     {
         int64_t pixindex = imgmap.im->array.SI32[ii];
         if ( ( pixindex > -1 )
@@ -108,12 +107,13 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
 
     printf("mapping table has %lu elements\n", nbpix);
 
-    uint64_t * __restrict map_outpixindex = (uint64_t*) malloc(sizeof(uint64_t) * nbpix);
-    uint64_t * __restrict map_inpixindex  = (uint64_t*) malloc(sizeof(uint64_t) * nbpix);
+    uint64_t * MILK_RESTRICT map_outpixindex =
+        (uint64_t*) malloc(sizeof(uint64_t) * nbpix);
+    uint64_t * MILK_RESTRICT map_inpixindex =
+        (uint64_t*) malloc(sizeof(uint64_t) * nbpix);
 
     nbpix = 0;
-        MILK_IVDEP
-    for(uint64_t ii = 0; ii < xsize*ysize; ii++)
+    for(uint64_t ii = 0; ii < (uint64_t)xsize*ysize; ii++)
     {
         int64_t pixindex = imgmap.im->array.SI32[ii];
         if ( ( pixindex > -1 )

--- a/src/coremods/COREMOD_arith/image_stats.c
+++ b/src/coremods/COREMOD_arith/image_stats.c
@@ -385,7 +385,8 @@ double MILK_HOT arith_image_max_IMGID(IMGID *imgin)
 
     else if(datatype == _DATATYPE_INT8)
     {
-        int8_t * restrict ptr = imgin->im->array.SI8;
+        int8_t * MILK_RESTRICT ptr =
+            MILK_ASSUME_ALIGNED(imgin->im->array.SI8);
         int8_t value = ptr[0];
 #ifdef _OPENMP
         #pragma omp parallel for simd reduction(max:value) if (nelement > OMP_NELEMENT_LIMIT)
@@ -403,7 +404,8 @@ double MILK_HOT arith_image_max_IMGID(IMGID *imgin)
 
     else if(datatype == _DATATYPE_INT16)
     {
-        int16_t * restrict ptr = imgin->im->array.SI16;
+        int16_t * MILK_RESTRICT ptr =
+            MILK_ASSUME_ALIGNED(imgin->im->array.SI16);
         int16_t value = ptr[0];
 #ifdef _OPENMP
         #pragma omp parallel for simd reduction(max:value) if (nelement > OMP_NELEMENT_LIMIT)
@@ -421,7 +423,8 @@ double MILK_HOT arith_image_max_IMGID(IMGID *imgin)
 
     else if(datatype == _DATATYPE_INT32)
     {
-        int32_t * restrict ptr = imgin->im->array.SI32;
+        int32_t * MILK_RESTRICT ptr =
+            MILK_ASSUME_ALIGNED(imgin->im->array.SI32);
         int32_t value = ptr[0];
 #ifdef _OPENMP
         #pragma omp parallel for simd reduction(max:value) if (nelement > OMP_NELEMENT_LIMIT)
@@ -439,7 +442,8 @@ double MILK_HOT arith_image_max_IMGID(IMGID *imgin)
 
     else if(datatype == _DATATYPE_INT64)
     {
-        int64_t * restrict ptr = imgin->im->array.SI64;
+        int64_t * MILK_RESTRICT ptr =
+            MILK_ASSUME_ALIGNED(imgin->im->array.SI64);
         int64_t value = ptr[0];
 #ifdef _OPENMP
         #pragma omp parallel for simd reduction(max:value) if (nelement > OMP_NELEMENT_LIMIT)

--- a/src/coremods/COREMOD_arith/imfunctions.c
+++ b/src/coremods/COREMOD_arith/imfunctions.c
@@ -643,9 +643,12 @@ errno_t arith_image_function_2_1_IMGID(
 #endif
             if (datatype == _DATATYPE_FLOAT && datatype1 == _DATATYPE_FLOAT && datatype2 == _DATATYPE_FLOAT)
             {
-                float *outptr = outimg->im->array.F;
-                float *in1ptr = inimg1->im->array.F;
-                float *in2ptr = inimg2->im->array.F;
+                float * MILK_RESTRICT outptr =
+                    MILK_ASSUME_ALIGNED(outimg->im->array.F);
+                const float * MILK_RESTRICT in1ptr =
+                    MILK_ASSUME_ALIGNED(inimg1->im->array.F);
+                const float * MILK_RESTRICT in2ptr =
+                    MILK_ASSUME_ALIGNED(inimg2->im->array.F);
 #ifdef _OPENMP
                 #pragma omp for simd
 #endif
@@ -656,9 +659,12 @@ errno_t arith_image_function_2_1_IMGID(
             }
             else if (datatype == _DATATYPE_DOUBLE && datatype1 == _DATATYPE_DOUBLE && datatype2 == _DATATYPE_DOUBLE)
             {
-                double *outptr = outimg->im->array.D;
-                double *in1ptr = inimg1->im->array.D;
-                double *in2ptr = inimg2->im->array.D;
+                double * MILK_RESTRICT outptr =
+                    MILK_ASSUME_ALIGNED(outimg->im->array.D);
+                const double * MILK_RESTRICT in1ptr =
+                    MILK_ASSUME_ALIGNED(inimg1->im->array.D);
+                const double * MILK_RESTRICT in2ptr =
+                    MILK_ASSUME_ALIGNED(inimg2->im->array.D);
 #ifdef _OPENMP
                 #pragma omp for simd
 #endif
@@ -669,7 +675,8 @@ errno_t arith_image_function_2_1_IMGID(
             }
             else if (datatype == _DATATYPE_FLOAT)
             {
-                float *outptr = outimg->im->array.F;
+                float * MILK_RESTRICT outptr =
+                    MILK_ASSUME_ALIGNED(outimg->im->array.F);
 #ifdef _OPENMP
                 #pragma omp for simd
 #endif
@@ -686,7 +693,8 @@ errno_t arith_image_function_2_1_IMGID(
             }
             else if (datatype == _DATATYPE_DOUBLE)
             {
-                double *outptr = outimg->im->array.D;
+                double * MILK_RESTRICT outptr =
+                    MILK_ASSUME_ALIGNED(outimg->im->array.D);
 #ifdef _OPENMP
                 #pragma omp for simd
 #endif

--- a/src/coremods/COREMOD_memory/image_copy.c
+++ b/src/coremods/COREMOD_memory/image_copy.c
@@ -299,9 +299,10 @@ imageID copy_image_ID_IMGID(
 
     imgout->md[0].write = 1;
 
-    memcpy(imgout->im->array.raw,
-           imgin->im->array.raw,
-           ImageStreamIO_typesize(datatype) * nelement);
+    __builtin_memcpy(
+        imgout->im->array.raw,
+        imgin->im->array.raw,
+        ImageStreamIO_typesize(datatype) * nelement);
 
     imgout->md[0].cnt0++;
     imgout->md[0].write = 0;
@@ -455,10 +456,11 @@ errno_t COREMOD_MEMORY_cp2shm_IMGID(
 
     imgout->md[0].write = 1;
 
-    memcpy(imgout->im->array.raw,
-           imgin->im->array.raw,
-           ImageStreamIO_typesize(datatype)
-               * imgin->md[0].nelement);
+    __builtin_memcpy(
+        imgout->im->array.raw,
+        imgin->im->array.raw,
+        ImageStreamIO_typesize(datatype)
+            * imgin->md[0].nelement);
 
     imgout->md[0].cnt0++;
     imgout->md[0].write = 0;

--- a/src/coremods/COREMOD_memory/stream_diff.c
+++ b/src/coremods/COREMOD_memory/stream_diff.c
@@ -104,7 +104,7 @@ imageID MILK_HOT COREMOD_MEMORY_streamDiff(
 
     uint32_t xsize = img0.md->size[0];
     uint32_t ysize = img0.md->size[1];
-    uint64_t xysize = xsize * ysize;
+    uint64_t xysize = (uint64_t)xsize * ysize;
 
     IMGID imgout =
         imgid_make_from_name(IDstreamout_name);
@@ -150,6 +150,7 @@ imageID MILK_HOT COREMOD_MEMORY_streamDiff(
         imgout.md->write = 1;
         if(ptrm == NULL)
         {
+            MILK_IVDEP
             for(uint64_t ii = 0;
                     ii < xysize; ii++)
             {
@@ -158,6 +159,7 @@ imageID MILK_HOT COREMOD_MEMORY_streamDiff(
         }
         else
         {
+            MILK_IVDEP
             for(uint64_t ii = 0;
                     ii < xysize; ii++)
             {

--- a/src/coremods/COREMOD_memory/stream_halfimdiff.c
+++ b/src/coremods/COREMOD_memory/stream_halfimdiff.c
@@ -82,7 +82,7 @@ imageID MILK_HOT COREMOD_MEMORY_stream_halfimDiff(
 
     uint32_t xsize  = xsizein;
     uint32_t ysize  = ysizein / 2;
-    uint64_t xysize = xsize * ysize;
+    uint64_t xysize = (uint64_t)xsize * ysize;
 
     uint8_t datatype    = img0.md->datatype;
     uint8_t datatypeout = _DATATYPE_FLOAT;


### PR DESCRIPTION
## Summary

Audit and fix missing performance optimizations across `COREMOD_arith` and `COREMOD_memory`. Adds `MILK_RESTRICT` + `MILK_ASSUME_ALIGNED` to critical hot paths, fixes silent integer overflow bugs, removes an incorrect `MILK_IVDEP`, and standardizes compiler hint usage.

## Changes

### Performance — restrict + alignment
- **`imfunctions.c`**: Add `MILK_RESTRICT` + `MILK_ASSUME_ALIGNED` + `const` to all 4 fast-path pointer aliases in the central arithmetic dispatch (float/double same-type and mixed-type). Every image arithmetic operation (`+`, `-`, `*`, `/`, `pow`) flows through these loops.
- **`image_stats.c`**: Replace bare `restrict` with `MILK_RESTRICT` + `MILK_ASSUME_ALIGNED` in 4 signed-integer branches of `arith_image_max_IMGID`, matching the existing unsigned-type pattern.
- **`image_copy.c`**: Replace `memcpy` with `__builtin_memcpy` in 2 bulk pixel copy paths (`copy_image_ID_IMGID`, `COREMOD_MEMORY_cp2shm_IMGID`).
- **`image_cropmask.c`**: Add `MILK_IVDEP` to inner pixel multiply loop.
- **`stream_diff.c`**: Add `MILK_IVDEP` to both element-wise diff loops.

### Correctness — uint32_t overflow
- **`stream_diff.c`**, **`stream_halfimdiff.c`**, **`image_pixremap.c`**: Fix `uint64_t xysize = xsize * ysize` where both operands are `uint32_t`. The multiplication silently wraps to zero at 65536×65536. Changed to `(uint64_t)xsize * ysize`.

### Correctness — incorrect MILK_IVDEP
- **`image_pixremap.c`**: Remove `MILK_IVDEP` from 2 counting loops that have a loop-carried dependency (`nbpix++`). Also standardize `__restrict` → `MILK_RESTRICT`.

## Prompt Summary

User requested an audit of missing performance optimizations (specifically `restrict` attribute usage) across the codebase. The audit uncovered missing `MILK_RESTRICT`/`MILK_ASSUME_ALIGNED` annotations, silent `uint32_t` overflow bugs, and an incorrect `MILK_IVDEP` annotation. All findings were prioritized (P0–P3) and the P0–P2 items were fixed.

## Testing
- Clean build with `cmake --build . -- -j$(nproc)` — 0 warnings, 0 errors.

## AI Authorship
- **Model**: Antigravity
- **User edits**: None — all changes generated by the agent.