### PR TITLE
fix: plug IMGID memory leaks in mkrandomim and stream_connect_create

### DIFF
--- a/plugins/milk-extra-src/image_gen/mkrandomim.c
+++ b/plugins/milk-extra-src/image_gen/mkrandomim.c
@@ -139,19 +139,16 @@ static MILK_HOT errno_t compute_function()
     DEBUG_TRACEPOINT("make IMGID for %s",
                      outim_name);
 
-    IMGID img = imgid_make_from_name_2D(
-        outim_name, outim_xsize, outim_ysize);
-
-    INSERT_STD_PROCINFO_COMPUTEFUNC_START
-
     /*
      * Connect to existing stream or create it.
-     * This populates img.im so make_image_random
-     * can access img.im->array.F[].
+     * Must be before the loop to avoid leaking
+     * img.mdt on every iteration.
      */
-    img = stream_connect_create_2D(
+    IMGID img = stream_connect_create_2D(
         outim_name, outim_xsize, outim_ysize,
         _DATATYPE_FLOAT);
+
+    INSERT_STD_PROCINFO_COMPUTEFUNC_START
 
     make_image_random(&img, distrib_val);
 

--- a/src/coremods/COREMOD_memory/imageID.h
+++ b/src/coremods/COREMOD_memory/imageID.h
@@ -458,6 +458,7 @@ static inline IMGID _stream_connect_create_2D_impl(
         imgc.mdt->size[1]    = ysize;
         imgc.mdt->NBkw       = NB_KEYWNODE_MAX;
         uint64_t imgerr = imgid_compare(img, imgc);
+        imgid_free(&imgc);
         printf("%lu errors\n", imgerr);
 
         // if doesn't pass test, erase from local memory
@@ -545,6 +546,7 @@ static inline IMGID stream_connect_create_3D(
         imgc.mdt->size[2]    = zsize;
         imgc.mdt->NBkw       = NB_KEYWNODE_MAX;
         uint64_t imgerr = imgid_compare(img, imgc);
+        imgid_free(&imgc);
         printf("%lu errors\n", imgerr);
 
         // if doesn't pass test, erase from local memory


### PR DESCRIPTION
## Summary

Fix two memory leaks causing the `mkrnd` process (milk-fpsexec-imggen-mkrandom) to grow unbounded in memory when running in a loop. One leak was in the compute function itself; the other was a systemic leak in the `stream_connect_create_2D/3D` helpers affecting all callers.

## Changes

### image_gen / mkrandomim.c
- Moved `stream_connect_create_2D()` **before** `INSERT_STD_PROCINFO_COMPUTEFUNC_START` (the loop), matching the correct pattern used by `mkdisk.c` and other compute units
- Removed the redundant `imgid_make_from_name_2D()` call that allocated an `mdt` immediately overwritten by the `stream_connect_create_2D` reassignment
- Previously, every loop iteration malloc'd a new `img.mdt` (~700 bytes) and leaked the previous one

### COREMOD_memory / imageID.h
- Added `imgid_free(&imgc)` in `_stream_connect_create_2D_impl()` after the comparison block — the temporary `IMGID imgc` used for format validation was created via `imgid_make()` (which mallocs `mdt`) but never freed
- Applied the same fix to `stream_connect_create_3D()`

## Verification

- [x] Build passes (`cmake --build . -- -j$(nproc)`)
- [x] All 38 tests pass (`ctest --output-on-failure`)

## Prompt Summary

User reported that the `mkrnd` process in `milk-demopipeline` was leaking memory with a growing footprint. Investigation traced the leak to `stream_connect_create_2D()` being called inside the compute loop (allocating a new IMGID each iteration without freeing the previous one), plus a systemic leak of a temporary comparison IMGID in the `stream_connect_create` helpers.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None