### PR TITLE
fix: harden stream pipeline error handling and resolve image initialization bugs

### DIFF
--- a/plugins/milk-extra-src/fft/DFT.c
+++ b/plugins/milk-extra-src/fft/DFT.c
@@ -472,6 +472,11 @@ errno_t fft_DFTinsertFPM(const char *pupin_name,
     printf("zfactor = %f\n", zfactor);
 
     IDin            = image_ID(pupin_name, dcimg, dcnimg);
+    if(IDin == -1)
+    {
+        PRINT_ERROR("image %s not found", pupin_name);
+        return RETURN_FAILURE;
+    }
     xsize           = dcimg[IDin].md[0].size[0];
     ysize           = dcimg[IDin].md[0].size[1];
     uint64_t xysize = (uint64_t) xsize;
@@ -530,6 +535,11 @@ errno_t fft_DFTinsertFPM(const char *pupin_name,
         // If amplitude >eps, turn pixel ON, save result in _fpmzmask
         //
         IDfpmz = image_ID(fpmz_name, dcimg, dcnimg);
+        if(IDfpmz == -1)
+        {
+            PRINT_ERROR("image %s not found", fpmz_name);
+            return RETURN_FAILURE;
+        }
         FUNC_CHECK_RETURN(
             create_2Dimage_ID("_fpmzmask", xsize, ysize, &IDfpmz_mask));
 
@@ -756,6 +766,11 @@ errno_t fft_DFTinsertFPM_re(const char *pupin_name,
     imageID ID_DFTmask00;
 
     imageID  IDin   = image_ID(pupin_name, dcimg, dcnimg);
+    if(IDin == -1)
+    {
+        PRINT_ERROR("image %s not found", pupin_name);
+        return RETURN_FAILURE;
+    }
     uint32_t xsize  = dcimg[IDin].md[0].size[0];
     uint32_t ysize  = dcimg[IDin].md[0].size[1];
     uint64_t xysize = xsize;
@@ -794,6 +809,11 @@ errno_t fft_DFTinsertFPM_re(const char *pupin_name,
 
     // ! Why read and re-create ?
     IDfpmz = image_ID(fpmz_name, dcimg, dcnimg);
+    if(IDfpmz == -1)
+    {
+        PRINT_ERROR("image %s not found", fpmz_name);
+        return RETURN_FAILURE;
+    }
     FUNC_CHECK_RETURN(
         create_2Dimage_ID("_fpmzmask", xsize, ysize, &IDfpmz_mask));
 

--- a/plugins/milk-extra-src/fft/dofft.c
+++ b/plugins/milk-extra-src/fft/dofft.c
@@ -375,9 +375,7 @@ imageID FFT_do1dfft(
 
     IMGID imgin =
         imgid_make_from_name(in_name);
-    resolveIMGID(&imgin,
-                 ERRMODE_ABORT,
-                 dcimg, dcnimg);
+    if(resolveIMGID(&imgin, ERRMODE_WARN, dcimg, dcnimg) != RETURN_SUCCESS) { return -1; }
 
     long naxis = imgin.md->naxis;
     uint8_t datatype =
@@ -389,7 +387,7 @@ imageID FFT_do1dfft(
     {
         PRINT_ERROR(
             "malloc returns NULL pointer");
-        abort();
+        return -1;
     }
 
     IMGID imgout =
@@ -539,7 +537,7 @@ imageID FFT_do1dfft(
                     PRINT_ERROR(
                         "malloc returns"
                         " NULL pointer");
-                    abort();
+                    return -1;
                 }
 
                 outptr =
@@ -553,7 +551,7 @@ imageID FFT_do1dfft(
                     PRINT_ERROR(
                         "malloc returns"
                         " NULL pointer");
-                    abort();
+                    return -1;
                 }
 
                 plan =
@@ -605,7 +603,7 @@ imageID FFT_do1dfft(
                     PRINT_ERROR(
                         "malloc returns"
                         " NULL pointer");
-                    abort();
+                    return -1;
                 }
 
                 outptr_double =
@@ -618,7 +616,7 @@ imageID FFT_do1dfft(
                     PRINT_ERROR(
                         "malloc returns"
                         " NULL pointer");
-                    abort();
+                    return -1;
                 }
 
                 plan_double =
@@ -691,9 +689,7 @@ imageID do1drfft(
 
     IMGID imgin =
         imgid_make_from_name(in_name);
-    resolveIMGID(&imgin,
-                 ERRMODE_ABORT,
-                 dcimg, dcnimg);
+    if(resolveIMGID(&imgin, ERRMODE_WARN, dcimg, dcnimg) != RETURN_SUCCESS) { return -1; }
 
     long naxis = imgin.md->naxis;
     uint8_t datatype =
@@ -705,7 +701,7 @@ imageID do1drfft(
     {
         PRINT_ERROR(
             "malloc returns NULL pointer");
-        abort();
+        return -1;
     }
 
     int fftaxis = 0;
@@ -806,7 +802,7 @@ imageID do1drfft(
                     PRINT_ERROR(
                         "malloc returns"
                         " NULL pointer");
-                    abort();
+                    return -1;
                 }
 
                 outptr =
@@ -820,7 +816,7 @@ imageID do1drfft(
                     PRINT_ERROR(
                         "malloc returns"
                         " NULL pointer");
-                    abort();
+                    return -1;
                 }
 
                 plan =
@@ -870,7 +866,7 @@ imageID do1drfft(
                     PRINT_ERROR(
                         "malloc returns"
                         " NULL pointer");
-                    abort();
+                    return -1;
                 }
 
                 outptr_double =
@@ -883,7 +879,7 @@ imageID do1drfft(
                     PRINT_ERROR(
                         "malloc returns"
                         " NULL pointer");
-                    abort();
+                    return -1;
                 }
 
                 plan_double =
@@ -1175,9 +1171,7 @@ imageID FFT_do2dfft(
 
     IMGID imgin =
         imgid_make_from_name(in_name);
-    resolveIMGID(&imgin,
-                 ERRMODE_ABORT,
-                 dcimg, dcnimg);
+    if(resolveIMGID(&imgin, ERRMODE_WARN, dcimg, dcnimg) != RETURN_SUCCESS) { return -1; }
 
     long naxis = imgin.md->naxis;
     uint8_t datatype =
@@ -1189,7 +1183,7 @@ imageID FFT_do2dfft(
     {
         PRINT_ERROR(
             "malloc returns NULL pointer");
-        abort();
+        return -1;
     }
 
     IMGID imgout =
@@ -1519,9 +1513,7 @@ imageID FFT_do2drfft(
 
     IMGID imgin =
         imgid_make_from_name(in_name);
-    resolveIMGID(&imgin,
-                 ERRMODE_ABORT,
-                 dcimg, dcnimg);
+    if(resolveIMGID(&imgin, ERRMODE_WARN, dcimg, dcnimg) != RETURN_SUCCESS) { return -1; }
 
     uint8_t datatype =
         imgin.md->datatype;
@@ -1533,7 +1525,7 @@ imageID FFT_do2drfft(
     {
         PRINT_ERROR(
             "malloc returns NULL pointer");
-        abort();
+        return -1;
     }
 
     uint32_t naxestmp[3];

--- a/src/coremods/COREMOD_memory/image_mk_reim_from_complex.c
+++ b/src/coremods/COREMOD_memory/image_mk_reim_from_complex.c
@@ -191,7 +191,7 @@ errno_t mk_reim_from_complex_IMGID(
     else
     {
         PRINT_ERROR("Wrong image type(s)\n");
-        abort();
+        return RETURN_FAILURE;
     }
 
     DEBUG_TRACE_FEXIT();


### PR DESCRIPTION
## Summary

This PR resolves a set of critical initialization and lifecycle errors across the MILK core memory, engine, and FFT components that could cause `SIGSEGV` runtime crashes in stream processing pipelines. It adds robustness to shared-memory operations, fixes null-pointer dereferences on uninitialized structures, and implements correct error propagation for failed dependencies, replacing implicit `abort()` calls with graceful failures.

## Changes

### Core Memory (`src/coremods/COREMOD_memory`)
- **`imageID.h`**: Fixed an uninitialized memory bug in `imgid_exists` by zero-initializing the `IMGID` structure. This prevents passing a garbage `mdt` pointer to `_resolveIMGID_impl` which could lead to unpredictable crashes.
- **`image_mk_complex_from_amph.c`**: Switched `ERRMODE_ABORT` to `ERRMODE_WARN` during image resolution, and explicitly added `RETURN_FAILURE` when `imginamp` or `imginpha` resolution fails (`ID == -1`). This prevents `mk_complex_from_amph` from erroneously proceeding (or aborting abruptly) when input streams are missing.
- **`image_mk_reim_from_complex.c`**: Replaced an unconditional `abort()` call with a graceful `RETURN_FAILURE` when the wrong image type is detected.

### Engine (`src/engine/libfps`)
- **`IMGID.h`**: Added `img->md = img->im->md` within `imgid_mkimage`. This ensures the metadata pointer inside the `IMGID` struct remains synchronized with the shared memory pointer after creation.
- **`fps_loadmemstream_lite.c`**: Added `__attribute__((visibility("hidden")))` to weak stub implementations (e.g., `file_exists`, `save_fits`, `load_fits`). This prevents the stubs from being exported by the shared library, averting runtime symbol shadowing that overrides the real implementations in `COREMOD_iofits`.

### Plugins (`plugins/milk-extra-src`)
- **FFT (`wisdom.c`, `permut.c`)**: Replaced abrupt `abort()` calls with `return RETURN_FAILURE` during file I/O operations, ensuring that the CLI and calling pipelines can catch and handle the error gracefully without terminating the entire process.
- **Image Generation (`image_gen/CMakeLists.txt`)**: Added `image_gen_complex.c` to the `SOURCEFILES` list, resolving a linker error (`undefined reference to 'image_gen_complex_cli'`).
- **Linear Optics (`linopt_imtools/makeCosRadModes.c`)**: Refactored the intermediate image and output cube creation to use `create_2Dimage_ID` and `create_3Dimage_ID` instead of standard `imgid_make_from_name_XX`. This ensures the created resources are correctly registered into the global image pool and can be referenced by downstream functions using `image_ID()`.

## Verification

- [x] Build passes (`/compile-test`)
- [x] Tested stream pipelines and confirmed they no longer segfault on missing dependencies, but instead fail gracefully with an explicit error message.

## Prompt Summary

The user was debugging runtime `SIGSEGV` crashes in stream pipelines when encountering missing initialization streams. The underlying cause revealed several places across the framework where error handling was insufficient, memory was uninitialized, or the code abruptly aborted. This PR hardens those initialization boundaries so pipelines can fail gracefully and safely instead of crashing.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None