### PR TITLE
refactor: standardize CLI error reporting across executables

### DIFF
--- a/src/cli/CLIcore/milk-fuzzy-match.c
+++ b/src/cli/CLIcore/milk-fuzzy-match.c
@@ -227,16 +227,15 @@ int main(int argc, char **argv)
                    strcmp(argv[argi], "--help") == 0) {
             break; /* handled above */
         } else {
-            fprintf(stderr,
-                    "Unknown option: %s\n",
-                    argv[argi]);
-            print_help(argv[0], 0);
+            printf("\n\033[1;31mERROR\033[0m: Unknown option: %s\n\n", argv[argi]);
+            print_help(argv[0], 1);
             return 1;
         }
     }
 
     if (argi >= argc) {
-        print_help(argv[0], 0);
+        printf("\n\033[1;31mERROR\033[0m: Missing QUERY argument.\n\n");
+        print_help(argv[0], 1);
         return 1;
     }
     query = argv[argi++];

--- a/src/cli/CLIcore/termview/milk-termview.c
+++ b/src/cli/CLIcore/termview/milk-termview.c
@@ -76,7 +76,8 @@ int main(int argc, char **argv)
     }
 
     if (argc < 2) {
-        fprintf(stderr, "Error: Missing stream name.\nRun %s -h for usage.\n", progname);
+        printf("\n\033[1;31mERROR\033[0m: Missing stream name.\n\n");
+        print_help(progname, 1);
         return 1;
     }
 

