### PR TITLE
feat: standardize V2 help for milk-fps-* lifecycle and query tools

### DIFF
--- a/src/engine/libfps/milk-fps-cmd.c
+++ b/src/engine/libfps/milk-fps-cmd.c
@@ -1,6 +1,10 @@
 /**
  * @file milk-fps-cmd.c
- * @brief Milk fps cmd module
+ * @brief FPS lifecycle command dispatcher.
+ *
+ * Compiled 5× with different binary names:
+ *   milk-fps-confstart, milk-fps-confstop, milk-fps-confstep,
+ *   milk-fps-runstart, milk-fps-runstop.
  */
 
 #include <stdio.h>
@@ -11,83 +15,179 @@
 
 #include "fps.h"
 #include "fps_globals.h"
+#include "milk_help.h"
 
-void print_help(const char *progname) {
-    printf("Usage: %s [OPTIONS] <fpsname>\n\n", progname);
-    
-    if (strcmp(progname, "milk-fps-confstart") == 0) {
-        printf("Starts the configuration process for the given FPS.\n");
-    } else if (strcmp(progname, "milk-fps-confstop") == 0) {
-        printf("Stops the configuration process for the given FPS.\n");
-    } else if (strcmp(progname, "milk-fps-runstart") == 0) {
-        printf("Starts the run process for the given FPS.\n");
-    } else if (strcmp(progname, "milk-fps-runstop") == 0) {
-        printf("Stops the run process for the given FPS.\n");
-    } else if (strcmp(progname, "milk-fps-confstep") == 0) {
-        printf("Runs a single configuration step for the given FPS.\n");
-    } else {
-        printf("Executes a command for the given FPS.\n");
-    }
+/* ─────────────────────────────────────────────────────────
+ * Per-variant descriptions
+ * ───────────────────────────────────────────────────────── */
 
-    printf("\nOPTIONS:\n");
-    printf("  %-15s %s\n", "-h, --help", "Show this help message and exit.");
-    printf("  %-15s %s\n", "-tmux", "Run the command inside the FPS tmux session.");
-    printf("                  If the tmux session does not exist, it will be automatically created.\n");
-    printf("\nDESCRIPTION:\n");
-    printf("  This tool allows sending standard lifecycle commands to an existing FPS.\n");
-    printf("  Executing without the -tmux flag will run the process locally in the current terminal,\n");
-    printf("  which will block the terminal (unless it's a stop command). Using -tmux dispatches\n");
-    printf("  the process to the appropriate tmux window ('conf' or 'run') to run in the background.\n");
+static const char *cmd_desc(const char *prog)
+{
+    if (strcmp(prog, "milk-fps-confstart") == 0)
+        return "start FPS configuration loop";
+    if (strcmp(prog, "milk-fps-confstop") == 0)
+        return "stop FPS configuration loop";
+    if (strcmp(prog, "milk-fps-confstep") == 0)
+        return "run one FPS configuration step";
+    if (strcmp(prog, "milk-fps-runstart") == 0)
+        return "start FPS run loop";
+    if (strcmp(prog, "milk-fps-runstop") == 0)
+        return "stop FPS run loop";
+    return "send lifecycle command to FPS";
 }
+
+static const char *cmd_desc_long(const char *prog)
+{
+    if (strcmp(prog, "milk-fps-confstart") == 0)
+        return
+            "Start the configuration loop for a Function Parameter Structure\n"
+            "(FPS). The conf loop reads FPS parameters from shared memory and\n"
+            "applies them to the running compute unit, allowing live parameter\n"
+            "updates without restarting the process. Use -tmux to dispatch\n"
+            "into the FPS tmux 'conf' window so it runs in the background.";
+    if (strcmp(prog, "milk-fps-confstop") == 0)
+        return
+            "Stop the configuration loop for a Function Parameter Structure\n"
+            "(FPS). Sends the confstop signal to the running compute unit.\n"
+            "Use -tmux to dispatch the stop command via the tmux session.";
+    if (strcmp(prog, "milk-fps-confstep") == 0)
+        return
+            "Run a single configuration step for a Function Parameter\n"
+            "Structure (FPS). Applies the current parameter values once\n"
+            "without entering a continuous conf loop. Useful for one-shot\n"
+            "parameter updates during testing or scripted calibration.";
+    if (strcmp(prog, "milk-fps-runstart") == 0)
+        return
+            "Start the run loop for a Function Parameter Structure (FPS).\n"
+            "The run loop executes the compute function continuously (or\n"
+            "semaphore-triggered), using the current FPS parameters. Use\n"
+            "-tmux to dispatch into the FPS tmux 'run' window so the loop\n"
+            "runs in the background independently of the terminal.";
+    if (strcmp(prog, "milk-fps-runstop") == 0)
+        return
+            "Stop the run loop for a Function Parameter Structure (FPS).\n"
+            "Sends the runstop signal to the running compute unit, causing\n"
+            "it to exit its main loop cleanly. Use -tmux to dispatch via\n"
+            "the tmux session.";
+    return
+        "Send a lifecycle command (confstart/confstop/confstep/runstart/\n"
+        "runstop) to a Function Parameter Structure (FPS).";
+}
+
+/* ─────────────────────────────────────────────────────────
+ * print_help() - Full formatted help output.
+ * @progname:  Executable name.
+ * @mh_color:  Non-zero to emit ANSI color.
+ * ───────────────────────────────────────────────────────── */
+
+static void print_help(const char *progname, int mh_color)
+{
+    milk_help_banner(progname, cmd_desc(progname), mh_color);
+
+    milk_help_section("Usage", mh_color);
+    printf("  %s%s%s [%s-tmux%s] %s<fpsname>%s\n\n",
+           mh_color ? MH_CMD : "", progname, mh_color ? MH_RST : "",
+           mh_color ? MH_OPT : "", mh_color ? MH_RST : "",
+           mh_color ? MH_ARG : "", mh_color ? MH_RST : "");
+
+    milk_help_section("Description", mh_color);
+    printf("  %s\n\n", cmd_desc_long(progname));
+
+    milk_help_section("Arguments", mh_color);
+    printf("  %s%-14s%s %s\n\n",
+           mh_color ? MH_ARG : "", "<fpsname>", mh_color ? MH_RST : "",
+           "Name of the target FPS");
+
+    milk_help_section("Options", mh_color);
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-h, --help",
+           mh_color ? MH_RST : "", "Show this help and exit");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-h1, --help-oneline",
+           mh_color ? MH_RST : "", "Print one-line description and exit");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-h2, --help-description",
+           mh_color ? MH_RST : "", "Print verbose description and exit");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-hm, --help-mono",
+           mh_color ? MH_RST : "", "Full help, no ANSI color");
+    printf("  %s%-25s%s %s\n\n",
+           mh_color ? MH_OPT : "", "-tmux",
+           mh_color ? MH_RST : "",
+           "Dispatch via FPS tmux session (runs in background)");
+
+    milk_help_section("Examples", mh_color);
+    printf("  %s$ %s%s%s %smyfps00%s\n",
+           mh_color ? MH_DIM : "",
+           mh_color ? MH_CMD : "", progname, mh_color ? MH_RST : "",
+           mh_color ? MH_ARG : "", mh_color ? MH_RST : "");
+    printf("  %s$ %s%s%s -tmux %smyfps00%s\n\n",
+           mh_color ? MH_DIM : "",
+           mh_color ? MH_CMD : "", progname, mh_color ? MH_RST : "",
+           mh_color ? MH_ARG : "", mh_color ? MH_RST : "");
+
+    const char *see_also[] = {
+        "milk-fps-list", "milk-fps-info", "milk-fps-set",
+        "milk-fpsCTRL",  "milk-fpsexec-help"
+    };
+    milk_help_see_also(see_also, 5, mh_color);
+}
+
+/* ─────────────────────────────────────────────────────────
+ * main()
+ * ───────────────────────────────────────────────────────── */
 
 int main(int argc, char *argv[])
 {
     const char *progname = basename(argv[0]);
 
-    /* One-line help — must come before any FPS connection */
-    for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "-h1") == 0 ||
-            strcmp(argv[i], "--help-oneline") == 0)
-        {
-            if (strcmp(progname, "milk-fps-confstart") == 0)
-                printf("start FPS configuration loop\n");
-            else if (strcmp(progname, "milk-fps-confstop") == 0)
-                printf("stop FPS configuration loop\n");
-            else if (strcmp(progname, "milk-fps-confstep") == 0)
-                printf("run one FPS configuration step\n");
-            else if (strcmp(progname, "milk-fps-runstart") == 0)
-                printf("start FPS run loop\n");
-            else if (strcmp(progname, "milk-fps-runstop") == 0)
-                printf("stop FPS run loop\n");
-            else
-                printf("send lifecycle command to FPS\n");
-            return 0;
-        }
+    int action = milk_help_init(argc, argv,
+                                cmd_desc(progname),
+                                cmd_desc_long(progname));
+    if (action == MH_ACTION_H1 || action == MH_ACTION_H2)
+    {
+        return 0;
     }
 
