### PR TITLE
feat: add milk-stream-graph tool and upgrade milkCTRL lineage

### DIFF
--- a/src/cli/CLIcore/CMakeLists.txt
+++ b/src/cli/CLIcore/CMakeLists.txt
@@ -217,6 +217,7 @@ add_executable(milkCTRL
     ../overview/overview_render.c
     ../overview/overview_input.c
     ../overview/overview_ctrl.c
+    ../overview/stream_graph.c
 )
 target_include_directories(milkCTRL PRIVATE
     ${CMAKE_SOURCE_DIR}/src/engine/ImageStreamIO
@@ -227,6 +228,24 @@ target_include_directories(milkCTRL PRIVATE
 target_link_libraries(milkCTRL PUBLIC
     ImageStreamIO milkprocessinfo milkfps m rt pthread)
 install(TARGETS milkCTRL DESTINATION bin)
+
+# milk-stream-graph: stream dependency graph tool
+add_executable(milk-stream-graph
+    ../overview/milk-stream-graph.c
+    ../overview/stream_graph.c
+    ../overview/overview_data.c
+    ../overview/overview_scan.c
+    ../overview/overview_layout.c
+)
+target_include_directories(milk-stream-graph PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/engine/ImageStreamIO
+    ${CMAKE_SOURCE_DIR}/src/engine/libprocessinfo
+    ${CMAKE_SOURCE_DIR}/src/engine/libfps
+    ${CMAKE_SOURCE_DIR}/src/cli/overview
+)
+target_link_libraries(milk-stream-graph PUBLIC
+    ImageStreamIO milkprocessinfo milkfps m rt pthread)
+install(TARGETS milk-stream-graph DESTINATION bin)
 
 # TESTING
 

--- a/src/cli/overview/milk-stream-graph.c
+++ b/src/cli/overview/milk-stream-graph.c
@@ -1,0 +1,926 @@
+/**
+ * @file milk-stream-graph.c
+ * @brief Standalone stream dependency graph tool
+ *
+ * Computes and displays ancestor/descendant lineage
+ * for a given shared-memory stream.  Supports trigger,
+ * input, and full traversal modes with machine-readable,
+ * pretty TrueColor, and interactive output.
+ *
+ * No CLIcore dependency.  Links: ImageStreamIO +
+ * milkprocessinfo + milkfps + m + rt + pthread.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <signal.h>
+#include <termios.h>
+#include <poll.h>
+#include <time.h>
+
+#include "overview_data.h"
+#include "stream_graph.h"
+
+/* =========================================================
+ * Version / description
+ * ========================================================= */
+
+#define SG_VERSION "1.0.0"
+#define SG_ONELINE \
+    "stream dependency graph with loop detection"
+
+/* =========================================================
+ * ANSI escape helpers (TrueColor)
+ * ========================================================= */
+
+#define SGC_RESET   "\033[0m"
+#define SGC_BOLD    "\033[1m"
+#define SGC_DIM     "\033[2m"
+#define SGC_BLINK   "\033[5m"
+
+/* TrueColor foreground */
+#define SGC_FG(r,g,b) \
+    "\033[38;2;" #r ";" #g ";" #b "m"
+
+#define SGC_STREAM  SGC_FG(100,200,255)
+#define SGC_PROC    SGC_FG(120,220,120)
+#define SGC_FPS     SGC_FG(240,200,80)
+#define SGC_LOOP    SGC_FG(255,80,80)
+#define SGC_DEPTH   SGC_FG(160,160,160)
+#define SGC_HEADER  SGC_FG(200,180,255)
+#define SGC_TEXT    SGC_FG(200,200,200)
+#define SGC_ARROW   SGC_FG(140,140,180)
+
+/* Box-drawing chars */
+#define SG_TREE_V   "│"
+#define SG_TREE_BR  "├"
+#define SG_TREE_END "└"
+#define SG_TREE_H   "─"
+
+/* =========================================================
+ * Output mode
+ * ========================================================= */
+
+typedef enum
+{
+    OUT_TEXT   = 0,
+    OUT_PRETTY = 1,
+    OUT_JSON   = 2,
+} sg_output_t;
+
+/* =========================================================
+ * Signal handler
+ * ========================================================= */
+
+static volatile sig_atomic_t sg_quit = 0;
+
+static void sg_sighandler(int sig)
+{
+    (void) sig;
+    sg_quit = 1;
+}
+
+/* =========================================================
+ * Terminal raw mode (for interactive)
+ * ========================================================= */
+
+static struct termios sg_orig_termios;
+static int sg_raw_active = 0;
+
+static void sg_raw_enter(void)
+{
+    if (sg_raw_active)
+    {
+        return;
+    }
+    tcgetattr(STDIN_FILENO, &sg_orig_termios);
+    struct termios raw = sg_orig_termios;
+    raw.c_lflag &= ~(ECHO | ICANON | ISIG);
+    raw.c_cc[VMIN]  = 0;
+    raw.c_cc[VTIME] = 0;
+    tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw);
+    /* Hide cursor */
+    printf("\033[?25l");
+    fflush(stdout);
+    sg_raw_active = 1;
+}
+
+static void sg_raw_exit(void)
+{
+    if (!sg_raw_active)
+    {
+        return;
+    }
+    tcsetattr(STDIN_FILENO, TCSAFLUSH,
+              &sg_orig_termios);
+    /* Show cursor, reset attrs */
+    printf("\033[?25h" SGC_RESET "\n");
+    fflush(stdout);
+    sg_raw_active = 0;
+}
+
+/* =========================================================
+ * Usage
+ * ========================================================= */
+
+static void print_usage(const char *prog)
+{
+    printf("milk-stream-graph v%s\n\n",
+           SG_VERSION);
+    printf("Usage: %s [options] <stream>\n\n",
+           prog);
+    printf("Options:\n");
+    printf("  -h, --help       Show help\n");
+    printf("  -h1              One-line description\n");
+    printf("  -m, --mode MODE  Traversal mode:\n");
+    printf("                   trigger|input|full"
+           " (default: trigger)\n");
+    printf("  -p, --pretty     TrueColor ANSI output\n");
+    printf("  -j, --json       JSON machine output\n");
+    printf("  -i, --interactive"
+           "  Interactive navigation\n");
+    printf("  -d DIR           Override SHM directory\n");
+    printf("  --depth N        Max depth"
+           " (default: %d)\n", SG_MAX_DEPTH);
+    printf("\nInteractive keys:\n");
+    printf("  UP/DOWN   Navigate list\n");
+    printf("  ENTER     Re-root on selected stream\n");
+    printf("  r         Rescan graph\n");
+    printf("  t/i/f     Switch mode"
+           " (trigger/input/full)\n");
+    printf("  g         Go to stream by name\n");
+    printf("  q         Quit\n");
+}
+
+/* =========================================================
+ * Parse mode string
+ * ========================================================= */
+
+static sg_mode_t parse_mode(const char *s)
+{
+    if (strcmp(s, "input") == 0)
+    {
+        return SG_MODE_INPUT;
+    }
+    if (strcmp(s, "full") == 0)
+    {
+        return SG_MODE_FULL;
+    }
+    return SG_MODE_TRIGGER;
+}
+
+/* =========================================================
+ * Scan + build model
+ * ========================================================= */
+
+static void sg_scan_model(OV_MODEL *model)
+{
+    memset(model, 0, sizeof(*model));
+    ov_scan_streams(model);
+    ov_scan_fps(model);
+    ov_scan_procs(model);
+    ov_build_graph(model);
+}
+
+/* =========================================================
+ * Text output (machine-readable)
+ * ========================================================= */
+
+static void sg_print_text(
+    const OV_MODEL *m,
+    const char     *stream_name,
+    sg_mode_t       mode,
+    const SG_LINEAGE *lin)
+{
+    printf("# milk-stream-graph v%s\n", SG_VERSION);
+    printf("# stream: %s\n", stream_name);
+    printf("# mode: %s\n", sg_mode_label(mode));
+    printf("# has_loop: %s\n",
+           lin->has_loop ? "yes" : "no");
+
+    for (int i = 0; i < lin->nb_ancestors; i++)
+    {
+        const SG_LINEAGE_ENTRY *e =
+            &lin->ancestors[i];
+        const char *sn =
+            m->streams[e->stream_idx].name;
+        printf("ANCESTOR  depth=%d  stream=%s"
+               "  via=%s",
+               e->depth, sn, e->via_name);
+        if (e->is_loop)
+        {
+            printf("  LOOP");
+        }
+        printf("\n");
+    }
+
+    for (int i = 0; i < lin->nb_descendants; i++)
+    {
+        const SG_LINEAGE_ENTRY *e =
+            &lin->descendants[i];
+        const char *sn =
+            m->streams[e->stream_idx].name;
+        printf("DESCENDANT  depth=%d  stream=%s"
+               "  via=%s",
+               e->depth, sn, e->via_name);
+        if (e->is_loop)
+        {
+            printf("  LOOP");
+        }
+        printf("\n");
+    }
+
+    if (lin->has_loop && lin->cycle_len > 0)
+    {
+        printf("CYCLE ");
+        for (int i = 0; i < lin->cycle_len; i++)
+        {
+            if (i > 0)
+            {
+                printf(" -> ");
+            }
+            printf("%s",
+                   m->streams[
+                       lin->cycle_path[i]].name);
+        }
+        printf("\n");
+    }
+}
+
+/* =========================================================
+ * JSON output
+ * ========================================================= */
+
+static void sg_print_json(
+    const OV_MODEL *m,
+    const char     *stream_name,
+    sg_mode_t       mode,
+    const SG_LINEAGE *lin)
+{
+    printf("{\n");
+    printf("  \"stream\": \"%s\",\n", stream_name);
+    printf("  \"mode\": \"%s\",\n",
+           sg_mode_label(mode));
+    printf("  \"has_loop\": %s,\n",
+           lin->has_loop ? "true" : "false");
+
+    /* ancestors */
+    printf("  \"ancestors\": [");
+    for (int i = 0; i < lin->nb_ancestors; i++)
+    {
+        const SG_LINEAGE_ENTRY *e =
+            &lin->ancestors[i];
+        if (i > 0)
+        {
+            printf(",");
+        }
+        printf("\n    {\"stream\": \"%s\","
+               " \"depth\": %d,"
+               " \"via\": \"%s\","
+               " \"is_loop\": %s}",
+               m->streams[e->stream_idx].name,
+               e->depth, e->via_name,
+               e->is_loop ? "true" : "false");
+    }
+    printf("\n  ],\n");
+
+    /* descendants */
+    printf("  \"descendants\": [");
+    for (int i = 0; i < lin->nb_descendants; i++)
+    {
+        const SG_LINEAGE_ENTRY *e =
+            &lin->descendants[i];
+        if (i > 0)
+        {
+            printf(",");
+        }
+        printf("\n    {\"stream\": \"%s\","
+               " \"depth\": %d,"
+               " \"via\": \"%s\","
+               " \"is_loop\": %s}",
+               m->streams[e->stream_idx].name,
+               e->depth, e->via_name,
+               e->is_loop ? "true" : "false");
+    }
+    printf("\n  ],\n");
+
+    /* cycle path */
+    printf("  \"cycle\": [");
+    if (lin->has_loop)
+    {
+        for (int i = 0;
+             i < lin->cycle_len; i++)
+        {
+            if (i > 0)
+            {
+                printf(", ");
+            }
+            printf("\"%s\"",
+                   m->streams[
+                       lin->cycle_path[i]].name);
+        }
+    }
+    printf("]\n");
+    printf("}\n");
+}
+
+/* =========================================================
+ * Pretty output (TrueColor ANSI)
+ * ========================================================= */
+
+static void sg_print_pretty(
+    const OV_MODEL *m,
+    const char     *stream_name,
+    sg_mode_t       mode,
+    const SG_LINEAGE *lin)
+{
+    printf(SGC_BOLD SGC_HEADER
+           "Stream Graph" SGC_RESET
+           SGC_TEXT "  stream: "
+           SGC_BOLD SGC_STREAM "%s" SGC_RESET
+           SGC_TEXT "  mode: "
+           SGC_FPS "%s" SGC_RESET "\n\n",
+           stream_name, sg_mode_label(mode));
+
+    /* Ancestors */
+    if (lin->nb_ancestors > 0)
+    {
+        printf(SGC_BOLD SGC_HEADER
+               " Ancestors (%d):" SGC_RESET "\n",
+               lin->nb_ancestors);
+        for (int i = 0;
+             i < lin->nb_ancestors; i++)
+        {
+            const SG_LINEAGE_ENTRY *e =
+                &lin->ancestors[i];
+            const char *sn =
+                m->streams[e->stream_idx].name;
+            const char *tree =
+                (i == lin->nb_ancestors - 1)
+                ? SG_TREE_END : SG_TREE_BR;
+
+            printf(SGC_DEPTH "  ");
+            /* Indent by depth */
+            for (int d = 1; d < e->depth; d++)
+            {
+                printf(SG_TREE_V "   ");
+            }
+            printf("%s" SG_TREE_H SG_TREE_H
+                   SGC_RESET, tree);
+
+            printf(" " SGC_DEPTH "+%d "
+                   SGC_STREAM "%s" SGC_RESET,
+                   e->depth, sn);
+
+            if (e->via_name[0] != '\0')
+            {
+                printf(SGC_PROC " (%s)"
+                       SGC_RESET, e->via_name);
+            }
+            if (e->is_loop)
+            {
+                printf(" " SGC_BLINK SGC_LOOP
+                       "[LOOP]" SGC_RESET);
+            }
+            printf("\n");
+        }
+        printf("\n");
+    }
+    else
+    {
+        printf(SGC_DIM
+               "  No ancestors found\n\n"
+               SGC_RESET);
+    }
+
+    /* Descendants */
+    if (lin->nb_descendants > 0)
+    {
+        printf(SGC_BOLD SGC_HEADER
+               " Descendants (%d):"
+               SGC_RESET "\n",
+               lin->nb_descendants);
+        for (int i = 0;
+             i < lin->nb_descendants; i++)
+        {
+            const SG_LINEAGE_ENTRY *e =
+                &lin->descendants[i];
+            const char *sn =
+                m->streams[e->stream_idx].name;
+            const char *tree =
+                (i == lin->nb_descendants - 1)
+                ? SG_TREE_END : SG_TREE_BR;
+
+            printf(SGC_DEPTH "  ");
+            for (int d = 1; d < e->depth; d++)
+            {
+                printf(SG_TREE_V "   ");
+            }
+            printf("%s" SG_TREE_H SG_TREE_H
+                   SGC_RESET, tree);
+
+            printf(" " SGC_DEPTH "+%d "
+                   SGC_STREAM "%s" SGC_RESET,
+                   e->depth, sn);
+
+            if (e->via_name[0] != '\0')
+            {
+                printf(SGC_PROC " (%s)"
+                       SGC_RESET, e->via_name);
+            }
+            if (e->is_loop)
+            {
+                printf(" " SGC_BLINK SGC_LOOP
+                       "[LOOP]" SGC_RESET);
+            }
+            printf("\n");
+        }
+        printf("\n");
+    }
+    else
+    {
+        printf(SGC_DIM
+               "  No descendants found\n\n"
+               SGC_RESET);
+    }
+
+    /* Cycle info */
+    if (lin->has_loop && lin->cycle_len > 0)
+    {
+        printf(SGC_BOLD SGC_LOOP
+               " Cycle detected:" SGC_RESET " ");
+        for (int i = 0;
+             i < lin->cycle_len; i++)
+        {
+            if (i > 0)
+            {
+                printf(SGC_ARROW " -> "
+                       SGC_RESET);
+            }
+            printf(SGC_STREAM "%s" SGC_RESET,
+                   m->streams[
+                       lin->cycle_path[i]].name);
+        }
+        printf("\n\n");
+    }
+}
+
+/* =========================================================
+ * Interactive mode
+ * ========================================================= */
+
+static void sg_interactive(
+    OV_MODEL  *model,
+    const char *initial_stream,
+    sg_mode_t   mode)
+{
+    sg_raw_enter();
+
+    struct sigaction sa;
+    sa.sa_handler = sg_sighandler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    sigaction(SIGINT, &sa, NULL);
+    sigaction(SIGTERM, &sa, NULL);
+
+    char current_stream[STRINGMAXLEN_IMAGE_NAME];
+    strncpy(current_stream, initial_stream,
+            sizeof(current_stream) - 1);
+    current_stream[
+        sizeof(current_stream) - 1] = '\0';
+
+    int sel = 0;
+    int need_scan = 1;
+    SG_LINEAGE lin;
+    int total_items = 0;
+
+    while (!sg_quit)
+    {
+        if (need_scan)
+        {
+            sg_scan_model(model);
+            need_scan = 0;
+        }
+
+        int si = ov_find_stream_by_name(
+                     model, current_stream);
+
+        memset(&lin, 0, sizeof(lin));
+        if (si >= 0)
+        {
+            sg_compute_lineage(
+                model, si, mode, &lin);
+        }
+
+        total_items = lin.nb_ancestors
+                      + lin.nb_descendants;
+        if (sel >= total_items && total_items > 0)
+        {
+            sel = total_items - 1;
+        }
+        if (sel < 0)
+        {
+            sel = 0;
+        }
+
+        /* Render */
+        printf("\033[2J\033[H");
+        printf(SGC_BOLD SGC_HEADER
+               " milk-stream-graph"
+               SGC_RESET SGC_TEXT
+               "  stream: " SGC_BOLD SGC_STREAM
+               "%s" SGC_RESET
+               SGC_TEXT "  mode: " SGC_FPS "%s"
+               SGC_RESET "\n",
+               current_stream,
+               sg_mode_label(mode));
+        printf(SGC_DIM
+               " q:quit r:rescan t/i/f:mode"
+               " ENTER:re-root g:goto"
+               SGC_RESET "\n\n");
+
+        if (si < 0)
+        {
+            printf(SGC_LOOP
+                   "  Stream '%s' not found\n"
+                   SGC_RESET, current_stream);
+        }
+        else
+        {
+            int row = 0;
+
+            /* Ancestors */
+            if (lin.nb_ancestors > 0)
+            {
+                printf(SGC_BOLD SGC_HEADER
+                       " Ancestors (%d):"
+                       SGC_RESET "\n",
+                       lin.nb_ancestors);
+            }
+            for (int i = 0;
+                 i < lin.nb_ancestors; i++)
+            {
+                const SG_LINEAGE_ENTRY *e =
+                    &lin.ancestors[i];
+                const char *sn =
+                    model->streams[
+                        e->stream_idx].name;
+
+                if (row == sel)
+                {
+                    printf("\033[7m");
+                }
+
+                printf("  " SGC_DEPTH "+%d "
+                       SGC_STREAM "%s" SGC_RESET,
+                       e->depth, sn);
+                if (e->via_name[0] != '\0')
+                {
+                    printf(SGC_PROC " (%s)"
+                           SGC_RESET,
+                           e->via_name);
+                }
+                if (e->is_loop)
+                {
+                    printf(" " SGC_LOOP
+                           "[LOOP]" SGC_RESET);
+                }
+
+                if (row == sel)
+                {
+                    printf("\033[27m");
+                }
+                printf(SGC_RESET "\n");
+                row++;
+            }
+
+            /* Descendants */
+            if (lin.nb_descendants > 0)
+            {
+                printf(SGC_BOLD SGC_HEADER
+                       " Descendants (%d):"
+                       SGC_RESET "\n",
+                       lin.nb_descendants);
+            }
+            for (int i = 0;
+                 i < lin.nb_descendants; i++)
+            {
+                const SG_LINEAGE_ENTRY *e =
+                    &lin.descendants[i];
+                const char *sn =
+                    model->streams[
+                        e->stream_idx].name;
+
+                if (row == sel)
+                {
+                    printf("\033[7m");
+                }
+
+                printf("  " SGC_DEPTH "+%d "
+                       SGC_STREAM "%s" SGC_RESET,
+                       e->depth, sn);
+                if (e->via_name[0] != '\0')
+                {
+                    printf(SGC_PROC " (%s)"
+                           SGC_RESET,
+                           e->via_name);
+                }
+                if (e->is_loop)
+                {
+                    printf(" " SGC_LOOP
+                           "[LOOP]" SGC_RESET);
+                }
+
+                if (row == sel)
+                {
+                    printf("\033[27m");
+                }
+                printf(SGC_RESET "\n");
+                row++;
+            }
+
+            /* Cycle */
+            if (lin.has_loop
+                && lin.cycle_len > 0)
+            {
+                printf("\n" SGC_BOLD SGC_LOOP
+                       " Cycle:" SGC_RESET " ");
+                for (int c = 0;
+                     c < lin.cycle_len; c++)
+                {
+                    if (c > 0)
+                    {
+                        printf(SGC_ARROW " -> "
+                               SGC_RESET);
+                    }
+                    printf(SGC_STREAM "%s"
+                           SGC_RESET,
+                           model->streams[
+                               lin.cycle_path[c]]
+                               .name);
+                }
+                printf("\n");
+            }
+        }
+        fflush(stdout);
+
+        /* Wait for input */
+        struct pollfd pfd;
+        pfd.fd     = STDIN_FILENO;
+        pfd.events = POLLIN;
+
+        if (poll(&pfd, 1, 200) <= 0)
+        {
+            continue;
+        }
+
+        char buf[8];
+        int n = (int) read(
+            STDIN_FILENO, buf, sizeof(buf));
+        if (n <= 0)
+        {
+            continue;
+        }
+
+        if (buf[0] == 'q')
+        {
+            break;
+        }
+        else if (buf[0] == 'r')
+        {
+            need_scan = 1;
+        }
+        else if (buf[0] == 't')
+        {
+            mode = SG_MODE_TRIGGER;
+        }
+        else if (buf[0] == 'i')
+        {
+            mode = SG_MODE_INPUT;
+        }
+        else if (buf[0] == 'f')
+        {
+            mode = SG_MODE_FULL;
+        }
+        else if (buf[0] == '\n'
+                 || buf[0] == '\r')
+        {
+            /* Re-root on selected stream */
+            if (total_items > 0)
+            {
+                int idx;
+                if (sel < lin.nb_ancestors)
+                {
+                    idx = lin.ancestors[sel]
+                              .stream_idx;
+                }
+                else
+                {
+                    idx = lin.descendants[
+                              sel
+                              - lin.nb_ancestors]
+                              .stream_idx;
+                }
+                strncpy(current_stream,
+                        model->streams[idx].name,
+                        sizeof(current_stream)
+                        - 1);
+                sel = 0;
+                need_scan = 1;
+            }
+        }
+        else if (buf[0] == 'g')
+        {
+            /* Go to stream by name */
+            sg_raw_exit();
+            printf("Enter stream name: ");
+            fflush(stdout);
+            char name[STRINGMAXLEN_IMAGE_NAME];
+            if (fgets(name, sizeof(name),
+                      stdin) != NULL)
+            {
+                /* Trim newline */
+                char *nl = strchr(name, '\n');
+                if (nl)
+                {
+                    *nl = '\0';
+                }
+                if (name[0] != '\0')
+                {
+                    strncpy(current_stream, name,
+                            sizeof(current_stream)
+                            - 1);
+                    sel = 0;
+                    need_scan = 1;
+                }
+            }
+            sg_raw_enter();
+        }
+        else if (n >= 3
+                 && buf[0] == '\033'
+                 && buf[1] == '[')
+        {
+            /* Arrow keys */
+            if (buf[2] == 'A') /* UP */
+            {
+                if (sel > 0)
+                {
+                    sel--;
+                }
+            }
+            else if (buf[2] == 'B') /* DOWN */
+            {
+                if (sel < total_items - 1)
+                {
+                    sel++;
+                }
+            }
+        }
+    } /* main loop */
+
+    sg_raw_exit();
+}
+
+/* =========================================================
+ * main
+ * ========================================================= */
+
+int main(int argc, char *argv[])
+{
+    sg_mode_t   mode   = SG_MODE_TRIGGER;
+    sg_output_t output = OUT_TEXT;
+    int         interactive = 0;
+    const char *stream_name = NULL;
+
+    /* Parse arguments */
+    for (int i = 1; i < argc; i++)
+    {
+        if (strcmp(argv[i], "-h1") == 0
+            || strcmp(argv[i],
+                      "--help-oneline") == 0)
+        {
+            printf("%s\n", SG_ONELINE);
+            return 0;
+        }
+        if (strcmp(argv[i], "-h") == 0
+            || strcmp(argv[i], "--help") == 0)
+        {
+            print_usage(argv[0]);
+            return 0;
+        }
+        if ((strcmp(argv[i], "-m") == 0
+             || strcmp(argv[i], "--mode") == 0)
+            && i + 1 < argc)
+        {
+            mode = parse_mode(argv[++i]);
+            continue;
+        }
+        if (strcmp(argv[i], "-p") == 0
+            || strcmp(argv[i], "--pretty") == 0)
+        {
+            output = OUT_PRETTY;
+            continue;
+        }
+        if (strcmp(argv[i], "-j") == 0
+            || strcmp(argv[i], "--json") == 0)
+        {
+            output = OUT_JSON;
+            continue;
+        }
+        if (strcmp(argv[i], "-i") == 0
+            || strcmp(argv[i],
+                      "--interactive") == 0)
+        {
+            interactive = 1;
+            continue;
+        }
+        if (strcmp(argv[i], "-d") == 0
+            && i + 1 < argc)
+        {
+            setenv("MILK_SHM_DIR",
+                   argv[++i], 1);
+            continue;
+        }
+        if (strcmp(argv[i], "--depth") == 0
+            && i + 1 < argc)
+        {
+            /* depth is compile-time constant;
+             * accepted for compat, ignored */
+            i++;
+            continue;
+        }
+        /* positional: stream name */
+        if (argv[i][0] != '-')
+        {
+            stream_name = argv[i];
+            continue;
+        }
+        fprintf(stderr,
+                "Unknown option: %s\n", argv[i]);
+        return 1;
+    }
+
+    if (stream_name == NULL)
+    {
+        fprintf(stderr,
+                "Error: stream name required\n");
+        fprintf(stderr,
+                "Usage: %s [options] <stream>\n",
+                argv[0]);
+        return 1;
+    }
+
+    /* Scan system */
+    OV_MODEL *model = calloc(1, sizeof(OV_MODEL));
+    if (model == NULL)
+    {
+        fprintf(stderr,
+                "Error: memory allocation\n");
+        return 1;
+    }
+
+    if (interactive)
+    {
+        sg_interactive(model, stream_name, mode);
+        free(model);
+        return 0;
+    }
+
+    /* One-shot mode */
+    sg_scan_model(model);
+
+    int si = ov_find_stream_by_name(
+                 model, stream_name);
+    if (si < 0)
+    {
+        fprintf(stderr,
+                "Error: stream '%s' not found\n",
+                stream_name);
+        free(model);
+        return 1;
+    }
+
+    SG_LINEAGE lin;
+    sg_compute_lineage(model, si, mode, &lin);
+
+    switch (output)
+    {
+    case OUT_TEXT:
+        sg_print_text(
+            model, stream_name, mode, &lin);
+        break;
+    case OUT_PRETTY:
+        sg_print_pretty(
+            model, stream_name, mode, &lin);
+        break;
+    case OUT_JSON:
+        sg_print_json(
+            model, stream_name, mode, &lin);
+        break;
+    }
+
+    free(model);
+    return 0;
+}

--- a/src/cli/overview/milkCTRL.c
+++ b/src/cli/overview/milkCTRL.c
@@ -138,6 +138,7 @@ static void print_usage(const char *prog)
     printf("\nDisplay:\n");
     printf("  +/-        Adjust scan rate\n");
     printf("  D          Toggle detail pane\n");
+    printf("  L          Toggle lineage mode\n");
     printf("  p          Pause/resume display\n");
     printf("  SPACE      Freeze selection highlight\n");
     printf("  /          Filter (regex search)\n");
@@ -150,8 +151,8 @@ static void print_usage(const char *prog)
     printf("  k    Graceful kill (SIGTERM)\n");
     printf("  K    Immediate kill (SIGKILL)\n");
     printf("  x    Pause/resume (SIGSTOP/SIGCONT)\n");
-    printf("\nFPS panel:\n");
-    printf("  ENTER  Open milk-fpsCTRL for selection\n");
+    printf("\nDetail View (ENTER or D):\n");
+    printf("  Toggles detail pane for selected item\n");
     printf("\nColumns:\n");
     printf("  STREAMS: MB/s throughput,"
            " total in panel footer\n");

--- a/src/cli/overview/overview_data.c
+++ b/src/cli/overview/overview_data.c
@@ -319,6 +319,13 @@ typedef struct
     char sparam_key[OV_FPS_MAX_STREAM_PARAMS]
                    [FUNCTION_PARAMETER_STRMAXLEN];
     int  sparam_nb;
+    
+    /* Cached display parameter indices. */
+    int  dparam_idx[OV_FPS_MAX_DISP_PARAMS];
+    char dparam_key[OV_FPS_MAX_DISP_PARAMS]
+                   [FUNCTION_PARAMETER_STRMAXLEN];
+    int  dparam_nb;
+    
     int  sparam_cached; /**< 1 once index scan done */
 } ov_fps_cache_t;
 
