### PR TITLE
fix: resolve image initialization errors and stabilize FFT pipelines

### DIFF
--- a/plugins/milk-extra-src/fft/permut.c
+++ b/plugins/milk-extra-src/fft/permut.c
@@ -145,6 +145,11 @@ int permut(const char *ID_name)
     // fflush(stdout);
 
     ID    = image_ID(ID_name, dcimg, dcnimg);
+    if(ID == -1)
+    {
+        PRINT_ERROR("Image \"%s\" not found", ID_name);
+        return RETURN_FAILURE;
+    }
     naxis = dcimg[ID].md[0].naxis;
 
     naxes0 = dcimg[ID].md[0].size[0];

--- a/plugins/milk-extra-src/fft/wisdom.c
+++ b/plugins/milk-extra-src/fft/wisdom.c
@@ -123,7 +123,7 @@ errno_t export_wisdom()
     if((fp = fopen(wisdom_file_single, "w")) == NULL)
     {
         PRINT_ERROR("Error creating wisdom file \"%s\"", wisdom_file_single);
-        abort();
+        return RETURN_FAILURE;
     }
 #ifdef MILK_MODULE
     fftwf_export_wisdom_to_file(fp);
@@ -133,7 +133,7 @@ errno_t export_wisdom()
     if((fp = fopen(wisdom_file_double, "w")) == NULL)
     {
         PRINT_ERROR("Error creating wisdom file \"%s\"", wisdom_file_double);
-        abort();
+        return RETURN_FAILURE;
     }
 #ifdef MILK_MODULE
     fftw_export_wisdom_to_file(fp);

--- a/plugins/milk-extra-src/image_gen/CMakeLists.txt
+++ b/plugins/milk-extra-src/image_gen/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCEFILES
 	image_gen_basic_shapes.c
 	image_gen_polygons.c
 	image_gen_profiles.c
+	image_gen_complex.c
 )
 
 