-    if (argc < 2) {
-        fprintf(stderr, "Usage: %s [OPTIONS] <fpsname>\n", progname);
+    int mh_color = (action == MH_ACTION_HELP);
+
+    if (action == MH_ACTION_HELP || action == MH_ACTION_MONO)
+    {
+        print_help(progname, mh_color);
+        return 0;
+    }
+
+    if (argc < 2)
+    {
+        fprintf(stderr,
+                "Error: Missing <fpsname>. "
+                "Run %s -h for usage.\n", progname);
         return 1;
     }
 
     int use_tmux = 0;
     const char *fpsname = NULL;
 
-    for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
-            print_help(progname);
-            return 0;
-        } else if (strcmp(argv[i], "-tmux") == 0) {
+    for (int i = 1; i < argc; i++)
+    {
+        if (strcmp(argv[i], "-tmux") == 0)
+        {
             use_tmux = 1;
-        } else if (fpsname == NULL) {
+        }
+        else if (fpsname == NULL)
+        {
             fpsname = argv[i];
-        } else {
-            fprintf(stderr, "Error: Unexpected argument '%s'.\n", argv[i]);
+        }
+        else
+        {
+            fprintf(stderr,
+                    "Error: Unexpected argument '%s'.\n", argv[i]);
             return 1;
         }
-    }
+    } // for i
 
