### PR TITLE
feat: milkCTRL diagnostic panel refinements and bug fixes

### DIFF
--- a/src/cli/overview/overview_ctrl.c
+++ b/src/cli/overview/overview_ctrl.c
@@ -167,7 +167,7 @@ void ov_ctrl_stream_delete(
     IMAGE im;
     memset(&im, 0, sizeof(im));
 
-    if (ImageStreamIO_openIm(&im, s->name) != 0)
+    if (ImageStreamIO_read_sharedmem_image_toIMAGE(s->name, &im) != 0)
     {
         if (log != NULL)
         {
@@ -179,7 +179,30 @@ void ov_ctrl_stream_delete(
         return;
     }
 
-    ImageStreamIO_destroyIm(&im);
+    /* Destroy semaphores */
+    for (int si = 0; si < im.md->sem; si++)
+    {
+        sem_destroy(im.semptr[si]);
+    }
+
+    /* Close (unmap + close fd) */
+    ImageStreamIO_closeIm(&im);
+
+    char fullpath[512];
+    ImageStreamIO_filename(fullpath, sizeof(fullpath), s->name);
+
+    if (unlink(fullpath) != 0)
+    {
+        if (log != NULL)
+        {
+            ov_cmdlog_push(log, OV_CMDLOG_FAIL,
+                           "Stream \"%s\" — delete"
+                           " failed (unlink)",
+                           s->name);
+        }
+        return;
+    }
+
     if (log != NULL)
     {
         ov_cmdlog_push(log, OV_CMDLOG_OK,

--- a/src/cli/overview/overview_data.c
+++ b/src/cli/overview/overview_data.c
@@ -40,6 +40,9 @@
 
 void ov_model_full_scan(OV_MODEL *model)
 {
+    static struct timespec s_last_scan = {0, 0};
+    static int s_has_prev_scan = 0;
+
     struct timespec t0, t1;
     clock_gettime(CLOCK_MONOTONIC, &t0);
 
@@ -47,11 +50,13 @@ void ov_model_full_scan(OV_MODEL *model)
     pid_cache_reset();
 
     /* Compute time delta for rate estimation
-     * (used by scache_rate_update inside scan) */
-    if (model->scan_count > 0)
+     * (used by scache_rate_update inside scan).
+     * Use a static timestamp so triple-buffered
+     * slots all share the same previous time. */
+    if (s_has_prev_scan)
     {
         struct timespec dt_ts = ov_timespec_diff(
-                                    model->last_scan_time, t0);
+                                    s_last_scan, t0);
         s_scan_dt_sec =
             (double) dt_ts.tv_sec
             + (double) dt_ts.tv_nsec * 1.0e-9;
@@ -79,6 +84,8 @@ void ov_model_full_scan(OV_MODEL *model)
     model->scan_time_ms =
         (double) dt.tv_sec * 1000.0
         + (double) dt.tv_nsec * 1.0e-6;
+    s_last_scan = t0;
+    s_has_prev_scan = 1;
     model->last_scan_time = t0;
     model->scan_count++;
 }

--- a/src/cli/overview/overview_data.h
+++ b/src/cli/overview/overview_data.h
@@ -93,6 +93,7 @@ typedef struct
     uint64_t cnt0;
     uint64_t cnt0_prev;
     double   update_hz;
+    int      cnt_active;  /**< cnt0 changed since last scan */
 
     /* ownership */
     pid_t    creatorPID;
@@ -186,6 +187,7 @@ typedef struct
 
     /* counters */
     int64_t  loopcnt;
+    int      cnt_active;  /**< loopcnt changed since last scan */
 
     /* timing */
     long     dtmedian_iter_ns;

--- a/src/cli/overview/overview_data_graph.c
+++ b/src/cli/overview/overview_data_graph.c
@@ -319,17 +319,24 @@ void ov_build_graph(OV_MODEL *model)
                 continue;
             }
 
-            uint64_t flags =
-                f->stream_param_flags[sp];
             const char *pname =
                 f->stream_param_name[sp];
 
-            int is_out = 0;
-            if (flags & FPFLAG_WRITE)
+            /* Skip procinfo trigger stream —
+             * already handled by
+             * PROC_TRIGGER_STREAM edges */
+            if (strstr(pname, "procinfo.trigger"))
             {
-                is_out = 1;
+                continue;
             }
-            else if (strstr(pname, "out") || strstr(pname, "OUT"))
+
+            /* Determine direction by param name.
+             * FPFLAG_WRITE cannot be used — it
+             * means "user-editable", which is
+             * set for both inputs and outputs. */
+            int is_out = 0;
+            if (strstr(pname, "out")
+                || strstr(pname, "OUT"))
             {
                 is_out = 1;
             }

--- a/src/cli/overview/overview_data_internal.h
+++ b/src/cli/overview/overview_data_internal.h
@@ -70,6 +70,9 @@ typedef struct
     unsigned long prev_stime;
     int           has_prev_cpu;
     float         cpu_pct;
+
+    int64_t       prev_loopcnt;
+    int           has_prev_loop;
 } ov_proc_cache_t;
 
 extern ov_proc_cache_t s_pcache[OV_MAX_PROCS];

--- a/src/cli/overview/overview_data_scan.c
+++ b/src/cli/overview/overview_data_scan.c
@@ -24,11 +24,17 @@ static void scache_rate_update(
 {
     ov_stream_cache_t *ce = &s_scache[ci];
 
+    s->cnt_active = 0;
     if (ce->has_prev && s_scan_dt_sec > 0.01)
     {
         uint64_t dc = s->cnt0 - ce->prev_cnt0;
         s->update_hz =
             (double) dc / s_scan_dt_sec;
+
+        if (dc > 0)
+        {
+            s->cnt_active = 1;
+        }
 
         /* Update sparkline in cache (auto-scale) */
         float sv = (float) s->update_hz;
@@ -765,6 +771,28 @@ void ov_scan_procs(OV_MODEL *model)
 
             {
                 ov_proc_cache_t *ce = &s_pcache[ci];
+
+                /* Hz from loopcnt delta (fallback) */
+                if (p->loop_hz < 0.1
+                    && ce->has_prev_loop
+                    && s_scan_dt_sec > 0.01)
+                {
+                    int64_t dlc =
+                        p->loopcnt - ce->prev_loopcnt;
+                    if (dlc > 0)
+                    {
+                        p->loop_hz =
+                            (double) dlc / s_scan_dt_sec;
+                    }
+                }
+                /* Flag whether counter is advancing */
+                p->cnt_active =
+                    (ce->has_prev_loop
+                     && p->loopcnt != ce->prev_loopcnt);
+                ce->prev_loopcnt  = p->loopcnt;
+                ce->has_prev_loop = 1;
+
+                /* CPU percent from tick delta */
                 unsigned long ut = 0, st = 0;
                 if (pid_get_cpu_ticks(pid, &ut, &st) == 0)
                 {
@@ -977,9 +1005,31 @@ void ov_scan_procs(OV_MODEL *model)
             p->MeasureTiming  = pinfo->MeasureTiming;
             p->rt_priority    = pinfo->RT_priority;
 
-            /* CPU% tracking via cache delta */
+            /* CPU% and Hz tracking via cache delta */
             {
                 ov_proc_cache_t *ce = &s_pcache[ci];
+
+                /* Hz from loopcnt delta (fallback) */
+                if (p->loop_hz < 0.1
+                    && ce->has_prev_loop
+                    && s_scan_dt_sec > 0.01)
+                {
+                    int64_t dlc =
+                        p->loopcnt - ce->prev_loopcnt;
+                    if (dlc > 0)
+                    {
+                        p->loop_hz =
+                            (double) dlc / s_scan_dt_sec;
+                    }
+                }
+                /* Flag whether counter is advancing */
+                p->cnt_active =
+                    (ce->has_prev_loop
+                     && p->loopcnt != ce->prev_loopcnt);
+                ce->prev_loopcnt  = p->loopcnt;
+                ce->has_prev_loop = 1;
+
+                /* CPU percent from tick delta */
                 unsigned long ut = 0, st = 0;
                 if (pid_get_cpu_ticks(pid, &ut, &st) == 0)
                 {

--- a/src/cli/overview/overview_input.c
+++ b/src/cli/overview/overview_input.c
@@ -587,6 +587,33 @@ static int ov_input__handle_sorting(int key, OV_LAYOUT *lay)
     return 0;
 }
 
+static const OV_STREAM *ov_input_get_sel_stream(const OV_LAYOUT *lay, const OV_MODEL *m)
+{
+    if (lay->sel_name_stream[0] == '\0') return NULL;
+    for (int i = 0; i < m->nb_streams; i++) {
+        if (strcmp(m->streams[i].name, lay->sel_name_stream) == 0) return &m->streams[i];
+    }
+    return NULL;
+}
+
+static const OV_PROC *ov_input_get_sel_proc(const OV_LAYOUT *lay, const OV_MODEL *m)
+{
+    if (lay->sel_name_proc[0] == '\0') return NULL;
+    for (int i = 0; i < m->nb_procs; i++) {
+        if (strcmp(m->procs[i].name, lay->sel_name_proc) == 0) return &m->procs[i];
+    }
+    return NULL;
+}
+
+static const OV_FPS *ov_input_get_sel_fps(const OV_LAYOUT *lay, const OV_MODEL *m)
+{
+    if (lay->sel_name_fps[0] == '\0') return NULL;
+    for (int i = 0; i < m->nb_fps; i++) {
+        if (strcmp(m->fps[i].name, lay->sel_name_fps) == 0) return &m->fps[i];
+    }
+    return NULL;
+}
+
 static int ov_input__handle_actions(int key, OV_LAYOUT *lay, const OV_MODEL *m)
 {
     OV_CMDLOG *log = &lay->cmdlog;
@@ -599,166 +626,118 @@ static int ov_input__handle_actions(int key, OV_LAYOUT *lay, const OV_MODEL *m)
             return 1;
         }
 
-        if (lay->focus == OV_FOCUS_FPS
-            && lay->sel_fps >= 0
-            && lay->sel_fps < m->nb_fps)
+        if (lay->focus == OV_FOCUS_FPS)
         {
-            ov_ctrl_fps_remove(&m->fps[lay->sel_fps], log);
-            return 1;
+            const OV_FPS *f = ov_input_get_sel_fps(lay, m);
+            if (f) ov_ctrl_fps_remove(f, log);
         }
-        else if (lay->focus == OV_FOCUS_PROCS
-                 && lay->sel_proc >= 0
-                 && lay->sel_proc < m->nb_procs)
+        else if (lay->focus == OV_FOCUS_PROCS)
         {
-            ov_ctrl_proc_remove(&m->procs[lay->sel_proc], log);
-            return 1;
+            const OV_PROC *p = ov_input_get_sel_proc(lay, m);
+            if (p) ov_ctrl_proc_remove(p, log);
         }
-        else if (lay->focus == OV_FOCUS_STREAMS
-                 && lay->sel_stream >= 0
-                 && lay->sel_stream < m->nb_streams)
+        else if (lay->focus == OV_FOCUS_STREAMS)
         {
-            ov_ctrl_stream_delete(&m->streams[lay->sel_stream], log);
-            return 1;
+            const OV_STREAM *s = ov_input_get_sel_stream(lay, m);
+            if (s) ov_ctrl_stream_delete(s, log);
         }
-    }
-
-    if (key == 'k' || key == 'K')
-    {
-        if (lay->focus == OV_FOCUS_PROCS
-            && lay->sel_proc >= 0
-            && lay->sel_proc < m->nb_procs)
-        {
-            const OV_PROC *p =
-                &m->procs[lay->sel_proc];
-            if (key == 'k')
-            {
-                ov_ctrl_proc_kill(p, log);
-            }
-            else if (key == 'K')
-            {
-                ov_ctrl_proc_sigkill(p, log);
-            }
-            return 1;
-        }
-        else if (lay->focus == OV_FOCUS_FPS
-                 && lay->sel_fps >= 0
-                 && lay->sel_fps < m->nb_fps)
-        {
-            const OV_FPS *f =
-                &m->fps[lay->sel_fps];
-            if (key == 'k')
-            {
-                ov_ctrl_fps_signal_pid(
-                    f, SIGTERM, log);
-            }
-            else if (key == 'K')
-            {
-                ov_ctrl_fps_signal_pid(
-                    f, SIGKILL, log);
-            }
-            else if (key == 'x')
-            {
-                ov_ctrl_fps_pause_toggle(f, log);
-            }
-            return 1;
-        }
-    }
-
-    if (key == 'C')
-    {
-        if (lay->focus == OV_FOCUS_PROCS)
-        {
-            ov_ctrl_procs_cleanup(log);
-            return 1;
-        }
+        return 1;
     }
 
     if (key == 'i')
     {
-        if (lay->focus == OV_FOCUS_STREAMS
-            && lay->sel_stream >= 0
-            && lay->sel_stream < m->nb_streams)
+        if (lay->focus == OV_FOCUS_STREAMS)
         {
-            ov_ctrl_inspect_item(OV_FOCUS_STREAMS, &m->streams[lay->sel_stream]);
-            return 1;
+            const OV_STREAM *s = ov_input_get_sel_stream(lay, m);
+            if (s) ov_ctrl_inspect_item(OV_FOCUS_STREAMS, s);
         }
-        else if (lay->focus == OV_FOCUS_PROCS
-                 && lay->sel_proc >= 0
-                 && lay->sel_proc < m->nb_procs)
+        else if (lay->focus == OV_FOCUS_PROCS)
         {
-            ov_ctrl_inspect_item(OV_FOCUS_PROCS, &m->procs[lay->sel_proc]);
-            return 1;
+            const OV_PROC *p = ov_input_get_sel_proc(lay, m);
+            if (p) ov_ctrl_inspect_item(OV_FOCUS_PROCS, p);
         }
-        else if (lay->focus == OV_FOCUS_FPS
-                 && lay->sel_fps >= 0
-                 && lay->sel_fps < m->nb_fps)
+        else if (lay->focus == OV_FOCUS_FPS)
         {
-            ov_ctrl_inspect_item(OV_FOCUS_FPS, &m->fps[lay->sel_fps]);
-            return 1;
+            const OV_FPS *f = ov_input_get_sel_fps(lay, m);
+            if (f) ov_ctrl_inspect_item(OV_FOCUS_FPS, f);
+        }
+        return 1;
+    }
+
+    int is_ctrl_action = 0;
+
+    if (lay->focus == OV_FOCUS_PROCS)
+    {
+        if (key == 'C')
+        {
+            is_ctrl_action = 1;
+            if (lay->ctrl_mode)
+            {
+                ov_ctrl_procs_cleanup(log);
+            }
+        }
+        else if (key == 'k' || key == 'K' || key == 'p' || key == ctrl('s') || key == 'e' || key == 'z')
+        {
+            is_ctrl_action = 1;
+            if (lay->ctrl_mode)
+            {
+                const OV_PROC *p = ov_input_get_sel_proc(lay, m);
+                if (p)
+                {
+                    if (key == 'k') ov_ctrl_proc_kill(p, log);
+                    else if (key == 'K') ov_ctrl_proc_sigkill(p, log);
+                    else if (key == 'p') ov_ctrl_proc_set_ctrlval(p, -1, log);
+                    else if (key == ctrl('s')) ov_ctrl_proc_set_ctrlval(p, 2, log);
+                    else if (key == 'e') ov_ctrl_proc_set_ctrlval(p, 3, log);
+                    else if (key == 'z') ov_ctrl_proc_zero_counters(p, log);
+                }
+            }
+        }
+    }
+    else if (lay->focus == OV_FOCUS_FPS)
+    {
+        if (key == 'k' || key == 'K' || key == 'x' || key == 'r' || key == 's')
+        {
+            is_ctrl_action = 1;
+            if (lay->ctrl_mode)
+            {
+                const OV_FPS *f = ov_input_get_sel_fps(lay, m);
+                if (f)
+                {
+                    if (key == 'k') ov_ctrl_fps_signal_pid(f, SIGTERM, log);
+                    else if (key == 'K') ov_ctrl_fps_signal_pid(f, SIGKILL, log);
+                    else if (key == 'x') ov_ctrl_fps_pause_toggle(f, log);
+                    else if (key == 'r') ov_ctrl_fps_run_toggle(f, log);
+                    else if (key == 's') ov_ctrl_fps_conf_toggle(f, log);
+                }
+            }
+        }
+    }
+    else if (lay->focus == OV_FOCUS_STREAMS)
+    {
+        if (key == OV_KEY_DEL)
+        {
+            is_ctrl_action = 1;
+            if (lay->ctrl_mode)
+            {
+                const OV_STREAM *s = ov_input_get_sel_stream(lay, m);
+                if (s) ov_ctrl_stream_delete(s, log);
+            }
         }
     }
 
-    if (lay->ctrl_mode)
+    if (is_ctrl_action)
     {
-        if (lay->focus == OV_FOCUS_FPS
-            && lay->sel_fps >= 0
-            && lay->sel_fps < m->nb_fps)
+        if (!lay->ctrl_mode)
         {
-            const OV_FPS *f =
-                &m->fps[lay->sel_fps];
-            if (key == 'r')
-            {
-                ov_ctrl_fps_run_toggle(f, log);
-                return 1;
-            }
-            if (key == 's')
-            {
-                ov_ctrl_fps_conf_toggle(f, log);
-                return 1;
-            }
+            char keyname[16];
+            if (key == ctrl('s')) snprintf(keyname, sizeof(keyname), "CTRL+s");
+            else if (key == OV_KEY_DEL) snprintf(keyname, sizeof(keyname), "DEL");
+            else snprintf(keyname, sizeof(keyname), "'%c'", key);
+            
+            ov_cmdlog_push(log, OV_CMDLOG_WARN, "%s requires CONTROL mode", keyname);
         }
-
-        if (lay->focus == OV_FOCUS_PROCS
-            && lay->sel_proc >= 0
-            && lay->sel_proc < m->nb_procs)
-        {
-            const OV_PROC *p =
-                &m->procs[lay->sel_proc];
-            if (key == 'p')
-            {
-                ov_ctrl_proc_set_ctrlval(p, -1, log);
-                return 1;
-            }
-            if (key == ctrl('s'))
-            {
-                ov_ctrl_proc_set_ctrlval(p, 2, log);
-                return 1;
-            }
-            if (key == 'e')
-            {
-                ov_ctrl_proc_set_ctrlval(p, 3, log);
-                return 1;
-            }
-            if (key == 'z')
-            {
-                ov_ctrl_proc_zero_counters(p, log);
-                return 1;
-            }
-        }
-
-
-        if (lay->focus == OV_FOCUS_STREAMS
-            && lay->sel_stream >= 0
-            && lay->sel_stream < m->nb_streams)
-        {
-            const OV_STREAM *s =
-                &m->streams[lay->sel_stream];
-            if (key == OV_KEY_DEL)
-            {
-                ov_ctrl_stream_delete(s, log);
-                return 1;
-            }
-        }
+        return 1;
     }
 
     return 0;
@@ -1089,6 +1068,29 @@ int ov_handle_key(
             if (*sel < *scroll) *scroll = *sel;
             if (*sel >= *scroll + page_h) *scroll = *sel - page_h + 1;
         }
+        return 0;
+    }
+
+    if (key == '?')
+    {
+        char keys_str[128];
+        char ctrl_str[128] = "";
+
+        // Base keys always available
+        snprintf(keys_str, sizeof(keys_str), "Keys: q c h G ? TAB D L F W i <>[]sS +-= F2-F6 / ESC");
+
+        if (lay->ctrl_mode)
+        {
+            if (lay->focus == OV_FOCUS_FPS)
+                snprintf(ctrl_str, sizeof(ctrl_str), " | CTRL (FPS): x r s k K ^e");
+            else if (lay->focus == OV_FOCUS_PROCS)
+                snprintf(ctrl_str, sizeof(ctrl_str), " | CTRL (PROC): p ^s e z C k K ^e");
+            else if (lay->focus == OV_FOCUS_STREAMS)
+                snprintf(ctrl_str, sizeof(ctrl_str), " | CTRL (STRM): DEL ^e");
+        }
+
+        ov_cmdlog_push(&lay->cmdlog, OV_CMDLOG_INFO, "%s%s", keys_str, ctrl_str);
+        if (lay->cmdlog_rows == 0) lay->cmdlog_rows = 4;
         return 0;
     }
 

--- a/src/cli/overview/overview_layout.h
+++ b/src/cli/overview/overview_layout.h
@@ -124,6 +124,10 @@ typedef struct {
     int          freeze_sel_fps;
     /* Lineage tracking mode: 0 = Trigger, 1 = Input */
     int          lineage_mode;
+    /* Track selected names to handle external removals */
+    char         sel_name_stream[80];
+    char         sel_name_proc[80];
+    char         sel_name_fps[80];
 } OV_LAYOUT;
 
 void ov_layout_compute(OV_LAYOUT *lay);

--- a/src/cli/overview/overview_render.c
+++ b/src/cli/overview/overview_render.c
@@ -388,7 +388,11 @@ void ov_render_frame(
         }
 
         if (sel_node >= 0) {
-            sg_compute_node_depths(mm, sel_node, SG_MODE_FULL, depths);
+            sg_mode_t smode =
+                (focus == OV_FOCUS_FPS)
+                ? SG_MODE_FPS : SG_MODE_FULL;
+            sg_compute_node_depths(
+                mm, sel_node, smode, depths);
         }
         ov_sort_set_depths(depths);
 
@@ -486,6 +490,87 @@ void ov_render_frame(
         OV_MODEL *mm = (OV_MODEL *)(uintptr_t) m;
         ov_apply_rank_sort(mm);
         g_last_model = m;
+    }
+
+    /* Enforce active selection tracking:
+     * If the selected item no longer exists in the filtered list
+     * (e.g. removed by an external process), reset the selection to 0.
+     * Otherwise, clamp bounds and update the tracked name. */
+    {
+        const char *names[OV_MAX_NODES];
+        int fidx[OV_MAX_NODES];
+
+        /* Streams */
+        for (int i = 0; i < m->nb_streams; i++) names[i] = m->streams[i].name;
+        int fn = ov_filter_build(lay->filter_stream, names, m->nb_streams, fidx, OV_MAX_NODES);
+        if (fn > 0) {
+            if (lay->sel_name_stream[0] != '\0') {
+                int still_exists = 0;
+                for (int i = 0; i < fn; i++) {
+                    if (strcmp(m->streams[fidx[i]].name, lay->sel_name_stream) == 0) {
+                        still_exists = 1;
+                        break;
+                    }
+                }
+                if (!still_exists) {
+                    lay->sel_stream = 0;
+                }
+            }
+            if (lay->sel_stream >= fn) lay->sel_stream = fn - 1;
+            if (lay->sel_stream < 0) lay->sel_stream = 0;
+            strncpy(lay->sel_name_stream, m->streams[fidx[lay->sel_stream]].name, 79);
+        } else {
+            lay->sel_stream = 0;
+            lay->sel_name_stream[0] = '\0';
+        }
+
+        /* Procs */
+        for (int i = 0; i < m->nb_procs; i++) names[i] = m->procs[i].name;
+        fn = ov_filter_build(lay->filter_proc, names, m->nb_procs, fidx, OV_MAX_NODES);
+        if (fn > 0) {
+            if (lay->sel_name_proc[0] != '\0') {
+                int still_exists = 0;
+                for (int i = 0; i < fn; i++) {
+                    if (strcmp(m->procs[fidx[i]].name, lay->sel_name_proc) == 0) {
+                        still_exists = 1;
+                        break;
+                    }
+                }
+                if (!still_exists) {
+                    lay->sel_proc = 0;
+                }
+            }
+            if (lay->sel_proc >= fn) lay->sel_proc = fn - 1;
+            if (lay->sel_proc < 0) lay->sel_proc = 0;
+            strncpy(lay->sel_name_proc, m->procs[fidx[lay->sel_proc]].name, 79);
+        } else {
+            lay->sel_proc = 0;
+            lay->sel_name_proc[0] = '\0';
+        }
+
+        /* FPS */
+        for (int i = 0; i < m->nb_fps; i++) names[i] = m->fps[i].name;
+        fn = ov_filter_build(lay->filter_fps, names, m->nb_fps, fidx, OV_MAX_NODES);
+        if (fn > 0) {
+            if (lay->sel_name_fps[0] != '\0') {
+                int still_exists = 0;
+                for (int i = 0; i < fn; i++) {
+                    if (strcmp(m->fps[fidx[i]].name, lay->sel_name_fps) == 0) {
+                        still_exists = 1;
+                        break;
+                    }
+                }
+                if (!still_exists) {
+                    lay->sel_fps = 0;
+                }
+            }
+            if (lay->sel_fps >= fn) lay->sel_fps = fn - 1;
+            if (lay->sel_fps < 0) lay->sel_fps = 0;
+            strncpy(lay->sel_name_fps, m->fps[fidx[lay->sel_fps]].name, 79);
+        } else {
+            lay->sel_fps = 0;
+            lay->sel_name_fps[0] = '\0';
+        }
     }
 
     /* Always patch graph node .index fields to

--- a/src/cli/overview/overview_render_detail.c
+++ b/src/cli/overview/overview_render_detail.c
@@ -77,15 +77,20 @@ static int ov_fps__render_detail_stream(
         {
             ov_buf_pos(row + ri, r.col + 1);
             ov_theme_bg(OV_BG_PANEL);
-            ov_theme_fg(OV_FG_TEXT);
+            ov_theme_fg(OV_FG_DIM);
+            ov_buf_printf(" cnt0: ");
+            ov_theme_fg(s->cnt_active
+                ? OV_FG_ACTIVE : OV_FG_DIM);
+            ov_buf_printf("%lu", (unsigned long) s->cnt0);
+            ov_theme_fg(OV_FG_DIM);
+            ov_buf_printf("  Hz: ");
+            ov_theme_fg(s->cnt_active
+                ? OV_FG_ACTIVE : OV_FG_DIM);
             int n = snprintf(NULL, 0,
                 " cnt0: %lu  Hz: %.1f",
                 (unsigned long) s->cnt0,
                 s->update_hz);
-            ov_buf_printf(
-                " cnt0: %lu  Hz: %.1f",
-                (unsigned long) s->cnt0,
-                s->update_hz);
+            ov_buf_printf("%.1f", s->update_hz);
             render_pad_spaces(n, r.width);
             ri++;
         }
@@ -441,12 +446,16 @@ static int ov_fps__render_detail_proc(
             ov_buf_pos(row + ri, r.col + 1);
             ov_theme_bg(OV_BG_PANEL);
             ov_theme_fg(OV_FG_TEXT);
+            ov_buf_printf(" Status: %s  Loops: ", sl);
+            ov_theme_fg(p->cnt_active
+                ? OV_FG_ACTIVE : OV_FG_DIM);
+            ov_buf_printf("%ld", (long) p->loopcnt);
+            ov_theme_fg(OV_FG_DIM);
+            ov_buf_printf("  Hz: ");
+            ov_theme_fg(p->cnt_active
+                ? OV_FG_ACTIVE : OV_FG_DIM);
+            ov_buf_printf("%.1f", p->loop_hz);
             int n = snprintf(NULL, 0,
-                " Status: %s  Loops: %ld"
-                "  Hz: %.1f",
-                sl, (long) p->loopcnt,
-                p->loop_hz);
-            ov_buf_printf(
                 " Status: %s  Loops: %ld"
                 "  Hz: %.1f",
                 sl, (long) p->loopcnt,

--- a/src/cli/overview/overview_render_fps.c
+++ b/src/cli/overview/overview_render_fps.c
@@ -80,7 +80,7 @@ void ov_render_fps_panel(
                        (sk == 3) ? "ANCESTRY" : "NAME",
                        (sk == 3) ? 3 : 0, sk, sd, 18);
         int w_c = sort_col_label(c_c, sizeof(c_c),
-                       "C", 1, sk, sd, 2);
+                       "CPID", 1, sk, sd, 7);
         int w_mem = sort_col_label(c_mem, sizeof(c_mem),
                        "MEM", 2, sk, sd, 5);
         int desc_w =
@@ -88,11 +88,11 @@ void ov_render_fps_panel(
             ? 30 : 20;
         hlen = snprintf(
             htext, sizeof(htext),
-            "%-*s %*s %1s %3s %*s"
-            " %-*s %8s %7s %7s",
-            w_name, c_name, w_c, c_c, "R", "STR", w_mem, c_mem,
+            "%-*s %*s %7s %3s %*s"
+            " %-*s %8s",
+            w_name, c_name, w_c, c_c, "RPID", "STR", w_mem, c_mem,
             desc_w, "DESCRIPTION",
-            "STATUS", "CPID", "RPID");
+            "STATUS");
     }
     
     {
@@ -118,10 +118,13 @@ void ov_render_fps_panel(
             int root_node = m->fps[root_fi].node_idx;
             if (root_node >= 0) {
                 int8_t node_depths[OV_MAX_NODES];
-                sg_compute_node_depths(m, root_node, SG_MODE_FULL, node_depths);
+                sg_compute_node_depths(
+                    m, root_node,
+                    SG_MODE_FPS, node_depths);
                 for (int fi = 0; fi < m->nb_fps; fi++) {
                     int n = m->fps[fi].node_idx;
-                    if (n >= 0) local_depth[fi] = node_depths[n];
+                    if (n >= 0 && node_depths[n] != 127)
+                        local_depth[fi] = node_depths[n];
                 }
             }
         }
@@ -232,8 +235,10 @@ void ov_render_fps_panel(
                         ? rel->sel_pid : 0;
 
             FPS_FIELD(OV_FG_FPS, "%-18.18s ", f->name);
-            FPS_PID_FIELD(f->confpid, "%2s ", f->conf_alive ? "C" : "-");
-            FPS_PID_FIELD(f->runpid, "%s ", f->run_alive ? "R" : "-");
+            if (f->confpid > 0) FPS_PID_FIELD(f->confpid, "%7d ", (int) f->confpid);
+            else FPS_FIELD(OV_FG_DIM, "%7s ", "-");
+            if (f->runpid > 0) FPS_PID_FIELD(f->runpid, "%7d ", (int) f->runpid);
+            else FPS_FIELD(OV_FG_DIM, "%7s ", "-");
             FPS_FIELD(OV_FG_TEXT, "%3d ", f->nb_stream_params);
             
             /* MEM */
@@ -255,8 +260,6 @@ void ov_render_fps_panel(
                     f->description);
             }
             FPS_FIELD(OV_FG_MUTED, "%08X ", f->md_status);
-            FPS_PID_FIELD(f->confpid, "%7d ", (int) f->confpid);
-            FPS_PID_FIELD(f->runpid, "%7d", (int) f->runpid);
             
             #undef FPS_PID_FIELD
             #undef FPS_FIELD

--- a/src/cli/overview/overview_render_procs.c
+++ b/src/cli/overview/overview_render_procs.c
@@ -121,7 +121,8 @@ static void ov_procs__render_rows(
                 sg_compute_node_depths(m, root_node, SG_MODE_FULL, node_depths);
                 for (int pi = 0; pi < m->nb_procs; pi++) {
                     int n = m->procs[pi].node_idx;
-                    if (n >= 0) local_depth[pi] = node_depths[n];
+                    if (n >= 0 && node_depths[n] != 127)
+                        local_depth[pi] = node_depths[n];
                 }
             }
         }
@@ -720,7 +721,8 @@ static void ov_procs__render_rows(
                 if (vv > mx) { vv = mx; }
                 if (vv > 0)
                 {
-                    ov_theme_fg(OV_FG_DIM);
+                    ov_theme_fg(p->cnt_active
+                        ? OV_FG_ACTIVE : OV_FG_DIM);
                     ov_buf_printf("%.*s", vv, fb + skip);
                     printed += vv;
                 }

--- a/src/cli/overview/overview_render_streams.c
+++ b/src/cli/overview/overview_render_streams.c
@@ -443,7 +443,8 @@ void ov_render_streams_panel(
             STRM_PID_FIELD(
                 s->ownerPID,
                 "%7d ", (int) s->ownerPID);
-            STRM_FIELD(OV_FG_CONN, "%10lu ", (unsigned long) s->cnt0);
+            STRM_FIELD(s->cnt_active ? OV_FG_ACTIVE : OV_FG_DIM,
+                "%10lu ", (unsigned long) s->cnt0);
             
             for (int sm = 0; sm < 10; sm++) {
                 if (sm < s->nb_sem) {

--- a/src/cli/overview/stream_graph.c
+++ b/src/cli/overview/stream_graph.c
@@ -94,6 +94,12 @@ static int sg_edge_matches_mode_from_stream(
                    == OV_EDGE_STREAM_READ_BY_PROC
                 || e->type
                    == OV_EDGE_PROC_WRITES_STREAM);
+
+    case SG_MODE_FPS:
+        /* FPS-centric: only FPS<->stream edges */
+        return (e->type == OV_EDGE_FPS_INPUT_STREAM
+                || e->type
+                   == OV_EDGE_FPS_OUTPUT_STREAM);
     } /* switch mode */
 
     return 0;
@@ -478,6 +484,8 @@ const char *sg_mode_label(sg_mode_t mode)
         return "Input";
     case SG_MODE_FULL:
         return "Full";
+    case SG_MODE_FPS:
+        return "FPS";
     }
     return "Unknown";
 }
@@ -533,9 +541,22 @@ void sg_compute_node_depths(
             if (e->src_node != cur.node) continue;
 
             if (cn->type == OV_NODE_STREAM) {
-                if (!sg_edge_matches_mode_from_stream(e, mode)) continue;
+                if (!sg_edge_matches_mode_from_stream(
+                        e, mode))
+                    continue;
+            } else if (mode == SG_MODE_FPS) {
+                /* FPS mode: only FPS<->stream edges */
+                if (!sg_edge_matches_mode_from_stream(
+                        e, mode))
+                    continue;
             } else {
-                if (m->nodes[e->tgt_node].type != OV_NODE_STREAM) continue;
+                /* From FPS/PROC: follow edges to streams
+                 * and FPS_RUNS_PROC edges (FPS->proc) */
+                int tgt_type =
+                    m->nodes[e->tgt_node].type;
+                if (tgt_type != OV_NODE_STREAM
+                    && e->type != OV_EDGE_FPS_RUNS_PROC)
+                    continue;
             }
 
             int next = e->tgt_node;
@@ -544,7 +565,8 @@ void sg_compute_node_depths(
 
             sg_bset(visited, next);
             int d = cur.depth;
-            if (cn->type == start_type) d++;
+            if (m->nodes[next].type == start_type)
+                d++;
 
             queue[qtail].node = next;
             queue[qtail].depth = d;
@@ -584,15 +606,32 @@ void sg_compute_node_depths(
             int next = e->src_node;
             if (next < 0 || next >= m->nb_nodes) continue;
             
-            if (cn->type != OV_NODE_STREAM) {
-                if (!sg_edge_matches_mode_from_stream(e, mode)) continue;
+            if (mode == SG_MODE_FPS) {
+                /* FPS mode: restrict to FPS<->stream
+                 * edges for both stream and non-stream
+                 * nodes */
+                if (!sg_edge_matches_mode_from_stream(
+                        e, mode))
+                    continue;
+            } else if (cn->type != OV_NODE_STREAM) {
+                /* Going upstream from PROC/FPS:
+                 * accept stream-related edges and
+                 * FPS_RUNS_PROC (proc<-FPS).
+                 * Stream nodes: no filter (accept
+                 * all reverse edges). */
+                if (!sg_edge_matches_mode_from_stream(
+                        e, mode)
+                    && e->type
+                       != OV_EDGE_FPS_RUNS_PROC)
+                    continue;
             }
 
             if (sg_bget(visited, next)) continue;
 
             sg_bset(visited, next);
             int d = cur.depth;
-            if (cn->type == start_type) d++;
+            if (m->nodes[next].type == start_type)
+                d++;
 
             queue[qtail].node = next;
             queue[qtail].depth = d;

--- a/src/cli/overview/stream_graph.h
+++ b/src/cli/overview/stream_graph.h
@@ -36,12 +36,14 @@
  * @SG_MODE_INPUT:   follow FPS input/read edges.
  * @SG_MODE_FULL:    follow all FPS stream params
  *                   (both input and output).
+ * @SG_MODE_FPS:     follow only FPS-stream edges.
  */
 typedef enum
 {
     SG_MODE_TRIGGER = 0,
     SG_MODE_INPUT   = 1,
     SG_MODE_FULL    = 2,
+    SG_MODE_FPS     = 3,
 } sg_mode_t;
 
 /* =========================================================

--- a/src/engine/libfps/fpsCTRL/fpsCTRL_FPSdisplay.c
+++ b/src/engine/libfps/fpsCTRL/fpsCTRL_FPSdisplay.c
@@ -975,8 +975,8 @@ static void fpsCTRL__render_parameter_rows(
                         screenprint_unsetbgcolor();
                     }
                 }
-                for(int l = 0; l < MAXNBLEVELS ; l++) child_index[l]++;
             }
+            for(int l = 0; l < MAXNBLEVELS ; l++) child_index[l]++;
             TUI_newline();
         }
 }

--- a/src/engine/libprocessinfo/processinfo_loopstep.c
+++ b/src/engine/libprocessinfo/processinfo_loopstep.c
@@ -23,9 +23,15 @@ int processinfo_loopstep(
 {
     int loopstatus = 1;
 
-    while(processinfo->CTRLval == 1)  // pause
+    if(processinfo->CTRLval == 1)  // pause
     {
-        usleep(50);
+        int prev_stat = processinfo->loopstat;
+        processinfo->loopstat = 2; // PROCESSINFO_LOOPSTAT_PAUSE
+        while(processinfo->CTRLval == 1)
+        {
+            usleep(50);
+        }
+        processinfo->loopstat = prev_stat;
     }
     if(processinfo->CTRLval == 2)  // single iteration
     {


### PR DESCRIPTION
## Summary

A collection of bug fixes and UX enhancements for the milkCTRL diagnostic TUI, addressing 10 user-reported issues. Changes span the overview dashboard, FPS parameter tree display, and processinfo loop control.

## Changes

### Bug Fixes
- **Stream deletion (`CTRL+e`) was silently failing** — the log showed "deleted" but the SHM file remained. Root cause: `ImageStreamIO_destroyIm` only unmaps memory; replaced with explicit `sem_destroy + closeIm + unlink` sequence.
- **PROCESSINFO status showed "RUN" when paused** — `processinfo_loopstep.c` didn't update `loopstat` during the CTRLval=1 pause wait. Now sets `LOOPSTAT_PAUSE` while blocked and restores afterward.
- **Ancestry not displayed in CONNECTIONS panel** — upstream BFS was incorrectly applying SG_MODE_FPS-only edge filters in non-FPS modes, pruning valid edges like `PROC_WRITES_STREAM`. Restored unfiltered upstream traversal for all modes except SG_MODE_FPS.
- **Hz column blank in PROCESSINFO panel** — the Hz computation relied exclusively on `dtmedian_iter_ns` (requires `MeasureTiming` enabled, which is typically OFF). Added `loopcnt`-delta fallback and fixed the triple-buffer scan-interval warmup by sharing the timestamp across model slots.
- **fpsCTRL parameter tree showed duplicate entries** — `child_index` increment was inside the rendering conditional instead of after it, causing misaligned entries.

### Features
- **`?` key prints available commands** — shows a list of valid keystrokes for the current mode in the log panel.
- **FPS column consolidation** — renamed `C`/`R` columns to `CPID`/`RPID` for clarity.
- **Active selection persistence** — if an external process removes the selected stream/proc/FPS, the selection now resets to the first item instead of leaving a stale index. Tracked via name-based selection (`sel_name_stream`, etc.).
- **Counter activity highlighting** — `cnt0` (streams) and `loopcnt` (processes) now glow green when actively incrementing and dim gray when stale. Applied across STREAMS panel, PROCESSINFO panel, and both DETAIL panels.

## Files Changed (17 files, +416 / -171)

| Component | File | Change |
|---|---|---|
| milkCTRL overview | `overview_ctrl.c` | Fix stream deletion |
| milkCTRL overview | `overview_data.c` | Fix scan interval sharing |
| milkCTRL overview | `overview_data.h` | Add `cnt_active` flags |
| milkCTRL overview | `overview_data_graph.c` | Edge directionality refinements |
| milkCTRL overview | `overview_data_internal.h` | Add loopcnt delta cache fields |
| milkCTRL overview | `overview_data_scan.c` | Hz fallback + cnt_active tracking |
| milkCTRL overview | `overview_input.c` | Name-based selection, control actions |
| milkCTRL overview | `overview_layout.h` | Selection name fields |
| milkCTRL overview | `overview_render.c` | Selection persistence, `?` help |
| milkCTRL overview | `overview_render_detail.c` | Counter activity coloring |
| milkCTRL overview | `overview_render_fps.c` | CPID/RPID columns |
| milkCTRL overview | `overview_render_procs.c` | Counter activity coloring |
| milkCTRL overview | `overview_render_streams.c` | Counter activity coloring |
| milkCTRL overview | `stream_graph.c` | Ancestry BFS fix |
| milkCTRL overview | `stream_graph.h` | Add `SG_MODE_FPS` |
| fpsCTRL | `fpsCTRL_FPSdisplay.c` | Fix child_index increment |
| processinfo | `processinfo_loopstep.c` | Set PAUSE status during wait |

## Testing
- Full build verified (`make -j` clean, no errors)
- Tested with `milk-demopipeline`:
  - Hz column populates correctly after 1 scan cycle
  - Ancestry traversal shows correct multi-hop lineage
  - Counter highlighting visually distinguishes active vs stale
  - Stream deletion via CTRL+e properly removes SHM files
  - PAUSE status correctly reflected in TUI

## Prompt Summary
User requested 10 specific TUI fixes and enhancements during a diagnostic session using `milk-demopipeline`. Issues ranged from incorrect status displays and broken deletion commands to missing Hz data and ancestry traversal failures.

## AI Authorship
- **Model**: Antigravity
- **User edits**: No direct source code edits by user