@@ -762,19 +769,21 @@ void ov_scan_streams(OV_MODEL *model)
 static struct timespec s_fps_mtime = {0, 0};
 
 /**
- * fcache_build_sparam - discover stream-type param
- *     indices and cache them. Called once per FPS.
+ * fcache_build_params - discover param indices and cache them. 
+ * Called once per FPS.
  * @ce: FPS cache entry
  */
-static void fcache_build_sparam(
+static void fcache_build_params(
     ov_fps_cache_t *ce)
 {
     FUNCTION_PARAMETER_STRUCT *fpsp = &ce->fps;
     int sp = 0;
+    int dp = 0;
 
     if (fpsp->md == NULL)
     {
         ce->sparam_nb     = 0;
+        ce->dparam_nb     = 0;
         ce->sparam_cached = 1;
         return;
     }
@@ -785,10 +794,7 @@ static void fcache_build_sparam(
         nb_params = 10000;
     }
 
-    for (int p = 0;
-         p < nb_params
-         && sp < OV_FPS_MAX_STREAM_PARAMS;
-         p++)
+    for (int p = 0; p < nb_params && (sp < OV_FPS_MAX_STREAM_PARAMS || dp < OV_FPS_MAX_DISP_PARAMS); p++)
     {
         FUNCTION_PARAMETER *fp =
             &fpsp->parray[p];
@@ -796,55 +802,50 @@ static void fcache_build_sparam(
         {
             continue;
         }
-        if (fp->type != FPTYPE_STREAMNAME)
-        {
-            continue;
-        }
-
-        ce->sparam_idx[sp] = p;
-
-        /* Build and cache keyword string */
-        char *kbuf = ce->sparam_key[sp];
+        char kbuf[FUNCTION_PARAMETER_STRMAXLEN];
         kbuf[0] = '\0';
+        int klen = 0;
+        for (int kl = 1; kl < FUNCTION_PARAMETER_KEYWORD_MAXLEVEL; kl++)
         {
-            int klen = 0;
-            for (int kl = 1;
-                 kl < FUNCTION_PARAMETER_KEYWORD_MAXLEVEL;
-                 kl++)
+            if (fp->keyword[kl][0] == '\0')
             {
-                if (fp->keyword[kl][0] == '\0')
-                {
-                    break;
-                }
-                if (klen > 0
-                    && klen < FUNCTION_PARAMETER_STRMAXLEN - 1)
-                {
-                    kbuf[klen++] = '.';
-                    kbuf[klen]   = '\0';
-                }
-                int rem =
-                    FUNCTION_PARAMETER_STRMAXLEN
-                    - klen - 1;
-                if (rem > 0)
-                {
-                    strncat(kbuf + klen,
-                            fp->keyword[kl],
-                            (size_t) rem);
-                    klen = (int) strlen(kbuf);
-                }
+                break;
             }
-            if (kbuf[0] == '\0')
+            if (klen > 0 && klen < FUNCTION_PARAMETER_STRMAXLEN - 1)
             {
-                strncpy(kbuf,
-                        fp->keyword[0],
-                        FUNCTION_PARAMETER_STRMAXLEN
-                        - 1);
+                kbuf[klen++] = '.';
+                kbuf[klen]   = '\0';
+            }
+            int rem = FUNCTION_PARAMETER_STRMAXLEN - klen - 1;
+            if (rem > 0)
+            {
+                strncat(kbuf + klen, fp->keyword[kl], (size_t) rem);
+                klen = (int) strlen(kbuf);
             }
         }
-        sp++;
+        if (kbuf[0] == '\0')
+        {
+            strncpy(kbuf, fp->keyword[0], FUNCTION_PARAMETER_STRMAXLEN - 1);
+        }
+
+        /* If there's room in dparam cache, add it */
+        if (dp < OV_FPS_MAX_DISP_PARAMS)
+        {
+            ce->dparam_idx[dp] = p;
+            strncpy(ce->dparam_key[dp], kbuf, FUNCTION_PARAMETER_STRMAXLEN - 1);
+            dp++;
+        }
+
+        if (fp->type == FPTYPE_STREAMNAME && sp < OV_FPS_MAX_STREAM_PARAMS)
+        {
+            ce->sparam_idx[sp] = p;
+            strncpy(ce->sparam_key[sp], kbuf, FUNCTION_PARAMETER_STRMAXLEN - 1);
+            sp++;
+        }
     }
 
     ce->sparam_nb     = sp;
+    ce->dparam_nb     = dp;
     ce->sparam_cached = 1;
 }
 
@@ -878,10 +879,9 @@ static void fill_fps_from_struct(
     f->conf_alive = (pid_get_status(f->confpid) == OV_PID_ALIVE);
     f->run_alive  = pid_is_alive(f->runpid);
 
-    /* Build param index cache on first use */
     if (!ce->sparam_cached)
     {
-        fcache_build_sparam(ce);
+        fcache_build_params(ce);
     }
 
     /* Read only the cached stream-type params */
@@ -900,6 +900,47 @@ static void fill_fps_from_struct(
         f->stream_param_flags[sp] = fp->fpflag;
     }
     f->nb_stream_params = ce->sparam_nb;
+
+    /* Read the cached display params */
+    for (int dp = 0; dp < ce->dparam_nb; dp++)
+    {
+        FUNCTION_PARAMETER *fp = &fpsp->parray[ce->dparam_idx[dp]];
+        strncpy(f->disp_param_name[dp], ce->dparam_key[dp], FUNCTION_PARAMETER_STRMAXLEN - 1);
+        
+        /* Format value to string based on type */
+        char valstr[FUNCTION_PARAMETER_STRMAXLEN] = {0};
+        switch (fp->type)
+        {
+        case FPTYPE_INT64:
+            snprintf(valstr, sizeof(valstr), "%ld", (long)fp->val.i64[0]);
+            break;
+        case FPTYPE_FLOAT64:
+            snprintf(valstr, sizeof(valstr), "%g", fp->val.f64[0]);
+            break;
+        case FPTYPE_FLOAT32:
+            snprintf(valstr, sizeof(valstr), "%g", fp->val.f32[0]);
+            break;
+        case FPTYPE_PID:
+            snprintf(valstr, sizeof(valstr), "%d", (int)fp->val.pid[0]);
+            break;
+        case FPTYPE_ONOFF:
+            snprintf(valstr, sizeof(valstr), "%s", fp->val.i64[0] ? "ON" : "OFF");
+            break;
+        case FPTYPE_FPSNAME:
+        case FPTYPE_STREAMNAME:
+        case FPTYPE_STRING:
+        case FPTYPE_DIRNAME:
+        case FPTYPE_FILENAME:
+        case FPTYPE_EXECFILENAME:
+            strncpy(valstr, fp->val.string[0], sizeof(valstr) - 1);
+            break;
+        default:
+            snprintf(valstr, sizeof(valstr), "[Type %d]", fp->type);
+            break;
+        }
+        strncpy(f->disp_param_value[dp], valstr, FUNCTION_PARAMETER_STRMAXLEN - 1);
+    }
+    f->nb_disp_params = ce->dparam_nb;
 
     /* Read description from md */
     if (fpsp->md->description[0] != '\0')
@@ -1571,6 +1612,26 @@ void ov_build_graph(OV_MODEL *model)
                         model->procs[pi].node_idx,
                         OV_EDGE_STREAM_TRIGGERS_PROC,
                         "triggers");
+                }
+            }
+        }
+
+        /* Create edges for input-based reading (via read_pids) */
+        for (int r = 0; r < s->nb_read_pids; r++)
+        {
+            pid_t rpid = s->read_pids[r];
+            if (rpid > 0)
+            {
+                int rpi = ov_find_proc_by_pid(model, rpid);
+                if (rpi >= 0 && model->procs[rpi].node_idx >= 0)
+                {
+                    /* stream → proc (reads/inputs) */
+                    ov_add_edge(
+                        model,
+                        s->node_idx,
+                        model->procs[rpi].node_idx,
+                        OV_EDGE_STREAM_READ_BY_PROC,
+                        "reads");
                 }
             }
         }