-    if (fpsname == NULL) {
+    if (fpsname == NULL)
+    {
         fprintf(stderr, "Error: Missing <fpsname>\n");
         return 1;
     }
@@ -95,51 +195,74 @@ int main(int argc, char *argv[])
     FPS fps;
     fps.SMfd = -1;
 
-    if (fps_connect(fpsname, &fps, 0) == -1) {
-        fprintf(stderr, "Error: cannot connect to FPS \"%s\".\n", fpsname);
+    if (fps_connect(fpsname, &fps, 0) == -1)
+    {
+        fprintf(stderr,
+                "Error: cannot connect to FPS \"%s\".\n", fpsname);
         return 1;
     }
 
     char *command = NULL;
-    if (strcmp(progname, "milk-fps-confstart") == 0) command = "confstart";
-    else if (strcmp(progname, "milk-fps-confstop") == 0) command = "confstop";
-    else if (strcmp(progname, "milk-fps-runstart") == 0) command = "runstart";
-    else if (strcmp(progname, "milk-fps-runstop") == 0) command = "runstop";
-    else if (strcmp(progname, "milk-fps-confstep") == 0) command = "confstep";
+    if (strcmp(progname, "milk-fps-confstart") == 0)
+        command = "confstart";
+    else if (strcmp(progname, "milk-fps-confstop") == 0)
+        command = "confstop";
+    else if (strcmp(progname, "milk-fps-runstart") == 0)
+        command = "runstart";
+    else if (strcmp(progname, "milk-fps-runstop") == 0)
+        command = "runstop";
+    else if (strcmp(progname, "milk-fps-confstep") == 0)
+        command = "confstep";
 
-    if (command == NULL) {
-        fprintf(stderr, "Error: unknown command \"%s\".\n", progname);
+    if (command == NULL)
+    {
+        fprintf(stderr,
+                "Error: unknown command \"%s\".\n", progname);
         fps_disconnect(&fps);
         return 1;
     }
 
-    if (strlen(fps.md->execfullpath) == 0 || strcmp(fps.md->execfullpath, "unknown") == 0) {
-        fprintf(stderr, "Error: execfullpath not set for FPS \"%s\".\n", fpsname);
+    if (strlen(fps.md->execfullpath) == 0
+        || strcmp(fps.md->execfullpath, "unknown") == 0)
+    {
+        fprintf(stderr,
+                "Error: execfullpath not set for FPS \"%s\".\n",
+                fpsname);
         fps_disconnect(&fps);
         return 1;
     }
 
-    if (use_tmux) {
+    if (use_tmux)
+    {
         functionparameter_FPS_tmux_ensure(&fps);
-        
+
         char extra_args[256];
-        snprintf(extra_args, sizeof(extra_args), " %s:%s", fpsname, command);
-        
-        if (functionparameter_FPS_tmux_send_dispatch(fpsname, command, fps.md->execfullpath, extra_args) != 0) {
-             fprintf(stderr, "Warning: Command '%s' not recognized for tmux dispatch, running locally...\n", command);
-             // fallback
-             char cmdline[1024];
-             snprintf(cmdline, sizeof(cmdline), "%s %s:%s", fps.md->execfullpath, fpsname, command);
-             printf("Executing locally: %s\n", cmdline);
-             int ret = system(cmdline);
-             fps_disconnect(&fps);
-             return WEXITSTATUS(ret);
+        snprintf(extra_args, sizeof(extra_args),
+                 " %s:%s", fpsname, command);
+
+        if (functionparameter_FPS_tmux_send_dispatch(
+                fpsname, command,
+                fps.md->execfullpath, extra_args) != 0)
+        {
+            fprintf(stderr,
+                    "Warning: '%s' not recognized for tmux dispatch,"
+                    " running locally...\n", command);
+            char cmdline[1024];
+            snprintf(cmdline, sizeof(cmdline),
+                     "%s %s:%s",
+                     fps.md->execfullpath, fpsname, command);
+            printf("Executing locally: %s\n", cmdline);
+            int ret = system(cmdline);
+            fps_disconnect(&fps);
+            return WEXITSTATUS(ret);
         }
-        
-    } else {
+    }
+    else
+    {
         char cmdline[1024];
-        snprintf(cmdline, sizeof(cmdline), "%s %s:%s", fps.md->execfullpath, fpsname, command);
-        
+        snprintf(cmdline, sizeof(cmdline),
+                 "%s %s:%s",
+                 fps.md->execfullpath, fpsname, command);
         printf("Executing locally: %s\n", cmdline);
         int ret = system(cmdline);
         fps_disconnect(&fps);

--- a/src/engine/libfps/milk-fps-info.c
+++ b/src/engine/libfps/milk-fps-info.c
@@ -30,12 +30,14 @@ volatile sig_atomic_t ov_sigTERM = 0;
  * ANSI helpers for connection display
  * ========================================================= */
 
-#define CI_RST    "\033[0m"
-#define CI_HDR    "\033[1;35m"
-#define CI_LABEL  "\033[1;34m"
-#define CI_STREAM "\033[1;36m"
-#define CI_PROC   "\033[1;33m"
-#define CI_DIM    "\033[2m"
+#include "milk_help.h"
+
+#define CI_RST    MH_RST
+#define CI_HDR    MH_HDR
+#define CI_LABEL  MH_ARG
+#define CI_STREAM MH_TITLE
+#define CI_PROC   MH_NOTE
+#define CI_DIM    MH_DIM
 
 /* =========================================================
  * Connection display (requires OV_MODEL)
@@ -188,27 +190,74 @@ static void print_connections(const char *fpsname)
  * Help
  * ========================================================= */
 
-static void print_help(const char *progname)
+#define FI_DESC \
+    "print content of a Function Parameter Structure (FPS)"
+
+#define FI_DESC_LONG \
+    "Display all parameters and current values for an FPS instance.\n" \
+    "Output columns: parameter key, type, current value, flags.\n" \
+    "With -v, also shows limits, defaults, and FPS header metadata.\n" \
+    "With -c, cross-references stream and process connections\n" \
+    "from the live system graph built by milkCTRL/overview."
+
+static void print_help(const char *progname, int mh_color)
 {
-    printf("Usage: %s [options] <fpsname>\n",
-           progname);
-    printf("Print content of a Function "
-           "Parameter Structure (FPS).\n");
-    printf("\nOptions:\n");
-    printf("  -v, --verbose        "
-           "Verbose mode\n");
-    printf("  -i, --info           "
-           "Show stream info on "
-           "separate line\n");
+    milk_help_banner(progname, FI_DESC, mh_color);
+
+    milk_help_section("Usage", mh_color);
+    printf("  %s%s%s [%soptions%s] %s<fpsname>%s\n\n",
+           mh_color ? MH_CMD : "", progname, mh_color ? MH_RST : "",
+           mh_color ? MH_OPT : "", mh_color ? MH_RST : "",
+           mh_color ? MH_ARG : "", mh_color ? MH_RST : "");
+
+    milk_help_section("Description", mh_color);
+    printf("  %s\n\n", FI_DESC_LONG);
+
+    milk_help_section("Arguments", mh_color);
+    printf("  %s%-14s%s %s\n\n",
+           mh_color ? MH_ARG : "", "<fpsname>",
+           mh_color ? MH_RST : "", "Name of the FPS to inspect");
+
+    milk_help_section("Options", mh_color);
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-v, --verbose",
+           mh_color ? MH_RST : "", "Verbose (limits, defaults, header)");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-i, --info",
+           mh_color ? MH_RST : "", "Show stream info on separate line");
 #ifdef FPS_INFO_CONNECTIONS
-    printf("  -c, --connections    "
-           "Show graph connections\n");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-c, --connections",
+           mh_color ? MH_RST : "", "Show stream/process graph connections");
 #endif
-    printf("  -h, --help           "
-           "Show this help message\n");
-    printf("  -h1, --help-oneline  "
-           "Print one-line description "
-           "and exit\n");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-h, --help",
+           mh_color ? MH_RST : "", "Show this help and exit");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-h1, --help-oneline",
+           mh_color ? MH_RST : "", "Print one-line description and exit");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-h2, --help-description",
+           mh_color ? MH_RST : "", "Print verbose description and exit");
+    printf("  %s%-25s%s %s\n\n",
+           mh_color ? MH_OPT : "", "-hm, --help-mono",
+           mh_color ? MH_RST : "", "Full help, no ANSI color");
+
+    milk_help_section("Examples", mh_color);
+    printf("  %s$ %smilk-fps-info%s %smyfps00%s\n",
+           mh_color ? MH_DIM : "",
+           mh_color ? MH_CMD : "", mh_color ? MH_RST : "",
+           mh_color ? MH_ARG : "", mh_color ? MH_RST : "");
+    printf("  %s$ %smilk-fps-info%s -v %smyfps00%s\n\n",
+           mh_color ? MH_DIM : "",
+           mh_color ? MH_CMD : "", mh_color ? MH_RST : "",
+           mh_color ? MH_ARG : "", mh_color ? MH_RST : "");
+
+    const char *see_also[] = {
+        "milk-fps-list", "milk-fps-set", "milk-fps-track",
+        "milk-fpsCTRL"
+    };
+    milk_help_see_also(see_also, 4, mh_color);
 }
 
 /* =========================================================
@@ -217,14 +266,16 @@ static void print_help(const char *progname)
 
 int main(int argc, char *argv[])
 {
-    /* Handle -h1/--help-oneline */
-    if (argc >= 2
-        && (strcmp(argv[1], "-h1") == 0
-            || strcmp(argv[1],
-                      "--help-oneline") == 0))
+    int action = milk_help_init(argc, argv,
+                                FI_DESC, FI_DESC_LONG);
+    if (action == MH_ACTION_H1 || action == MH_ACTION_H2)
     {
-        printf("print content of a Function "
-               "Parameter Structure (FPS)\n");
+        return 0;
+    }
+    int mh_color = (action == MH_ACTION_HELP);
+    if (action == MH_ACTION_HELP || action == MH_ACTION_MONO)
+    {
+        print_help(argv[0], mh_color);
         return 0;
     }
 
@@ -258,15 +309,11 @@ int main(int argc, char *argv[])
             show_connections = 1;
             break;
         case 'h':
-            print_help(argv[0]);
-            return 0;
         case '1':
-            printf("print content of a "
-                   "Function Parameter "
-                   "Structure (FPS)\n");
-            return 0;
+            /* Handled above by milk_help_init() */
+            break;
         default:
-            print_help(argv[0]);
+            print_help(argv[0], 0);
             return 1;
         }
     }