--- a/src/cli/libmilkscript/CLIcore_checkargs.c
+++ b/src/cli/libmilkscript/CLIcore_checkargs.c
@@ -188,10 +188,15 @@ static int CLI_checkarg0(
     {
         if(errmsg == 1)
         {
-            printf("arg %d: wrong arg type (expected %s but got %s)\n",
-                   CLIargnum - 1,
-                   CLIargtype_to_string(funcargtype),
-                   CMDARGTOKEN_type_to_string(data.cmdargtoken[CLIargnum].type));
+            printf(
+                "\033[1;31mERROR\033[0m"
+                " arg %d: wrong type"
+                " (expected %s, got %s)\n",
+                CLIargnum - 1,
+                CLIargtype_to_string(funcargtype),
+                CMDARGTOKEN_type_to_string(
+                    data.cmdargtoken[CLIargnum]
+                        .type));
         }
         rval = 1;
     }
@@ -475,10 +480,18 @@ errno_t CLI_checkarg_array(
             {
                 if(data.cmdargtoken[2].type == CLIARG_MISSING)
                 {
-                    printf("Setting parameter %s : input missing\n",
-                           data.cmdargtoken[1].val.string);
+                    printf(
+                        "\n\033[1;31mERROR\033[0m"
+                        " Setting parameter %s :"
+                        " input missing\n",
+                        data.cmdargtoken[1]
+                            .val.string);
+                    help_command(
+                        data.cmd[data.cmdindex]
+                            .key);
                     DEBUG_TRACE_FEXIT();
-                    return RETURN_CLICHECKARGARRAY_FAILURE;
+                    return
+                        RETURN_CLICHECKARGARRAY_FAILURE;
                 }
 
                 // Update the parameter in FPS
@@ -509,8 +522,13 @@ errno_t CLI_checkarg_array(
     {
         if(data.cmdargtoken[2].type == CLIARG_MISSING)
         {
-            printf("Setting arg %s : input missing\n",
-                   fpscliarg[argindexmatch].fpstag);
+            printf(
+                "\n\033[1;31mERROR\033[0m"
+                " Setting arg %s :"
+                " input missing\n",
+                fpscliarg[argindexmatch].fpstag);
+            help_command(
+                data.cmd[data.cmdindex].key);
             DEBUG_TRACE_FEXIT();
             return RETURN_CLICHECKARGARRAY_FAILURE;
         }
@@ -596,8 +614,13 @@ errno_t CLI_checkarg_array(
         }
         else
         {
-            printf("Setting arg %s : Wrong type\n",
-                   fpscliarg[argindexmatch].fpstag);
+            printf(
+                "\n\033[1;31mERROR\033[0m"
+                " Setting arg %s :"
+                " wrong type\n",
+                fpscliarg[argindexmatch].fpstag);
+            help_command(
+                data.cmd[data.cmdindex].key);
             DEBUG_TRACE_FEXIT();
             return RETURN_CLICHECKARGARRAY_FAILURE;
         }
@@ -775,14 +798,20 @@ errno_t CLI_checkarg_array(
                 }
                 else
                 {
-                    printf("Error: Missing mandatory argument %d (%s: %s)\n",
-                           CLIarg,
-                           fpscliarg[arg].fpstag,
-                           fpscliarg[arg].descr);
-                    help_command(data.cmd[data.cmdindex].key);
+                    printf(
+                        "\n\033[1;31mERROR\033[0m"
+                        " Missing mandatory"
+                        " argument %d (%s: %s)\n",
+                        CLIarg,
+                        fpscliarg[arg].fpstag,
+                        fpscliarg[arg].descr);
+                    help_command(
+                        data.cmd[data.cmdindex]
+                            .key);
                     argcheck_process_flag = 0;
                     DEBUG_TRACE_FEXIT();
-                    return RETURN_CLICHECKARGARRAY_FAILURE;
+                    return
+                        RETURN_CLICHECKARGARRAY_FAILURE;
                 }
             }
 
@@ -944,6 +973,13 @@ errno_t CLI_checkarg_array(
     }
     else
     {
+        printf(
+            "\n\033[1;31mERROR\033[0m"
+            " %d argument(s) have wrong"
+            " type\n",
+            nberr);
+        help_command(
+            data.cmd[data.cmdindex].key);
         DEBUG_TRACE_FEXIT();
         return RETURN_CLICHECKARGARRAY_FAILURE;
     }

--- a/src/cli/overview/milk-procinfo-info.c
+++ b/src/cli/overview/milk-procinfo-info.c
@@ -472,7 +472,8 @@ int main(int argc, char *argv[])
             target_pid = (pid_t) atoi(optarg);
             break;
         default:
-            print_help(argv[0], 0);
+            printf("\n\033[1;31mERROR\033[0m invalid option\n\n");
+            print_help(argv[0], 1);
             return 1;
         }
     }
@@ -485,10 +486,8 @@ int main(int argc, char *argv[])
 
     if (target_pid <= 0 && proc_name == NULL)
     {
-        fprintf(stderr,
-                "Error: process name or "
-                "--pid required\n\n");
-        print_help(argv[0], 0);
+        printf("\n\033[1;31mERROR\033[0m process name or --pid required\n\n");
+        print_help(argv[0], 1);
         return 1;
     }
 

--- a/src/cli/overview/milk-stream-graph.c
+++ b/src/cli/overview/milk-stream-graph.c
@@ -889,18 +889,15 @@ int main(int argc, char *argv[])
             stream_name = argv[i];
             continue;
         }
-        fprintf(stderr,
-                "Unknown option: %s\n", argv[i]);
+        printf("\n\033[1;31mERROR\033[0m: Invalid option: %s\n\n", argv[i]);
+        print_usage(argv[0], mh_color);
         return 1;
     }
 
     if (stream_name == NULL)
     {
-        fprintf(stderr,
-                "Error: stream name required\n");
-        fprintf(stderr,
-                "Usage: %s [options] <stream>\n",
-                argv[0]);
+        printf("\n\033[1;31mERROR\033[0m: stream name required.\n\n");
+        print_usage(argv[0], mh_color);
         return 1;
     }
 

--- a/src/cli/overview/milk-stream-info.c
+++ b/src/cli/overview/milk-stream-info.c
@@ -548,16 +548,16 @@ int main(int argc, char *argv[])
         {
         case 'h': break; /* handled above */
         default:
-            print_help(argv[0], 0);
+            printf("\n\033[1;31mERROR\033[0m invalid option\n\n");
+            print_help(argv[0], 1);
             return 1;
         }
     }
 
     if (optind >= argc)
     {
-        fprintf(stderr,
-                "Error: stream name required\n\n");
-        print_help(argv[0], 0);
+        printf("\n\033[1;31mERROR\033[0m stream name required\n\n");
+        print_help(argv[0], 1);
         return 1;
     }
 

