### PR TITLE
refactor: modularize procCTRL TUI rendering and logic

### DIFF
--- a/src/engine/libprocessinfo/CMakeLists.txt
+++ b/src/engine/libprocessinfo/CMakeLists.txt
@@ -111,6 +111,8 @@ add_executable(milk-procCTRL
     procCTRL/procCTRL_PIDcollectSystemInfo.c
     procCTRL/procCTRL_processinfo_scan.c
     procCTRL/procCTRL_TUI.c
+    procCTRL/procCTRL_TUI_render.c
+    procCTRL/procCTRL_TUI_input.c
     procCTRL/procCTRL_TUI_sort.c
     procCTRL/procCTRL_TUIcompat.c
 )

--- a/src/engine/libprocessinfo/procCTRL/procCTRL_TUI.c
+++ b/src/engine/libprocessinfo/procCTRL/procCTRL_TUI.c
@@ -67,7 +67,7 @@ static char local_shmdir[STRINGMAXLEN_DIRNAME];
 int procCTRL_debug_mode = 0;
 char procCTRL_logfile[1024] = "";
 
-static short unsigned int wrow, wcol;
+short unsigned int wrow, wcol;
 
 extern PROCESSINFOLIST *pinfolist;
 
@@ -156,37 +156,7 @@ static inline void *link_scan_shm(const char *name, size_t size) {
     return ptr;
 }
 