@@ -275,7 +322,7 @@ int main(int argc, char *argv[])
     {
         fprintf(stderr,
                 "Error: missing FPS name.\n");
-        print_help(argv[0]);
+        print_help(argv[0], 0);
         return 1;
     }
 

--- a/src/engine/libfps/milk-fps-list.c
+++ b/src/engine/libfps/milk-fps-list.c
@@ -14,39 +14,95 @@
 #include "fps.h"
 #include "fps_globals.h"
 #include "fps_scan.h"
+#include "milk_help.h"
 
-/* ANSI color codes */
-#define C_TITLE "\033[1;36m"  /* Cyan Bold   */
-#define C_HDR   "\033[1;34m"  /* Blue Bold   */
-#define C_NAME  "\033[1;32m"  /* Green Bold  */
-#define C_TYPE  "\033[1;33m"  /* Yellow Bold */
-#define C_SIZE  "\033[1m"     /* White Bold  */
-#define C_CNT   "\033[1;35m"  /* Magenta Bold */
-#define C_SEM   "\033[36m"    /* Cyan        */
-#define C_LINK  "\033[36m"    /* Cyan        */
-#define C_ERR   "\033[1;31m"  /* Red Bold    */
-#define C_DIM   "\033[2m"     /* Dim         */
-#define C_RST   "\033[0m"     /* Reset       */
+/* local color aliases — keep for table rendering, map to MH_* */
+#define C_TITLE MH_TITLE
+#define C_HDR   MH_HDR
+#define C_NAME  MH_CMD
+#define C_TYPE  MH_NOTE
+#define C_SIZE  MH_BOLD
+#define C_CNT   MH_ARG
+#define C_SEM   MH_DFLT
+#define C_LINK  MH_DFLT
+#define C_ERR   MH_ERR
+#define C_DIM   MH_DIM
+#define C_RST   MH_RST
 