--- a/plugins/milk-extra-src/linopt_imtools/makeCosRadModes.c
+++ b/plugins/milk-extra-src/linopt_imtools/makeCosRadModes.c
@@ -80,13 +80,11 @@ errno_t linopt_imtools_makeCosRadModes(
 
     long size2 = size * size;
 
-    IMGID imgr =
-        imgid_make_from_name_2D(
-            "linopt_tmpr", size, size);
-    imgr.mdt->shared = 0;
-    imgr.im = (IMAGE *) calloc(
-        1, sizeof(IMAGE));
-    imgid_mkimage(&imgr);
+    /* Intermediate r-coord image: registered in the global pool
+     * so that delete_image_ID() can find and free it. */
+    imageID IDr;
+    FUNC_CHECK_RETURN(
+        create_2Dimage_ID("linopt_tmpr", size, size, &IDr));
 
     FILE *fp =
         fopen("ModesExpr_CosRad.txt", "w");
@@ -105,28 +103,25 @@ errno_t linopt_imtools_makeCosRadModes(
     for(long ii = 0; ii < size; ii++)
     {
         float x =
-            (1.0 * ii - 0.5 * size)
+            (1.0f * ii - 0.5f * size)
             / radius;
         for(long jj = 0;
             jj < size; jj++)
         {
             float y =
-                (1.0 * jj - 0.5 * size)
+                (1.0f * jj - 0.5f * size)
                 / radius;
-            float r =
-                sqrt(x * x + y * y);
-            imgr.im->array.F[
-                jj * size + ii] = r;
+            data.core.image[IDr].array.F[
+                jj * size + ii] =
+                sqrtf(x * x + y * y);
         }
     }
 
-    IMGID imgout =
-        imgid_make_from_name_3D(
-            ID_name, size, size, kmax);
-    imgout.mdt->shared = 0;
-    imgout.im = (IMAGE *) calloc(
-        1, sizeof(IMAGE));
-    imgid_mkimage(&imgout);
+    /* Output 3-D modes cube: registered in the global pool
+     * so that the caller can find it with image_ID(). */
+    imageID IDout;
+    FUNC_CHECK_RETURN(
+        create_3Dimage_ID(ID_name, size, size, kmax, &IDout));
 
     for(long k = 0; k < kmax; k++)
     {
@@ -134,12 +129,12 @@ errno_t linopt_imtools_makeCosRadModes(
             ii < size2; ii++)
         {
             float r =
-                imgr.im->array.F[ii];
+                data.core.image[IDr].array.F[ii];
             if(r < radfactlim)
             {
-                imgout.im->array.F[
+                data.core.image[IDout].array.F[
                     k * size2 + ii] =
-                    cos(r * M_PI * k);
+                    cosf(r * (float) M_PI * k);
             }
         }
     }
@@ -151,7 +146,7 @@ errno_t linopt_imtools_makeCosRadModes(
 
     if(outID != NULL)
     {
-        *outID = imgout.ID;
+        *outID = IDout;
     }
 
     DEBUG_TRACE_FEXIT();

--- a/src/coremods/COREMOD_memory/imageID.h
+++ b/src/coremods/COREMOD_memory/imageID.h
@@ -121,7 +121,10 @@ static inline imageID _resolveIMGID_impl(
             img->createcnt = imagearray[img->ID].createcnt;
 
             // Populate the IMGID from the imageID metadata
-            imgid_update_creationparams(img);
+            if(img->mdt != NULL)
+            {
+                imgid_update_creationparams(img);
+            }
         }
     }
 
@@ -206,7 +209,7 @@ static inline int imgid_exists(const char *name)
         return 0;
     }
 
-    IMGID img;
+    IMGID img = {0}; // Zero-initialize so img.mdt is NULL
     img.ID        = -1;
     img.im        = NULL;
     img.md        = NULL;

--- a/src/coremods/COREMOD_memory/image_mk_complex_from_amph.c
+++ b/src/coremods/COREMOD_memory/image_mk_complex_from_amph.c
@@ -71,11 +71,19 @@ errno_t mk_complex_from_amph_IMGID(
     DEBUG_TRACE_FSTART();
 
     resolveIMGID(
-        imginamp, ERRMODE_ABORT,
+        imginamp, ERRMODE_WARN,
         dcimg, dcnimg);
+    if(imginamp->ID == -1) {
+        return RETURN_FAILURE;
+    }
+
     resolveIMGID(
-        imginpha, ERRMODE_ABORT,
+        imginpha, ERRMODE_WARN,
         dcimg, dcnimg);
+    if(imginpha->ID == -1) {
+        return RETURN_FAILURE;
+    }
+
 
     uint8_t datatype_am = imginamp->md->datatype;
     uint8_t datatype_ph = imginpha->md->datatype;
@@ -299,7 +307,7 @@ errno_t mk_complex_from_amph_IMGID(
     else
     {
         PRINT_ERROR("Wrong image type(s)\n");
-        abort();
+        return RETURN_FAILURE;
     }
 
     DEBUG_TRACE_FEXIT();

--- a/src/engine/libfps/IMGID.h
+++ b/src/engine/libfps/IMGID.h
@@ -693,6 +693,7 @@ static inline uint64_t imgid_compare_md(
 static inline void imgid_mkimage(IMGID * img)
 {
     ImageStreamIO_createIm(img->im, img->name, img->mdt->naxis, img->mdt->size, img->mdt->datatype, img->mdt->shared, img->mdt->NBkw, img->mdt->CBsize);
+    img->md = img->im->md;
     img->createcnt++;
 }
 

--- a/src/engine/libfps/fps_loadmemstream_lite.c
+++ b/src/engine/libfps/fps_loadmemstream_lite.c
@@ -283,14 +283,19 @@ imageID COREMOD_IOFITS_LoadMemStream(
  * When linking statically (USE_STATIC_LTO), the
  * real implementations in COREMOD_iofits_compute
  * override these weak versions.
+ *
+ * visibility("hidden") prevents these stubs from
+ * being exported by the shared library, avoiding
+ * shadowing of the real symbols from
+ * libmilkCOREMODiofits.so at runtime.
  */
-__attribute__((weak))
+__attribute__((weak, visibility("hidden")))
 int file_exists(const char *filename)
 {
     return access(filename, F_OK) != -1;
 }
 
-__attribute__((weak))
+__attribute__((weak, visibility("hidden")))
 int is_fits_file(const char *filename)
 {
     const char *ext = strrchr(filename, '.');
@@ -301,7 +306,7 @@ int is_fits_file(const char *filename)
     return 0;
 }
 
-__attribute__((weak))
+__attribute__((weak, visibility("hidden")))
 int save_fits(
     const char *imname,
     const char *filename
@@ -312,7 +317,7 @@ int save_fits(
     return -1;
 }
 
-__attribute__((weak))
+__attribute__((weak, visibility("hidden")))
 int load_fits(
     const char *filename,
     const char *imname,
@@ -327,7 +332,7 @@ int load_fits(
     return -1;
 }
 
-__attribute__((weak))
+__attribute__((weak, visibility("hidden")))
 int copy_image_ID(
     const char *name1,
     const char *name2,


### PR DESCRIPTION
## Summary

This PR resolves a set of critical initialization and lifecycle errors across the MILK core memory, engine, and FFT components that were causing `SIGSEGV` runtime crashes in the `cormk2Dprolate` coronagraph pipeline. It adds robustness to shared-memory operations, fixes null-pointer dereferences on uninitialized structures, and implements correct error propagation for failed dependencies, replacing implicit `abort()` calls with graceful failures.

## Changes

### Core Memory (`src/coremods/COREMOD_memory`)
- **`imageID.h`**: Fixed an uninitialized memory bug in `imgid_exists` by zero-initializing the `IMGID` structure. This prevents passing a garbage `mdt` pointer to `_resolveIMGID_impl` which could lead to unpredictable crashes.
- **`image_mk_complex_from_amph.c`**: Switched `ERRMODE_ABORT` to `ERRMODE_WARN` during image resolution, and explicitly added `RETURN_FAILURE` when `imginamp` or `imginpha` resolution fails (`ID == -1`). This prevents `mk_complex_from_amph` from erroneously proceeding (or aborting abruptly) when input streams are missing.

### Engine (`src/engine/libfps`)
- **`IMGID.h`**: Added `img->md = img->im->md` within `imgid_mkimage`. This ensures the metadata pointer inside the `IMGID` struct remains synchronized with the shared memory pointer after creation.
- **`fps_loadmemstream_lite.c`**: Added `__attribute__((visibility("hidden")))` to weak stub implementations (e.g., `file_exists`, `save_fits`, `load_fits`). This prevents the stubs from being exported by the shared library, averting runtime symbol shadowing that overrides the real implementations in `COREMOD_iofits`.

### Plugins (`plugins/milk-extra-src`)
- **FFT (`wisdom.c`, `permut.c`)**: Replaced abrupt `abort()` calls with `return RETURN_FAILURE` during file I/O operations, ensuring that the CLI and calling pipelines can catch and handle the error gracefully without terminating the entire process.
- **Image Generation (`image_gen/CMakeLists.txt`)**: Added `image_gen_complex.c` to the `SOURCEFILES` list, resolving a linker error (`undefined reference to 'image_gen_complex_cli'`).
- **Linear Optics (`linopt_imtools/makeCosRadModes.c`)**: Refactored the intermediate image and output cube creation to use `create_2Dimage_ID` and `create_3Dimage_ID` instead of standard `imgid_make_from_name_XX`. This ensures the created resources are correctly registered into the global image pool and can be referenced by downstream functions using `image_ID()`.

## Verification

- [x] Build passes (`/compile-test`)
- [x] Tested the `coro.cormk2Dprolateld` pipeline and confirmed it no longer segfaults on missing dependencies, but instead fails gracefully with an explicit error message.

## Prompt Summary

The user was debugging runtime `SIGSEGV` crashes in the `cormk2Dprolate` coronagraph pipeline when encountering missing initialization streams like `apostart`. The underlying cause revealed several places across the framework where error handling was insufficient or memory was uninitialized. This PR hardens those initialization boundaries so pipelines can fail gracefully and safely instead of crashing.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None