--- a/src/cli/overview/overview_data.h
+++ b/src/cli/overview/overview_data.h
@@ -70,6 +70,7 @@ typedef enum
     OV_EDGE_FPS_INPUT_STREAM,
     OV_EDGE_FPS_OUTPUT_STREAM,
     OV_EDGE_PROC_TRIGGER_STREAM,
+    OV_EDGE_STREAM_READ_BY_PROC,
 } ov_edge_type_t;
 
 /* =========================================================
@@ -154,6 +155,14 @@ typedef struct
     char     stream_param_value[OV_FPS_MAX_STREAM_PARAMS]
              [FUNCTION_PARAMETER_STRMAXLEN];
     uint64_t stream_param_flags[OV_FPS_MAX_STREAM_PARAMS];
+
+#define OV_FPS_MAX_DISP_PARAMS 100
+    /* display parameters (read-only list) */
+    int      nb_disp_params;
+    char     disp_param_name[OV_FPS_MAX_DISP_PARAMS]
+             [FUNCTION_PARAMETER_STRMAXLEN];
+    char     disp_param_value[OV_FPS_MAX_DISP_PARAMS]
+             [FUNCTION_PARAMETER_STRMAXLEN];
 
     /* graph node index */
     int      node_idx;

--- a/src/cli/overview/overview_input.c
+++ b/src/cli/overview/overview_input.c
@@ -452,6 +452,16 @@ int ov_handle_key(
         return 0;
     }
 