--- a/src/cli/overview/milkCTRL.c
+++ b/src/cli/overview/milkCTRL.c
@@ -192,10 +192,16 @@ int main(int argc, char *argv[])
             print_usage(argv[0]);
             return 0;
         }
-        if (strcmp(argv[i], "-d") == 0
+        else if (strcmp(argv[i], "-d") == 0
             && (i + 1 < argc))
         {
             setenv("MILK_SHM_DIR", argv[++i], 1);
+        }
+        else if (argv[i][0] == '-')
+        {
+            printf("\n\033[1;31mERROR\033[0m: Invalid option: %s\n\n", argv[i]);
+            print_usage(argv[0]);
+            return 1;
         }
     }
 

--- a/src/cli/streamCTRL/milk-streamCTRL.c
+++ b/src/cli/streamCTRL/milk-streamCTRL.c
@@ -116,6 +116,12 @@ int main(int argc, char *argv[])
         {
             setenv("MILK_SHM_DIR", argv[++i], 1);
         }
+        else
+        {
+            printf("\n\033[1;31mERROR\033[0m: Invalid option or argument '%s'.\n\n", argv[i]);
+            print_help(progname, 1);
+            return 1;
+        }
     }
 
     /* Install signal handlers */

--- a/src/coremods/COREMOD_memory/cnt2push_main.c
+++ b/src/coremods/COREMOD_memory/cnt2push_main.c
@@ -46,6 +46,7 @@ void print_help() {
 
 int main(int argc, char *argv[]) {
     if (argc < 2) {
+        printf("\n\033[1;31mERROR\033[0m Missing arguments\n");
         print_help();
         return 1;
     }
@@ -71,7 +72,8 @@ int main(int argc, char *argv[]) {
             if (i + 1 < argc) {
                 val = atoll(argv[++i]);
             } else {
-                fprintf(stderr, "Error: -v requires an argument\n");
+                printf("\n\033[1;31mERROR\033[0m -v requires an argument\n");
+                print_help();
                 return 1;
             }
         } else if (strcmp(argv[i], "-a") == 0 || strcmp(argv[i], "--abs") == 0) {
@@ -85,14 +87,16 @@ int main(int argc, char *argv[]) {
             if (streamname == NULL && argv[i][0] != '-') {
                 streamname = argv[i];
             } else {
-                fprintf(stderr, "Unknown argument: %s\n", argv[i]);
+                printf("\n\033[1;31mERROR\033[0m Unknown argument: %s\n", argv[i]);
+                print_help();
                 return 1;
             }
         }
     }
 
     if (streamname == NULL) {
-        fprintf(stderr, "Error: stream name required\n");
+        printf("\n\033[1;31mERROR\033[0m stream name required\n");
+        print_help();
         return 1;
     }
 

--- a/src/coremods/COREMOD_memory/milk-stream-create.c
+++ b/src/coremods/COREMOD_memory/milk-stream-create.c
@@ -161,9 +161,8 @@ int main(int argc, char *argv[])
             case 't':
                 dtype = parse_dtype(optarg);
                 if (dtype == 0) {
-                    fprintf(stderr,
-                            "Unknown type: %s\n",
-                            optarg);
+                    printf("\n\033[1;31mERROR\033[0m unknown type: %s\n\n", optarg);
+                    print_help(argv[0]);
                     return 1;
                 }
                 break;
@@ -174,6 +173,7 @@ int main(int argc, char *argv[])
                 print_help(argv[0]);
                 return 0;
             default:
+                printf("\n\033[1;31mERROR\033[0m invalid option\n\n");
                 print_help(argv[0]);
                 return 1;
         }
@@ -181,9 +181,7 @@ int main(int argc, char *argv[])
 
     int npos = argc - optind;
     if (npos < 2) {
-        fprintf(stderr,
-                "Error: need at least name"
-                " and xsize.\n\n");
+        printf("\n\033[1;31mERROR\033[0m need at least name and xsize\n\n");
         print_help(argv[0]);
         return 1;
     }

--- a/src/coremods/COREMOD_memory/milk-stream-list.c
+++ b/src/coremods/COREMOD_memory/milk-stream-list.c
@@ -105,7 +105,8 @@ int main(int argc, char *argv[])
                 break;
             case 'h': break; /* handled above */
             default:
-                print_help(argv[0], 0);
+                printf("\n\033[1;31mERROR\033[0m: Invalid option.\n\n");
+                print_help(argv[0], 1);
                 return 1;
         }
     }

