### PR TITLE
chore: finalize standalone plugin migration and add demo pipeline

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -53,12 +53,6 @@
 [submodule "plugins/milk-extra-src/cudacomp"]
 	path = plugins/milk-extra-src/cudacomp
 	url = ""
-[submodule "plugins/milk-extra-src/WFpropagate"]
-	path = plugins/milk-extra-src/WFpropagate
-	url = ""
-[submodule "plugins/milk-extra-src/OpticsMaterials"]
-	path = plugins/milk-extra-src/OpticsMaterials
-	url = ""
 [submodule "cacao"]
 	path = plugins/cacao-src
 	url = ""

--- a/plugins/milk-extra-src/linopt_imtools/makeCPAmodes.h
+++ b/plugins/milk-extra-src/linopt_imtools/makeCPAmodes.h
@@ -8,19 +8,26 @@
 
 errno_t CLIADDCMD_linopt_imtools__makeCPAmodes();
 
-errno_t linopt_imtools_makeCPAmodes(IMGID *imgoutm,
-                                    long        size,
-                                    float       rCPAmin,
-                                    float       rCPAmax,
-                                    float       CPAmax,
-                                    float       deltaCPA,
-                                    float       radius,
-                                    float       radfactlim,
-                                    int         writeMfile,
-                                    long       *outNBmax,
-                                    IMGID       imgmask,
-                                    float       extrfactor,
-                                    float       extroffset
-                                   );
+errno_t linopt_imtools_makeCPAmodes(
+    IMGID          *imgoutm,
+    uint32_t        sizex,
+    uint32_t        sizey,
+    float           xcenter,
+    float           ycenter,
+    float           rCPAmin,
+    float           rCPAmax,
+    float           CPAmax,
+    float           deltaCPA,
+    float           radius,
+    float           radfactlim,
+    float           fpowerlaw,
+    float           fpowerlaw_minf,
+    float           fpowerlaw_maxf,
+    uint32_t        writeMfile,
+    long           *outNBmax,
+    IMGID           imgmask,
+    float           extrfactor,
+    float           extroffset
+);
 
 #endif

--- a/src/engine/libfps/CMakeLists.txt
+++ b/src/engine/libfps/CMakeLists.txt
@@ -219,6 +219,7 @@ add_executable(milk-fpsexec-help milk-fpsexec-help.c)
 install(TARGETS milk-fpsexec-help DESTINATION bin)
 
 install(PROGRAMS scripts/milk-fpsexec-list DESTINATION bin)
+install(PROGRAMS scripts/milk-demopipeline DESTINATION bin)
 install(PROGRAMS scripts/milk-latency-audit DESTINATION bin)
 
 add_executable(milk-fps-help milk-fps-help.c)

--- a/src/engine/libfps/scripts/milk-demopipeline
+++ b/src/engine/libfps/scripts/milk-demopipeline
@@ -1,0 +1,65 @@
+#!/bin/bash
+# milk-demopipeline
+# Start a simple 4-node FPS pipeline for demonstration.
+
+FRAMERATE=100
+
+# Parse arguments
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h1|--help-oneline)
+            echo "start a simple 4-node FPS pipeline for demonstration"
+            exit 0
+            ;;
+        -h|--help)
+            cat <<'EOF'
+Usage: milk-demopipeline [OPTIONS]
+
+Start a simple 4-node FPS pipeline for demonstration.
+This script sets up a basic image processing chain inside tmux:
+1. Random image generation
+2. Gaussian filtering
+3. Image truncation
+4. Stream monitoring
+
+Options:
+  -f, --framerate HZ   Set the framerate of the pipeline in Hz (default: 100).
+  -h, --help           Print this help message.
+  -h1, --help-oneline  Print one-line description and exit.
+EOF
+            exit 0
+            ;;
+        -f|--framerate)
+            FRAMERATE="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use -h for help."
+            exit 1
+            ;;
+    esac
+done
+
+# Calculate delay in seconds
+DELAY=$(awk "BEGIN {print 1.0 / $FRAMERATE}")
+
+echo "Starting milk framework demo pipeline at $FRAMERATE Hz (delay: $DELAY s)..."
+
+# 1. Generate a 512x512 random image (uniform distribution)
+milk-fpsexec-imggen-mkrandom -tmux -procinfo -loopd "$DELAY" exec random_in 512 512 0
+sleep 0.5
+
+# 2. Apply a Gaussian filter (sigma 5.0, size 15).
+milk-fpsexec-imgfilt-gaussfilt -tmux -procinfo -loopd "$DELAY" exec random_in blurred_out 5.0 15
+sleep 0.5
+
+# 3. Truncate pixel values between 0.2 and 0.8.
+milk-fpsexec-arith-imtrunc -tmux -procinfo -loopd "$DELAY" exec blurred_out 0.2 0.8 truncated_out
+sleep 0.5
+
+# 4. Stream monitor to collect stats. Triggered by 'truncated_out' semaphore
+milk-fpsexec-info-strmonproc -tmux -procinfo -loops exec truncated_out 1 100
+
+echo "Pipeline successfully started in tmux sessions."
+echo "You can now open 'milkCTRL' to view the running processes, FPS parameters, and streaming data."


### PR DESCRIPTION
## Summary

Finalizes the extraction of `WFpropagate` and `OpticsMaterials` into standalone plugins by removing their legacy ghost entries from `.gitmodules` and cleans up an outdated function signature. Also adds a new FPS execution showcase script (`milk-demopipeline`) to demonstrate process orchestration.

## Changes

### Core Framework (`.gitmodules`)
- Removed legacy `WFpropagate` and `OpticsMaterials` ghost entries from `.gitmodules`. They were not tracked in the source tree but had lingering configuration entries. Both are now treated uniformly as standalone plugins symlinked into `plugins/`.

### Engine / FPS (`src/engine/libfps`)
- Added `milk-demopipeline` bash script showcasing a functional sequence of FPS processes.
- Updated `CMakeLists.txt` to install the `milk-demopipeline` script.

### Plugins (`plugins/milk-extra-src/linopt_imtools`)
- Updated `linopt_imtools_makeCPAmodes` function signature in `makeCPAmodes.h` to match its implementation.

## Verification

- [x] Build passes (`/compile-test`)
- [x] Plugins successfully compile as standalone entities (verified via `coffee` build).
- [x] `milk-demopipeline` is installed to bin correctly.

## Prompt Summary

The user requested to finalize the transition of `OpticsMaterials` and `WFpropagate` from `milk-extra-src` to standalone, symlinked plugins, just like `cacao`. This PR removes the residual ghost submodules from the main repository. Additionally, it bundles the new FPS execution showcase pipeline requested in a previous session to serve as a baseline for testing `milkCTRL` and process flow. 

## AI Authorship

- **Model**: Antigravity
- **User edits**: None