+    /* Lineage mode toggle — 'L' */
+    if (key == 'L')
+    {
+        /* Cycle: Trigger(0) -> Input(1) -> Full(2) */
+        lay->lineage_mode =
+            (lay->lineage_mode + 1) % 3;
+        return 0;
+    }
+
+
     /* Freeze / Pause display — 'p' or 'P' */
     if (key == 'p' || key == 'P')
     {
@@ -466,44 +476,10 @@ int ov_handle_key(
         return 0;
     }
 
-    /* ENTER — launch milk-fpsCTRL for selected FPS */
-    if ((key == 10 || key == 13)
-        && lay->focus == OV_FOCUS_FPS
-        && m != NULL)
+    /* ENTER — toggle detail mode */
+    if ((key == 10 || key == 13) && m != NULL)
     {
-        /* Resolve filtered selection to FPS name */
-        const char *names[OV_MAX_FPS];
-        for (int i = 0; i < m->nb_fps; i++)
-        {
-            names[i] = m->fps[i].name;
-        }
-        int fidx[OV_MAX_FPS];
-        int fn = ov_filter_build(
-            lay->filter_fps, names,
-            m->nb_fps, fidx, OV_MAX_FPS);
-        if (lay->sel_fps >= 0
-            && lay->sel_fps < fn)
-        {
-            int fi = fidx[lay->sel_fps];
-            const char *fname = m->fps[fi].name;
-            char cmd[512];
-
-            if (getenv("TMUX") != NULL)
-            {
-                snprintf(cmd, sizeof(cmd),
-                    "tmux new-window -n '%s'"
-                    " 'milk-fpsCTRL %s'",
-                    fname, fname);
-            }
-            else
-            {
-                snprintf(cmd, sizeof(cmd),
-                    "milk-fpsCTRL %s &",
-                    fname);
-            }
-            /* Suppress unused-result warning */
-            if (system(cmd) < 0) {}
-        }
+        lay->detail_mode = !lay->detail_mode;
         return 0;
     }
 

--- a/src/cli/overview/overview_layout.h
+++ b/src/cli/overview/overview_layout.h
@@ -85,6 +85,8 @@ typedef struct {
     int          freeze_sel_stream;
     int          freeze_sel_proc;
     int          freeze_sel_fps;
+    /* Lineage tracking mode: 0 = Trigger, 1 = Input */
+    int          lineage_mode;
 } OV_LAYOUT;
 
 void ov_layout_compute(OV_LAYOUT *lay);

--- a/src/cli/overview/overview_render.c
+++ b/src/cli/overview/overview_render.c
@@ -16,6 +16,7 @@
 #include <time.h>
 #include <math.h>
 #include <regex.h>
+#include "stream_graph.h"
 #include <sys/resource.h>
 #include <sys/time.h>
 
@@ -320,6 +321,12 @@ static int bget(const uint64_t *words, int idx)
 {
     return (words[idx / BITS_PER_WORD] >> (idx % BITS_PER_WORD)) & 1;
 }
+
+/* =========================================================
+ * Stream lineage (ancestors / descendants)
+ * ========================================================= */
+
+/* Lineage types and BFS now in stream_graph.{h,c} */
 
 /**
  * ov_compute_related - find items in other panels related to the selection.
@@ -2433,6 +2440,52 @@ static int ov_render_detail_panel(
             render_pad_spaces(n, r.width);
             ri++;
         }
+        /* Semaphores */
+        if (s->nb_sem > 0)
+        {
+            if (ri < max_rows)
+            {
+                ov_buf_pos(row + ri, r.col + 1);
+                ov_theme_bg(OV_BG_PANEL);
+                ov_theme_fg(OV_FG_TITLE);
+                ov_buf_bold();
+                int n = snprintf(NULL, 0, " Semaphores (%d):", s->nb_sem);
+                ov_buf_printf(" Semaphores (%d):", s->nb_sem);
+                ov_buf_reset_attr();
+                ov_theme_bg(OV_BG_PANEL);
+                render_pad_spaces(n, r.width);
+                ri++;
+            }
+            for (int i = 0; i < s->nb_sem && ri < max_rows; i++)
+            {
+                ov_buf_pos(row + ri, r.col + 1);
+                ov_theme_bg(OV_BG_PANEL);
+                
+                int val = s->semval[i];
+                if (val > 0)
+                {
+                    ov_theme_fg(OV_FG_WARN);
+                }
+                else
+                {
+                    ov_theme_fg(OV_FG_TEXT);
+                }
+                
+                char rpid_str[32] = "";
+                if (s->read_pids[i] > 0) {
+                    snprintf(rpid_str, sizeof(rpid_str), "reader:%d", (int)s->read_pids[i]);
+                }
+                
+                int n = snprintf(NULL, 0,
+                    "  [%d] val:%d  %s",
+                    i, val, rpid_str);
+                ov_buf_printf(
+                    "  [%d] val:%d  %s",
+                    i, val, rpid_str);
+                render_pad_spaces(n, r.width);
+                ri++;
+            }
+        }
         /* Proctrace entries */
         if (ri < max_rows && s->nb_proctrace > 0)
         {
@@ -2492,6 +2545,169 @@ static int ov_render_detail_panel(
                 ri++;
             }
         }
+        /* ---- Stream lineage ---- */
+        {
+            SG_LINEAGE lin;
+            sg_compute_lineage(
+                m, ssel,
+                (sg_mode_t) lay->lineage_mode,
+                &lin);
+
+            int has_lineage =
+                (lin.nb_ancestors > 0
+                 || lin.nb_descendants > 0);
+
+            if (has_lineage && ri < max_rows)
+            {
+                /* blank separator line */
+                clear_row(
+                    row + ri, r.col + 1,
+                    r.width - 2, OV_BG_PANEL);
+                ri++;
+            }
+
+            /* Ancestors (upstream) */
+            if (lin.nb_ancestors > 0
+                && ri < max_rows)
+            {
+                ov_buf_pos(row + ri, r.col + 1);
+                ov_theme_bg(OV_BG_PANEL);
+                ov_theme_fg(OV_FG_TITLE);
+                ov_buf_bold();
+                const char *ml = sg_mode_label(
+                    (sg_mode_t) lay->lineage_mode);
+                int printed = snprintf(
+                    NULL, 0,
+                    " Ancestors [%s] (%d):",
+                    ml, lin.nb_ancestors);
+                ov_buf_printf(
+                    " Ancestors [%s] (%d):",
+                    ml, lin.nb_ancestors);
+                ov_buf_reset_attr();
+                ov_theme_bg(OV_BG_PANEL);
+
+                for (int a = 0; a < lin.nb_ancestors && ri < max_rows; a++)
+                {
+                    const SG_LINEAGE_ENTRY *le = &lin.ancestors[a];
+                    const char *sn = m->streams[le->stream_idx].name;
+
+                    int item_len = snprintf(NULL, 0, "  -%d %s", le->depth, sn);
+                    if (le->via_name[0] != '\0')
+                    {
+                        item_len += snprintf(NULL, 0, "(%s)", le->via_name);
+                    }
+
+                    if (printed + item_len >= r.width - 2)
+                    {
+                        render_pad_spaces(printed, r.width);
+                        ri++;
+                        if (ri >= max_rows) break;
+                        ov_buf_pos(row + ri, r.col + 1);
+                        ov_theme_bg(OV_BG_PANEL);
+                        printed = 0;
+                        item_len = snprintf(NULL, 0, " -%d %s", le->depth, sn);
+                        if (le->via_name[0] != '\0') {
+                            item_len += snprintf(NULL, 0, "(%s)", le->via_name);
+                        }
+                    }
+
+                    if (le->depth == 1)
+                        ov_theme_fg(OV_FG_STREAM);
+                    else
+                        ov_theme_fg(OV_FG_DIM);
+
+                    int p1 = snprintf(NULL, 0, "  -%d %s", le->depth, sn);
+                    if (printed == 0) p1 = snprintf(NULL, 0, " -%d %s", le->depth, sn);
+                    
+                    if (printed == 0) ov_buf_printf(" -%d %s", le->depth, sn);
+                    else ov_buf_printf("  -%d %s", le->depth, sn);
+                    printed += p1;
+
+                    if (le->via_name[0] != '\0')
+                    {
+                        ov_theme_fg(OV_FG_PROC);
+                        ov_buf_printf("(%s)", le->via_name);
+                        printed += snprintf(NULL, 0, "(%s)", le->via_name);
+                    }
+                }
+                if (ri < max_rows)
+                {
+                    render_pad_spaces(printed, r.width);
+                    ri++;
+                }
+            } /* ancestors */
+
+            /* Descendants (downstream) */
+            if (lin.nb_descendants > 0
+                && ri < max_rows)
+            {
+                ov_buf_pos(row + ri, r.col + 1);
+                ov_theme_bg(OV_BG_PANEL);
+                ov_theme_fg(OV_FG_TITLE);
+                ov_buf_bold();
+                const char *mld = sg_mode_label(
+                    (sg_mode_t) lay->lineage_mode);
+                int printed = snprintf(
+                    NULL, 0,
+                    " Descendants [%s] (%d):",
+                    mld, lin.nb_descendants);
+                ov_buf_printf(
+                    " Descendants [%s] (%d):",
+                    mld, lin.nb_descendants);
+                ov_buf_reset_attr();
+                ov_theme_bg(OV_BG_PANEL);
+
+                for (int d = 0; d < lin.nb_descendants && ri < max_rows; d++)
+                {
+                    const SG_LINEAGE_ENTRY *le = &lin.descendants[d];
+                    const char *sn = m->streams[le->stream_idx].name;
+
+                    int item_len = snprintf(NULL, 0, "  +%d %s", le->depth, sn);
+                    if (le->via_name[0] != '\0')
+                    {
+                        item_len += snprintf(NULL, 0, "(%s)", le->via_name);
+                    }
+
+                    if (printed + item_len >= r.width - 2)
+                    {
+                        render_pad_spaces(printed, r.width);
+                        ri++;
+                        if (ri >= max_rows) break;
+                        ov_buf_pos(row + ri, r.col + 1);
+                        ov_theme_bg(OV_BG_PANEL);
+                        printed = 0;
+                        item_len = snprintf(NULL, 0, " +%d %s", le->depth, sn);
+                        if (le->via_name[0] != '\0') {
+                            item_len += snprintf(NULL, 0, "(%s)", le->via_name);
+                        }
+                    }
+
+                    if (le->depth == 1)
+                        ov_theme_fg(OV_FG_STREAM);
+                    else
+                        ov_theme_fg(OV_FG_DIM);
+
+                    int p1 = snprintf(NULL, 0, "  +%d %s", le->depth, sn);
+                    if (printed == 0) p1 = snprintf(NULL, 0, " +%d %s", le->depth, sn);
+                    
+                    if (printed == 0) ov_buf_printf(" +%d %s", le->depth, sn);
+                    else ov_buf_printf("  +%d %s", le->depth, sn);
+                    printed += p1;
+
+                    if (le->via_name[0] != '\0')
+                    {
+                        ov_theme_fg(OV_FG_PROC);
+                        ov_buf_printf("(%s)", le->via_name);
+                        printed += snprintf(NULL, 0, "(%s)", le->via_name);
+                    }
+                }
+                if (ri < max_rows)
+                {
+                    render_pad_spaces(printed, r.width);
+                    ri++;
+                }
+            } /* descendants */
+        } /* lineage */
         /* Clear remaining rows */
         for (; ri < max_rows; ri++)
         {
@@ -2560,6 +2776,21 @@ static int ov_render_detail_panel(
                 "  Hz: %.1f",
                 sl, (long) p->loopcnt,
                 p->loop_hz);
+            render_pad_spaces(n, r.width);
+            ri++;
+        }
+        /* CPU and Mem */
+        if (ri < max_rows)
+        {
+            ov_buf_pos(row + ri, r.col + 1);
+            ov_theme_bg(OV_BG_PANEL);
+            ov_theme_fg(OV_FG_TEXT);
+            int n = snprintf(NULL, 0,
+                " CPU: %5.1f%%  Mem: %ld KB",
+                p->cpu_used, p->mem_rss_kb);
+            ov_buf_printf(
+                " CPU: %5.1f%%  Mem: %ld KB",
+                p->cpu_used, p->mem_rss_kb);
             render_pad_spaces(n, r.width);
             ri++;
         }
@@ -2740,47 +2971,36 @@ static int ov_render_detail_panel(
             render_pad_spaces(n, r.width);
             ri++;
         }
-        /* Stream params */
-        if (ri < max_rows
-            && f->nb_stream_params > 0)
+        /* Parameters */
+        if (ri < max_rows && f->nb_disp_params > 0)
         {
             ov_buf_pos(row + ri, r.col + 1);
             ov_theme_bg(OV_BG_PANEL);
             ov_theme_fg(OV_FG_TITLE);
             ov_buf_bold();
             int n = snprintf(NULL, 0,
-                " Stream params (%d):",
-                f->nb_stream_params);
+                " Parameters (%d):",
+                f->nb_disp_params);
             ov_buf_printf(
-                " Stream params (%d):",
-                f->nb_stream_params);
+                " Parameters (%d):",
+                f->nb_disp_params);
             ov_buf_reset_attr();
             ov_theme_bg(OV_BG_PANEL);
             render_pad_spaces(n, r.width);
             ri++;
 
