### PR TITLE
feat: add SHM entity info diagnostic tools

### DIFF
--- a/src/cli/CLIcore/CMakeLists.txt
+++ b/src/cli/CLIcore/CMakeLists.txt
@@ -250,6 +250,36 @@ target_link_libraries(milk-stream-graph PUBLIC
     ImageStreamIO milkprocessinfo milkfps m rt pthread)
 install(TARGETS milk-stream-graph DESTINATION bin)
 
+# milk-stream-info: detailed stream info with connections
+add_executable(milk-stream-info
+    ../overview/milk-stream-info.c
+    ../overview/overview_data.c
+)
+target_include_directories(milk-stream-info PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/engine/ImageStreamIO
+    ${CMAKE_SOURCE_DIR}/src/engine/libprocessinfo
+    ${CMAKE_SOURCE_DIR}/src/engine/libfps
+    ${CMAKE_SOURCE_DIR}/src/cli/overview
+)
+target_link_libraries(milk-stream-info PUBLIC
+    ImageStreamIO milkprocessinfo milkfps m rt pthread)
+install(TARGETS milk-stream-info DESTINATION bin)
+
+# milk-procinfo-info: detailed processinfo with connections
+add_executable(milk-procinfo-info
+    ../overview/milk-procinfo-info.c
+    ../overview/overview_data.c
+)
+target_include_directories(milk-procinfo-info PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/engine/ImageStreamIO
+    ${CMAKE_SOURCE_DIR}/src/engine/libprocessinfo
+    ${CMAKE_SOURCE_DIR}/src/engine/libfps
+    ${CMAKE_SOURCE_DIR}/src/cli/overview
+)
+target_link_libraries(milk-procinfo-info PUBLIC
+    ImageStreamIO milkprocessinfo milkfps m rt pthread)
+install(TARGETS milk-procinfo-info DESTINATION bin)
+
 # TESTING
 
 include(CTest)