-void print_help(const char *progname) {
-    printf("Usage: %s [options] [regex pattern]\n", progname);
-    printf("List active FPS instances.\n");
-    printf("\n");
-    printf("Options:\n");
-    printf("  -v, --verbose   Verbose mode (print search directory and details)\n");
-    printf("  -e, --exec      Show full path to executable\n");
-    printf("  -h, --help      Show this help message\n");
+#define FL_DESC "list Function Parameter Structures (FPS) in shared memory"
+#define FL_DESC_LONG \
+    "Scan /dev/shm for active FPS instances and print a summary table.\n" \
+    "Each row shows FPS name, executable, CLI key, conf/run PIDs,\n" \
+    "tmux status, and short description.\n" \
+    "An optional regex pattern filters which FPS names are shown."
+
+static void print_help(const char *progname, int mh_color)
+{
+    milk_help_banner(progname, FL_DESC, mh_color);
+
+    milk_help_section("Usage", mh_color);
+    printf("  %s%s%s [%soptions%s] [%sregex%s]\n\n",
+           mh_color ? MH_CMD : "", progname, mh_color ? MH_RST : "",
+           mh_color ? MH_OPT : "", mh_color ? MH_RST : "",
+           mh_color ? MH_ARG : "", mh_color ? MH_RST : "");
+
+    milk_help_section("Description", mh_color);
+    printf("  %s\n\n", FL_DESC_LONG);
+
+    milk_help_section("Arguments", mh_color);
+    printf("  %s%-14s%s %s\n\n",
+           mh_color ? MH_ARG : "", "[regex]",
+           mh_color ? MH_RST : "",
+           "Optional POSIX extended regex to filter by FPS name");
+
+    milk_help_section("Options", mh_color);
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-v, --verbose",
+           mh_color ? MH_RST : "",
+           "Verbose (print search directory and details)");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-e, --exec",
+           mh_color ? MH_RST : "", "Show full path to executable");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-h, --help",
+           mh_color ? MH_RST : "", "Show this help and exit");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-h1, --help-oneline",
+           mh_color ? MH_RST : "", "Print one-line description and exit");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-h2, --help-description",
+           mh_color ? MH_RST : "", "Print verbose description and exit");
+    printf("  %s%-25s%s %s\n\n",
+           mh_color ? MH_OPT : "", "-hm, --help-mono",
+           mh_color ? MH_RST : "", "Full help, no ANSI color");
+
+    milk_help_section("Examples", mh_color);
+    printf("  %s$ %smilk-fps-list%s\n",
+           mh_color ? MH_DIM : "",
+           mh_color ? MH_CMD : "", mh_color ? MH_RST : "");
+    printf("  %s$ %smilk-fps-list%s %smyfps.*%s\n\n",
+           mh_color ? MH_DIM : "",
+           mh_color ? MH_CMD : "", mh_color ? MH_RST : "",
+           mh_color ? MH_ARG : "", mh_color ? MH_RST : "");
+
+    const char *see_also[] = {
+        "milk-fps-info", "milk-fps-rm", "milk-fps-set", "milk-fpsCTRL"
+    };
+    milk_help_see_also(see_also, 4, mh_color);
 }
 
 int main(int argc, char *argv[])
 {
-    /* Handle -h1/--help-oneline before getopt so "-h1" is not
-     * parsed as "-h" (flag) + "1" (unknown). */
-    if (argc >= 2 &&
-        (strcmp(argv[1], "-h1") == 0 ||
-         strcmp(argv[1], "--help-oneline") == 0))
+    int action = milk_help_init(argc, argv,
+                                FL_DESC, FL_DESC_LONG);
+    if (action == MH_ACTION_H1 || action == MH_ACTION_H2)
     {
-        printf("list Function Parameter Structures (FPS) in shared memory\\n");
+        return 0;
+    }
+    int mh_color = (action == MH_ACTION_HELP);
+    if (action == MH_ACTION_HELP || action == MH_ACTION_MONO)
+    {
+        print_help(argv[0], mh_color);
         return 0;
     }
 
@@ -62,8 +118,11 @@ int main(int argc, char *argv[])
         {0, 0, 0, 0}
     };
 
-    while ((opt = getopt_long(argc, argv, "veh1", long_options, NULL)) != -1) {
-        switch (opt) {
+    while ((opt = getopt_long(argc, argv, "veh1",
+                              long_options, NULL)) != -1)
+    {
+        switch (opt)
+        {
             case 'v':
                 verbose = 1;
                 break;
@@ -71,13 +130,11 @@ int main(int argc, char *argv[])
                 show_exec = 1;
                 break;
             case 'h':
-                print_help(argv[0]);
-                return 0;
             case '1':
-                printf("list Function Parameter Structures (FPS) in shared memory\\n");
-                return 0;
+                /* Handled above by milk_help_init() */
+                break;
             default:
-                print_help(argv[0]);
+                print_help(argv[0], 0);
                 return 1;
         }
     }

--- a/src/engine/libfps/milk-fps-rm.c
+++ b/src/engine/libfps/milk-fps-rm.c
@@ -14,20 +14,60 @@
 
 #include "fps.h"
 #include "fps_FPSremove.h"
+#include "milk_help.h"
 
-void print_help(const char *progname) {
-    printf("Usage: %s [options] [fpsname | regex pattern]\n", progname);
-    printf("Remove a Function Parameter Structure (FPS).\n");
-    printf("\n");
-    printf("If no FPS name is given, lists existing FPS instances\n");
-    printf("and prompts for selection. Multiple items can be\n");
-    printf("selected using numbers, ranges, or 'all' (e.g. 1 3 5-7).\n");
-    printf("A regex can be provided to filter the list.\n");
-    printf("\n");
-    printf("Options:\n");
-    printf("  -f, --force     Force removal by killing running processes\n");
-    printf("  -v, --verbose   Verbose mode\n");
-    printf("  -h, --help      Show this help message\n");
+#define FR_DESC \
+    "remove Function Parameter Structure (FPS) from shared memory"
+#define FR_DESC_LONG \
+    "Remove one or more FPS instances from /dev/shm.\n" \
+    "Without a name argument, scans for all FPS instances and presents\n" \
+    "an interactive selection menu. With a name or regex, removes\n" \
+    "matching instances directly. Use -f to kill running processes\n" \
+    "before removal (otherwise running FPSes are left untouched)."
+
+static void print_help(const char *progname, int mh_color)
+{
+    milk_help_banner(progname, FR_DESC, mh_color);
+    milk_help_section("Usage", mh_color);
+    printf("  %s%s%s [%soptions%s] [%sfpsname%s | %sregex%s]\n\n",
+           mh_color ? MH_CMD : "", progname, mh_color ? MH_RST : "",
+           mh_color ? MH_OPT : "", mh_color ? MH_RST : "",
+           mh_color ? MH_ARG : "", mh_color ? MH_RST : "",
+           mh_color ? MH_ARG : "", mh_color ? MH_RST : "");
+    milk_help_section("Description", mh_color);
+    printf("  %s\n\n", FR_DESC_LONG);
+    milk_help_section("Options", mh_color);
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-f, --force",
+           mh_color ? MH_RST : "", "Kill running processes before removal");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-v, --verbose",
+           mh_color ? MH_RST : "", "Verbose output");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-h, --help",
+           mh_color ? MH_RST : "", "Show this help and exit");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-h1, --help-oneline",
+           mh_color ? MH_RST : "", "One-line description and exit");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-h2, --help-description",
+           mh_color ? MH_RST : "", "Verbose description and exit");
+    printf("  %s%-25s%s %s\n\n",
+           mh_color ? MH_OPT : "", "-hm, --help-mono",
+           mh_color ? MH_RST : "", "Full help, no ANSI color");
+    milk_help_section("Examples", mh_color);
+    printf("  %s$ milk-fps-rm%s              %s# interactive%s\n",
+           mh_color ? MH_CMD : "", mh_color ? MH_RST : "",
+           mh_color ? MH_DIM : "", mh_color ? MH_RST : "");
+    printf("  %s$ milk-fps-rm%s %smyfps00%s\n",
+           mh_color ? MH_CMD : "", mh_color ? MH_RST : "",
+           mh_color ? MH_ARG : "", mh_color ? MH_RST : "");
+    printf("  %s$ milk-fps-rm%s -f %smyfps00%s\n\n",
+           mh_color ? MH_CMD : "", mh_color ? MH_RST : "",
+           mh_color ? MH_ARG : "", mh_color ? MH_RST : "");
+    const char *see_also[] = { "milk-fps-list", "milk-fps-info",
+                               "milk-fps-confstop", "milk-fps-runstop" };
+    milk_help_see_also(see_also, 4, mh_color);
 }
 
 /**
@@ -290,13 +330,14 @@ static int remove_fps(
 
 int main(int argc, char *argv[])
 {
-    /* Handle -h1/--help-oneline before getopt so "-h1" is not
-     * parsed as "-h" (flag) + "1" (unknown). */
-    if (argc >= 2 &&
-        (strcmp(argv[1], "-h1") == 0 ||
-         strcmp(argv[1], "--help-oneline") == 0))
+    int action = milk_help_init(argc, argv,
+                                FR_DESC, FR_DESC_LONG);
+    if (action == MH_ACTION_H1 || action == MH_ACTION_H2)
+        return 0;
+    int mh_color = (action == MH_ACTION_HELP);
+    if (action == MH_ACTION_HELP || action == MH_ACTION_MONO)
     {
-        printf("remove Function Parameter Structure (FPS) from shared memory\\n");
+        print_help(argv[0], mh_color);
         return 0;
     }
 