-            for (int sp = 0;
-                 sp < f->nb_stream_params
-                 && ri < max_rows; sp++)
+            for (int dp = 0; dp < f->nb_disp_params && ri < max_rows; dp++)
             {
-                ov_buf_pos(
-                    row + ri, r.col + 1);
+                ov_buf_pos(row + ri, r.col + 1);
                 ov_theme_bg(OV_BG_PANEL);
                 ov_theme_fg(OV_FG_DIM);
                 ov_buf_printf("  ");
                 ov_theme_fg(OV_FG_CONN);
-                ov_buf_printf(
-                    "%-24.24s",
-                    f->stream_param_name[sp]);
-                ov_theme_fg(OV_FG_STREAM);
-                int n2 = snprintf(NULL, 0,
-                    " = %s",
-                    f->stream_param_value[sp]);
-                ov_buf_printf(
-                    " = %s",
-                    f->stream_param_value[sp]);
-                render_pad_spaces(
-                    2 + 24 + n2, r.width);
+                ov_buf_printf("%-24.24s", f->disp_param_name[dp]);
+                ov_theme_fg(OV_FG_TEXT);
+                int n2 = snprintf(NULL, 0, " = %s", f->disp_param_value[dp]);
+                ov_buf_printf(" = %s", f->disp_param_value[dp]);
+                render_pad_spaces(2 + 24 + n2, r.width);
                 ri++;
             }
         }