--- a/src/cli/overview/milk-procinfo-info.c
+++ b/src/cli/overview/milk-procinfo-info.c
@@ -1,0 +1,513 @@
+/**
+ * @file milk-procinfo-info.c
+ * @brief Print detailed info for a single processinfo
+ *
+ * Displays process status, timing statistics, trigger
+ * configuration, and cross-referenced connections
+ * (writes, reads, FPS linkage) using the OV_MODEL graph.
+ *
+ * No CLIcore dependency. Links: ImageStreamIO +
+ * milkprocessinfo + milkfps + m + rt + pthread.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <signal.h>
+
+#include "overview_data.h"
+
+/* Required by overview_defs.h (extern) */
+volatile sig_atomic_t ov_sigINT  = 0;
+volatile sig_atomic_t ov_sigTERM = 0;
+
+/* =========================================================
+ * One-line description (for -h1)
+ * ========================================================= */
+
+#define PI_ONELINE \
+    "print detailed info and connections " \
+    "for a processinfo entry"
+
+/* =========================================================
+ * ANSI color helpers
+ * ========================================================= */
+
+#define C_RST    "\033[0m"
+#define C_BOLD   "\033[1m"
+#define C_DIM    "\033[2m"
+#define C_TITLE  "\033[1;36m"
+#define C_HDR    "\033[1;35m"
+#define C_LABEL  "\033[1;34m"
+#define C_NAME   "\033[1;32m"
+#define C_STREAM "\033[1;36m"
+#define C_FPS    "\033[1;33m"
+#define C_VAL    "\033[1;37m"
+#define C_ALIVE  "\033[1;32m"
+#define C_DEAD   "\033[1;31m"
+#define C_WARN   "\033[1;31m"
+#define C_RUN    "\033[1;32m"
+#define C_STOP   "\033[2m"
+
+/* =========================================================
+ * Loop status / CTRL val strings
+ * ========================================================= */
+
+static const char *loopstat_str(int stat)
+{
+    switch (stat)
+    {
+    case 0:
+        return C_STOP "IDLE" C_RST;
+    case 1:
+        return C_RUN "ACTIVE" C_RST;
+    case 2:
+        return C_WARN "ERROR" C_RST;
+    case 3:
+        return C_WARN "CRASHED" C_RST;
+    default:
+        return C_DIM "UNKNOWN" C_RST;
+    }
+}
+
+static const char *ctrlval_str(int val)
+{
+    switch (val)
+    {
+    case 0:
+        return C_STOP "STOP" C_RST;
+    case 1:
+        return C_RUN "RUN" C_RST;
+    case 2:
+        return C_WARN "PAUSE" C_RST;
+    default:
+        return C_DIM "UNKNOWN" C_RST;
+    }
+}
+
+static const char *trigmode_str(int mode)
+{
+    switch (mode)
+    {
+    case 0:
+        return "IMMEDIATE";
+    case 1:
+        return "SEMAPHORE";
+    case 2:
+        return "DELAY";
+    case 3:
+        return "TIMER";
+    default:
+        return "UNKNOWN";
+    }
+}
+
+/* =========================================================
+ * Print the processinfo
+ * ========================================================= */
+
+static void print_proc_info(
+    const OV_MODEL *m,
+    int pi)
+{
+    const OV_PROC *p = &m->procs[pi];
+
+    /* ---- Header ---- */
+    printf(C_TITLE
+           "========================================"
+           "================\n" C_RST);
+    printf(C_LABEL " %-20s" C_RST ": "
+           C_NAME "%s" C_RST "\n",
+           "Process Name", p->name);
+    printf(C_LABEL " %-20s" C_RST ": "
+           C_VAL "%d" C_RST " [%s]\n",
+           "PID", (int) p->PID,
+           (pid_get_status(p->PID)
+               == OV_PID_ALIVE)
+               ? C_ALIVE "ALIVE" C_RST
+               : C_DEAD "DEAD" C_RST);
+    printf(C_TITLE
+           "========================================"
+           "================\n" C_RST);
+
+    /* ---- Status ---- */
+    printf("\n" C_HDR " Status" C_RST "\n");
+    printf("   %-18s: %s\n",
+           "Loop stat",
+           loopstat_str(p->loopstat));
+    printf("   %-18s: %s\n",
+           "CTRL val",
+           ctrlval_str(p->CTRLval));
+    printf("   %-18s: " C_VAL "%ld" C_RST "\n",
+           "Loop count",
+           (long) p->loopcnt);
+    if (p->rt_priority > 0)
+    {
+        printf("   %-18s: " C_VAL "%d" C_RST "\n",
+               "RT priority", p->rt_priority);
+    }
+    if (p->cpu_used > 0.01f)
+    {
+        printf("   %-18s: " C_VAL "%.1f%%"
+               C_RST "\n",
+               "CPU usage", p->cpu_used);
+    }
+    if (p->mem_rss_kb > 0)
+    {
+        printf("   %-18s: " C_VAL "%ld KB"
+               C_RST "\n",
+               "RSS memory", p->mem_rss_kb);
+    }
+
+    /* ---- Timing ---- */
+    printf("\n" C_HDR " Timing" C_RST "\n");
+    if (p->dtmedian_iter_ns > 0)
+    {
+        double iter_us =
+            (double) p->dtmedian_iter_ns / 1e3;
+        printf("   %-18s: " C_VAL "%.1f µs"
+               C_RST "  (%.1f Hz)\n",
+               "Iter (median)", iter_us,
+               p->loop_hz);
+    }
+    else
+    {
+        printf("   %-18s: " C_DIM "N/A" C_RST "\n",
+               "Iter (median)");
+    }
+    if (p->dtmedian_exec_ns > 0)
+    {
+        double exec_us =
+            (double) p->dtmedian_exec_ns / 1e3;
+        double duty = 0.0;
+        if (p->dtmedian_iter_ns > 0)
+        {
+            duty = 100.0
+                   * (double) p->dtmedian_exec_ns
+                   / (double) p->dtmedian_iter_ns;
+        }
+        printf("   %-18s: " C_VAL "%.1f µs"
+               C_RST "  (duty: %.1f%%)\n",
+               "Exec (median)", exec_us, duty);
+    }
+    else
+    {
+        printf("   %-18s: " C_DIM "N/A" C_RST "\n",
+               "Exec (median)");
+    }
+    printf("   %-18s: %s\n",
+           "Measure timing",
+           p->MeasureTiming
+               ? C_ALIVE "ON" C_RST
+               : C_DIM "OFF" C_RST);
+
+    /* ---- Trigger ---- */
+    printf("\n" C_HDR " Trigger" C_RST "\n");
+    printf("   %-18s: " C_VAL "%s (%d)"
+           C_RST "\n",
+           "Mode",
+           trigmode_str(p->triggermode),
+           p->triggermode);
+    if (p->trigstreamname[0] != '\0')
+    {
+        printf("   %-18s: " C_STREAM "%s"
+               C_RST "\n",
+               "Stream", p->trigstreamname);
+    }
+    if (p->triggermode == 1)
+    {
+        printf("   %-18s: " C_VAL "%d"
+               C_RST "\n",
+               "Semaphore", p->triggersem);
+    }
+    printf("   %-18s: " C_VAL "%d" C_RST
+           " (cumul: %lu)\n",
+           "Missed frames",
+           p->triggermissed,
+           (unsigned long)
+               p->triggermissed_cumul);
+
+    /* ---- Connections (from graph) ---- */
+    printf("\n" C_HDR " Connections"
+           C_RST " (from system graph)\n");
+
+    int pni = p->node_idx;
+    if (pni < 0)
+    {
+        printf("   " C_DIM
+               "(process not in graph)"
+               C_RST "\n");
+    }
+    else
+    {
+        int found_any = 0;
+
+        /* Triggered by (stream → proc) */
+        for (int e = 0; e < m->nb_edges; e++)
+        {
+            if (m->edges[e].tgt_node != pni)
+            {
+                continue;
+            }
+            if (m->edges[e].type
+                != OV_EDGE_STREAM_TRIGGERS_PROC
+                && m->edges[e].type
+                != OV_EDGE_PROC_TRIGGER_STREAM)
+            {
+                continue;
+            }
+            int ni = m->edges[e].src_node;
+            if (ni < 0
+                || ni >= m->nb_nodes
+                || m->nodes[ni].type
+                    != OV_NODE_STREAM)
+            {
+                continue;
+            }
+            int si = m->nodes[ni].index;
+            printf("   %-18s: " C_STREAM "%s"
+                   C_RST "\n",
+                   "Triggered by",
+                   m->streams[si].name);
+            found_any = 1;
+        }
+
+        /* Writes (proc → stream) */
+        for (int e = 0; e < m->nb_edges; e++)
+        {
+            if (m->edges[e].src_node != pni)
+            {
+                continue;
+            }
+            if (m->edges[e].type
+                != OV_EDGE_PROC_WRITES_STREAM)
+            {
+                continue;
+            }
+            int ni = m->edges[e].tgt_node;
+            if (ni < 0
+                || ni >= m->nb_nodes
+                || m->nodes[ni].type
+                    != OV_NODE_STREAM)
+            {
+                continue;
+            }
+            int si = m->nodes[ni].index;
+            printf("   %-18s: " C_STREAM "%s"
+                   C_RST "\n",
+                   "Writes",
+                   m->streams[si].name);
+            found_any = 1;
+        }
+
+        /* Reads (stream → proc via sem) */
+        for (int e = 0; e < m->nb_edges; e++)
+        {
+            if (m->edges[e].tgt_node != pni)
+            {
+                continue;
+            }
+            if (m->edges[e].type
+                != OV_EDGE_STREAM_READ_BY_PROC)
+            {
+                continue;
+            }
+            int ni = m->edges[e].src_node;
+            if (ni < 0
+                || ni >= m->nb_nodes
+                || m->nodes[ni].type
+                    != OV_NODE_STREAM)
+            {
+                continue;
+            }
+            int si = m->nodes[ni].index;
+            printf("   %-18s: " C_STREAM "%s"
+                   C_RST "\n",
+                   "Reads (sem)",
+                   m->streams[si].name);
+            found_any = 1;
+        }
+
+        /* Managed by FPS (FPS → proc) */
+        for (int e = 0; e < m->nb_edges; e++)
+        {
+            if (m->edges[e].tgt_node != pni)
+            {
+                continue;
+            }
+            if (m->edges[e].type
+                != OV_EDGE_FPS_RUNS_PROC)
+            {
+                continue;
+            }
+            int ni = m->edges[e].src_node;
+            if (ni < 0
+                || ni >= m->nb_nodes
+                || m->nodes[ni].type
+                    != OV_NODE_FPS)
+            {
+                continue;
+            }
+            int fi = m->nodes[ni].index;
+            printf("   %-18s: " C_FPS "%s"
+                   C_RST "\n",
+                   "Managed by FPS",
+                   m->fps[fi].name);
+            found_any = 1;
+        }
+
+        if (!found_any)
+        {
+            printf("   " C_DIM
+                   "(no connections found)"
+                   C_RST "\n");
+        }
+    }
+
+    printf("\n");
+}
+
+/* =========================================================
+ * Help
+ * ========================================================= */
+
+static void print_help(void)
+{
+    printf(
+        "Usage: milk-procinfo-info [options] "
+        "<process_name | --pid PID>\n\n"
+        "%s\n\n"
+        "Options:\n"
+        "  --pid PID           "
+        "Look up process by PID\n"
+        "  -h, --help          "
+        "Show this help\n"
+        "  -h1, --help-oneline "
+        "Print one-line description\n",
+        PI_ONELINE);
+}
+
+/* =========================================================
+ * Find proc by name in model
+ * ========================================================= */
+
+static int find_proc_by_name(
+    const OV_MODEL *m,
+    const char *name)
+{
+    for (int i = 0; i < m->nb_procs; i++)
+    {
+        if (m->procs[i].valid
+            && strcmp(m->procs[i].name,
+                      name) == 0)
+        {
+            return i;
+        }
+    }
+    return -1;
+}
+
+/* =========================================================
+ * main
+ * ========================================================= */
+
+int main(int argc, char *argv[])
+{
+    /* Handle -h1 before getopt */
+    if (argc >= 2
+        && (strcmp(argv[1], "-h1") == 0
+            || strcmp(argv[1],
+                      "--help-oneline") == 0))
+    {
+        printf("%s\n", PI_ONELINE);
+        return 0;
+    }
+
+    pid_t target_pid = 0;
+
+    static struct option long_opts[] = {
+        {"help", no_argument, 0, 'h'},
+        {"pid",  required_argument, 0, 'p'},
+        {0, 0, 0, 0}
+    };
+
+    int opt;
+    while ((opt = getopt_long(
+                argc, argv, "hp:",
+                long_opts, NULL)) != -1)
+    {
+        switch (opt)
+        {
+        case 'h':
+            print_help();
+            return 0;
+        case 'p':
+            target_pid = (pid_t) atoi(optarg);
+            break;
+        default:
+            print_help();
+            return 1;
+        }
+    }
+
+    const char *proc_name = NULL;
+    if (optind < argc)
+    {
+        proc_name = argv[optind];
+    }
+
+    if (target_pid <= 0 && proc_name == NULL)
+    {
+        fprintf(stderr,
+                "Error: process name or "
+                "--pid required\n\n");
+        print_help();
+        return 1;
+    }
+
+    /* Build the system model */
+    OV_MODEL model;
+    memset(&model, 0, sizeof(model));
+    ov_model_full_scan(&model);
+
+    /* Find the requested process */
+    int pi = -1;
+    if (target_pid > 0)
+    {
+        pi = ov_find_proc_by_pid(
+                 &model, target_pid);
+    }
+    else
+    {
+        pi = find_proc_by_name(
+                 &model, proc_name);
+    }
+
+    if (pi < 0)
+    {
+        if (target_pid > 0)
+        {
+            fprintf(stderr,
+                    C_WARN "Error:" C_RST
+                    " process with PID %d "
+                    "not found\n",
+                    (int) target_pid);
+        }
+        else
+        {
+            fprintf(stderr,
+                    C_WARN "Error:" C_RST
+                    " process '%s' not found"
+                    "\n", proc_name);
+        }
+        ov_scan_cache_cleanup();
+        return 1;
+    }
+
+    print_proc_info(&model, pi);
+
+    ov_scan_cache_cleanup();
+    return 0;
+}