@@ -312,26 +353,17 @@ int main(int argc, char *argv[])
         {0, 0, 0, 0}
     };
 
-    while ((opt = getopt_long(argc, argv,
-                              "fvh1",
-                              long_options,
-                              NULL)) != -1)
+    while ((opt = getopt_long(argc, argv, "fvh1",
+                              long_options, NULL)) != -1)
     {
-        switch (opt) {
-            case 'f':
-                force = 1;
-                break;
-            case 'v':
-                verbose = 1;
-                break;
+        switch (opt)
+        {
+            case 'f': force   = 1; break;
+            case 'v': verbose = 1; break;
             case 'h':
-                print_help(argv[0]);
-                return 0;
-            case '1':
-                printf("remove Function Parameter Structure (FPS) from shared memory\\n");
-                return 0;
+            case '1': break; /* handled above */
             default:
-                print_help(argv[0]);
+                print_help(argv[0], 0);
                 return 1;
         }
     }

--- a/src/engine/libfps/milk-fps-search.c
+++ b/src/engine/libfps/milk-fps-search.c
@@ -14,50 +14,69 @@
 #include "fps_globals.h"
 #include "fps_scan.h"
 #include "fps_printparameter_valuestring.h"
+#include "milk_help.h"
 
-/* ANSI color codes */
-#define C_TITLE "\033[1;36m"  /* Cyan Bold   */
-#define C_HDR   "\033[1;34m"  /* Blue Bold   */
-#define C_NAME  "\033[1;32m"  /* Green Bold  */
-#define C_TYPE  "\033[1;33m"  /* Yellow Bold */
-#define C_SIZE  "\033[1m"     /* White Bold  */
-#define C_CNT   "\033[1;35m"  /* Magenta Bold */
-#define C_SEM   "\033[36m"    /* Cyan        */
-#define C_LINK  "\033[36m"    /* Cyan        */
-#define C_ERR   "\033[1;31m"  /* Red Bold    */
-#define C_DIM   "\033[2m"     /* Dim         */
-#define C_RST   "\033[0m"     /* Reset       */
+#define C_TITLE MH_TITLE
+#define C_HDR   MH_HDR
+#define C_NAME  MH_CMD
+#define C_TYPE  MH_NOTE
+#define C_DIM   MH_DIM
+#define C_RST   MH_RST
 
-void print_help(const char *progname) {
-    printf("Usage: %s [options] <regex pattern>\n", progname);
-    printf("Search for parameters across all active FPS instances matching a regex pattern.\n");
-    printf("The regex pattern is matched against the full parameter name, which is formatted as:\n");
-    printf("  <fpsname>.<parameter_key>\n");
-    printf("\n");
-    printf("Examples:\n");
-    printf("  %s \".*\"\n", progname);
-    printf("      Match all parameters in all active FPS instances.\n");
-    printf("  %s \"^myfps\\.\"\n", progname);
-    printf("      Match all parameters in the FPS named 'myfps'.\n");
-    printf("  %s \"\\.procinfo\\.\"\n", progname);
-    printf("      Match all parameters containing '.procinfo.' across all FPS instances.\n");
-    printf("  %s \"^myfps\\.procinfo\\.enabled$\" \n", progname);
-    printf("      Match the exact parameter 'procinfo.enabled' in the FPS 'myfps'.\n");
-    printf("\n");
-    printf("Options:\n");
-    printf("  -v, --verbose   Verbose mode (print search details)\n");
-    printf("  -h, --help      Show this help message\n");
+#define FS_DESC "search FPS parameters for matching values"
+#define FS_DESC_LONG \
+    "Scan all active FPS instances in /dev/shm and print every\n" \
+    "parameter whose full name (<fpsname>.<key>) matches the given\n" \
+    "POSIX extended regular expression.\n" \
+    "Output columns: keyword, type, current value, description."
+
+static void print_help(const char *progname, int mh_color)
+{
+    milk_help_banner(progname, FS_DESC, mh_color);
+    milk_help_section("Usage", mh_color);
+    printf("  %s%s%s [%soptions%s] %s<regex>%s\n\n",
+           mh_color ? MH_CMD : "", progname, mh_color ? MH_RST : "",
+           mh_color ? MH_OPT : "", mh_color ? MH_RST : "",
+           mh_color ? MH_ARG : "", mh_color ? MH_RST : "");
+    milk_help_section("Description", mh_color);
+    printf("  %s\n\n", FS_DESC_LONG);
+    milk_help_section("Options", mh_color);
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-v, --verbose",
+           mh_color ? MH_RST : "", "Verbose output");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-h, --help",
+           mh_color ? MH_RST : "", "Show this help and exit");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-h1, --help-oneline",
+           mh_color ? MH_RST : "", "One-line description and exit");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-h2, --help-description",
+           mh_color ? MH_RST : "", "Verbose description and exit");
+    printf("  %s%-25s%s %s\n\n",
+           mh_color ? MH_OPT : "", "-hm, --help-mono",
+           mh_color ? MH_RST : "", "Full help, no ANSI color");
+    milk_help_section("Examples", mh_color);
+    printf("  %s$ milk-fps-search %s\".*\"%s\n",
+           mh_color ? MH_DIM : "",
+           mh_color ? MH_ARG : "", mh_color ? MH_RST : "");
+    printf("  %s$ milk-fps-search %s\"^myfps\\\\.\"\n%s\n",
+           mh_color ? MH_DIM : "",
+           mh_color ? MH_ARG : "", mh_color ? MH_RST : "");
+    const char *see_also[] = { "milk-fps-list", "milk-fps-info" };
+    milk_help_see_also(see_also, 2, mh_color);
 }
 
 int main(int argc, char *argv[])
 {
-    /* Handle -h1/--help-oneline before getopt so "-h1" is not
-     * parsed as "-h" (flag) + "1" (unknown). */
-    if (argc >= 2 &&
-        (strcmp(argv[1], "-h1") == 0 ||
-         strcmp(argv[1], "--help-oneline") == 0))
+    int action = milk_help_init(argc, argv,
+                                FS_DESC, FS_DESC_LONG);
+    if (action == MH_ACTION_H1 || action == MH_ACTION_H2)
+        return 0;
+    int mh_color = (action == MH_ACTION_HELP);
+    if (action == MH_ACTION_HELP || action == MH_ACTION_MONO)
     {
-        printf("search FPS parameters for matching values\\n");
+        print_help(argv[0], mh_color);
         return 0;
     }
 
@@ -71,26 +90,24 @@ int main(int argc, char *argv[])
         {0, 0, 0, 0}
     };
 
