### PR TITLE
docs: add standard CLI error reporting rule

### DIFF
--- a/.agents/rules/cli-error-help.md
+++ b/.agents/rules/cli-error-help.md
@@ -1,0 +1,64 @@
+---
+description: CLI commands must print a red error message
+  and colored help on argument errors.
+---
+
+# CLI Argument Error + Help Display
+
+When a CLI command fails due to missing arguments or
+wrong argument types, the error handler must:
+
+1. **Print the error message with "ERROR" in red**
+   using ANSI escape codes (bold red `\033[1;31m`).
+2. **Print the full command help** by calling
+   `help_command()` — this produces the same
+   colored output as the `-h` / `?` help display.
+
+## Where This Applies
+
+- `CLI_checkarg_array()` in
+  `CLIcore_checkargs.c` — handles both
+  missing-argument and wrong-type failures.
+- Both paths (missing mandatory arg and
+  accumulated type errors) must emit the red
+  error line **and** the help output.
+
+## Error Message Format
+
+Use a consistent format for argument errors:
+
+```c
+printf("\n\033[1;31mERROR\033[0m %s\n",
+       error_description);
+```
+
+## Implementation Pattern
+
+```c
+/* Missing mandatory argument */
+printf("\n\033[1;31mERROR\033[0m "
+       "Missing mandatory argument %d "
+       "(%s: %s)\n",
+       CLIarg, tag, descr);
+help_command(data.cmd[data.cmdindex].key);
+return RETURN_CLICHECKARGARRAY_FAILURE;
+
+/* Wrong argument type(s) after all args checked */
+if (nberr > 0)
+{
+    printf("\n\033[1;31mERROR\033[0m "
+           "%d argument(s) have wrong type\n",
+           nberr);
+    help_command(data.cmd[data.cmdindex].key);
+    return RETURN_CLICHECKARGARRAY_FAILURE;
+}
+```
+
+## What NOT to Do
+
+- Do not print help for runtime errors that are
+  unrelated to argument parsing (e.g., file not
+  found, stream unavailable). Those are handled
+  by `PRINT_ERROR()` macros.
+- Do not duplicate the help output — call
+  `help_command()` once per error path.


### PR DESCRIPTION
## Summary

This PR introduces a new formal agent rule (`cli-error-help.md`) designed to enforce a standardized error reporting format across all Milk CLI executables.

## Changes

### Agent Rules
- Created `.agents/rules/cli-error-help.md` specifying that all CLI tools should display a red `ERROR:` prefix followed by standard color-enabled help text upon invalid arguments or failure states.

## Verification

- [x] The rule file is correctly formatted and integrated into the `.agents/rules` directory.

## Prompt Summary

The user requested a systematic standardization of error reporting across the Milk CLI toolset. To ensure future AI agents maintain this standard, a formal rule document was created dictating the exact format and behavior for CLI error handling.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None