--- a/src/cli/overview/milk-stream-info.c
+++ b/src/cli/overview/milk-stream-info.c
@@ -1,0 +1,569 @@
+/**
+ * @file milk-stream-info.c
+ * @brief Print detailed info for a single SHM stream
+ *
+ * Displays stream metadata (type, dimensions, counters,
+ * semaphores) and cross-referenced connections (written
+ * by, triggers, read by, FPS linkage) using the
+ * OV_MODEL graph.
+ *
+ * No CLIcore dependency. Links: ImageStreamIO +
+ * milkprocessinfo + milkfps + m + rt + pthread.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <signal.h>
+
+#include "overview_data.h"
+
+/* Required by overview_defs.h (extern) */
+volatile sig_atomic_t ov_sigINT  = 0;
+volatile sig_atomic_t ov_sigTERM = 0;
+
+/* =========================================================
+ * One-line description (for -h1)
+ * ========================================================= */
+
+#define SI_ONELINE \
+    "print detailed info and connections " \
+    "for a shared-memory stream"
+
+/* =========================================================
+ * ANSI color helpers
+ * ========================================================= */
+
+#define C_RST    "\033[0m"
+#define C_BOLD   "\033[1m"
+#define C_DIM    "\033[2m"
+#define C_TITLE  "\033[1;36m"
+#define C_HDR    "\033[1;35m"
+#define C_LABEL  "\033[1;34m"
+#define C_NAME   "\033[1;32m"
+#define C_PROC   "\033[1;33m"
+#define C_FPS    "\033[1;33m"
+#define C_VAL    "\033[1;37m"
+#define C_ALIVE  "\033[1;32m"
+#define C_DEAD   "\033[1;31m"
+#define C_WARN   "\033[1;31m"
+#define C_SEP    "\033[36m"
+
+/* =========================================================
+ * Datatype name helper
+ * ========================================================= */
+
+static const char *dtype_name(uint8_t dt)
+{
+    switch (dt)
+    {
+    case _DATATYPE_UINT8:
+        return "UINT8";
+    case _DATATYPE_INT8:
+        return "INT8";
+    case _DATATYPE_UINT16:
+        return "UINT16";
+    case _DATATYPE_INT16:
+        return "INT16";
+    case _DATATYPE_UINT32:
+        return "UINT32";
+    case _DATATYPE_INT32:
+        return "INT32";
+    case _DATATYPE_UINT64:
+        return "UINT64";
+    case _DATATYPE_INT64:
+        return "INT64";
+    case _DATATYPE_FLOAT:
+        return "FLOAT";
+    case _DATATYPE_DOUBLE:
+        return "DOUBLE";
+    case _DATATYPE_COMPLEX_FLOAT:
+        return "COMPLEX_FLOAT";
+    case _DATATYPE_COMPLEX_DOUBLE:
+        return "COMPLEX_DOUBLE";
+    default:
+        return "UNKNOWN";
+    }
+}
+
+static unsigned int dtype_bytes(uint8_t dt)
+{
+    switch (dt)
+    {
+    case _DATATYPE_UINT8:
+    case _DATATYPE_INT8:
+        return 1;
+    case _DATATYPE_UINT16:
+    case _DATATYPE_INT16:
+        return 2;
+    case _DATATYPE_UINT32:
+    case _DATATYPE_INT32:
+    case _DATATYPE_FLOAT:
+        return 4;
+    case _DATATYPE_UINT64:
+    case _DATATYPE_INT64:
+    case _DATATYPE_DOUBLE:
+    case _DATATYPE_COMPLEX_FLOAT:
+        return 8;
+    case _DATATYPE_COMPLEX_DOUBLE:
+        return 16;
+    default:
+        return 0;
+    }
+}
+
+/* =========================================================
+ * PID status string
+ * ========================================================= */
+
+static const char *pid_status_str(pid_t pid)
+{
+    if (pid <= 0)
+    {
+        return C_DIM "N/A" C_RST;
+    }
+    ov_pid_status_t st = pid_get_status(pid);
+    switch (st)
+    {
+    case OV_PID_ALIVE:
+        return C_ALIVE "ALIVE" C_RST;
+    case OV_PID_ZOMBIE:
+        return C_WARN "ZOMBIE" C_RST;
+    default:
+        return C_DEAD "DEAD" C_RST;
+    }
+}
+
+/* =========================================================
+ * Find process name from model by PID
+ * ========================================================= */
+
+static const char *proc_name_by_pid(
+    const OV_MODEL *m,
+    pid_t pid)
+{
+    int pi = ov_find_proc_by_pid(m, pid);
+    if (pi >= 0)
+    {
+        return m->procs[pi].name;
+    }
+    return NULL;
+}
+
+/* =========================================================
+ * Print the stream info
+ * ========================================================= */
+
+static void print_stream_info(
+    const OV_MODEL *m,
+    int si)
+{
+    const OV_STREAM *s = &m->streams[si];
+
+    /* ---- Header ---- */
+    printf(C_TITLE
+           "========================================"
+           "================\n" C_RST);
+    printf(C_LABEL " %-20s" C_RST ": "
+           C_NAME "%s" C_RST "\n",
+           "Stream Name", s->name);
+    printf(C_LABEL " %-20s" C_RST ": "
+           C_VAL "%s (%d)" C_RST "\n",
+           "Data Type",
+           dtype_name(s->datatype),
+           s->datatype);
+
+    /* Dimensions */
+    {
+        char dimstr[64];
+        if (s->naxis == 1)
+        {
+            snprintf(dimstr, sizeof(dimstr),
+                     "1D  %u",
+                     (unsigned) s->size[0]);
+        }
+        else if (s->naxis == 2)
+        {
+            snprintf(dimstr, sizeof(dimstr),
+                     "2D  %u x %u",
+                     (unsigned) s->size[0],
+                     (unsigned) s->size[1]);
+        }
+        else
+        {
+            snprintf(dimstr, sizeof(dimstr),
+                     "3D  %u x %u x %u",
+                     (unsigned) s->size[0],
+                     (unsigned) s->size[1],
+                     (unsigned) s->size[2]);
+        }
+        printf(C_LABEL " %-20s" C_RST ": "
+               C_VAL "%s" C_RST "\n",
+               "Dimensions", dimstr);
+    }
+
+    printf(C_LABEL " %-20s" C_RST ": "
+           C_VAL "%lu" C_RST "\n",
+           "Elements",
+           (unsigned long) s->nelement);
+
+    {
+        unsigned long bytes =
+            (unsigned long) s->nelement
+            * dtype_bytes(s->datatype);
+        printf(C_LABEL " %-20s" C_RST ": "
+               C_VAL "%lu bytes" C_RST "\n",
+               "Memory", bytes);
+    }
+
+    printf(C_LABEL " %-20s" C_RST ": "
+           C_VAL "%lu" C_RST "\n",
+           "Inode",
+           (unsigned long) s->inode);
+    printf(C_TITLE
+           "========================================"
+           "================\n" C_RST);
+
+    /* ---- Ownership ---- */
+    printf("\n" C_HDR " Ownership" C_RST "\n");
+    {
+        const char *cname =
+            proc_name_by_pid(m, s->creatorPID);
+        printf("   %-18s: " C_PROC "%d" C_RST,
+               "Creator PID",
+               (int) s->creatorPID);
+        if (cname)
+        {
+            printf(" (%s)", cname);
+        }
+        printf(" [%s]\n",
+               pid_status_str(s->creatorPID));
+    }
+    {
+        const char *oname =
+            proc_name_by_pid(m, s->ownerPID);
+        printf("   %-18s: " C_PROC "%d" C_RST,
+               "Owner PID",
+               (int) s->ownerPID);
+        if (oname)
+        {
+            printf(" (%s)", oname);
+        }
+        printf(" [%s]\n",
+               pid_status_str(s->ownerPID));
+    }
+
+    /* ---- Counters ---- */
+    printf("\n" C_HDR " Counters" C_RST "\n");
+    printf("   %-18s: " C_VAL "%lu" C_RST "\n",
+           "cnt0",
+           (unsigned long) s->cnt0);
+    if (s->update_hz > 0.01)
+    {
+        printf("   %-18s: " C_VAL "%.1f Hz"
+               C_RST "\n",
+               "Update rate", s->update_hz);
+    }
+
+    /* ---- Semaphores ---- */
+    printf("\n" C_HDR " Semaphores" C_RST
+           " (%d active)\n", s->nb_sem);
+    if (s->nb_sem > 0)
+    {
+        printf("   ");
+        for (int i = 0; i < s->nb_sem; i++)
+        {
+            printf("[%d]=%d  ", i, s->semval[i]);
+        }
+        printf("\n");
+    }
+
+    /* ---- Connections (from graph) ---- */
+    printf("\n" C_HDR " Connections"
+           C_RST " (from system graph)\n");
+
+    int sni = s->node_idx;
+    if (sni < 0)
+    {
+        printf("   " C_DIM
+               "(stream not in graph)"
+               C_RST "\n");
+    }
+    else
+    {
+        int found_any = 0;
+
+        /* Written by (PROC → stream) */
+        for (int e = 0; e < m->nb_edges; e++)
+        {
+            if (m->edges[e].tgt_node != sni)
+            {
+                continue;
+            }
+            if (m->edges[e].type
+                != OV_EDGE_PROC_WRITES_STREAM)
+            {
+                continue;
+            }
+            int ni = m->edges[e].src_node;
+            if (ni < 0
+                || ni >= m->nb_nodes
+                || m->nodes[ni].type
+                    != OV_NODE_PROC)
+            {
+                continue;
+            }
+            int pi = m->nodes[ni].index;
+            printf("   %-18s: " C_PROC "%s"
+                   C_RST " (PID %d)\n",
+                   "Written by",
+                   m->procs[pi].name,
+                   (int) m->procs[pi].PID);
+            found_any = 1;
+        }
+
+        /* Triggers (stream → PROC) */
+        for (int e = 0; e < m->nb_edges; e++)
+        {
+            if (m->edges[e].src_node != sni)
+            {
+                continue;
+            }
+            if (m->edges[e].type
+                != OV_EDGE_STREAM_TRIGGERS_PROC
+                && m->edges[e].type
+                != OV_EDGE_PROC_TRIGGER_STREAM)
+            {
+                continue;
+            }
+            int ni = m->edges[e].tgt_node;
+            if (ni < 0
+                || ni >= m->nb_nodes
+                || m->nodes[ni].type
+                    != OV_NODE_PROC)
+            {
+                continue;
+            }
+            int pi = m->nodes[ni].index;
+            printf("   %-18s: " C_PROC "%s"
+                   C_RST " (PID %d)\n",
+                   "Triggers",
+                   m->procs[pi].name,
+                   (int) m->procs[pi].PID);
+            found_any = 1;
+        }
+
+        /* Read by (stream → PROC via sem) */
+        for (int e = 0; e < m->nb_edges; e++)
+        {
+            if (m->edges[e].src_node != sni)
+            {
+                continue;
+            }
+            if (m->edges[e].type
+                != OV_EDGE_STREAM_READ_BY_PROC)
+            {
+                continue;
+            }
+            int ni = m->edges[e].tgt_node;
+            if (ni < 0
+                || ni >= m->nb_nodes
+                || m->nodes[ni].type
+                    != OV_NODE_PROC)
+            {
+                continue;
+            }
+            int pi = m->nodes[ni].index;
+            printf("   %-18s: " C_PROC "%s"
+                   C_RST " (PID %d)\n",
+                   "Read by (sem)",
+                   m->procs[pi].name,
+                   (int) m->procs[pi].PID);
+            found_any = 1;
+        }
+
+        /* FPS input to (stream → FPS) */
+        for (int e = 0; e < m->nb_edges; e++)
+        {
+            if (m->edges[e].src_node != sni)
+            {
+                continue;
+            }
+            if (m->edges[e].type
+                != OV_EDGE_FPS_INPUT_STREAM)
+            {
+                continue;
+            }
+            int ni = m->edges[e].tgt_node;
+            if (ni < 0
+                || ni >= m->nb_nodes
+                || m->nodes[ni].type
+                    != OV_NODE_FPS)
+            {
+                continue;
+            }
+            int fi = m->nodes[ni].index;
+            printf("   %-18s: " C_FPS "%s"
+                   C_RST "\n",
+                   "FPS input to",
+                   m->fps[fi].name);
+            found_any = 1;
+        }
+
+        /* FPS output of (FPS → stream) */
+        for (int e = 0; e < m->nb_edges; e++)
+        {
+            if (m->edges[e].tgt_node != sni)
+            {
+                continue;
+            }
+            if (m->edges[e].type
+                != OV_EDGE_FPS_OUTPUT_STREAM)
+            {
+                continue;
+            }
+            int ni = m->edges[e].src_node;
+            if (ni < 0
+                || ni >= m->nb_nodes
+                || m->nodes[ni].type
+                    != OV_NODE_FPS)
+            {
+                continue;
+            }
+            int fi = m->nodes[ni].index;
+            printf("   %-18s: " C_FPS "%s"
+                   C_RST "\n",
+                   "FPS output of",
+                   m->fps[fi].name);
+            found_any = 1;
+        }
+
+        if (!found_any)
+        {
+            printf("   " C_DIM
+                   "(no connections found)"
+                   C_RST "\n");
+        }
+    }
+
+    /* ---- Process trace ---- */
+    if (s->nb_proctrace > 0)
+    {
+        printf("\n" C_HDR " Process Trace"
+               C_RST " (STREAM_PROC_TRACE)\n");
+        for (int t = 0;
+             t < s->nb_proctrace; t++)
+        {
+            const char *pn =
+                proc_name_by_pid(
+                    m, s->proctrace_pid[t]);
+            printf("   [%d] PID=%-6d"
+                   "  trig_inode=%-8lu"
+                   "  mode=%d",
+                   t,
+                   (int) s->proctrace_pid[t],
+                   (unsigned long)
+                       s->proctrace_inode[t],
+                   s->proctrace_trigmode[t]);
+            if (pn)
+            {
+                printf("  (%s)", pn);
+            }
+            printf("\n");
+        }
+    }
+
+    printf("\n");
+}
+
+/* =========================================================
+ * Help
+ * ========================================================= */
+
+static void print_help(void)
+{
+    printf(
+        "Usage: milk-stream-info [options] "
+        "<stream_name>\n\n"
+        "%s\n\n"
+        "Options:\n"
+        "  -h, --help          "
+        "Show this help\n"
+        "  -h1, --help-oneline "
+        "Print one-line description\n",
+        SI_ONELINE);
+}
+
+/* =========================================================
+ * main
+ * ========================================================= */
+
+int main(int argc, char *argv[])
+{
+    /* Handle -h1 before getopt */
+    if (argc >= 2
+        && (strcmp(argv[1], "-h1") == 0
+            || strcmp(argv[1],
+                      "--help-oneline") == 0))
+    {
+        printf("%s\n", SI_ONELINE);
+        return 0;
+    }
+
+    static struct option long_opts[] = {
+        {"help", no_argument, 0, 'h'},
+        {0, 0, 0, 0}
+    };
+
+    int opt;
+    while ((opt = getopt_long(
+                argc, argv, "h",
+                long_opts, NULL)) != -1)
+    {
+        switch (opt)
+        {
+        case 'h':
+            print_help();
+            return 0;
+        default:
+            print_help();
+            return 1;
+        }
+    }
+
+    if (optind >= argc)
+    {
+        fprintf(stderr,
+                "Error: stream name required\n\n");
+        print_help();
+        return 1;
+    }
+
+    const char *stream_name = argv[optind];
+
+    /* Build the system model */
+    OV_MODEL model;
+    memset(&model, 0, sizeof(model));
+    ov_model_full_scan(&model);
+
+    /* Find the requested stream */
+    int si = ov_find_stream_by_name(
+                 &model, stream_name);
+    if (si < 0)
+    {
+        fprintf(stderr,
+                C_WARN "Error:" C_RST
+                " stream '%s' not found "
+                "in shared memory\n",
+                stream_name);
+        ov_scan_cache_cleanup();
+        return 1;
+    }
+
+    print_stream_info(&model, si);
+
+    ov_scan_cache_cleanup();
+    return 0;
+}