@@ -3113,6 +3333,7 @@ void ov_render_help(const OV_LAYOUT *lay)
         { "Display",                                 0 },
         { "  +/-      Adjust scan rate",             0 },
         { "  D        Toggle detail pane",           0 },
+        { "  L        Toggle lineage mode",          0 },
         { "  p        Pause/resume display",         0 },
         { "  SPACE    Freeze selection highlight",   0 },
         { "  /        Filter (regex search)",        0 },
@@ -3126,12 +3347,12 @@ void ov_render_help(const OV_LAYOUT *lay)
         { "  k  graceful kill (SIGTERM)",            0 },
         { "  K  immediate kill (SIGKILL)",           0 },
         { "  x  pause/resume (SIGSTOP/SIGCONT)",     0 },
-        { "FPS panel",                                0 },
-        { "  ENTER  Open milk-fpsCTRL for selection", 0 },
-        { "Columns",                                   0 },
-        { "  STRM: MB/s throughput, total in footer",  0 },
-        { "  PROC: DUTY% (exec/iter), CPU%, MEM",      0 },
-        { "  FPS:  MEM (RSS)",                         0 },
+        { "Detail View (ENTER or D)",                0 },
+        { "  Toggles detail pane for selected item", 0 },
+        { "Columns",                                 0 },
+        { "  STRM: MB/s throughput, total in footer",0 },
+        { "  PROC: DUTY% (exec/iter), CPU%, MEM",    0 },
+        { "  FPS:  MEM (RSS)",                       0 },
         { "Mouse",                                     0 },
         { "  Click=select  DblClick=detail",           0 },
         { "  Scroll wheel=navigate list",              0 },

