### PR TITLE
fix: lock panel focus to current view in milkCTRL F3–F6 tabs

### DIFF
--- a/src/cli/overview/overview_input.c
+++ b/src/cli/overview/overview_input.c
@@ -475,23 +475,41 @@ static int ov_input__handle_misc_toggles(int key, OV_LAYOUT *lay, const OV_MODEL
 
     if (key == OV_KEY_LEFT || key == OV_KEY_RIGHT)
     {
+        /* In single-panel views (F3–F6), lock focus to
+         * the panel being shown — only allow left-right
+         * panel cycling on the Dashboard.
+         */
+        if (lay->view != OV_VIEW_DASHBOARD)
+        {
+            return 1;
+        }
+
         if (key == OV_KEY_LEFT)
         {
-            if (lay->focus == OV_FOCUS_STREAMS) lay->focus = OV_FOCUS_GRAPH;
-            else if (lay->focus == OV_FOCUS_PROCS) lay->focus = OV_FOCUS_STREAMS;
-            else if (lay->focus == OV_FOCUS_FPS) lay->focus = OV_FOCUS_PROCS;
+            if (lay->focus == OV_FOCUS_STREAMS)
+                lay->focus = OV_FOCUS_GRAPH;
+            else if (lay->focus == OV_FOCUS_PROCS)
+                lay->focus = OV_FOCUS_STREAMS;
+            else if (lay->focus == OV_FOCUS_FPS)
+                lay->focus = OV_FOCUS_PROCS;
             else if (lay->focus == OV_FOCUS_GRAPH)
             {
-                if (lay->view == OV_VIEW_DASHBOARD && !lay->detail_mode) lay->focus = OV_FOCUS_FPS;
-                else lay->focus = OV_FOCUS_STREAMS;
+                if (!lay->detail_mode)
+                    lay->focus = OV_FOCUS_FPS;
+                else
+                    lay->focus = OV_FOCUS_STREAMS;
             }
         }
         else
         {
-            if (lay->focus == OV_FOCUS_STREAMS) lay->focus = OV_FOCUS_PROCS;
-            else if (lay->focus == OV_FOCUS_PROCS) lay->focus = OV_FOCUS_FPS;
-            else if (lay->focus == OV_FOCUS_FPS) lay->focus = OV_FOCUS_GRAPH;
-            else if (lay->focus == OV_FOCUS_GRAPH) lay->focus = OV_FOCUS_STREAMS;
+            if (lay->focus == OV_FOCUS_STREAMS)
+                lay->focus = OV_FOCUS_PROCS;
+            else if (lay->focus == OV_FOCUS_PROCS)
+                lay->focus = OV_FOCUS_FPS;
+            else if (lay->focus == OV_FOCUS_FPS)
+                lay->focus = OV_FOCUS_GRAPH;
+            else if (lay->focus == OV_FOCUS_GRAPH)
+                lay->focus = OV_FOCUS_STREAMS;
         }
         return 1;
     }


### PR DESCRIPTION
## Summary

Prevents left-right arrow keys from cycling panel focus to invisible panels when milkCTRL is in a single-panel view (F3–F6).

## Changes

### milkCTRL Input Handling
- **`src/cli/overview/overview_input.c`** — Added an early-return guard in `ov_input__handle_misc_toggles()` so that `OV_KEY_LEFT`/`OV_KEY_RIGHT` only cycle panel focus when `lay->view == OV_VIEW_DASHBOARD`. In single-panel views (Graph, Streams, Procs, FPS), the key is consumed but focus stays locked to the panel being shown.

## Verification

- [x] Build passes (`make -j`)
- [x] All 38 tests pass (`ctest --output-on-failure`)

## Prompt Summary

User requested that when milkCTRL is in tabs F3, F4, F5, or F6, the left-right arrow keys should not change focus to a panel different from the one currently shown. A single early-return guard was the simplest correct fix.

## AI Authorship

- **Model:** Antigravity
- **User edits:** None