-    while ((opt = getopt_long(argc, argv, "vh1", long_options, NULL)) != -1) {
-        switch (opt) {
-            case 'v':
-                verbose = 1;
-                break;
+    while ((opt = getopt_long(argc, argv, "vh1",
+                              long_options, NULL)) != -1)
+    {
+        switch (opt)
+        {
+            case 'v': verbose = 1; break;
             case 'h':
-                print_help(argv[0]);
-                return 0;
-            case '1':
-                printf("search FPS parameters for matching values\\n");
-                return 0;
+            case '1': break; /* handled above */
             default:
-                print_help(argv[0]);
+                print_help(argv[0], 0);
                 return 1;
         }
     }
 
-    if (optind >= argc) {
+    if (optind >= argc)
+    {
         fprintf(stderr, "Error: missing regex pattern argument.\n");
-        print_help(argv[0]);
+        print_help(argv[0], 0);
         return 1;
     }
 

--- a/src/engine/libfps/milk-fps-set.c
+++ b/src/engine/libfps/milk-fps-set.c
@@ -16,15 +16,18 @@
 #include "fps_disconnect.h"
 #include "fps_paramvalue.h"
 #include "fps_GetParamIndex.h"
+#include "milk_help.h"
 
-// Helper to check if string starts with prefix
-int starts_with(const char *pre, const char *str) {
+/* Helper to check if string starts with prefix */
+static int starts_with(const char *pre, const char *str)
+{
     size_t lenpre = strlen(pre);
     size_t lenstr = strlen(str);
     return lenstr < lenpre ? 0 : strncmp(pre, str, lenpre) == 0;
 }
 
-const char* get_type_name(uint32_t type) {
+static const char *get_type_name(uint32_t type)
+{
     if (type & FPTYPE_INT32) return "INT32";
     if (type & FPTYPE_UINT32) return "UINT32";
     if (type & FPTYPE_INT64) return "INT64";
@@ -44,12 +47,51 @@ const char* get_type_name(uint32_t type) {
     return "UNKNOWN";
 }
 
-void print_help(const char *progname) {
-    printf("Usage: %s [options] <FPSname>.<parameter> <value>\n", progname);
-    printf("Set value of an FPS parameter.\n");
-    printf("\n");
-    printf("Options:\n");
-    printf("  -h, --help      Show this help message\n");
+#define FSET_DESC \
+    "set a parameter value in a Function Parameter Structure (FPS)"
+#define FSET_DESC_LONG \
+    "Write a new value to a named FPS parameter in shared memory.\n" \
+    "The parameter is specified as <FPSname>.<paramkey>.\n" \
+    "Supported types: INT32, UINT32, INT64, UINT64, FLOAT32, FLOAT64,\n" \
+    "STRING, FILENAME, STREAMNAME, ONOFF, TIMESPEC, PID.\n" \
+    "TIMESPEC parameters accept a float value in seconds (e.g. 0.001)."
+
+static void print_help(const char *progname, int mh_color)
+{
+    milk_help_banner(progname, FSET_DESC, mh_color);
+    milk_help_section("Usage", mh_color);
+    printf("  %s%s%s %s<FPSname>.<param>%s %s<value>%s\n\n",
+           mh_color ? MH_CMD : "", progname, mh_color ? MH_RST : "",
+           mh_color ? MH_ARG : "", mh_color ? MH_RST : "",
+           mh_color ? MH_ARG : "", mh_color ? MH_RST : "");
+    milk_help_section("Description", mh_color);
+    printf("  %s\n\n", FSET_DESC_LONG);
+    milk_help_section("Options", mh_color);
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-h, --help",
+           mh_color ? MH_RST : "", "Show this help and exit");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-h1, --help-oneline",
+           mh_color ? MH_RST : "", "One-line description and exit");
+    printf("  %s%-25s%s %s\n",
+           mh_color ? MH_OPT : "", "-h2, --help-description",
+           mh_color ? MH_RST : "", "Verbose description and exit");
+    printf("  %s%-25s%s %s\n\n",
+           mh_color ? MH_OPT : "", "-hm, --help-mono",
+           mh_color ? MH_RST : "", "Full help, no ANSI color");
+    milk_help_section("Examples", mh_color);
+    printf("  %s$ milk-fps-set%s %smyfps00.procinfo.enabled%s %sTRUE%s\n",
+           mh_color ? MH_CMD : "", mh_color ? MH_RST : "",
+           mh_color ? MH_ARG : "", mh_color ? MH_RST : "",
+           mh_color ? MH_DFLT : "", mh_color ? MH_RST : "");
+    printf("  %s$ milk-fps-set%s %smyfps00.loopfreq%s %s100.0%s\n\n",
+           mh_color ? MH_CMD : "", mh_color ? MH_RST : "",
+           mh_color ? MH_ARG : "", mh_color ? MH_RST : "",
+           mh_color ? MH_DFLT : "", mh_color ? MH_RST : "");
+    const char *see_also[] = {
+        "milk-fps-info", "milk-fps-list", "milk-fps-track"
+    };
+    milk_help_see_also(see_also, 3, mh_color);
 }
 
 void do_completion_scan(const char *word) {
@@ -120,19 +162,22 @@ void do_completion_scan(const char *word) {
 
 int main(int argc, char *argv[])
 {
-    /* Handle -h1/--help-oneline before getopt so "-h1" is not
-     * parsed as "-h" (flag) + "1" (unknown). */
-    if (argc >= 2 &&
-        (strcmp(argv[1], "-h1") == 0 ||
-         strcmp(argv[1], "--help-oneline") == 0))
+    int action = milk_help_init(argc, argv,
+                                FSET_DESC, FSET_DESC_LONG);
+    if (action == MH_ACTION_H1 || action == MH_ACTION_H2)
+        return 0;
+    int mh_color = (action == MH_ACTION_HELP);
+    if (action == MH_ACTION_HELP || action == MH_ACTION_MONO)
     {
-        printf("set a parameter value in a Function Parameter Structure (FPS)\\n");
+        print_help(argv[0], mh_color);
         return 0;
     }
 
-    // Check for bash completion mode
-    if (getenv("COMP_LINE") != NULL) {
-        if (argc >= 3) {
+    /* Check for bash completion mode */
+    if (getenv("COMP_LINE") != NULL)
+    {
+        if (argc >= 3)
+        {
             do_completion_scan(argv[2]);
             return 0;
         }
@@ -146,27 +191,26 @@ int main(int argc, char *argv[])
         {0, 0, 0, 0}
     };
 
-    while ((opt = getopt_long(argc, argv, "h1", long_options, &option_index)) != -1) {
-        switch (opt) {
+    while ((opt = getopt_long(argc, argv, "h1",
+                              long_options, &option_index)) != -1)
+    {
+        switch (opt)
+        {
             case 'h':
-                print_help(argv[0]);
-                return 0;
-            case '1':
-                printf("set a parameter value in a Function Parameter Structure (FPS)\\n");
-                return 0;
+            case '1': break; /* handled above */
             default:
-                print_help(argv[0]);
+                print_help(argv[0], 0);
                 return 1;
         }
     }
 
-    if (optind + 2 > argc) {
-        if (optind + 1 == argc) {
-             fprintf(stderr, "Error: Missing value.\n");
-        } else {
-             fprintf(stderr, "Error: Missing arguments.\n");
-        }
-        print_help(argv[0]);
+    if (optind + 2 > argc)
+    {
+        if (optind + 1 == argc)
+            fprintf(stderr, "Error: Missing value.\n");
+        else
+            fprintf(stderr, "Error: Missing arguments.\n");
+        print_help(argv[0], 0);
         return 1;
     }
 


### PR DESCRIPTION
## Summary

Migrates all six `milk-fps-*` standalone executables to the unified V2
help architecture (`milk_help_init`), adding consistent `-h`, `-h1`,
`-h2`, and `-hm` support. Companion to PR #300 which covered the
procinfo, stream, and sequencer tools.

## Changes

### libfps — fps management tools

- **milk-fps-cmd.c** (`confstart`/`confstop`/`confstep`/`runstart`/`runstop`):
  replace per-name `if/else` `print_help()` with a unified V2 banner +
  per-command description block; add `MH_*` color macros; add `-h2`/`-hm`
- **milk-fps-info.c**: replace legacy `print_help()` with V2 9-section
  layout; add `FI_DESC_LONG`; migrate to `milk_help_init()`
- **milk-fps-list.c**: same V2 migration; full options table with see-also
- **milk-fps-rm.c**: same V2 migration
- **milk-fps-search.c**: same V2 migration
- **milk-fps-set.c**: same V2 migration

All targets already had libfps in their include paths (same source
directory), so no CMake changes were needed.

## Verification

- [x] All 6 files compile clean (`cmake --build . -j$(nproc)`)
- [x] `-h1` verified on all 6 tools: correct one-liner, exit 0
- [x] `-h2` verified on all 6 tools: verbose description, exit 0
- [x] `-hm` verified: full monochrome help, exit 0

## Prompt Summary

After completing PR #300 (diagnostic tool help V2 standardization), six
unstaged `milk-fps-*` modifications were discovered in the working tree
from the same help-standardization session. The user requested a separate
PR to keep the fps tools as a distinct changeset.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None