--- a/src/engine/libfps/CMakeLists.txt
+++ b/src/engine/libfps/CMakeLists.txt
@@ -243,11 +243,21 @@ target_link_libraries(milk-fps-search PUBLIC
 )
 install(TARGETS milk-fps-search DESTINATION bin)
 
-add_executable(milk-fps-info milk-fps-info.c)
-target_link_libraries(milk-fps-info PUBLIC 
+add_executable(milk-fps-info
+    milk-fps-info.c
+    ${CMAKE_SOURCE_DIR}/src/cli/overview/overview_data.c
+)
+target_compile_definitions(milk-fps-info PRIVATE
+    FPS_INFO_CONNECTIONS)
+target_include_directories(milk-fps-info PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/engine/ImageStreamIO
+    ${CMAKE_SOURCE_DIR}/src/engine/libprocessinfo
+    ${CMAKE_SOURCE_DIR}/src/cli/overview
+)
+target_link_libraries(milk-fps-info PUBLIC
     milkfpsStandalone
-    pthread
-    m
+    ImageStreamIO milkprocessinfo
+    pthread m rt
 )
 install(TARGETS milk-fps-info DESTINATION bin)
 

--- a/src/engine/libfps/milk-fps-info.c
+++ b/src/engine/libfps/milk-fps-info.c
@@ -1,6 +1,10 @@
 /**
  * @file milk-fps-info.c
- * @brief Milk fps info module
+ * @brief Print content and connections of an FPS entry
+ *
+ * Shows FPS header, parameter table, and optionally
+ * cross-referenced connections (run process, input/output
+ * streams) using the OV_MODEL graph.
  */
 
 #include <stdio.h>
@@ -8,69 +12,269 @@
 #include <unistd.h>
 #include <string.h>
 #include <getopt.h>
+#include <signal.h>
 
 #include "fps.h"
 #include "fps_globals.h"
 #include "fps_scan.h"
 #include "fps_printparameter_valuestring.h"
 
-void print_help(const char *progname) {
-    printf("Usage: %s [options] <fpsname>\n", progname);
-    printf("Print content of a Function Parameter Structure (FPS).\n");
+#ifdef FPS_INFO_CONNECTIONS
+#include "overview_data.h"
+/* Required by overview_defs.h (extern) */
+volatile sig_atomic_t ov_sigINT  = 0;
+volatile sig_atomic_t ov_sigTERM = 0;
+#endif
+
+/* =========================================================
+ * ANSI helpers for connection display
+ * ========================================================= */
+
+#define CI_RST    "\033[0m"
+#define CI_HDR    "\033[1;35m"
+#define CI_LABEL  "\033[1;34m"
+#define CI_STREAM "\033[1;36m"
+#define CI_PROC   "\033[1;33m"
+#define CI_DIM    "\033[2m"
+
+/* =========================================================
+ * Connection display (requires OV_MODEL)
+ * ========================================================= */
+
+#ifdef FPS_INFO_CONNECTIONS
+static void print_connections(const char *fpsname)
+{
+    OV_MODEL model;
+    memset(&model, 0, sizeof(model));
+    ov_model_full_scan(&model);
+
+    /* Find our FPS in the model */
+    int fi = -1;
+    for (int i = 0; i < model.nb_fps; i++)
+    {
+        if (model.fps[i].valid
+            && strcmp(model.fps[i].name,
+                      fpsname) == 0)
+        {
+            fi = i;
+            break;
+        }
+    }
+
+    if (fi < 0)
+    {
+        printf("\n" CI_HDR " Connections" CI_RST
+               CI_DIM
+               " (FPS not found in graph)"
+               CI_RST "\n\n");
+        ov_scan_cache_cleanup();
+        return;
+    }
+
+    int fni = model.fps[fi].node_idx;
+    if (fni < 0)
+    {
+        printf("\n" CI_HDR " Connections" CI_RST
+               CI_DIM
+               " (FPS not in graph)"
+               CI_RST "\n\n");
+        ov_scan_cache_cleanup();
+        return;
+    }
+
+    printf("\n" CI_HDR " Connections" CI_RST
+           " (from system graph)\n");
+
+    int found_any = 0;
+
+    /* FPS → process (runs) */
+    for (int e = 0; e < model.nb_edges; e++)
+    {
+        if (model.edges[e].src_node != fni)
+        {
+            continue;
+        }
+        if (model.edges[e].type
+            != OV_EDGE_FPS_RUNS_PROC)
+        {
+            continue;
+        }
+        int ni = model.edges[e].tgt_node;
+        if (ni < 0
+            || ni >= model.nb_nodes
+            || model.nodes[ni].type
+                != OV_NODE_PROC)
+        {
+            continue;
+        }
+        int pi = model.nodes[ni].index;
+        printf("   %-18s: " CI_PROC "%s"
+               CI_RST " (PID %d)\n",
+               "Runs process",
+               model.procs[pi].name,
+               (int) model.procs[pi].PID);
+        found_any = 1;
+    }
+
+    /* stream → FPS (input) */
+    for (int e = 0; e < model.nb_edges; e++)
+    {
+        if (model.edges[e].tgt_node != fni)
+        {
+            continue;
+        }
+        if (model.edges[e].type
+            != OV_EDGE_FPS_INPUT_STREAM)
+        {
+            continue;
+        }
+        int ni = model.edges[e].src_node;
+        if (ni < 0
+            || ni >= model.nb_nodes
+            || model.nodes[ni].type
+                != OV_NODE_STREAM)
+        {
+            continue;
+        }
+        int si = model.nodes[ni].index;
+        printf("   %-18s: " CI_STREAM "%s"
+               CI_RST "\n",
+               "Input stream",
+               model.streams[si].name);
+        found_any = 1;
+    }
+
+    /* FPS → stream (output) */
+    for (int e = 0; e < model.nb_edges; e++)
+    {
+        if (model.edges[e].src_node != fni)
+        {
+            continue;
+        }
+        if (model.edges[e].type
+            != OV_EDGE_FPS_OUTPUT_STREAM)
+        {
+            continue;
+        }
+        int ni = model.edges[e].tgt_node;
+        if (ni < 0
+            || ni >= model.nb_nodes
+            || model.nodes[ni].type
+                != OV_NODE_STREAM)
+        {
+            continue;
+        }
+        int si = model.nodes[ni].index;
+        printf("   %-18s: " CI_STREAM "%s"
+               CI_RST "\n",
+               "Output stream",
+               model.streams[si].name);
+        found_any = 1;
+    }
+
+    if (!found_any)
+    {
+        printf("   " CI_DIM
+               "(no connections found)"
+               CI_RST "\n");
+    }
+
     printf("\n");
-    printf("Options:\n");
-    printf("  -v, --verbose        Verbose mode\n");
-    printf("  -i, --info           Show detailed stream information on separate line\n");
-    printf("  -h, --help           Show this help message\n");
-    printf("  -h1, --help-oneline  Print one-line description and exit\n");
+    ov_scan_cache_cleanup();
 }
+#endif /* FPS_INFO_CONNECTIONS */
+
+/* =========================================================
+ * Help
+ * ========================================================= */
+
+static void print_help(const char *progname)
+{
+    printf("Usage: %s [options] <fpsname>\n",
+           progname);
+    printf("Print content of a Function "
+           "Parameter Structure (FPS).\n");
+    printf("\nOptions:\n");
+    printf("  -v, --verbose        "
+           "Verbose mode\n");
+    printf("  -i, --info           "
+           "Show stream info on "
+           "separate line\n");
+#ifdef FPS_INFO_CONNECTIONS
+    printf("  -c, --connections    "
+           "Show graph connections\n");
+#endif
+    printf("  -h, --help           "
+           "Show this help message\n");
+    printf("  -h1, --help-oneline  "
+           "Print one-line description "
+           "and exit\n");
+}
+
+/* =========================================================
+ * main
+ * ========================================================= */
 
 int main(int argc, char *argv[])
 {
-    /* Handle -h1/--help-oneline before getopt so "-h1" is not
-     * parsed as "-h" (flag) + "1" (unknown). */
-    if (argc >= 2 &&
-        (strcmp(argv[1], "-h1") == 0 ||
-         strcmp(argv[1], "--help-oneline") == 0))
+    /* Handle -h1/--help-oneline */
+    if (argc >= 2
+        && (strcmp(argv[1], "-h1") == 0
+            || strcmp(argv[1],
+                      "--help-oneline") == 0))
     {
-        printf("print content of a Function Parameter Structure (FPS)\\n");
+        printf("print content of a Function "
+               "Parameter Structure (FPS)\n");
         return 0;
     }
 
     int verbose = 0;
     int show_info = 0;
+    int show_connections = 0;
     int opt;
 
     static struct option long_options[] = {
         {"verbose",      no_argument, 0, 'v'},
         {"info",         no_argument, 0, 'i'},
+        {"connections",  no_argument, 0, 'c'},
         {"help",         no_argument, 0, 'h'},
         {"help-oneline", no_argument, 0, '1'},
         {0, 0, 0, 0}
     };
 
-    while ((opt = getopt_long(argc, argv, "vih1", long_options, NULL)) != -1) {
-        switch (opt) {
-            case 'v':
-                verbose = 1;
-                break;
-            case 'i':
-                show_info = 1;
-                break;
-            case 'h':
-                print_help(argv[0]);
-                return 0;
-            case '1':
-                printf("print content of a Function Parameter Structure (FPS)\n");
-                return 0;
-            default:
-                print_help(argv[0]);
-                return 1;
+    while ((opt = getopt_long(
+                argc, argv, "vich1",
+                long_options, NULL)) != -1)
+    {
+        switch (opt)
+        {
+        case 'v':
+            verbose = 1;
+            break;
+        case 'i':
+            show_info = 1;
+            break;
+        case 'c':
+            show_connections = 1;
+            break;
+        case 'h':
+            print_help(argv[0]);
+            return 0;
+        case '1':
+            printf("print content of a "
+                   "Function Parameter "
+                   "Structure (FPS)\n");
+            return 0;
+        default:
+            print_help(argv[0]);
+            return 1;
         }
     }
 
-    if (optind >= argc) {
-        fprintf(stderr, "Error: missing FPS name.\n");
+    if (optind >= argc)
+    {
+        fprintf(stderr,
+                "Error: missing FPS name.\n");
         print_help(argv[0]);
         return 1;
     }
@@ -80,14 +284,32 @@ int main(int argc, char *argv[])
     FPS fps;
     fps.SMfd = -1;
 
-    if (fps_connect(fpsname, &fps, 0) == -1) {
-        fprintf(stderr, "Error: cannot connect to FPS '%s'.\n", fpsname);
+    if (fps_connect(fpsname, &fps, 0) == -1)
+    {
+        fprintf(stderr,
+                "Error: cannot connect "
+                "to FPS '%s'.\n", fpsname);
         return 1;
     }
 
-    function_parameter_print_info(&fps, verbose, show_info);
+    function_parameter_print_info(
+        &fps, verbose, show_info);
 
     fps_disconnect(&fps);
+
+#ifdef FPS_INFO_CONNECTIONS
+    if (show_connections)
+    {
+        print_connections(fpsname);
+    }
+#else
+    if (show_connections)
+    {
+        fprintf(stderr,
+                "Warning: --connections not "
+                "available in this build\n");
+    }
+#endif
 
     return 0;
 }


### PR DESCRIPTION
## Summary

Add three standalone diagnostic CLI tools for inspecting shared-memory entities with graph-based connection lineage, using the `OV_MODEL` infrastructure.

## Changes

### New Tools (`src/cli/overview/`)
- **`milk-stream-info <name>`** — Prints stream metadata (type, dimensions, counters, semaphores, ownership) and graph connections (written-by, triggers, read-by, FPS input/output linkage)
- **`milk-procinfo-info <name|--pid PID>`** — Prints process status, timing/duty cycle, trigger configuration, and graph connections (writes, reads, FPS management)

### Enhanced Tool (`src/engine/libfps/`)
- **`milk-fps-info -c <name>`** — New `--connections` / `-c` flag displays graph connections (run process, input/output streams) alongside the existing parameter table. Compiled with `FPS_INFO_CONNECTIONS` define for graceful degradation.

### Build System
- `src/cli/CLIcore/CMakeLists.txt` — Added targets for `milk-stream-info` and `milk-procinfo-info`
- `src/engine/libfps/CMakeLists.txt` — Updated `milk-fps-info` target with `overview_data.c`, connection compile flag, and extra link dependencies

## Verification

- [x] Build passes (all 3 targets compile clean)
- [x] `-h1` one-line help works for all 3 tools
- [x] `-h` full help works for all 3 tools
- [x] Error handling tested (missing stream/process → clean error + exit 1)
- [x] Live testing with `cam01` stream and `pb*` FPS entries

## Prompt Summary

User requested standalone executables to print terminal-friendly summaries of SHM stream, processinfo, and FPS entries, including connection lineage (read-by, written-by, triggers). A common naming pattern (`milk-{entity}-info`) was agreed on, and the `OV_MODEL` graph infrastructure was chosen for consistent cross-entity connection resolution.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None