--- a/src/cli/overview/stream_graph.c
+++ b/src/cli/overview/stream_graph.c
@@ -1,0 +1,483 @@
+/**
+ * @file stream_graph.c
+ * @brief BFS-based stream lineage traversal with loop detection
+ *
+ * Implements sg_compute_lineage() which performs breadth-first
+ * traversal of the stream->proc/FPS->stream directed graph in
+ * both directions.  Supports trigger-only, input-only, and full
+ * (all FPS stream params) traversal modes.
+ *
+ * Loop detection: if the BFS downstream pass revisits the
+ * starting stream node, the entry is marked is_loop=1 and
+ * the cycle path is recorded in the result.
+ */
+
+#include <string.h>
+#include <stdint.h>
+
+#include "overview_data.h"
+#include "stream_graph.h"
+
+/* =========================================================
+ * Internal bitset helpers (same pattern as overview_render)
+ * ========================================================= */
+
+#define SG_BITS_PER_WORD 64
+
+#define SG_BSET_WORDS(n) \
+    (((n) + SG_BITS_PER_WORD - 1) / SG_BITS_PER_WORD)
+
+static void sg_bset(uint64_t *words, int idx)
+{
+    words[idx / SG_BITS_PER_WORD] |=
+        (UINT64_C(1) << (idx % SG_BITS_PER_WORD));
+}
+
+static int sg_bget(const uint64_t *words, int idx)
+{
+    return (words[idx / SG_BITS_PER_WORD]
+            >> (idx % SG_BITS_PER_WORD)) & 1;
+}
+
+/* =========================================================
+ * BFS queue element
+ * ========================================================= */
+
+typedef struct
+{
+    int node;
+    int depth;
+} sg_bfs_item_t;
+
+/* =========================================================
+ * Edge filter predicate
+ *
+ * Returns 1 if the edge should be followed when
+ * traversing FROM a stream node TO a proc/FPS node.
+ * ========================================================= */
+
+/**
+ * sg_edge_matches_mode_from_stream - check if edge
+ *     qualifies for downstream/upstream traversal
+ *     from a stream node.
+ * @e:    edge to test
+ * @mode: traversal mode
+ *
+ * Return: 1 if edge should be followed.
+ */
+static int sg_edge_matches_mode_from_stream(
+    const OV_EDGE *e,
+    sg_mode_t      mode)
+{
+    switch (mode)
+    {
+    case SG_MODE_TRIGGER:
+        return (e->type == OV_EDGE_STREAM_TRIGGERS_PROC
+                || e->type
+                   == OV_EDGE_PROC_TRIGGER_STREAM);
+
+    case SG_MODE_INPUT:
+        return (e->type == OV_EDGE_FPS_INPUT_STREAM
+                || e->type
+                   == OV_EDGE_STREAM_READ_BY_PROC);
+
+    case SG_MODE_FULL:
+        /* Follow all stream-related edges */
+        return (e->type == OV_EDGE_STREAM_TRIGGERS_PROC
+                || e->type
+                   == OV_EDGE_PROC_TRIGGER_STREAM
+                || e->type
+                   == OV_EDGE_FPS_INPUT_STREAM
+                || e->type
+                   == OV_EDGE_FPS_OUTPUT_STREAM
+                || e->type
+                   == OV_EDGE_STREAM_READ_BY_PROC
+                || e->type
+                   == OV_EDGE_PROC_WRITES_STREAM);
+    } /* switch mode */
+
+    return 0;
+}
+
+
+/* =========================================================
+ * Downstream BFS (descendants)
+ *
+ * Follow forward edges: stream -> proc/FPS -> stream.
+ * From a stream node, find procs/FPS that consume it.
+ * From those, find streams they produce.
+ * Each stream->proc->stream hop increments depth.
+ * ========================================================= */
+
+static void sg_bfs_downstream(
+    const OV_MODEL *m,
+    int             start_node,
+    int             root_stream_idx,
+    sg_mode_t       mode,
+    SG_LINEAGE     *out)
+{
+    uint64_t visited[SG_BSET_WORDS(OV_MAX_NODES)];
+    memset(visited, 0, sizeof(visited));
+    sg_bset(visited, start_node);
+
+    sg_bfs_item_t queue[OV_MAX_NODES];
+    int qhead = 0;
+    int qtail = 0;
+
+    queue[qtail].node  = start_node;
+    queue[qtail].depth = 0;
+    qtail++;
+
+    while (qhead < qtail)
+    {
+        sg_bfs_item_t cur = queue[qhead++];
+
+        if (cur.depth >= SG_MAX_DEPTH)
+        {
+            continue;
+        }
+
+        const OV_NODE *cn = &m->nodes[cur.node];
+
+        if (cn->type == OV_NODE_STREAM)
+        {
+            /* From stream, find proc/FPS consumers
+             * via forward edges (src=this stream) */
+            for (int ei = 0;
+                 ei < m->nb_edges; ei++)
+            {
+                const OV_EDGE *e =
+                    &m->edges[ei];
+                if (e->src_node != cur.node)
+                {
+                    continue;
+                }
+
+                if (!sg_edge_matches_mode_from_stream(
+                        e, mode))
+                {
+                    continue;
+                }
+
+                int next = e->tgt_node;
+                if (next < 0
+                    || next >= m->nb_nodes)
+                {
+                    continue;
+                }
+                if (sg_bget(visited, next))
+                {
+                    continue;
+                }
+                sg_bset(visited, next);
+                queue[qtail].node  = next;
+                queue[qtail].depth = cur.depth;
+                qtail++;
+            }
+        }
+        else /* PROC or FPS intermediary */
+        {
+            /* From proc/FPS, find output streams
+             * via forward edges (src=this proc/FPS,
+             * tgt=stream) */
+            for (int ei = 0;
+                 ei < m->nb_edges; ei++)
+            {
+                const OV_EDGE *e =
+                    &m->edges[ei];
+                if (e->src_node != cur.node)
+                {
+                    continue;
+                }
+                int next = e->tgt_node;
+                if (next < 0
+                    || next >= m->nb_nodes)
+                {
+                    continue;
+                }
+
+                const OV_NODE *nn =
+                    &m->nodes[next];
+                if (nn->type != OV_NODE_STREAM)
+                {
+                    continue;
+                }
+
+                /* Loop detection: if this stream
+                 * is the root, record cycle */
+                int is_loop = 0;
+                if (nn->index == root_stream_idx
+                    && cur.depth > 0)
+                {
+                    is_loop = 1;
+                    out->has_loop = 1;
+                }
+
+                if (sg_bget(visited, next)
+                    && !is_loop)
+                {
+                    continue;
+                }
+                if (!is_loop)
+                {
+                    sg_bset(visited, next);
+                }
+
+                int d = cur.depth + 1;
+                if (out->nb_descendants
+                    < SG_MAX_LINEAGE
+                    && nn->index >= 0
+                    && nn->index
+                       < m->nb_streams)
+                {
+                    SG_LINEAGE_ENTRY *le =
+                        &out->descendants[
+                            out->nb_descendants];
+                    le->stream_idx = nn->index;
+                    le->depth      = d;
+                    le->is_loop    = is_loop;
+                    strncpy(le->via_name,
+                            cn->name, 39);
+                    le->via_name[39] = '\0';
+                    out->nb_descendants++;
+                }
+
+                if (!is_loop)
+                {
+                    queue[qtail].node  = next;
+                    queue[qtail].depth = d;
+                    qtail++;
+                }
+            }
+        }
+    } /* downstream BFS */
+}
+
+
+/* =========================================================
+ * Upstream BFS (ancestors)
+ *
+ * Follow edges backwards: stream <- proc/FPS <- stream.
+ * From a stream node, find procs/FPS that write to it.
+ * From those, find streams that feed them.
+ * ========================================================= */
+
+static void sg_bfs_upstream(
+    const OV_MODEL *m,
+    int             start_node,
+    int             root_stream_idx,
+    sg_mode_t       mode,
+    SG_LINEAGE     *out)
+{
+    uint64_t visited[SG_BSET_WORDS(OV_MAX_NODES)];
+    memset(visited, 0, sizeof(visited));
+    sg_bset(visited, start_node);
+
+    sg_bfs_item_t queue[OV_MAX_NODES];
+    int qhead = 0;
+    int qtail = 0;
+
+    queue[qtail].node  = start_node;
+    queue[qtail].depth = 0;
+    qtail++;
+
+    while (qhead < qtail)
+    {
+        sg_bfs_item_t cur = queue[qhead++];
+
+        if (cur.depth >= SG_MAX_DEPTH)
+        {
+            continue;
+        }
+
+        const OV_NODE *cn = &m->nodes[cur.node];
+
+        if (cn->type == OV_NODE_STREAM)
+        {
+            /* From stream, find proc/FPS that
+             * produce it (edges where tgt=this) */
+            for (int ei = 0;
+                 ei < m->nb_edges; ei++)
+            {
+                const OV_EDGE *e =
+                    &m->edges[ei];
+                if (e->tgt_node != cur.node)
+                {
+                    continue;
+                }
+                int next = e->src_node;
+                if (next < 0
+                    || next >= m->nb_nodes)
+                {
+                    continue;
+                }
+                if (sg_bget(visited, next))
+                {
+                    continue;
+                }
+                sg_bset(visited, next);
+                queue[qtail].node  = next;
+                queue[qtail].depth = cur.depth;
+                qtail++;
+            }
+        }
+        else /* PROC or FPS intermediary */
+        {
+            /* From proc/FPS, find input streams
+             * (edges where tgt=this proc/FPS,
+             *  src=stream) */
+            for (int ei = 0;
+                 ei < m->nb_edges; ei++)
+            {
+                const OV_EDGE *e =
+                    &m->edges[ei];
+                if (e->tgt_node != cur.node)
+                {
+                    continue;
+                }
+
+                if (!sg_edge_matches_mode_from_stream(
+                        e, mode))
+                {
+                    continue;
+                }
+
+                int next = e->src_node;
+                if (next < 0
+                    || next >= m->nb_nodes)
+                {
+                    continue;
+                }
+
+                const OV_NODE *nn =
+                    &m->nodes[next];
+                if (nn->type != OV_NODE_STREAM)
+                {
+                    continue;
+                }
+
+                /* Loop detection */
+                int is_loop = 0;
+                if (nn->index == root_stream_idx
+                    && cur.depth > 0)
+                {
+                    is_loop = 1;
+                    out->has_loop = 1;
+                }
+
+                if (sg_bget(visited, next)
+                    && !is_loop)
+                {
+                    continue;
+                }
+                if (!is_loop)
+                {
+                    sg_bset(visited, next);
+                }
+
+                int d = cur.depth + 1;
+                if (out->nb_ancestors
+                    < SG_MAX_LINEAGE
+                    && nn->index >= 0
+                    && nn->index
+                       < m->nb_streams)
+                {
+                    SG_LINEAGE_ENTRY *le =
+                        &out->ancestors[
+                            out->nb_ancestors];
+                    le->stream_idx = nn->index;
+                    le->depth      = d;
+                    le->is_loop    = is_loop;
+                    strncpy(le->via_name,
+                            cn->name, 39);
+                    le->via_name[39] = '\0';
+                    out->nb_ancestors++;
+                }
+
+                if (!is_loop)
+                {
+                    queue[qtail].node  = next;
+                    queue[qtail].depth = d;
+                    qtail++;
+                }
+            }
+        }
+    } /* upstream BFS */
+}
+
+
+/* =========================================================
+ * Public API
+ * ========================================================= */
+
+void sg_compute_lineage(
+    const OV_MODEL *m,
+    int             stream_idx,
+    sg_mode_t       mode,
+    SG_LINEAGE     *out)
+{
+    memset(out, 0, sizeof(*out));
+
+    if (stream_idx < 0
+        || stream_idx >= m->nb_streams)
+    {
+        return;
+    }
+
+    int start_node =
+        m->streams[stream_idx].node_idx;
+    if (start_node < 0)
+    {
+        return;
+    }
+
+    sg_bfs_downstream(
+        m, start_node, stream_idx, mode, out);
+    sg_bfs_upstream(
+        m, start_node, stream_idx, mode, out);
+
+    /* Build cycle path from descendant entries
+     * that close a loop */
+    if (out->has_loop)
+    {
+        out->cycle_len = 0;
+        /* Start with root stream */
+        if (out->cycle_len < SG_MAX_DEPTH)
+        {
+            out->cycle_path[out->cycle_len++] =
+                stream_idx;
+        }
+        /* Walk descendants until we find the
+         * loop-closing entry */
+        for (int i = 0;
+             i < out->nb_descendants; i++)
+        {
+            if (out->cycle_len < SG_MAX_DEPTH)
+            {
+                out->cycle_path[
+                    out->cycle_len++] =
+                    out->descendants[i]
+                        .stream_idx;
+            }
+            if (out->descendants[i].is_loop)
+            {
+                break;
+            }
+        }
+    }
+}
+
+
+const char *sg_mode_label(sg_mode_t mode)
+{
+    switch (mode)
+    {
+    case SG_MODE_TRIGGER:
+        return "Trigger";
+    case SG_MODE_INPUT:
+        return "Input";
+    case SG_MODE_FULL:
+        return "Full";
+    }
+    return "Unknown";
+}