--- a/src/coremods/COREMOD_memory/milk-stream-rm.c
+++ b/src/coremods/COREMOD_memory/milk-stream-rm.c
@@ -355,7 +355,8 @@ int main(int argc, char *argv[])
             break;
         case 'h': break; /* handled above */
         default:
-            print_help(argv[0], 0);
+            printf("\n\033[1;31mERROR\033[0m: Invalid option.\n\n");
+            print_help(argv[0], 1);
             return 1;
         }
     }

--- a/src/coremods/COREMOD_memory/milk-streamCTRL-cli.c
+++ b/src/coremods/COREMOD_memory/milk-streamCTRL-cli.c
@@ -338,6 +338,7 @@ int main(int argc, char *argv[])
             print_help(progname, 1);
             return 0;
         default:
+            printf("\n\033[1;31mERROR\033[0m: Invalid option.\n\n");
             print_help(progname, 1);
             return 1;
         }

--- a/src/coremods/COREMOD_memory/scripts/milk-rmshmim
+++ b/src/coremods/COREMOD_memory/scripts/milk-rmshmim
@@ -61,8 +61,9 @@ while getopts :h FLAG; do
             exit
             ;;
         \?)
-            echo -e \\n"Option -${BOLD}$OPTARG${NORM} not allowed."
+            echo -e "\n\033[1;31mERROR\033[0m Option -${OPTARG} not allowed."
             printHELP
+            exit 1
             ;;
     esac
 done
@@ -73,10 +74,10 @@ shift $((OPTIND-1))
 
 if [ "$1" = "help" ] || [ "$#" -ne $NBARGS ]; then
     if [ "$#" -ne $NBARGS ]; then
-        echo "$(tput setaf 1)$(tput bold) Illegal number of parameters ($NBARGS params required, $# entered) $(tput sgr0)"
+        echo -e "\n\033[1;31mERROR\033[0m Illegal number of parameters ($NBARGS params required, $# entered)"
     fi
     printHELP
-    exit
+    exit 1
 fi
 
 IFS=',' read -r -a array <<< "$1"

--- a/src/coremods/COREMOD_memory/scripts/milk-shmimlog
+++ b/src/coremods/COREMOD_memory/scripts/milk-shmimlog
@@ -101,8 +101,9 @@ while getopts :hc: FLAG; do
             CPUset="$OPTARG"
             ;;
         \?) #unrecognized option - show help
-            echo -e \\n"Option -${BOLD}$OPTARG${NORM} not allowed."
+            echo -e "\n\033[1;31mERROR\033[0m Option -${OPTARG} not allowed."
             printHELP
+            exit 1
             ;;
     esac
 done
@@ -111,10 +112,10 @@ shift $((OPTIND-1))
 
 if [ "$1" = "help" ] || [ "$#" -ne $NBARGS ]; then
     if [ "$#" -ne $NBARGS ]; then
-        echo "$(tput setaf 1)$(tput bold) Illegal number of parameters ($NBARGS params required, $# entered) $(tput sgr0)"
+        echo -e "\n\033[1;31mERROR\033[0m Illegal number of parameters ($NBARGS params required, $# entered)"
     fi
     printHELP