-#include <sys/resource.h>
-
-typedef struct {
-    PROCINFOPROC *procinfoproc;
-    PROCSCAN_SHM *scan_shm;
-    FILE *flog;
-    char procdname[STRINGMAXLEN_DIRNAME];
-    float frequ;
-    int pindexSelected;
-    int pindexActiveSelected;
-    long doffsetindex;
-    int freeze;
-    int loopOK;
-    int Xexit;
-    char monstring[200];
-    int monstringlen;
-    int last_ch;
-    float tool_cpu_pcnt;
-    float actual_fps;
-    
-    struct timespec t_last_scan;
-    struct timespec t_now;
-    struct rusage usage_prev;
-    struct rusage usage_cur;
-    struct timespec t_usage_prev;
-    struct timespec t_usage_cur;
-    struct timespec t_disp_prev;
-    struct timespec t_disp_cur;
-} procctrl_context_t;
-
-static void procctrl_render_frame(procctrl_context_t *ctx, int NBactive);
+#include "procCTRL_TUI_internal.h"
 
 static void procctrl_update_stats(procctrl_context_t *ctx) {
     clock_gettime(CLOCK_MONOTONIC, &ctx->t_now);
@@ -211,639 +181,16 @@ static void procctrl_update_stats(procctrl_context_t *ctx) {
     ctx->t_disp_prev = ctx->t_disp_cur;
 }
 
-static void procctrl_handle_keyboard_event(procctrl_context_t *ctx, int ch, int NBactive) {
-    ctx->last_ch = ch;
-    if (ctx->flog) {
-        char tbuf[64];
-        struct timespec ts;
-        clock_gettime(CLOCK_REALTIME, &ts);
-        struct tm *tm_info = gmtime(&ts.tv_sec);
-        size_t len = strftime(tbuf, sizeof(tbuf), "%Y%m%dT%H:%M:%S", tm_info);
-        snprintf(tbuf + len, sizeof(tbuf) - len, ".%06ld", ts.tv_nsec / 1000);
-        fprintf(ctx->flog, "%s Input: %d\\n", tbuf, ch);
-        fflush(ctx->flog);
-    }
-
-    if (ch == 545 || ch == 560 || ch == 443 || ch == 564 || ch == 554) {
-         ctx->procinfoproc->DisplayMode--;
-         if (ctx->procinfoproc->DisplayMode < 1) ctx->procinfoproc->DisplayMode = 6;
-         if (ctx->flog) { fprintf(ctx->flog, "  -> Mode changed to %d\\n", ctx->procinfoproc->DisplayMode); fflush(ctx->flog); }
-    }
-    else if (ch == 561 || ch == 566 || ch == 444 || ch == 565 || ch == 569) {
-         ctx->procinfoproc->DisplayMode++;
-         if (ctx->procinfoproc->DisplayMode > 6) ctx->procinfoproc->DisplayMode = 1;
-         if (ctx->flog) { fprintf(ctx->flog, "  -> Mode changed to %d\\n", ctx->procinfoproc->DisplayMode); fflush(ctx->flog); }
-    }
-    else if (ch >= '0' && ch <= '9') {
-         int cidx = ch - '0';
-         int m = ctx->procinfoproc->DisplayMode;
-         if (m >= 0 && m < 10)
-             ctx->procinfoproc->col_visible[m][cidx] = !ctx->procinfoproc->col_visible[m][cidx];
-    }
-    else if (ch == ANSI_KEY_F2) ctx->procinfoproc->DisplayMode = PROCCTRL_DISPLAYMODE_CTRL;
-    else if (ch == ANSI_KEY_F3) ctx->procinfoproc->DisplayMode = PROCCTRL_DISPLAYMODE_RESOURCES;
-    else if (ch == ANSI_KEY_F4) ctx->procinfoproc->DisplayMode = PROCCTRL_DISPLAYMODE_TRIGGER;
-    else if (ch == ANSI_KEY_F5) ctx->procinfoproc->DisplayMode = PROCCTRL_DISPLAYMODE_TIMING;
-    else if (ch == ANSI_KEY_F6) ctx->procinfoproc->DisplayMode = PROCCTRL_DISPLAYMODE_PROCINFO;
-    else if (ch == 'h')      ctx->procinfoproc->DisplayMode = PROCCTRL_DISPLAYMODE_HELP;
-    else if (ch == ANSI_KEY_CTRL_LEFT) {
-        ctx->procinfoproc->DisplayMode--;
-        if(ctx->procinfoproc->DisplayMode < 1) ctx->procinfoproc->DisplayMode = 6;
-    }
-    else if (ch == ANSI_KEY_CTRL_RIGHT) {
-        ctx->procinfoproc->DisplayMode++;
-        if(ctx->procinfoproc->DisplayMode > 6) ctx->procinfoproc->DisplayMode = 1;
-    }
-    else if (ch == 'x' || ch == 3) { ctx->loopOK = 0; ctx->Xexit = 1; }
-    else if (ch == 'f') { ctx->freeze = !ctx->freeze; }
-    else if (ch == '+' || ch == '=') { ctx->frequ *= 1.2; if (ctx->frequ > 1000.0) ctx->frequ = 1000.0; }
-    else if (ch == '-') { ctx->frequ /= 1.2; if (ctx->frequ < 0.1) ctx->frequ = 0.1; }
-    else if (ch == ' ' && ctx->pindexSelected >= 0) {
-         ctx->procinfoproc->selectedarray[ctx->pindexSelected] = !ctx->procinfoproc->selectedarray[ctx->pindexSelected];
-    }
-    else if (ch == ANSI_KEY_UP && NBactive > 0) {
-         ctx->pindexActiveSelected--; if (ctx->pindexActiveSelected < 0) ctx->pindexActiveSelected = 0;
-    }
-    else if (ch == ANSI_KEY_DOWN && NBactive > 0) {
-         ctx->pindexActiveSelected++; if (ctx->pindexActiveSelected >= NBactive) ctx->pindexActiveSelected = NBactive - 1;
-    }
-    else if (ch == ANSI_KEY_LEFT) {
-         ctx->procinfoproc->selected_col--;
-         if (ctx->procinfoproc->selected_col < 1) ctx->procinfoproc->selected_col = 9;
-    }
-    else if (ch == ANSI_KEY_RIGHT) {
-         ctx->procinfoproc->selected_col++;
-         if (ctx->procinfoproc->selected_col > 9) ctx->procinfoproc->selected_col = 1;
-    }
-    else if (ch == 'r' || ch == 'R') {
-        int all = (ch == 'R');
-        for(int i=0; i<PROCESSINFOLISTSIZE; i++) {
-            if (all || i == ctx->pindexSelected) {
-                if (pinfolist->active[i] == 2 || pinfolist->active[i] == 3) pinfolist->active[i] = 0;
-            }
-        }
-    }
-    else if ((ch == 'T' || ch == 'K' || ch == 'I') && NBactive > 0) {
-        int sig = (ch == 'T') ? SIGTERM : (ch == 'K') ? SIGKILL : SIGINT;
-        int any_sel = 0;
-        for(int i=0; i<PROCESSINFOLISTSIZE; i++) if(ctx->procinfoproc->selectedarray[i]) {
-            kill(pinfolist->PIDarray[i], sig);
-            any_sel = 1;
-        }
-        if(!any_sel && ctx->pindexSelected >= 0) kill(pinfolist->PIDarray[ctx->pindexSelected], sig);
-    }
-    else if (ch == 's') {
-         int m = ctx->procinfoproc->DisplayMode;
-         ctx->procinfoproc->sort_mode[m] = m;
-         if (ctx->procinfoproc->sort_col[m] == ctx->procinfoproc->selected_col) {
-             ctx->procinfoproc->sort_dir[m] = !ctx->procinfoproc->sort_dir[m];
-         } else {
-             ctx->procinfoproc->sort_col[m] = ctx->procinfoproc->selected_col;
-             ctx->procinfoproc->sort_dir[m] = 0;
-         }
-    }
-    else if (ch == 'S') {
-         int m_curr = ctx->procinfoproc->DisplayMode;
-         int smod = ctx->procinfoproc->sort_mode[m_curr];
-         int scol = ctx->procinfoproc->sort_col[m_curr];
-         int sdir = ctx->procinfoproc->sort_dir[m_curr];
-         for(int m=0; m<10; m++) {
-             ctx->procinfoproc->sort_mode[m] = smod;
-             ctx->procinfoproc->sort_col[m] = scol;
-             ctx->procinfoproc->sort_dir[m] = sdir;
-         }
-    }
-    else if ((ch == 'p' || ch == 19 || ch == 'e') && NBactive > 0) {
-        int val = (ch == 'p') ? -1 : (ch == 19) ? 2 : 3;
-        int any_sel = 0;
-        for(int i=0; i<PROCESSINFOLISTSIZE; i++) if(ctx->procinfoproc->selectedarray[i]) {
-            if (val == -1 && ctx->procinfoproc->pinfoarray[i]) ctx->procinfoproc->pinfoarray[i]->CTRLval = (ctx->procinfoproc->pinfoarray[i]->CTRLval == 0) ? 1 : 0;
-            else if (ctx->procinfoproc->pinfoarray[i]) ctx->procinfoproc->pinfoarray[i]->CTRLval = val;
-            any_sel = 1;
-        }
-        if(!any_sel && ctx->pindexSelected >= 0 && ctx->procinfoproc->pinfoarray[ctx->pindexSelected]) {
-            if (val == -1) ctx->procinfoproc->pinfoarray[ctx->pindexSelected]->CTRLval = (ctx->procinfoproc->pinfoarray[ctx->pindexSelected]->CTRLval == 0) ? 1 : 0;
-            else ctx->procinfoproc->pinfoarray[ctx->pindexSelected]->CTRLval = val;
-        }
-    }
-    else if ((ch == 'z' || ch == 'Z') && NBactive > 0) {
-        int all = (ch == 'Z');
-        for(int i=0; i<PROCESSINFOLISTSIZE; i++) if((all || ctx->procinfoproc->selectedarray[i]) && ctx->procinfoproc->pinfoarray[i]) {
-            ctx->procinfoproc->pinfoarray[i]->loopcnt = 0;
-        }
-        if(!all && !ctx->procinfoproc->selectedarray[ctx->pindexSelected] && ctx->pindexSelected >= 0 && ctx->procinfoproc->pinfoarray[ctx->pindexSelected]) {
-            ctx->procinfoproc->pinfoarray[ctx->pindexSelected]->loopcnt = 0;
-        }
-    }
-}
-
-
-
-static void procctrl_render_frame(procctrl_context_t *ctx, int NBactive) {
-    int m = ctx->procinfoproc->DisplayMode;
-    int pindexSelected = ctx->pindexSelected;
-    int pindexActiveSelected = ctx->pindexActiveSelected;
-        if (ctx->freeze == 0) {
-            sc_frame_clear();
-            TUI_clearscreen(&wrow, &wcol);
-            snprintf(ctx->monstring, ctx->monstringlen, "Mode %d   PRESS x TO STOP MONITOR", ctx->procinfoproc->DisplayMode);
-            TUI_print_header(ctx->monstring, '-');
-            TUI_newline();
-            
-            {
-                struct stat shm_stat;
-                char shm_list_fname[STRINGMAXLEN_FULLFILENAME];
-                WRITE_FULLFILENAME(shm_list_fname, "%s/processinfo.list.shm", ctx->procdname);
-                if(stat(shm_list_fname, &shm_stat) == 0) {
-                    char timestr[100];
-                    struct tm *tm_info = gmtime(&shm_stat.st_mtime);
-                    strftime(timestr, 100, "%Y-%m-%d %H:%M:%S", tm_info);
-                    TUI_printfw("List: %-25s (Upd: %s)  ToolCPU: %5.2f%% (%4.1f fps)", shm_list_fname, timestr, ctx->tool_cpu_pcnt, ctx->actual_fps);
-                    if (ctx->flog) TUI_printfw(" K:%d", ctx->last_ch);
-                    TUI_newline();
-                }
-            }
-            
-            if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_HELP) screenprint_setcolor(2);
-            TUI_printfw("[h] Help");
-            if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_HELP) screenprint_unsetcolor(2);
-            TUI_printfw("   ");
-
-            if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_CTRL) screenprint_setcolor(2);
-            TUI_printfw("[F2] CTRL");
-            if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_CTRL) screenprint_unsetcolor(2);
-            TUI_printfw("   ");
-
-            if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_RESOURCES) screenprint_setcolor(2);
-            TUI_printfw("[F3] Resources");
-            if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_RESOURCES) screenprint_unsetcolor(2);
-            TUI_printfw("   ");
-
-            if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_TRIGGER) screenprint_setcolor(2);
-            TUI_printfw("[F4] Triggering");
-            if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_TRIGGER) screenprint_unsetcolor(2);
-            TUI_printfw("   ");
-
-            if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_TIMING) screenprint_setcolor(2);
-            TUI_printfw("[F5] Timing");
-            if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_TIMING) screenprint_unsetcolor(2);
-            TUI_printfw("   ");
-
-            if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_PROCINFO) screenprint_setcolor(2);
-            TUI_printfw("[F6] PROCINFO");
-            if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_PROCINFO) screenprint_unsetcolor(2);
-            TUI_newline();
-
-            // Column visibility status line
-            {
-                const char *colnames[10] = {NULL};
-                int nbcol = 0;
-                switch(ctx->procinfoproc->DisplayMode) {
-                    case PROCCTRL_DISPLAYMODE_CTRL:
-                        {
-                            static const char *names[] = {"", "idx", "status", "pid", "tstart", "pname", "state", "lcnt", "msg", ""};
-                            for(int i=0; i<10; i++) colnames[i] = names[i];
-                            nbcol = 8;
-                        }
-                        break;
-                    case PROCCTRL_DISPLAYMODE_RESOURCES:
-                        {
-                            static const char *names[] = {"", "idx", "status", "pid", "pname", "prio", "cpu", "mem", "thr", ""};
-                            for(int i=0; i<10; i++) colnames[i] = names[i];
-                            nbcol = 8;
-                        }
-                        break;
-                    case PROCCTRL_DISPLAYMODE_TRIGGER:
-                        {
-                            static const char *names[] = {"", "idx", "status", "pid", "pname", "tmode", "tstream", "tsem", "tcnt", "tmiss"};
-                            for(int i=0; i<10; i++) colnames[i] = names[i];
-                            nbcol = 9;
-                        }
-                        break;
-                    case PROCCTRL_DISPLAYMODE_TIMING:
-                        {
-                            static const char *names[] = {"", "idx", "status", "pid", "pname", "freq", "exec", "over", "", ""};
-                            for(int i=0; i<10; i++) colnames[i] = names[i];
-                            nbcol = 7;
-                        }
-                        break;
-                    case PROCCTRL_DISPLAYMODE_PROCINFO:
-                        {
-                            static const char *names[] = {"", "idx", "status", "pid", "pname", "RT", "loopMax", "trig", "timeout", "timing"};
-                            for(int i=0; i<10; i++) colnames[i] = names[i];
-                            nbcol = 9;
-                        }
-                        break;
-                }
-
-                if (nbcol > 0) {
-                    int m = ctx->procinfoproc->DisplayMode;
-                    if (ctx->procinfoproc->selected_col > nbcol) ctx->procinfoproc->selected_col = nbcol;
-                    if (ctx->procinfoproc->selected_col < 1) ctx->procinfoproc->selected_col = 1;
-
-                    for(int i=1; i<=nbcol; i++) {
-                        char colinfo[40];
-                        if (i == ctx->procinfoproc->sort_col[m]) {
-                            snprintf(colinfo, 40, "%d:%s%c", i, colnames[i], ctx->procinfoproc->sort_dir[m] ? 'v' : '^');
-                        } else {
-                            snprintf(colinfo, 40, "%d:%s", i, colnames[i]);
-                        }
-
-                        if (i == ctx->procinfoproc->selected_col) screenprint_setcolor(10);
-                        if (ctx->procinfoproc->col_visible[m][i]) {
-                            screenprint_setbold(); // Bold font, no background highlight
-                            TUI_printfw("%s ", colinfo);
-                            screenprint_unsetbold();
-                        } else {
-                            TUI_printfw("%s ", colinfo); // Normal text
-                        }
-                        if (i == ctx->procinfoproc->selected_col) screenprint_unsetcolor(10);
-                    }
-                    TUI_newline();
-                }
-                TUI_newline();
-            }
-
-            if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_HELP) {
-                TUI_printfw("MILK Process Control (procCTRL) - HELP");
-                TUI_newline();
-                TUI_printfw("Navigation:  ");
-                screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("F2-F6"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Modes (CTRL, Res, Trig, Tim, PInfo)   ");
-                screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("UP/DN"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Selection");
-                TUI_newline();
-                TUI_printfw("             ");
-                screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("SPACE"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Select process (batch)                ");
-                screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("1-9"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw("   : Toggle Cols");
-                TUI_newline();
-                TUI_printfw("             ");
-                screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("LEFT/RGHT"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Highlight Column                      ");
-                screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("^L/^R"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Cycle Tabs");
-                TUI_newline();
-                TUI_printfw("Control:     ");
-                screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("p"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Pause/Resume   ");
-                screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("^S"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Step   ");
-                screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("e"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Exit   ");
-                screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("T/K/I"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : TERM/KILL/INT");
-                TUI_newline();
-                TUI_printfw("             ");
-                screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("r/R"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Rem Log (Sel/All)   ");
-                screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("z/Z"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Zero Cnt (Sel/All)");
-                TUI_newline();
-                TUI_printfw("Other:       ");
-                screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("f"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Freeze   ");
-                screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("s/S"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Sort (Tab/All)   ");
-                screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("+/-"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Update freq   ");
-                screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("x"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Exit procCTRL");
-                TUI_newline();
-            }
-            else {
-                int dispindexMax = wrow - 6;
-
-                int margin_dn = 2;
-                int margin_up = 2;
-
-                if (margin_dn >= dispindexMax) {
-                    margin_dn = dispindexMax - 1;
-                }
-                if (margin_dn < 0) {
-                    margin_dn = 0;
-                }
-                if (margin_up >= dispindexMax) {
-                    margin_up = dispindexMax - 1;
-                }
-                if (margin_up < 0) {
-                    margin_up = 0;
-                }
-
-                while (ctx->pindexActiveSelected - ctx->doffsetindex > dispindexMax - 1 - margin_dn) {
-                    ctx->doffsetindex++;
-                }
-
-                while (ctx->pindexActiveSelected < ctx->doffsetindex + margin_up) {
-                    ctx->doffsetindex--;
-                }
-
-                if (ctx->pindexActiveSelected < ctx->doffsetindex) {
-                    ctx->doffsetindex = ctx->pindexActiveSelected;
-                }
-                if (ctx->pindexActiveSelected >= ctx->doffsetindex + dispindexMax) {
-                    ctx->doffsetindex = ctx->pindexActiveSelected - dispindexMax + 1;
-                }
-
-                if (ctx->doffsetindex < 0) {
-                    ctx->doffsetindex = 0;
-                }
-
-                int lastindex = ctx->doffsetindex + dispindexMax;
-                if (lastindex > NBactive) {
-                    lastindex = NBactive;
-                }
-
-                for(int dispindex = ctx->doffsetindex; dispindex < lastindex; dispindex++) {
-                    if (dispindex == ctx->doffsetindex && ctx->doffsetindex > 0) {
-                        screenprint_setbold();
-                        screenprint_setcolor(3);
-                        TUI_printfw("      ^^^^ %d more entries above ^^^^", (int)(ctx->doffsetindex + 1));
-                        screenprint_unsetcolor(3);
-                        screenprint_unsetbold();
-                        TUI_newline();
-                        continue;
-                    }
-
-                    if (dispindex == lastindex - 1 && lastindex < NBactive) {
-                        screenprint_setbold();
-                        screenprint_setcolor(3);
-                        TUI_printfw("      vvvv %d more entries below vvvv", (int)(NBactive - lastindex + 1));
-                        screenprint_unsetcolor(3);
-                        screenprint_unsetbold();
-                        TUI_newline();
-                        continue;
-                    }
-
-                if (ctx->scan_shm == NULL) break;
-                int pindex;
-                if (ctx->procinfoproc->sort_col[m] > 0) pindex = ctx->procinfoproc->local_sorted_pindex[dispindex];
-                else pindex = ctx->scan_shm->sorted_pindex[dispindex];
-                
-                if (pindex >= 0 && pindex < PROCESSINFOLISTSIZE && (ctx->procinfoproc->pinfommapped[pindex] || pinfolist->active[pindex] != 0)) {
-                        if (pindex == ctx->pindexSelected) screenprint_setreverse();
-                        
-                        if (ctx->procinfoproc->selectedarray[pindex]) TUI_printfw("* "); else TUI_printfw("  ");
-                        
-                        int m = ctx->procinfoproc->DisplayMode;
-
-                        // Column 1: idx
-                        if (ctx->procinfoproc->col_visible[m][1]) {
-                            if (ctx->procinfoproc->selected_col == 1) screenprint_setcolor(10);
-                            TUI_printfw("%4d ", pindex);
-                            if (ctx->procinfoproc->selected_col == 1) screenprint_unsetcolor(10);
-                        }
-
-                        // Column 2: status
-                        if (ctx->procinfoproc->col_visible[m][2]) {
-                            if (ctx->procinfoproc->selected_col == 2) screenprint_setcolor(10);
-                            if (pinfolist->active[pindex] == 1) {
-                                screenprint_setcolor(6); TUI_printfw("%-10s ", "ACTIVE"); screenprint_unsetcolor(6);
-                            } else if (pinfolist->active[pindex] == 2) {
-                                screenprint_setcolor(7); TUI_printfw("%-10s ", "STOPPED"); screenprint_unsetcolor(7);
-                            } else if (pinfolist->active[pindex] == 3) {
-                                screenprint_setcolor(8); TUI_printfw("%-10s ", "CRASHED"); screenprint_unsetcolor(8);
-                            } else {
-                                TUI_printfw("%-10s ", "OFF");
-                            }
-                            if (ctx->procinfoproc->selected_col == 2) screenprint_unsetcolor(10);
-                        }
-                        
-                        // Column 3: pid
-                        if (ctx->procinfoproc->col_visible[m][3]) {
-                            if (ctx->procinfoproc->selected_col == 3) screenprint_setcolor(10);
-                            pid_t pid = pinfolist->PIDarray[pindex];
-                            int pid_exists = (kill(pid, 0) == 0);
-                            if (!pid_exists) screenprint_setcolor(4);
-                            char state = ctx->scan_shm->pinfodisp[pindex].state;
-                            if (state == 0) state = ' ';
-                            TUI_printfw("%7d %c ", pid, state);
-                            if (!pid_exists) screenprint_unsetcolor(4);
-                            if (ctx->procinfoproc->selected_col == 3) screenprint_unsetcolor(10);
-                        }
-
-                        if (ctx->scan_shm && pindex < PROCESSINFOLISTSIZE && pinfolist->active[pindex] == 1 && ctx->scan_shm->request_scan[pindex] == 0) {
-                            ctx->scan_shm->request_scan[pindex] = 1;
-                        }
-
-                        if (m == PROCCTRL_DISPLAYMODE_CTRL) {
-                            // 4: tstart
-                            if (ctx->procinfoproc->col_visible[m][4]) {
-                                if (ctx->procinfoproc->selected_col == 4) screenprint_setcolor(10);
-                                char tbuf[30];
-                                time_t sec = (time_t)pinfolist->createtime[pindex];
-                                long usec = (long)((pinfolist->createtime[pindex] - sec) * 1000000);
-                                struct tm *tm_info = gmtime(&sec);
-                                strftime(tbuf, 20, "%Y%m%dT%H:%M:%S", tm_info);
-                                snprintf(tbuf + 19,
-                                         sizeof(tbuf) - 19,
-                                         ".%06ld", usec);
-                                TUI_printfw("%s ", tbuf);
-                                if (ctx->procinfoproc->selected_col == 4) screenprint_unsetcolor(10);
-                            }
-
-                            // 5: pname
-                            if (ctx->procinfoproc->col_visible[m][5]) {
-                                if (ctx->procinfoproc->selected_col == 5) screenprint_setcolor(10);
-                                TUI_printfw("%-25s ", pinfolist->pnamearray[pindex]);
-                                if (ctx->procinfoproc->selected_col == 5) screenprint_unsetcolor(10);
-                            }
-
-                            int   ctrlval = (ctx->procinfoproc->pinfoarray[pindex]) ? ctx->procinfoproc->pinfoarray[pindex]->CTRLval : 0;
-                            long  loopcnt = ctx->scan_shm->pinfodisp[pindex].loopcnt;
-                            char *desc    = ctx->scan_shm->pinfodisp[pindex].statusmsg;
-
-                            // 6: state
-                            if (ctx->procinfoproc->col_visible[m][6]) {
-                                if (ctx->procinfoproc->selected_col == 6) screenprint_setcolor(10);
-                                if (ctrlval == 1) {
-                                     screenprint_setcolor(3); screenprint_setblink(); TUI_printfw("C1"); screenprint_unsetcolor(3); screenprint_unsetblink(); TUI_printfw(" ");
-                                } else {
-                                     TUI_printfw("C%d ", ctrlval); 
-                                }
-                                if (ctx->procinfoproc->selected_col == 6) screenprint_unsetcolor(10);
-                            }
-
-                            // 7: lcnt
-                            if (ctx->procinfoproc->col_visible[m][7]) {
-                                if (ctx->procinfoproc->selected_col == 7) screenprint_setcolor(10);
-                                if (loopcnt != ctx->procinfoproc->loopcntarray[pindex]) {
-                                     screenprint_setcolor(6); TUI_printfw("%10ld ", loopcnt); screenprint_unsetcolor(6);
-                                } else {
-                                     TUI_printfw("%10ld ", loopcnt); 
-                                }
-                                ctx->procinfoproc->loopcntarray[pindex] = loopcnt;
-                                if (ctx->procinfoproc->selected_col == 7) screenprint_unsetcolor(10);
-                            }
-
-                            // 8: msg
-                            if (ctx->procinfoproc->col_visible[m][8]) {
-                                if (ctx->procinfoproc->selected_col == 8) screenprint_setcolor(10);
-                                TUI_printfw("%-30s ", desc); 
-                                if (ctx->procinfoproc->selected_col == 8) screenprint_unsetcolor(10);
-                            }
-                        }
-                        else if (m == PROCCTRL_DISPLAYMODE_RESOURCES) {
-                            // 4: pname
-                            if (ctx->procinfoproc->col_visible[m][4]) {
-                                if (ctx->procinfoproc->selected_col == 4) screenprint_setcolor(10);
-                                TUI_printfw("%-25s ", pinfolist->pnamearray[pindex]);
-                                if (ctx->procinfoproc->selected_col == 4) screenprint_unsetcolor(10);
-                            }
-                            // 5: prio
-                            if (ctx->procinfoproc->col_visible[m][5]) {
-                                if (ctx->procinfoproc->selected_col == 5) screenprint_setcolor(10);
-                                TUI_printfw("P%2d ", ctx->scan_shm->pinfodisp[pindex].rt_priority); 
-                                if (ctx->procinfoproc->selected_col == 5) screenprint_unsetcolor(10);
-                            }
-                            // 6: cpu
-                            if (ctx->procinfoproc->col_visible[m][6]) {
-                                if (ctx->procinfoproc->selected_col == 6) screenprint_setcolor(10);
-                                TUI_printfw("CPU:%5.1f%% ", ctx->scan_shm->pinfodisp[pindex].subprocCPUloadarray_timeaveraged[0]);
-                                if (ctx->procinfoproc->selected_col == 6) screenprint_unsetcolor(10);
-                            }
-                            // 7: mem
-                            if (ctx->procinfoproc->col_visible[m][7]) {
-                                if (ctx->procinfoproc->selected_col == 7) screenprint_setcolor(10);
-                                TUI_printfw("MEM:%7ldkB ", ctx->scan_shm->pinfodisp[pindex].VmRSSarray[0]);
-                                if (ctx->procinfoproc->selected_col == 7) screenprint_unsetcolor(10);
-                            }
-                            // 8: thr
-                            if (ctx->procinfoproc->col_visible[m][8]) {
-                                if (ctx->procinfoproc->selected_col == 8) screenprint_setcolor(10);
-                                TUI_printfw("Thr:%3d ", ctx->scan_shm->pinfodisp[pindex].threads);
-                                if (ctx->procinfoproc->selected_col == 8) screenprint_unsetcolor(10);
-                            }
-                        }
-                        else if (m == PROCCTRL_DISPLAYMODE_TRIGGER) {
-                            // 4: pname
-                            if (ctx->procinfoproc->col_visible[m][4]) {
-                                if (ctx->procinfoproc->selected_col == 4) screenprint_setcolor(10);
-                                TUI_printfw("%-25s ", pinfolist->pnamearray[pindex]);
-                                if (ctx->procinfoproc->selected_col == 4) screenprint_unsetcolor(10);
-                            }
-                            // 5: tmode
-                            if (ctx->procinfoproc->col_visible[m][5]) {
-                                if (ctx->procinfoproc->selected_col == 5) screenprint_setcolor(10);
-                                TUI_printfw("TR:%d ", ctx->scan_shm->pinfodisp[pindex].triggermode);
-                                if (ctx->procinfoproc->selected_col == 5) screenprint_unsetcolor(10);
-                            }
-                            // 6: tstream
-                            if (ctx->procinfoproc->col_visible[m][6]) {
-                                if (ctx->procinfoproc->selected_col == 6) screenprint_setcolor(10);
-                                TUI_printfw("%-15s ", ctx->scan_shm->pinfodisp[pindex].triggerstreamname);
-                                if (ctx->procinfoproc->selected_col == 6) screenprint_unsetcolor(10);
-                            }
-                            // 7: tsem
-                            if (ctx->procinfoproc->col_visible[m][7]) {
-                                if (ctx->procinfoproc->selected_col == 7) screenprint_setcolor(10);
-                                TUI_printfw("S:%d ", ctx->scan_shm->pinfodisp[pindex].triggersem);
-                                if (ctx->procinfoproc->selected_col == 7) screenprint_unsetcolor(10);
-                            }
-                            // 8: tcnt
-                            if (ctx->procinfoproc->col_visible[m][8]) {
-                                if (ctx->procinfoproc->selected_col == 8) screenprint_setcolor(10);
-                                TUI_printfw("CNT:%ld ", (long)ctx->scan_shm->pinfodisp[pindex].triggerstreamcnt);
-                                if (ctx->procinfoproc->selected_col == 8) screenprint_unsetcolor(10);
-                            }
-                            // 9: tmiss
-                            if (ctx->procinfoproc->col_visible[m][9]) {
-                                if (ctx->procinfoproc->selected_col == 9) screenprint_setcolor(10);
-                                TUI_printfw("M:%d/%ld ", ctx->scan_shm->pinfodisp[pindex].triggermissedframe, (long)ctx->scan_shm->pinfodisp[pindex].triggermissedframe_cumul);
-                                if (ctx->procinfoproc->selected_col == 9) screenprint_unsetcolor(10);
-                            }
-                        }
-                        else if (m == PROCCTRL_DISPLAYMODE_TIMING) {
-                            // 4: pname
-                            if (ctx->procinfoproc->col_visible[m][4]) {
-                                if (ctx->procinfoproc->selected_col == 4) screenprint_setcolor(10);
-                                TUI_printfw("%-25s ", pinfolist->pnamearray[pindex]);
-                                if (ctx->procinfoproc->selected_col == 4) screenprint_unsetcolor(10);
-                            }
-                            if (ctx->scan_shm->pinfodisp[pindex].MeasureTiming) {
-                                double freq = 0.0;
-                                if (ctx->scan_shm->pinfodisp[pindex].dtmedian_iter_ns > 0) freq = 1.0e9 / ctx->scan_shm->pinfodisp[pindex].dtmedian_iter_ns;
-                                double exec_ms = 1.0e-6 * ctx->scan_shm->pinfodisp[pindex].dtmedian_exec_ns;
-                                double overhead = 0.0;
-                                if (ctx->scan_shm->pinfodisp[pindex].dtmedian_iter_ns > 0) overhead = 100.0 * ctx->scan_shm->pinfodisp[pindex].dtmedian_exec_ns / ctx->scan_shm->pinfodisp[pindex].dtmedian_iter_ns;
-                                // 5: freq
-                                if (ctx->procinfoproc->col_visible[m][5]) {
-                                    if (ctx->procinfoproc->selected_col == 5) screenprint_setcolor(10);
-                                    TUI_printfw("%8.2fHz ", freq);
-                                    if (ctx->procinfoproc->selected_col == 5) screenprint_unsetcolor(10);
-                                }
-                                // 6: exec
-                                if (ctx->procinfoproc->col_visible[m][6]) {
-                                    if (ctx->procinfoproc->selected_col == 6) screenprint_setcolor(10);
-                                    TUI_printfw("Exec:%7.3fms ", exec_ms);
-                                    if (ctx->procinfoproc->selected_col == 6) screenprint_unsetcolor(10);
-                                }
-                                // 7: over
-                                if (ctx->procinfoproc->col_visible[m][7]) {
-                                    if (ctx->procinfoproc->selected_col == 7) screenprint_setcolor(10);
-                                    TUI_printfw("(%5.1f%%) ", overhead);
-                                    if (ctx->procinfoproc->selected_col == 7) screenprint_unsetcolor(10);
-                                }
-                            } else {
-                                TUI_printfw("--- Timing Disabled ---");
-                            }
-                        }
-                        else if (m == PROCCTRL_DISPLAYMODE_PROCINFO) {
-                            // 4: pname
-                            if (ctx->procinfoproc->col_visible[m][4]) {
-                                if (ctx->procinfoproc->selected_col == 4) screenprint_setcolor(10);
-                                TUI_printfw("%-25s ", pinfolist->pnamearray[pindex]);
-                                if (ctx->procinfoproc->selected_col == 4) screenprint_unsetcolor(10);
-                            }
-                            // 5: RT
-                            if (ctx->procinfoproc->col_visible[m][5]) {
-                                if (ctx->procinfoproc->selected_col == 5) screenprint_setcolor(10);
-                                TUI_printfw("RT:%2d ", ctx->scan_shm->pinfodisp[pindex].rt_priority);
-                                if (ctx->procinfoproc->selected_col == 5) screenprint_unsetcolor(10);
-                            }
-                            // 6: loopMax
-                            if (ctx->procinfoproc->col_visible[m][6]) {
-                                if (ctx->procinfoproc->selected_col == 6) screenprint_setcolor(10);
-                                TUI_printfw("Lmax:%7ld ", ctx->scan_shm->pinfodisp[pindex].loopcntMax);
-                                if (ctx->procinfoproc->selected_col == 6) screenprint_unsetcolor(10);
-                            }
-                            // 7: trig
-                            if (ctx->procinfoproc->col_visible[m][7]) {
-                                if (ctx->procinfoproc->selected_col == 7) screenprint_setcolor(10);
-                                TUI_printfw("Trig:%d ", ctx->scan_shm->pinfodisp[pindex].triggermode);
-                                if (ctx->procinfoproc->selected_col == 7) screenprint_unsetcolor(10);
-                            }
-                            // 8: timeout
-                            if (ctx->procinfoproc->col_visible[m][8]) {
-                                if (ctx->procinfoproc->selected_col == 8) screenprint_setcolor(10);
-                                double tout = ctx->scan_shm->pinfodisp[pindex].triggertimeout.tv_sec + 1e-9 * ctx->scan_shm->pinfodisp[pindex].triggertimeout.tv_nsec;
-                                TUI_printfw("TO:%5.2f ", tout);
-                                if (ctx->procinfoproc->selected_col == 8) screenprint_unsetcolor(10);
-                            }
-                            // 9: timing
-                            if (ctx->procinfoproc->col_visible[m][9]) {
-                                if (ctx->procinfoproc->selected_col == 9) screenprint_setcolor(10);
-                                TUI_printfw("Tim:%d ", ctx->scan_shm->pinfodisp[pindex].MeasureTiming);
-                                if (ctx->procinfoproc->selected_col == 9) screenprint_unsetcolor(10);
-                            }
-                        }
-                        else {
-                            TUI_printfw("(Mode %d not impl)", m);
-                        }
-
-                        if (pindex == ctx->pindexSelected) screenprint_unsetreverse();
-                        TUI_newline();
-                    }
-                }
-            }
-            TUI_cleartobottom();
-            sc_frame_flush();
-        }
-}
-
-
-errno_t processinfo_CTRLscreen()
-{
-    if (getenv("PROCCTRL_DEBUG")) procCTRL_debug_mode = 1;
-    if (procCTRL_debug_mode) printf("DEBUG: processinfo_CTRLscreen start\n");
-
-    procctrl_context_t ctx;
-    memset(&ctx, 0, sizeof(procctrl_context_t));
-
+static errno_t procctrl_init(procctrl_context_t *ctx) {
     if (strlen(procCTRL_logfile) > 0) {
-        ctx.flog = fopen(procCTRL_logfile, "a");
-        if (ctx.flog) {
-            fprintf(ctx.flog, "\n--- processinfo_CTRLscreen started ---\n");
-            fflush(ctx.flog);
+        ctx->flog = fopen(procCTRL_logfile, "a");
+        if (ctx->flog) {
+            fprintf(ctx->flog, "\n--- processinfo_CTRLscreen started ---\n");
+            fflush(ctx->flog);
         }
     }
 
-    if (ctx.flog) { fprintf(ctx.flog, "Checking for daemon...\n"); fflush(ctx.flog); }
+    if (ctx->flog) { fprintf(ctx->flog, "Checking for daemon...\n"); fflush(ctx->flog); }
     if (system("pgrep \"milk-procCTRL-s\" > /dev/null") != 0) {
         fprintf(stderr, "\nWARNING: milk-procCTRL-scan daemon is not running.\n");
         printf("Start it now in tmux session 'milk-procCTRL-scan'? [y/n] ");
@@ -855,82 +202,130 @@ errno_t processinfo_CTRLscreen()
             sleep(1);
             if (system("pgrep \"milk-procCTRL-s\" > /dev/null") != 0) {
                 fprintf(stderr, "ERROR: Failed to launch milk-procCTRL-scan daemon.\n");
-                if (ctx.flog) fclose(ctx.flog);
+                if (ctx->flog) fclose(ctx->flog);
                 return RETURN_FAILURE;
             }
         } else {
             fprintf(stderr, "ERROR: milk-procCTRL-scan daemon is required for this tool.\n");
-            if (ctx.flog) fclose(ctx.flog);
+            if (ctx->flog) fclose(ctx->flog);
             return RETURN_FAILURE;
         }
     }
 
     processinfo_procdirname(local_shmdir);
-    processinfo_procdirname(ctx.procdname);
+    processinfo_procdirname(ctx->procdname);
 
-    if (ctx.flog) { fprintf(ctx.flog, "Allocating procinfoproc...\n"); fflush(ctx.flog); }
-    ctx.procinfoproc = (PROCINFOPROC *) calloc(1, sizeof(PROCINFOPROC));
-    if(ctx.procinfoproc == NULL) {
+    if (ctx->flog) { fprintf(ctx->flog, "Allocating procinfoproc...\n"); fflush(ctx->flog); }
+    ctx->procinfoproc = (PROCINFOPROC *) calloc(1, sizeof(PROCINFOPROC));
+    if(ctx->procinfoproc == NULL) {
         PRINT_ERROR("calloc returns NULL pointer");
-        if (ctx.flog) fclose(ctx.flog);
+        if (ctx->flog) fclose(ctx->flog);
         return RETURN_FAILURE;
     }
 
-    ctx.procinfoproc->NBcpus = GetNumberCPUs(ctx.procinfoproc);
-    GetCPUloads(ctx.procinfoproc); 
+    ctx->procinfoproc->NBcpus = GetNumberCPUs(ctx->procinfoproc);
+    GetCPUloads(ctx->procinfoproc); 
 
-    if(system("which cset > /dev/null 2>&1") == 0) ctx.procinfoproc->has_cset = 1;
-    else ctx.procinfoproc->has_cset = 0;
+    if(system("which cset > /dev/null 2>&1") == 0) ctx->procinfoproc->has_cset = 1;
+    else ctx->procinfoproc->has_cset = 0;
 
     for(int m=0; m<10; m++) {
-        for(int i=0; i<10; i++) ctx.procinfoproc->col_visible[m][i] = 1;
-        ctx.procinfoproc->sort_col[m] = 0;
-        ctx.procinfoproc->sort_dir[m] = 0;
-        ctx.procinfoproc->sort_mode[m] = m;
+        for(int i=0; i<10; i++) ctx->procinfoproc->col_visible[m][i] = 1;
+        ctx->procinfoproc->sort_col[m] = 0;
+        ctx->procinfoproc->sort_dir[m] = 0;
+        ctx->procinfoproc->sort_mode[m] = m;
     }
-    ctx.procinfoproc->selected_col = 1;
+    ctx->procinfoproc->selected_col = 1;
 
-    STRINGLISTENTRY *CPUsetList = (STRINGLISTENTRY *) malloc(sizeof(STRINGLISTENTRY) * 1000);
-    int NBCPUset __attribute__((unused)) = processinfo_CPUsets_List(CPUsetList, ctx.procinfoproc->has_cset);
+    ctx->CPUsetList = (STRINGLISTENTRY *) malloc(sizeof(STRINGLISTENTRY) * 1000);
+    int NBCPUset __attribute__((unused)) = processinfo_CPUsets_List(ctx->CPUsetList, ctx->procinfoproc->has_cset);
 
-    if (ctx.flog) { fprintf(ctx.flog, "Connecting to process list...\n"); fflush(ctx.flog); }
+    if (ctx->flog) { fprintf(ctx->flog, "Connecting to process list...\n"); fflush(ctx->flog); }
     if(processinfo_shm_list_create() == -1) {
         printf("==== ERROR: CANNOT ACCESS PROCESS LIST ====\n");
-        if (ctx.flog) fclose(ctx.flog);
+        if (ctx->flog) fclose(ctx->flog);
         return RETURN_FAILURE;
     }
-    ctx.procinfoproc->pinfolist = pinfolist;
+    ctx->procinfoproc->pinfolist = pinfolist;
     
     char scan_shm_name[STRINGMAXLEN_FULLFILENAME];
-    snprintf(scan_shm_name, sizeof(scan_shm_name), "%s/%s", ctx.procdname, PROCESSINFO_SCAN_SHM_NAME);
-    if (ctx.flog) { fprintf(ctx.flog, "Linking to scan SHM: %s\n", scan_shm_name); fflush(ctx.flog); }
-    ctx.scan_shm = (PROCSCAN_SHM *) link_scan_shm(scan_shm_name, sizeof(PROCSCAN_SHM));
-    if (ctx.scan_shm == MAP_FAILED) {
+    snprintf(scan_shm_name, sizeof(scan_shm_name), "%s/%s", ctx->procdname, PROCESSINFO_SCAN_SHM_NAME);
+    if (ctx->flog) { fprintf(ctx->flog, "Linking to scan SHM: %s\n", scan_shm_name); fflush(ctx->flog); }
+    ctx->scan_shm = (PROCSCAN_SHM *) link_scan_shm(scan_shm_name, sizeof(PROCSCAN_SHM));
+    if (ctx->scan_shm == MAP_FAILED) {
         printf("WARNING: Could not link to scan SHM %s. Stats may be missing.\n", scan_shm_name);
-        ctx.scan_shm = NULL;
+        ctx->scan_shm = NULL;
     }
 
     TUI_set_screenprintmode(SCREENPRINT_NCURSES);
     if(getenv("MILK_TUIPRINT_STDIO")) TUI_set_screenprintmode(SCREENPRINT_STDIO);
     
-    if (ctx.flog) { fprintf(ctx.flog, "Initializing terminal...\n"); fflush(ctx.flog); }
+    if (ctx->flog) { fprintf(ctx->flog, "Initializing terminal...\n"); fflush(ctx->flog); }
     ansi_raw_mode_enter();
     TUI_init_terminal(&wrow, &wcol);
     if(wrow < 10) wrow = 10;
 
-    if (ctx.flog) { fprintf(ctx.flog, "Allocating pinfodisp buffer (250MB)\n"); fflush(ctx.flog); }
-    ctx.procinfoproc->pinfodisp = (PROCESSINFODISP *) calloc(PROCESSINFOLISTSIZE, sizeof(PROCESSINFODISP));
-    if (ctx.procinfoproc->pinfodisp == NULL) {
+    if (ctx->flog) { fprintf(ctx->flog, "Allocating pinfodisp buffer (250MB)\n"); fflush(ctx->flog); }
+    ctx->procinfoproc->pinfodisp = (PROCESSINFODISP *) calloc(PROCESSINFOLISTSIZE, sizeof(PROCESSINFODISP));
+    if (ctx->procinfoproc->pinfodisp == NULL) {
         ansi_raw_mode_exit();
         fprintf(stderr, "FATAL ERROR: Could not allocate 250MB process info buffer.\n");
-        if (ctx.flog) fclose(ctx.flog);
+        if (ctx->flog) fclose(ctx->flog);
         return RETURN_FAILURE;
     }
-    ctx.procinfoproc->NBpinfodisp = PROCESSINFOLISTSIZE;
+    ctx->procinfoproc->NBpinfodisp = PROCESSINFOLISTSIZE;
     
-    ctx.procinfoproc->DisplayMode = PROCCTRL_DISPLAYMODE_CTRL;
-    ctx.procinfoproc->loop = 1;
-    ctx.procinfoproc->twaitus = 1000000;
+    ctx->procinfoproc->DisplayMode = PROCCTRL_DISPLAYMODE_CTRL;
+    ctx->procinfoproc->loop = 1;
+    ctx->procinfoproc->twaitus = 1000000;
+
+    ctx->t_last_scan.tv_sec = 0; ctx->t_last_scan.tv_nsec = 0;
+    ctx->frequ = 32.0;
+    ctx->pindexSelected = -1;
+    ctx->pindexActiveSelected = 0;
+    ctx->doffsetindex = 0;
+    ctx->freeze = 0;
+    ctx->loopOK = 1;
+    ctx->Xexit = 0;
+    ctx->monstringlen = 200;
+    ctx->last_ch = -1;
+
+    getrusage(RUSAGE_SELF, &ctx->usage_prev);
+    clock_gettime(CLOCK_MONOTONIC, &ctx->t_usage_prev);
+    ctx->tool_cpu_pcnt = 0.0;
+
+    clock_gettime(CLOCK_MONOTONIC, &ctx->t_disp_prev);
+    ctx->actual_fps = 0.0;
+
+    return RETURN_SUCCESS;
+}
+
+static void procctrl_cleanup(procctrl_context_t *ctx) {
+    ansi_raw_mode_exit();
+    if (ctx->scan_shm) munmap(ctx->scan_shm, sizeof(PROCSCAN_SHM));
+    if (ctx->procinfoproc) {
+        for(long i=0; i<PROCESSINFOLISTSIZE; i++) if(ctx->procinfoproc->pinfommapped[i]) {
+            if (ctx->procinfoproc->pinfoarray[i] != NULL && ctx->procinfoproc->pinfoarray[i] != (PROCESSINFO*)MAP_FAILED)
+                processinfo_shm_close(ctx->procinfoproc->pinfoarray[i], ctx->procinfoproc->fdarray[i]);
+        }
+        free(ctx->procinfoproc->pinfodisp);
+        free(ctx->procinfoproc);
+    }
+    if (ctx->CPUsetList) free(ctx->CPUsetList);
+
+    if (ctx->flog) { fprintf(ctx->flog, "--- processinfo_CTRLscreen ended ---\n"); fclose(ctx->flog); }
+}
+errno_t processinfo_CTRLscreen()
+{
+    if (getenv("PROCCTRL_DEBUG")) procCTRL_debug_mode = 1;
+    if (procCTRL_debug_mode) printf("DEBUG: processinfo_CTRLscreen start\n");
+
+    procctrl_context_t ctx;
+    memset(&ctx, 0, sizeof(procctrl_context_t));
+
+    if (procctrl_init(&ctx) != RETURN_SUCCESS) {
+        return RETURN_FAILURE;
+    }
 
     int backstderr = -1, newstderr = -1;
     if (procCTRL_debug_mode == 0) {
@@ -940,24 +335,6 @@ errno_t processinfo_CTRLscreen()
         dup2(newstderr, STDERR_FILENO);
         close(newstderr);
     }
-
-    ctx.t_last_scan.tv_sec = 0; ctx.t_last_scan.tv_nsec = 0;
-    ctx.frequ = 32.0;
-    ctx.pindexSelected = -1;
-    ctx.pindexActiveSelected = 0;
-    ctx.doffsetindex = 0;
-    ctx.freeze = 0;
-    ctx.loopOK = 1;
-    ctx.Xexit = 0;
-    ctx.monstringlen = 200;
-    ctx.last_ch = -1;
-
-    getrusage(RUSAGE_SELF, &ctx.usage_prev);
-    clock_gettime(CLOCK_MONOTONIC, &ctx.t_usage_prev);
-    ctx.tool_cpu_pcnt = 0.0;
-
-    clock_gettime(CLOCK_MONOTONIC, &ctx.t_disp_prev);
-    ctx.actual_fps = 0.0;
 
     if (ctx.flog) { fprintf(ctx.flog, "Entering main loop.\n"); fflush(ctx.flog); }
     sc_frame_clear();
@@ -1002,21 +379,13 @@ errno_t processinfo_CTRLscreen()
         procctrl_render_frame(&ctx, NBactive);
     }
 
-    ansi_raw_mode_exit();
-    if (ctx.scan_shm) munmap(ctx.scan_shm, sizeof(PROCSCAN_SHM));
-    for(long i=0; i<PROCESSINFOLISTSIZE; i++) if(ctx.procinfoproc->pinfommapped[i]) {
-        if (ctx.procinfoproc->pinfoarray[i] != NULL && ctx.procinfoproc->pinfoarray[i] != (PROCESSINFO*)MAP_FAILED)
-            processinfo_shm_close(ctx.procinfoproc->pinfoarray[i], ctx.procinfoproc->fdarray[i]);
-    }
-    free(ctx.procinfoproc->pinfodisp);
-    free(ctx.procinfoproc);
-    free(CPUsetList);
+    procctrl_cleanup(&ctx);
 
     if (procCTRL_debug_mode == 0) {
         fflush(stderr);
         dup2(backstderr, STDERR_FILENO);
         close(backstderr);
     }
-    if (ctx.flog) { fprintf(ctx.flog, "--- processinfo_CTRLscreen ended ---\n"); fclose(ctx.flog); }
+    
     return RETURN_SUCCESS;
 }

--- a/src/engine/libprocessinfo/procCTRL/procCTRL_TUI_input.c
+++ b/src/engine/libprocessinfo/procCTRL/procCTRL_TUI_input.c
@@ -1,0 +1,131 @@
+#include <signal.h>
+#include <time.h>
+#include <stdio.h>
+#include "procCTRL_TUI_internal.h"
+#include "procCTRL_ansi.h"
+
+void procctrl_handle_keyboard_event(procctrl_context_t *ctx, int ch, int NBactive) {
+    ctx->last_ch = ch;
+    if (ctx->flog) {
+        char tbuf[64];
+        struct timespec ts;
+        clock_gettime(CLOCK_REALTIME, &ts);
+        struct tm *tm_info = gmtime(&ts.tv_sec);
+        size_t len = strftime(tbuf, sizeof(tbuf), "%Y%m%dT%H:%M:%S", tm_info);
+        snprintf(tbuf + len, sizeof(tbuf) - len, ".%06ld", ts.tv_nsec / 1000);
+        fprintf(ctx->flog, "%s Input: %d\\n", tbuf, ch);
+        fflush(ctx->flog);
+    }
+
+    if (ch == 545 || ch == 560 || ch == 443 || ch == 564 || ch == 554) {
+         ctx->procinfoproc->DisplayMode--;
+         if (ctx->procinfoproc->DisplayMode < 1) ctx->procinfoproc->DisplayMode = 6;
+         if (ctx->flog) { fprintf(ctx->flog, "  -> Mode changed to %d\\n", ctx->procinfoproc->DisplayMode); fflush(ctx->flog); }
+    }
+    else if (ch == 561 || ch == 566 || ch == 444 || ch == 565 || ch == 569) {
+         ctx->procinfoproc->DisplayMode++;
+         if (ctx->procinfoproc->DisplayMode > 6) ctx->procinfoproc->DisplayMode = 1;
+         if (ctx->flog) { fprintf(ctx->flog, "  -> Mode changed to %d\\n", ctx->procinfoproc->DisplayMode); fflush(ctx->flog); }
+    }
+    else if (ch >= '0' && ch <= '9') {
+         int cidx = ch - '0';
+         int m = ctx->procinfoproc->DisplayMode;
+         if (m >= 0 && m < 10)
+             ctx->procinfoproc->col_visible[m][cidx] = !ctx->procinfoproc->col_visible[m][cidx];
+    }
+    else if (ch == ANSI_KEY_F2) ctx->procinfoproc->DisplayMode = PROCCTRL_DISPLAYMODE_CTRL;
+    else if (ch == ANSI_KEY_F3) ctx->procinfoproc->DisplayMode = PROCCTRL_DISPLAYMODE_RESOURCES;
+    else if (ch == ANSI_KEY_F4) ctx->procinfoproc->DisplayMode = PROCCTRL_DISPLAYMODE_TRIGGER;
+    else if (ch == ANSI_KEY_F5) ctx->procinfoproc->DisplayMode = PROCCTRL_DISPLAYMODE_TIMING;
+    else if (ch == ANSI_KEY_F6) ctx->procinfoproc->DisplayMode = PROCCTRL_DISPLAYMODE_PROCINFO;
+    else if (ch == 'h')      ctx->procinfoproc->DisplayMode = PROCCTRL_DISPLAYMODE_HELP;
+    else if (ch == ANSI_KEY_CTRL_LEFT) {
+        ctx->procinfoproc->DisplayMode--;
+        if(ctx->procinfoproc->DisplayMode < 1) ctx->procinfoproc->DisplayMode = 6;
+    }
+    else if (ch == ANSI_KEY_CTRL_RIGHT) {
+        ctx->procinfoproc->DisplayMode++;
+        if(ctx->procinfoproc->DisplayMode > 6) ctx->procinfoproc->DisplayMode = 1;
+    }
+    else if (ch == 'x' || ch == 3) { ctx->loopOK = 0; ctx->Xexit = 1; }
+    else if (ch == 'f') { ctx->freeze = !ctx->freeze; }
+    else if (ch == '+' || ch == '=') { ctx->frequ *= 1.2; if (ctx->frequ > 1000.0) ctx->frequ = 1000.0; }
+    else if (ch == '-') { ctx->frequ /= 1.2; if (ctx->frequ < 0.1) ctx->frequ = 0.1; }
+    else if (ch == ' ' && ctx->pindexSelected >= 0) {
+         ctx->procinfoproc->selectedarray[ctx->pindexSelected] = !ctx->procinfoproc->selectedarray[ctx->pindexSelected];
+    }
+    else if (ch == ANSI_KEY_UP && NBactive > 0) {
+         ctx->pindexActiveSelected--; if (ctx->pindexActiveSelected < 0) ctx->pindexActiveSelected = 0;
+    }
+    else if (ch == ANSI_KEY_DOWN && NBactive > 0) {
+         ctx->pindexActiveSelected++; if (ctx->pindexActiveSelected >= NBactive) ctx->pindexActiveSelected = NBactive - 1;
+    }
+    else if (ch == ANSI_KEY_LEFT) {
+         ctx->procinfoproc->selected_col--;
+         if (ctx->procinfoproc->selected_col < 1) ctx->procinfoproc->selected_col = 9;
+    }
+    else if (ch == ANSI_KEY_RIGHT) {
+         ctx->procinfoproc->selected_col++;
+         if (ctx->procinfoproc->selected_col > 9) ctx->procinfoproc->selected_col = 1;
+    }
+    else if (ch == 'r' || ch == 'R') {
+        int all = (ch == 'R');
+        for(int i=0; i<PROCESSINFOLISTSIZE; i++) {
+            if (all || i == ctx->pindexSelected) {
+                if (pinfolist->active[i] == 2 || pinfolist->active[i] == 3) pinfolist->active[i] = 0;
+            }
+        }
+    }
+    else if ((ch == 'T' || ch == 'K' || ch == 'I') && NBactive > 0) {
+        int sig = (ch == 'T') ? SIGTERM : (ch == 'K') ? SIGKILL : SIGINT;
+        int any_sel = 0;
+        for(int i=0; i<PROCESSINFOLISTSIZE; i++) if(ctx->procinfoproc->selectedarray[i]) {
+            kill(pinfolist->PIDarray[i], sig);
+            any_sel = 1;
+        }
+        if(!any_sel && ctx->pindexSelected >= 0) kill(pinfolist->PIDarray[ctx->pindexSelected], sig);
+    }
+    else if (ch == 's') {
+         int m = ctx->procinfoproc->DisplayMode;
+         ctx->procinfoproc->sort_mode[m] = m;
+         if (ctx->procinfoproc->sort_col[m] == ctx->procinfoproc->selected_col) {
+             ctx->procinfoproc->sort_dir[m] = !ctx->procinfoproc->sort_dir[m];
+         } else {
+             ctx->procinfoproc->sort_col[m] = ctx->procinfoproc->selected_col;
+             ctx->procinfoproc->sort_dir[m] = 0;
+         }
+    }
+    else if (ch == 'S') {
+         int m_curr = ctx->procinfoproc->DisplayMode;
+         int smod = ctx->procinfoproc->sort_mode[m_curr];
+         int scol = ctx->procinfoproc->sort_col[m_curr];
+         int sdir = ctx->procinfoproc->sort_dir[m_curr];
+         for(int m=0; m<10; m++) {
+             ctx->procinfoproc->sort_mode[m] = smod;
+             ctx->procinfoproc->sort_col[m] = scol;
+             ctx->procinfoproc->sort_dir[m] = sdir;
+         }
+    }
+    else if ((ch == 'p' || ch == 19 || ch == 'e') && NBactive > 0) {
+        int val = (ch == 'p') ? -1 : (ch == 19) ? 2 : 3;
+        int any_sel = 0;
+        for(int i=0; i<PROCESSINFOLISTSIZE; i++) if(ctx->procinfoproc->selectedarray[i]) {
+            if (val == -1 && ctx->procinfoproc->pinfoarray[i]) ctx->procinfoproc->pinfoarray[i]->CTRLval = (ctx->procinfoproc->pinfoarray[i]->CTRLval == 0) ? 1 : 0;
+            else if (ctx->procinfoproc->pinfoarray[i]) ctx->procinfoproc->pinfoarray[i]->CTRLval = val;
+            any_sel = 1;
+        }
+        if(!any_sel && ctx->pindexSelected >= 0 && ctx->procinfoproc->pinfoarray[ctx->pindexSelected]) {
+            if (val == -1) ctx->procinfoproc->pinfoarray[ctx->pindexSelected]->CTRLval = (ctx->procinfoproc->pinfoarray[ctx->pindexSelected]->CTRLval == 0) ? 1 : 0;
+            else ctx->procinfoproc->pinfoarray[ctx->pindexSelected]->CTRLval = val;
+        }
+    }
+    else if ((ch == 'z' || ch == 'Z') && NBactive > 0) {
+        int all = (ch == 'Z');
+        for(int i=0; i<PROCESSINFOLISTSIZE; i++) if((all || ctx->procinfoproc->selectedarray[i]) && ctx->procinfoproc->pinfoarray[i]) {
+            ctx->procinfoproc->pinfoarray[i]->loopcnt = 0;
+        }
+        if(!all && !ctx->procinfoproc->selectedarray[ctx->pindexSelected] && ctx->pindexSelected >= 0 && ctx->procinfoproc->pinfoarray[ctx->pindexSelected]) {
+            ctx->procinfoproc->pinfoarray[ctx->pindexSelected]->loopcnt = 0;
+        }
+    }
+}

--- a/src/engine/libprocessinfo/procCTRL/procCTRL_TUI_internal.h
+++ b/src/engine/libprocessinfo/procCTRL/procCTRL_TUI_internal.h
@@ -1,0 +1,56 @@
+#ifndef _PROCCTRL_TUI_INTERNAL_H
+#define _PROCCTRL_TUI_INTERNAL_H
+
+#include <stdio.h>
+#include <time.h>
+#include <sys/resource.h>
+
+#include "procCTRL_TUI.h"
+#include "processtools.h"
+#include "processinfo_scan_shm.h"
+#include "processinfo_procdirname.h"
+#include "processinfo_shm_create.h"
+#include "milkDebugTools.h"
+
+extern short unsigned int wrow;
+extern short unsigned int wcol;
+
+
+typedef struct {
+    PROCINFOPROC *procinfoproc;
+    PROCSCAN_SHM *scan_shm;
+    FILE *flog;
+    char procdname[STRINGMAXLEN_DIRNAME];
+    float frequ;
+    int pindexSelected;
+    int pindexActiveSelected;
+    long doffsetindex;
+    int freeze;
+    int loopOK;
+    int Xexit;
+    char monstring[200];
+    int monstringlen;
+    int last_ch;
+    float tool_cpu_pcnt;
+    float actual_fps;
+    
+    struct timespec t_last_scan;
+    struct timespec t_now;
+    struct rusage usage_prev;
+    struct rusage usage_cur;
+    struct timespec t_usage_prev;
+    struct timespec t_usage_cur;
+    struct timespec t_disp_prev;
+    struct timespec t_disp_cur;
+    STRINGLISTENTRY *CPUsetList;
+} procctrl_context_t;
+
+// Render function
+void procctrl_render_frame(procctrl_context_t *ctx, int NBactive);
+
+// Input handling function
+void procctrl_handle_keyboard_event(procctrl_context_t *ctx, int ch, int NBactive);
+
+#endif
+
+extern PROCESSINFOLIST *pinfolist;

--- a/src/engine/libprocessinfo/procCTRL/procCTRL_TUI_render.c
+++ b/src/engine/libprocessinfo/procCTRL/procCTRL_TUI_render.c
@@ -1,0 +1,526 @@
+#include <stdio.h>
+#include <sys/stat.h>
+
+#include "procCTRL_TUI_internal.h"
+#include "procCTRL_TUIcompat.h"
+#include "procCTRL_ansi.h"
+
+static void procctrl_render_header(procctrl_context_t *ctx) {
+    struct stat shm_stat;
+    char shm_list_fname[STRINGMAXLEN_FULLFILENAME];
+    WRITE_FULLFILENAME(shm_list_fname, "%s/processinfo.list.shm", ctx->procdname);
+    if(stat(shm_list_fname, &shm_stat) == 0) {
+        char timestr[100];
+        struct tm *tm_info = gmtime(&shm_stat.st_mtime);
+        strftime(timestr, 100, "%Y-%m-%d %H:%M:%S", tm_info);
+        TUI_printfw("List: %-25s (Upd: %s)  ToolCPU: %5.2f%% (%4.1f fps)", shm_list_fname, timestr, ctx->tool_cpu_pcnt, ctx->actual_fps);
+        if (ctx->flog) TUI_printfw(" K:%d", ctx->last_ch);
+        TUI_newline();
+    }
+}
+
+static void procctrl_render_mode_tabs(procctrl_context_t *ctx) {
+    if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_HELP) screenprint_setcolor(2);
+    TUI_printfw("[h] Help");
+    if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_HELP) screenprint_unsetcolor(2);
+    TUI_printfw("   ");
+
+    if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_CTRL) screenprint_setcolor(2);
+    TUI_printfw("[F2] CTRL");
+    if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_CTRL) screenprint_unsetcolor(2);
+    TUI_printfw("   ");
+
+    if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_RESOURCES) screenprint_setcolor(2);
+    TUI_printfw("[F3] Resources");
+    if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_RESOURCES) screenprint_unsetcolor(2);
+    TUI_printfw("   ");
+
+    if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_TRIGGER) screenprint_setcolor(2);
+    TUI_printfw("[F4] Triggering");
+    if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_TRIGGER) screenprint_unsetcolor(2);
+    TUI_printfw("   ");
+
+    if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_TIMING) screenprint_setcolor(2);
+    TUI_printfw("[F5] Timing");
+    if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_TIMING) screenprint_unsetcolor(2);
+    TUI_printfw("   ");
+
+    if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_PROCINFO) screenprint_setcolor(2);
+    TUI_printfw("[F6] PROCINFO");
+    if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_PROCINFO) screenprint_unsetcolor(2);
+    TUI_newline();
+}
+
+static void procctrl_render_column_headers(procctrl_context_t *ctx) {
+    const char *colnames[10] = {NULL};
+    int nbcol = 0;
+    int m = ctx->procinfoproc->DisplayMode;
+
+    switch(m) {
+        case PROCCTRL_DISPLAYMODE_CTRL:
+            {
+                static const char *names[] = {"", "idx", "status", "pid", "tstart", "pname", "state", "lcnt", "msg", ""};
+                for(int i=0; i<10; i++) colnames[i] = names[i];
+                nbcol = 8;
+            }
+            break;
+        case PROCCTRL_DISPLAYMODE_RESOURCES:
+            {
+                static const char *names[] = {"", "idx", "status", "pid", "pname", "prio", "cpu", "mem", "thr", ""};
+                for(int i=0; i<10; i++) colnames[i] = names[i];
+                nbcol = 8;
+            }
+            break;
+        case PROCCTRL_DISPLAYMODE_TRIGGER:
+            {
+                static const char *names[] = {"", "idx", "status", "pid", "pname", "tmode", "tstream", "tsem", "tcnt", "tmiss"};
+                for(int i=0; i<10; i++) colnames[i] = names[i];
+                nbcol = 9;
+            }
+            break;
+        case PROCCTRL_DISPLAYMODE_TIMING:
+            {
+                static const char *names[] = {"", "idx", "status", "pid", "pname", "freq", "exec", "over", "", ""};
+                for(int i=0; i<10; i++) colnames[i] = names[i];
+                nbcol = 7;
+            }
+            break;
+        case PROCCTRL_DISPLAYMODE_PROCINFO:
+            {
+                static const char *names[] = {"", "idx", "status", "pid", "pname", "RT", "loopMax", "trig", "timeout", "timing"};
+                for(int i=0; i<10; i++) colnames[i] = names[i];
+                nbcol = 9;
+            }
+            break;
+    }
+
+    if (nbcol > 0) {
+        if (ctx->procinfoproc->selected_col > nbcol) ctx->procinfoproc->selected_col = nbcol;
+        if (ctx->procinfoproc->selected_col < 1) ctx->procinfoproc->selected_col = 1;
+
+        for(int i=1; i<=nbcol; i++) {
+            char colinfo[40];
+            if (i == ctx->procinfoproc->sort_col[m]) {
+                snprintf(colinfo, 40, "%d:%s%c", i, colnames[i], ctx->procinfoproc->sort_dir[m] ? 'v' : '^');
+            } else {
+                snprintf(colinfo, 40, "%d:%s", i, colnames[i]);
+            }
+
+            if (i == ctx->procinfoproc->selected_col) screenprint_setcolor(10);
+            if (ctx->procinfoproc->col_visible[m][i]) {
+                screenprint_setbold(); // Bold font, no background highlight
+                TUI_printfw("%s ", colinfo);
+                screenprint_unsetbold();
+            } else {
+                TUI_printfw("%s ", colinfo); // Normal text
+            }
+            if (i == ctx->procinfoproc->selected_col) screenprint_unsetcolor(10);
+        }
+        TUI_newline();
+    }
+    TUI_newline();
+}
+
+static void procctrl_render_help(void) {
+    TUI_printfw("MILK Process Control (procCTRL) - HELP");
+    TUI_newline();
+    TUI_printfw("Navigation:  ");
+    screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("F2-F6"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Modes (CTRL, Res, Trig, Tim, PInfo)   ");
+    screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("UP/DN"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Selection");
+    TUI_newline();
+    TUI_printfw("             ");
+    screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("SPACE"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Select process (batch)                ");
+    screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("1-9"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw("   : Toggle Cols");
+    TUI_newline();
+    TUI_printfw("             ");
+    screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("LEFT/RGHT"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Highlight Column                      ");
+    screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("^L/^R"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Cycle Tabs");
+    TUI_newline();
+    TUI_printfw("Control:     ");
+    screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("p"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Pause/Resume   ");
+    screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("^S"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Step   ");
+    screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("e"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Exit   ");
+    screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("T/K/I"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : TERM/KILL/INT");
+    TUI_newline();
+    TUI_printfw("             ");
+    screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("r/R"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Rem Log (Sel/All)   ");
+    screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("z/Z"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Zero Cnt (Sel/All)");
+    TUI_newline();
+    TUI_printfw("Other:       ");
+    screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("f"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Freeze   ");
+    screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("s/S"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Sort (Tab/All)   ");
+    screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("+/-"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Update freq   ");
+    screenprint_setcolor(1); screenprint_setbold(); TUI_printfw("x"); screenprint_unsetcolor(1); screenprint_unsetbold(); TUI_printfw(" : Exit procCTRL");
+    TUI_newline();
+}
+
+static void procctrl_render_row_ctrl(procctrl_context_t *ctx, int m, int pindex) {
+    // 4: tstart
+    if (ctx->procinfoproc->col_visible[m][4]) {
+        if (ctx->procinfoproc->selected_col == 4) screenprint_setcolor(10);
+        char tbuf[30];
+        time_t sec = (time_t)pinfolist->createtime[pindex];
+        long usec = (long)((pinfolist->createtime[pindex] - sec) * 1000000);
+        struct tm *tm_info = gmtime(&sec);
+        strftime(tbuf, 20, "%Y%m%dT%H:%M:%S", tm_info);
+        snprintf(tbuf + 19,
+                    sizeof(tbuf) - 19,
+                    ".%06ld", usec);
+        TUI_printfw("%s ", tbuf);
+        if (ctx->procinfoproc->selected_col == 4) screenprint_unsetcolor(10);
+    }
+
+    // 5: pname
+    if (ctx->procinfoproc->col_visible[m][5]) {
+        if (ctx->procinfoproc->selected_col == 5) screenprint_setcolor(10);
+        TUI_printfw("%-25s ", pinfolist->pnamearray[pindex]);
+        if (ctx->procinfoproc->selected_col == 5) screenprint_unsetcolor(10);
+    }
+
+    int   ctrlval = (ctx->procinfoproc->pinfoarray[pindex]) ? ctx->procinfoproc->pinfoarray[pindex]->CTRLval : 0;
+    long  loopcnt = ctx->scan_shm->pinfodisp[pindex].loopcnt;
+    char *desc    = ctx->scan_shm->pinfodisp[pindex].statusmsg;
+
+    // 6: state
+    if (ctx->procinfoproc->col_visible[m][6]) {
+        if (ctx->procinfoproc->selected_col == 6) screenprint_setcolor(10);
+        if (ctrlval == 1) {
+                screenprint_setcolor(3); screenprint_setblink(); TUI_printfw("C1"); screenprint_unsetcolor(3); screenprint_unsetblink(); TUI_printfw(" ");
+        } else {
+                TUI_printfw("C%d ", ctrlval); 
+        }
+        if (ctx->procinfoproc->selected_col == 6) screenprint_unsetcolor(10);
+    }
+
+    // 7: lcnt
+    if (ctx->procinfoproc->col_visible[m][7]) {
+        if (ctx->procinfoproc->selected_col == 7) screenprint_setcolor(10);
+        if (loopcnt != ctx->procinfoproc->loopcntarray[pindex]) {
+                screenprint_setcolor(6); TUI_printfw("%10ld ", loopcnt); screenprint_unsetcolor(6);
+        } else {
+                TUI_printfw("%10ld ", loopcnt); 
+        }
+        ctx->procinfoproc->loopcntarray[pindex] = loopcnt;
+        if (ctx->procinfoproc->selected_col == 7) screenprint_unsetcolor(10);
+    }
+
+    // 8: msg
+    if (ctx->procinfoproc->col_visible[m][8]) {
+        if (ctx->procinfoproc->selected_col == 8) screenprint_setcolor(10);
+        TUI_printfw("%-30s ", desc); 
+        if (ctx->procinfoproc->selected_col == 8) screenprint_unsetcolor(10);
+    }
+}
+
+static void procctrl_render_row_resources(procctrl_context_t *ctx, int m, int pindex) {
+    // 4: pname
+    if (ctx->procinfoproc->col_visible[m][4]) {
+        if (ctx->procinfoproc->selected_col == 4) screenprint_setcolor(10);
+        TUI_printfw("%-25s ", pinfolist->pnamearray[pindex]);
+        if (ctx->procinfoproc->selected_col == 4) screenprint_unsetcolor(10);
+    }
+    // 5: prio
+    if (ctx->procinfoproc->col_visible[m][5]) {
+        if (ctx->procinfoproc->selected_col == 5) screenprint_setcolor(10);
+        TUI_printfw("P%2d ", ctx->scan_shm->pinfodisp[pindex].rt_priority); 
+        if (ctx->procinfoproc->selected_col == 5) screenprint_unsetcolor(10);
+    }
+    // 6: cpu
+    if (ctx->procinfoproc->col_visible[m][6]) {
+        if (ctx->procinfoproc->selected_col == 6) screenprint_setcolor(10);
+        TUI_printfw("CPU:%5.1f%% ", ctx->scan_shm->pinfodisp[pindex].subprocCPUloadarray_timeaveraged[0]);
+        if (ctx->procinfoproc->selected_col == 6) screenprint_unsetcolor(10);
+    }
+    // 7: mem
+    if (ctx->procinfoproc->col_visible[m][7]) {
+        if (ctx->procinfoproc->selected_col == 7) screenprint_setcolor(10);
+        TUI_printfw("MEM:%7ldkB ", ctx->scan_shm->pinfodisp[pindex].VmRSSarray[0]);
+        if (ctx->procinfoproc->selected_col == 7) screenprint_unsetcolor(10);
+    }
+    // 8: thr
+    if (ctx->procinfoproc->col_visible[m][8]) {
+        if (ctx->procinfoproc->selected_col == 8) screenprint_setcolor(10);
+        TUI_printfw("Thr:%3d ", ctx->scan_shm->pinfodisp[pindex].threads);
+        if (ctx->procinfoproc->selected_col == 8) screenprint_unsetcolor(10);
+    }
+}
+
+static void procctrl_render_row_trigger(procctrl_context_t *ctx, int m, int pindex) {
+    // 4: pname
+    if (ctx->procinfoproc->col_visible[m][4]) {
+        if (ctx->procinfoproc->selected_col == 4) screenprint_setcolor(10);
+        TUI_printfw("%-25s ", pinfolist->pnamearray[pindex]);
+        if (ctx->procinfoproc->selected_col == 4) screenprint_unsetcolor(10);
+    }
+    // 5: tmode
+    if (ctx->procinfoproc->col_visible[m][5]) {
+        if (ctx->procinfoproc->selected_col == 5) screenprint_setcolor(10);
+        TUI_printfw("TR:%d ", ctx->scan_shm->pinfodisp[pindex].triggermode);
+        if (ctx->procinfoproc->selected_col == 5) screenprint_unsetcolor(10);
+    }
+    // 6: tstream
+    if (ctx->procinfoproc->col_visible[m][6]) {
+        if (ctx->procinfoproc->selected_col == 6) screenprint_setcolor(10);
+        TUI_printfw("%-15s ", ctx->scan_shm->pinfodisp[pindex].triggerstreamname);
+        if (ctx->procinfoproc->selected_col == 6) screenprint_unsetcolor(10);
+    }
+    // 7: tsem
+    if (ctx->procinfoproc->col_visible[m][7]) {
+        if (ctx->procinfoproc->selected_col == 7) screenprint_setcolor(10);
+        TUI_printfw("S:%d ", ctx->scan_shm->pinfodisp[pindex].triggersem);
+        if (ctx->procinfoproc->selected_col == 7) screenprint_unsetcolor(10);
+    }
+    // 8: tcnt
+    if (ctx->procinfoproc->col_visible[m][8]) {
+        if (ctx->procinfoproc->selected_col == 8) screenprint_setcolor(10);
+        TUI_printfw("CNT:%ld ", (long)ctx->scan_shm->pinfodisp[pindex].triggerstreamcnt);
+        if (ctx->procinfoproc->selected_col == 8) screenprint_unsetcolor(10);
+    }
+    // 9: tmiss
+    if (ctx->procinfoproc->col_visible[m][9]) {
+        if (ctx->procinfoproc->selected_col == 9) screenprint_setcolor(10);
+        TUI_printfw("M:%d/%ld ", ctx->scan_shm->pinfodisp[pindex].triggermissedframe, (long)ctx->scan_shm->pinfodisp[pindex].triggermissedframe_cumul);
+        if (ctx->procinfoproc->selected_col == 9) screenprint_unsetcolor(10);
+    }
+}
+
+static void procctrl_render_row_timing(procctrl_context_t *ctx, int m, int pindex) {
+    // 4: pname
+    if (ctx->procinfoproc->col_visible[m][4]) {
+        if (ctx->procinfoproc->selected_col == 4) screenprint_setcolor(10);
+        TUI_printfw("%-25s ", pinfolist->pnamearray[pindex]);
+        if (ctx->procinfoproc->selected_col == 4) screenprint_unsetcolor(10);
+    }
+    if (ctx->scan_shm->pinfodisp[pindex].MeasureTiming) {
+        double freq = 0.0;
+        if (ctx->scan_shm->pinfodisp[pindex].dtmedian_iter_ns > 0) freq = 1.0e9 / ctx->scan_shm->pinfodisp[pindex].dtmedian_iter_ns;
+        double exec_ms = 1.0e-6 * ctx->scan_shm->pinfodisp[pindex].dtmedian_exec_ns;
+        double overhead = 0.0;
+        if (ctx->scan_shm->pinfodisp[pindex].dtmedian_iter_ns > 0) overhead = 100.0 * ctx->scan_shm->pinfodisp[pindex].dtmedian_exec_ns / ctx->scan_shm->pinfodisp[pindex].dtmedian_iter_ns;
+        // 5: freq
+        if (ctx->procinfoproc->col_visible[m][5]) {
+            if (ctx->procinfoproc->selected_col == 5) screenprint_setcolor(10);
+            TUI_printfw("%8.2fHz ", freq);
+            if (ctx->procinfoproc->selected_col == 5) screenprint_unsetcolor(10);
+        }
+        // 6: exec
+        if (ctx->procinfoproc->col_visible[m][6]) {
+            if (ctx->procinfoproc->selected_col == 6) screenprint_setcolor(10);
+            TUI_printfw("Exec:%7.3fms ", exec_ms);
+            if (ctx->procinfoproc->selected_col == 6) screenprint_unsetcolor(10);
+        }
+        // 7: over
+        if (ctx->procinfoproc->col_visible[m][7]) {
+            if (ctx->procinfoproc->selected_col == 7) screenprint_setcolor(10);
+            TUI_printfw("(%5.1f%%) ", overhead);
+            if (ctx->procinfoproc->selected_col == 7) screenprint_unsetcolor(10);
+        }
+    } else {
+        TUI_printfw("--- Timing Disabled ---");
+    }
+}
+
+static void procctrl_render_row_procinfo(procctrl_context_t *ctx, int m, int pindex) {
+    // 4: pname
+    if (ctx->procinfoproc->col_visible[m][4]) {
+        if (ctx->procinfoproc->selected_col == 4) screenprint_setcolor(10);
+        TUI_printfw("%-25s ", pinfolist->pnamearray[pindex]);
+        if (ctx->procinfoproc->selected_col == 4) screenprint_unsetcolor(10);
+    }
+    // 5: RT
+    if (ctx->procinfoproc->col_visible[m][5]) {
+        if (ctx->procinfoproc->selected_col == 5) screenprint_setcolor(10);
+        TUI_printfw("RT:%2d ", ctx->scan_shm->pinfodisp[pindex].rt_priority);
+        if (ctx->procinfoproc->selected_col == 5) screenprint_unsetcolor(10);
+    }
+    // 6: loopMax
+    if (ctx->procinfoproc->col_visible[m][6]) {
+        if (ctx->procinfoproc->selected_col == 6) screenprint_setcolor(10);
+        TUI_printfw("Lmax:%7ld ", ctx->scan_shm->pinfodisp[pindex].loopcntMax);
+        if (ctx->procinfoproc->selected_col == 6) screenprint_unsetcolor(10);
+    }
+    // 7: trig
+    if (ctx->procinfoproc->col_visible[m][7]) {
+        if (ctx->procinfoproc->selected_col == 7) screenprint_setcolor(10);
+        TUI_printfw("Trig:%d ", ctx->scan_shm->pinfodisp[pindex].triggermode);
+        if (ctx->procinfoproc->selected_col == 7) screenprint_unsetcolor(10);
+    }
+    // 8: timeout
+    if (ctx->procinfoproc->col_visible[m][8]) {
+        if (ctx->procinfoproc->selected_col == 8) screenprint_setcolor(10);
+        double tout = ctx->scan_shm->pinfodisp[pindex].triggertimeout.tv_sec + 1e-9 * ctx->scan_shm->pinfodisp[pindex].triggertimeout.tv_nsec;
+        TUI_printfw("TO:%5.2f ", tout);
+        if (ctx->procinfoproc->selected_col == 8) screenprint_unsetcolor(10);
+    }
+    // 9: timing
+    if (ctx->procinfoproc->col_visible[m][9]) {
+        if (ctx->procinfoproc->selected_col == 9) screenprint_setcolor(10);
+        TUI_printfw("Tim:%d ", ctx->scan_shm->pinfodisp[pindex].MeasureTiming);
+        if (ctx->procinfoproc->selected_col == 9) screenprint_unsetcolor(10);
+    }
+}
+
+static void procctrl_render_process_list(procctrl_context_t *ctx, int NBactive) {
+    int dispindexMax = wrow - 6;
+
+    int margin_dn = 2;
+    int margin_up = 2;
+
+    if (margin_dn >= dispindexMax) {
+        margin_dn = dispindexMax - 1;
+    }
+    if (margin_dn < 0) {
+        margin_dn = 0;
+    }
+    if (margin_up >= dispindexMax) {
+        margin_up = dispindexMax - 1;
+    }
+    if (margin_up < 0) {
+        margin_up = 0;
+    }
+
+    while (ctx->pindexActiveSelected - ctx->doffsetindex > dispindexMax - 1 - margin_dn) {
+        ctx->doffsetindex++;
+    }
+
+    while (ctx->pindexActiveSelected < ctx->doffsetindex + margin_up) {
+        ctx->doffsetindex--;
+    }
+
+    if (ctx->pindexActiveSelected < ctx->doffsetindex) {
+        ctx->doffsetindex = ctx->pindexActiveSelected;
+    }
+    if (ctx->pindexActiveSelected >= ctx->doffsetindex + dispindexMax) {
+        ctx->doffsetindex = ctx->pindexActiveSelected - dispindexMax + 1;
+    }
+
+    if (ctx->doffsetindex < 0) {
+        ctx->doffsetindex = 0;
+    }
+
+    int lastindex = ctx->doffsetindex + dispindexMax;
+    if (lastindex > NBactive) {
+        lastindex = NBactive;
+    }
+
+    for(int dispindex = ctx->doffsetindex; dispindex < lastindex; dispindex++) {
+        if (dispindex == ctx->doffsetindex && ctx->doffsetindex > 0) {
+            screenprint_setbold();
+            screenprint_setcolor(3);
+            TUI_printfw("      ^^^^ %d more entries above ^^^^", (int)(ctx->doffsetindex + 1));
+            screenprint_unsetcolor(3);
+            screenprint_unsetbold();
+            TUI_newline();
+            continue;
+        }
+
+        if (dispindex == lastindex - 1 && lastindex < NBactive) {
+            screenprint_setbold();
+            screenprint_setcolor(3);
+            TUI_printfw("      vvvv %d more entries below vvvv", (int)(NBactive - lastindex + 1));
+            screenprint_unsetcolor(3);
+            screenprint_unsetbold();
+            TUI_newline();
+            continue;
+        }
+
+        if (ctx->scan_shm == NULL) break;
+        int pindex;
+        int m = ctx->procinfoproc->DisplayMode;
+        
+        if (ctx->procinfoproc->sort_col[m] > 0) pindex = ctx->procinfoproc->local_sorted_pindex[dispindex];
+        else pindex = ctx->scan_shm->sorted_pindex[dispindex];
+        
+        if (pindex >= 0 && pindex < PROCESSINFOLISTSIZE && (ctx->procinfoproc->pinfommapped[pindex] || pinfolist->active[pindex] != 0)) {
+            if (pindex == ctx->pindexSelected) screenprint_setreverse();
+            
+            if (ctx->procinfoproc->selectedarray[pindex]) TUI_printfw("* "); else TUI_printfw("  ");
+            
+            // Column 1: idx
+            if (ctx->procinfoproc->col_visible[m][1]) {
+                if (ctx->procinfoproc->selected_col == 1) screenprint_setcolor(10);
+                TUI_printfw("%4d ", pindex);
+                if (ctx->procinfoproc->selected_col == 1) screenprint_unsetcolor(10);
+            }
+
+            // Column 2: status
+            if (ctx->procinfoproc->col_visible[m][2]) {
+                if (ctx->procinfoproc->selected_col == 2) screenprint_setcolor(10);
+                if (pinfolist->active[pindex] == 1) {
+                    screenprint_setcolor(6); TUI_printfw("%-10s ", "ACTIVE"); screenprint_unsetcolor(6);
+                } else if (pinfolist->active[pindex] == 2) {
+                    screenprint_setcolor(7); TUI_printfw("%-10s ", "STOPPED"); screenprint_unsetcolor(7);
+                } else if (pinfolist->active[pindex] == 3) {
+                    screenprint_setcolor(8); TUI_printfw("%-10s ", "CRASHED"); screenprint_unsetcolor(8);
+                } else {
+                    TUI_printfw("%-10s ", "OFF");
+                }
+                if (ctx->procinfoproc->selected_col == 2) screenprint_unsetcolor(10);
+            }
+            
+            // Column 3: pid
+            if (ctx->procinfoproc->col_visible[m][3]) {
+                if (ctx->procinfoproc->selected_col == 3) screenprint_setcolor(10);
+                pid_t pid = pinfolist->PIDarray[pindex];
+                int pid_exists = (kill(pid, 0) == 0);
+                if (!pid_exists) screenprint_setcolor(4);
+                char state = ctx->scan_shm->pinfodisp[pindex].state;
+                if (state == 0) state = ' ';
+                TUI_printfw("%7d %c ", pid, state);
+                if (!pid_exists) screenprint_unsetcolor(4);
+                if (ctx->procinfoproc->selected_col == 3) screenprint_unsetcolor(10);
+            }
+
+            if (ctx->scan_shm && pindex < PROCESSINFOLISTSIZE && pinfolist->active[pindex] == 1 && ctx->scan_shm->request_scan[pindex] == 0) {
+                ctx->scan_shm->request_scan[pindex] = 1;
+            }
+
+            switch (m) {
+                case PROCCTRL_DISPLAYMODE_CTRL:
+                    procctrl_render_row_ctrl(ctx, m, pindex);
+                    break;
+                case PROCCTRL_DISPLAYMODE_RESOURCES:
+                    procctrl_render_row_resources(ctx, m, pindex);
+                    break;
+                case PROCCTRL_DISPLAYMODE_TRIGGER:
+                    procctrl_render_row_trigger(ctx, m, pindex);
+                    break;
+                case PROCCTRL_DISPLAYMODE_TIMING:
+                    procctrl_render_row_timing(ctx, m, pindex);
+                    break;
+                case PROCCTRL_DISPLAYMODE_PROCINFO:
+                    procctrl_render_row_procinfo(ctx, m, pindex);
+                    break;
+                default:
+                    TUI_printfw("(Mode %d not impl)", m);
+                    break;
+            }
+
+            if (pindex == ctx->pindexSelected) screenprint_unsetreverse();
+            TUI_newline();
+        }
+    }
+}
+
+void procctrl_render_frame(procctrl_context_t *ctx, int NBactive) {
+    if (ctx->freeze == 0) {
+        sc_frame_clear();
+        TUI_clearscreen(&wrow, &wcol);
+        snprintf(ctx->monstring, ctx->monstringlen, "Mode %d   PRESS x TO STOP MONITOR", ctx->procinfoproc->DisplayMode);
+        TUI_print_header(ctx->monstring, '-');
+        TUI_newline();
+        
+        procctrl_render_header(ctx);
+        procctrl_render_mode_tabs(ctx);
+        procctrl_render_column_headers(ctx);
+        
+        if (ctx->procinfoproc->DisplayMode == PROCCTRL_DISPLAYMODE_HELP) {
+            procctrl_render_help();
+        } else {
+            procctrl_render_process_list(ctx, NBactive);
+        }
+        
+        TUI_cleartobottom();
+        sc_frame_flush();
+    }
+}


### PR DESCRIPTION
## Summary
Refactor the `milk-procCTRL` TUI implementation to vastly improve maintainability, reduce monolithic function complexity, and optimize code organization by modularizing rendering, input handling, and initialization routines into separate source files.

## Changes

### `src/engine/libprocessinfo/procCTRL/`
- **`procCTRL_TUI_internal.h`**: Created to define the shared `procctrl_context_t` structure and expose internal helper prototypes.
- **`procCTRL_TUI_render.c`**: Extracted the 500-line monolithic `procctrl_render_frame` into discrete layout helpers and isolated, mode-specific row-rendering functions for each display mode (CTRL, Resources, Trigger, Timing, Procinfo).
- **`procCTRL_TUI_input.c`**: Extracted keyboard interaction event handlers.
- **`procCTRL_TUI.c`**: Refactored the main loop, adding static `procctrl_init` and `procctrl_cleanup` helpers to significantly reduce LOC and complexity within the main `processinfo_CTRLscreen` function.
- **`CMakeLists.txt`**: Added the new source files to the `milk-procCTRL` build target.

## Verification
- [x] Build passes (`make -C _build milk-procCTRL`)
- [x] Confirmed TUI rendering functionality and build consistency

## Prompt Summary
The user requested code quality improvements and refactoring of the `milk-procCTRL` TUI rendering logic, focusing on reducing lines of code per file and function, optimizing organization for readability, and isolating mode-specific display logic into dedicated row-rendering functions while maintaining current functionality and build integrity.

## AI Authorship
- **Model**: Antigravity
- **User edits**: None