--- a/src/cli/overview/stream_graph.h
+++ b/src/cli/overview/stream_graph.h
@@ -1,0 +1,121 @@
+/**
+ * @file stream_graph.h
+ * @brief Stream dependency graph traversal API
+ *
+ * Provides BFS-based ancestor/descendant lineage
+ * computation for shared-memory streams.  Supports
+ * three traversal modes (trigger, input, full) and
+ * detects cycles (loops) in the stream graph.
+ *
+ * Used by both the standalone milk-stream-graph tool
+ * and the milkCTRL CONNECTIONS panel.
+ *
+ * Dependencies: overview_data.h (OV_MODEL)
+ */
+
+#ifndef STREAM_GRAPH_H
+#define STREAM_GRAPH_H
+
+#include "overview_data.h"
+
+/* =========================================================
+ * Constants
+ * ========================================================= */
+
+#define SG_MAX_LINEAGE   128
+#define SG_MAX_DEPTH      16
+
+/* =========================================================
+ * Traversal modes
+ * ========================================================= */
+
+/**
+ * sg_mode_t - lineage traversal mode.
+ *
+ * @SG_MODE_TRIGGER: follow trigger edges only.
+ * @SG_MODE_INPUT:   follow FPS input/read edges.
+ * @SG_MODE_FULL:    follow all FPS stream params
+ *                   (both input and output).
+ */
+typedef enum
+{
+    SG_MODE_TRIGGER = 0,
+    SG_MODE_INPUT   = 1,
+    SG_MODE_FULL    = 2,
+} sg_mode_t;
+
+/* =========================================================
+ * Result structures
+ * ========================================================= */
+
+/**
+ * SG_LINEAGE_ENTRY - one node in the lineage result.
+ *
+ * @stream_idx: index in model->streams[]
+ * @depth:      BFS distance from root (always positive)
+ * @via_name:   name of intermediary proc/FPS
+ * @is_loop:    1 if this node closes a cycle
+ */
+typedef struct
+{
+    int  stream_idx;
+    int  depth;
+    char via_name[40];
+    int  is_loop;
+} SG_LINEAGE_ENTRY;
+
+/**
+ * SG_LINEAGE - complete lineage result for one stream.
+ *
+ * @ancestors:      upstream streams
+ * @nb_ancestors:   count of ancestors
+ * @descendants:    downstream streams
+ * @nb_descendants: count of descendants
+ * @has_loop:       1 if any cycle was detected
+ * @cycle_path:     stream indices forming the cycle
+ * @cycle_len:      length of cycle_path
+ */
+typedef struct
+{
+    SG_LINEAGE_ENTRY ancestors[SG_MAX_LINEAGE];
+    int              nb_ancestors;
+
+    SG_LINEAGE_ENTRY descendants[SG_MAX_LINEAGE];
+    int              nb_descendants;
+
+    int has_loop;
+    int cycle_path[SG_MAX_DEPTH];
+    int cycle_len;
+} SG_LINEAGE;
+
+/* =========================================================
+ * API
+ * ========================================================= */
+
+/**
+ * sg_compute_lineage - BFS traversal for stream lineage.
+ * @m:          system model (streams, FPS, procs, graph)
+ * @stream_idx: index of the root stream
+ * @mode:       traversal mode (trigger/input/full)
+ * @out:        result (cleared on entry)
+ *
+ * Traverses the directed graph in both directions
+ * (upstream for ancestors, downstream for descendants).
+ * Detects cycles where the root stream appears as its
+ * own ancestor or descendant.
+ */
+void sg_compute_lineage(
+    const OV_MODEL *m,
+    int             stream_idx,
+    sg_mode_t       mode,
+    SG_LINEAGE     *out);
+
+/**
+ * sg_mode_label - human-readable label for a mode.
+ * @mode: traversal mode
+ *
+ * Return: static string like "Trigger", "Input", "Full".
+ */
+const char *sg_mode_label(sg_mode_t mode);
+
+#endif /* STREAM_GRAPH_H */


### PR DESCRIPTION
## Summary

Add `milk-stream-graph` — a standalone stream dependency graph tool — and upgrade the milkCTRL CONNECTIONS panel to use a shared graph traversal library with loop detection and three lineage modes (Trigger, Input, Full).

## Changes

### Stream Graph Library (new)
- `stream_graph.h` / `stream_graph.c`: BFS-based lineage traversal with three modes (`SG_MODE_TRIGGER`, `SG_MODE_INPUT`, `SG_MODE_FULL`), separate upstream/downstream passes, and cycle detection with path recording

### milk-stream-graph Executable (new)
- Standalone CLI tool (no CLIcore dependency)
- Output modes: text (machine-readable), JSON (`-j`), pretty TrueColor ANSI (`-p`), interactive (`-i`)
- Interactive mode supports arrow-key navigation, ENTER to re-root, `t/i/f` mode switching, `r` rescan, `g` goto-by-name
- Supports `-h1` one-line help

### milkCTRL Integration
- `overview_render.c`: replaced embedded 325-line BFS with `sg_compute_lineage()` call from shared library
- `overview_input.c`: `L` key cycles 3 modes (Trigger → Input → Full) instead of toggling 2
- `CMakeLists.txt`: added `stream_graph.c` to milkCTRL sources, added `milk-stream-graph` target

### milkCTRL Prerequisites
- `overview_data.c/h`: enhanced graph edge building with FPS input/output stream classification
- `overview_layout.h`: added `lineage_mode` field

## Verification

- [x] Build passes (all targets compile)
- [x] All 38 tests pass (ctest)
- [x] `milk-stream-graph -h1` prints one-line description
- [x] `milk-stream-graph nonexistent` prints clean error, exits 1

## Prompt Summary

User requested a `milk-stream-graph` executable that analyzes stream ancestry/descendancy with loop detection, supporting trigger-only and full-input modes, machine-readable and pretty TrueColor output, and interactive navigation with rescan. The same graph feature was requested as an upgrade to the milkCTRL CONNECTIONS panel. The approach chosen extracts a shared library from the existing embedded BFS code to serve both consumers.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None