-    exit
+    exit 1
 fi
 
 # ======================= CHECK REQUIRED FILES =================================

--- a/src/coremods/COREMOD_memory/scripts/milk-shmimpurge
+++ b/src/coremods/COREMOD_memory/scripts/milk-shmimpurge
@@ -68,8 +68,9 @@ while getopts :hf: FLAG; do
             echo "using filter ${FILTERSTRING}"
             ;;
         \?)
-            echo -e \\n"Option -${BOLD}$OPTARG${NORM} not allowed."
+            echo -e "\n\033[1;31mERROR\033[0m Option -${OPTARG} not allowed."
             printHELP
+            exit 1
             ;;
     esac
 done
@@ -80,10 +81,10 @@ shift $((OPTIND-1))
 
 if [ "$1" = "help" ] || [ "$#" -ne $NBARGS ]; then
     if [ "$#" -ne $NBARGS ]; then
-        echo "$(tput setaf 1)$(tput bold) Illegal number of parameters ($NBARGS params required, $# entered) $(tput sgr0)"
+        echo -e "\n\033[1;31mERROR\033[0m Illegal number of parameters ($NBARGS params required, $# entered)"
     fi
     printHELP
-    exit
+    exit 1
 fi
 
 milk -n ${pname} << EOF

--- a/src/engine/libfps/fpsCTRL/milk-fpsCTRL.c
+++ b/src/engine/libfps/fpsCTRL/milk-fpsCTRL.c
@@ -161,7 +161,9 @@ int main(int argc, char *argv[]) {
             case 'h':
                 print_usage(argv[0]);
                 return 0;
+            case '?':
             default:
+                printf("\n\033[1;31mERROR\033[0m: Invalid option.\n\n");
                 print_usage(argv[0]);
                 return 1;
         }

--- a/src/engine/libfps/milk-fps-cmd.c
+++ b/src/engine/libfps/milk-fps-cmd.c
@@ -159,9 +159,8 @@ int main(int argc, char *argv[])
 
     if (argc < 2)
     {
-        fprintf(stderr,
-                "Error: Missing <fpsname>. "
-                "Run %s -h for usage.\n", progname);
+        printf("\n\033[1;31mERROR\033[0m missing <fpsname>\n\n");
+        print_help(progname, 1);
         return 1;
     }
 
@@ -180,15 +179,16 @@ int main(int argc, char *argv[])
         }
         else
         {
-            fprintf(stderr,
-                    "Error: Unexpected argument '%s'.\n", argv[i]);
+            printf("\n\033[1;31mERROR\033[0m unexpected argument '%s'\n\n", argv[i]);
+            print_help(progname, 1);
             return 1;
         }
     } // for i
 
     if (fpsname == NULL)
     {
-        fprintf(stderr, "Error: Missing <fpsname>\n");
+        printf("\n\033[1;31mERROR\033[0m missing <fpsname>\n\n");
+        print_help(progname, 1);
         return 1;
     }
 

--- a/src/engine/libfps/milk-fps-info.c
+++ b/src/engine/libfps/milk-fps-info.c
@@ -313,16 +313,16 @@ int main(int argc, char *argv[])
             /* Handled above by milk_help_init() */
             break;
         default:
-            print_help(argv[0], 0);
+            printf("\n\033[1;31mERROR\033[0m invalid option\n\n");
+            print_help(argv[0], 1);
             return 1;
         }
     }
 
     if (optind >= argc)
     {
-        fprintf(stderr,
-                "Error: missing FPS name.\n");
-        print_help(argv[0], 0);
+        printf("\n\033[1;31mERROR\033[0m missing FPS name.\n\n");
+        print_help(argv[0], 1);
         return 1;
     }
 

--- a/src/engine/libfps/milk-fps-list.c
+++ b/src/engine/libfps/milk-fps-list.c
@@ -134,7 +134,8 @@ int main(int argc, char *argv[])
                 /* Handled above by milk_help_init() */
                 break;
             default:
-                print_help(argv[0], 0);
+                printf("\n\033[1;31mERROR\033[0m invalid option\n\n");
+                print_help(argv[0], 1);
                 return 1;
         }
     }

--- a/src/engine/libfps/milk-fps-rm.c
+++ b/src/engine/libfps/milk-fps-rm.c
@@ -363,7 +363,8 @@ int main(int argc, char *argv[])
             case 'h':
             case '1': break; /* handled above */
             default:
-                print_help(argv[0], 0);
+                printf("\n\033[1;31mERROR\033[0m invalid option\n\n");
+                print_help(argv[0], 1);
                 return 1;
         }
     }

--- a/src/engine/libfps/milk-fps-search.c
+++ b/src/engine/libfps/milk-fps-search.c
@@ -99,15 +99,16 @@ int main(int argc, char *argv[])
             case 'h':
             case '1': break; /* handled above */
             default:
-                print_help(argv[0], 0);
+                printf("\n\033[1;31mERROR\033[0m invalid option\n\n");
+                print_help(argv[0], 1);
                 return 1;
         }
     }
 
     if (optind >= argc)
     {
-        fprintf(stderr, "Error: missing regex pattern argument.\n");
-        print_help(argv[0], 0);
+        printf("\n\033[1;31mERROR\033[0m missing regex pattern argument\n\n");
+        print_help(argv[0], 1);
         return 1;
     }
 

--- a/src/engine/libfps/milk-fps-set.c
+++ b/src/engine/libfps/milk-fps-set.c
@@ -199,7 +199,8 @@ int main(int argc, char *argv[])
             case 'h':
             case '1': break; /* handled above */
             default:
-                print_help(argv[0], 0);
+                printf("\n\033[1;31mERROR\033[0m invalid option\n\n");
+                print_help(argv[0], 1);
                 return 1;
         }
     }
@@ -207,10 +208,10 @@ int main(int argc, char *argv[])
     if (optind + 2 > argc)
     {
         if (optind + 1 == argc)
-            fprintf(stderr, "Error: Missing value.\n");
+            printf("\n\033[1;31mERROR\033[0m missing value\n\n");
         else
-            fprintf(stderr, "Error: Missing arguments.\n");
-        print_help(argv[0], 0);
+            printf("\n\033[1;31mERROR\033[0m missing arguments\n\n");
+        print_help(argv[0], 1);
         return 1;
     }
 

--- a/src/engine/libfps/milk-fps-track.c
+++ b/src/engine/libfps/milk-fps-track.c
@@ -130,7 +130,8 @@ int main(int argc, char *argv[])
             case 'h':
             case '1': break; /* handled above */
             default:
-                print_help(argv[0], 0);
+                printf("\n\033[1;31mERROR\033[0m invalid option\n\n");
+                print_help(argv[0], 1);
                 return 1;
         }
     }

--- a/src/engine/libfpsseq/milk-seq.c
+++ b/src/engine/libfpsseq/milk-seq.c
@@ -235,16 +235,15 @@ int main(int argc, char **argv)
             do_daemon = 1;
             i++;
         } else {
-            fprintf(stderr, "Unknown flag: %s\n", argv[i]);
-            print_help(argv[0], 0);
+            printf("\n\033[1;31mERROR\033[0m invalid option: %s\n\n", argv[i]);
+            print_help(argv[0], 1);
             return 1;
         }
     }
 
     if (seq_name[0] == '\0') {
-        fprintf(stderr,
-                "Error: Sequencer name (-n) is "
-                "required.\n");
+        printf("\n\033[1;31mERROR\033[0m sequencer name (-n) is required\n\n");
+        print_help(argv[0], 1);
         return 1;
     }
 

--- a/src/engine/libprocessinfo/milk-procinfo-rm.c
+++ b/src/engine/libprocessinfo/milk-procinfo-rm.c
@@ -99,8 +99,10 @@ int main(int argc, char *argv[])
             case 'c': clean_dead = 1; break;
             case 'v': verbose = 1; break;
             case 'h': break; /* handled above */
+            case '?':
             default:
-                print_help(argv[0], 0);
+                printf("\n\033[1;31mERROR\033[0m: Invalid option.\n\n");
+                print_help(argv[0], 1);
                 return 1;
         }
     }
@@ -111,8 +113,8 @@ int main(int argc, char *argv[])
         if (clean_dead) {
             pattern = ".*";
         } else {
-            fprintf(stderr, "Error: missing process name.\n");
-            print_help(argv[0], 0);
+            printf("\n\033[1;31mERROR\033[0m Missing process name.\n");
+            print_help(argv[0], 1);
             return 1;
         }
     }
@@ -125,7 +127,8 @@ int main(int argc, char *argv[])
     if (ret != 0) {
         char error_msg[128];
         regerror(ret, &regex, error_msg, sizeof(error_msg));
-        fprintf(stderr, "Error: Invalid regular expression. %s\n", error_msg);
+        printf("\n\033[1;31mERROR\033[0m Invalid regular expression. %s\n", error_msg);
+        print_help(argv[0], 1);
         return 1;
     }
 

--- a/src/engine/libprocessinfo/procCTRL/milk-procCTRL-scan.c
+++ b/src/engine/libprocessinfo/procCTRL/milk-procCTRL-scan.c
@@ -226,6 +226,11 @@ int main(int argc, char *argv[]) {
             case 'R':
                 rebuild = 1;
                 break;
+            case '?':
+            default:
+                printf("\n\033[1;31mERROR\033[0m: Invalid option.\n\n");
+                printf("Usage: %s [-r rate_hz] [-v] [-R]\n", argv[0]);
+                return 1;
         }
     }
 

--- a/src/engine/libprocessinfo/procCTRL/milk-procCTRL.c
+++ b/src/engine/libprocessinfo/procCTRL/milk-procCTRL.c
@@ -159,7 +159,9 @@ int main(int argc, char *argv[])
             case 'l':
                 strncpy(procCTRL_logfile, optarg, 1023);
                 break;
+            case '?':
             default:
+                printf("\n\033[1;31mERROR\033[0m: Invalid option.\n\n");
                 print_help(argv[0]);
                 return 1;
         }

--- a/src/engine/libprocessinfo/procCTRL/milk-procinfo-list.c
+++ b/src/engine/libprocessinfo/procCTRL/milk-procinfo-list.c
@@ -101,7 +101,8 @@ int main(int argc, char *argv[])
         {
             case 'h': break; /* handled above */
             default:
-                print_help(argv[0], 0);
+                printf("\n\033[1;31mERROR\033[0m invalid option\n\n");
+                print_help(argv[0], 1);
                 return 1;
         }
     }

--- a/src/fpsvalkey/milk-fps-valkey.c
+++ b/src/fpsvalkey/milk-fps-valkey.c
@@ -282,7 +282,9 @@ int main(int argc, char *argv[])
         case 'h':
             print_help(argv[0]);
             return 0;
+        case '?':
         default:
+            printf("\n\033[1;31mERROR\033[0m: Invalid option.\n\n");
             print_help(argv[0]);
             return 1;
         }


### PR DESCRIPTION
## Summary

Standardizes the error reporting interface across the Milk CLI toolchain for invalid flags and missing arguments.

## Changes

### Coremods & Engine CLI
- Refactored `getopt_long` default blocks and custom argument validation logic across 30 executable entry points.
- Enforced a uniform failure format: a red `ERROR:` prefix followed by color-enabled help text (`print_help(argv[0], 1)`).
- Eliminated fragmented `fprintf(stderr, ...)` usages in favor of standardized visual feedback.

## Verification

- [x] Build passes (`make -j && make install`)
- [x] Manual verification of executables with invalid arguments confirms correct red ERROR formatting and colored help output.

## Prompt Summary

The user requested a systematic standardization of error reporting across all remaining Milk CLI executables. The goal was to ensure a uniform failure interface where missing arguments or syntax errors print an "error" message in red followed by color-enabled help text, mirroring the `-h` option's output.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None