### PR TITLE
feat: standardize diagnostic tool help menus with milk_help

### DIFF
--- a/src/cli/overview/milkCTRL.c
+++ b/src/cli/overview/milkCTRL.c
@@ -125,23 +125,35 @@ static void print_help(const char *prog, int mh_color)
 
     milk_help_section("Description", mh_color);
     printf("  milkCTRL is the unified system dashboard TUI for the milk framework.\n"
-           "  It provides a consolidated view of all shared-memory components,\n"
-           "  including data streams, Function Processing Systems (FPS), and\n"
-           "  active processes.\n"
+           "  It provides a comprehensive, consolidated view of all shared-memory\n"
+           "  components across the machine, including data streams, Function\n"
+           "  Processing Systems (FPS), and active managed processes. Designed for\n"
+           "  low-latency, real-time environments, it allows operators to trace\n"
+           "  entire dataflow pipelines and diagnose bottlenecks dynamically.\n"
            "\n"
            "  Key capabilities include:\n"
-           "  - %s: Visualizes dataflow lineage between streams\n"
-           "    and the processes reading/writing them.\n"
-           "  - %s: Monitors cache misses (L1D, LLC, dTLB) per\n"
-           "    process iteration using Linux perf counters.\n"
-           "  - %s: Control execution states (pause, step, kill)\n"
-           "    and clean up zombie streams or stale memory segments safely.\n"
+           "  - %s: Visually traces dataflow lineage between streams\n"
+           "    and the specific processes reading or writing to them.\n"
+           "  - %s: Monitors cache misses (L1D, LLC, dTLB),\n"
+           "    instructions per cycle, and branching via Linux perf counters.\n"
+           "  - %s: Manipulates execution states (pause, step, kill)\n"
+           "    and cleans up zombie streams or stale memory segments safely.\n"
            "  - %s: Real-time metrics on process CPU usage, memory\n"
-           "    (RSS), context switching, and pipeline throughput.\n\n",
+           "    (RSS), context switching, sleep/run states, and pipeline throughput.\n\n",
            MH(MH_BOLD, "Live Pipeline Topology"),
            MH(MH_BOLD, "Hardware Diagnostics"),
            MH(MH_BOLD, "Process Orchestration"),
            MH(MH_BOLD, "System Telemetry"));
+
+    milk_help_section("Dashboard Layout", mh_color);
+    printf("  The TUI is organized into specialized views (tabs), selectable via F2-F6:\n"
+           "  - %s (F2): All panels (Streams, Processes, FPS) sharing the screen\n"
+           "  - %s (F3): Dedicated full-screen view of Streams\n"
+           "  - %s (F4): Dedicated full-screen view of Processes\n"
+           "  - %s  (F5): Dedicated full-screen view of FPS modules\n"
+           "  - %s (F6): Visual node graph showing data flow and lineage\n\n",
+           MH(MH_BOLD, "DASH"), MH(MH_BOLD, "STRM"), MH(MH_BOLD, "PROC"),
+           MH(MH_BOLD, "FPS"), MH(MH_BOLD, "CONN"));
 
     milk_help_section("Options", mh_color);
     printf("  %s                      Show this help\n", MH(MH_OPT, "-h, --help"));
@@ -150,47 +162,45 @@ static void print_help(const char *prog, int mh_color)
     printf("  %s %s                         Override SHM directory\n\n", MH(MH_OPT, "-d"), MH(MH_ARG, "DIR"));
 
     milk_help_section("Navigation", mh_color);
-    printf("  %s, %s             Switch views\n", MH(MH_OPT, "F2-F6"), MH(MH_OPT, "^Left/^Right"));
-    printf("  %s                             Cycle panel focus\n", MH(MH_OPT, "TAB"));
-    printf("  %s                           Navigate list\n", MH(MH_OPT, "UP/DN"));
-    printf("  %s                      Panel focus / scroll\n", MH(MH_OPT, "Left/Right"));
-    printf("  %s                         Scroll page\n", MH(MH_OPT, "PgUp/Dn"));
-    printf("  %s                        Jump to top/bottom\n\n", MH(MH_OPT, "Home/End"));
+    printf("  %s, %s             Switch views (Dashboard, Streams, Procs, FPS, Graph)\n", MH(MH_OPT, "F2-F6"), MH(MH_OPT, "^Left/^Right"));
+    printf("  %s                             Cycle focus between active panels\n", MH(MH_OPT, "TAB"));
+    printf("  %s                           Navigate rows in focused list\n", MH(MH_OPT, "UP/DN"));
+    printf("  %s                       Ancestry navigation (jump to prev/next connected node)\n", MH(MH_OPT, "SHIFT+UP/DN"));
+    printf("  %s                      Scroll panel horizontally (or cycle focus on F2)\n", MH(MH_OPT, "Left/Right"));
+    printf("  %s                         Scroll page up/down\n", MH(MH_OPT, "PgUp/Dn"));
+    printf("  %s                        Jump to top/bottom of list\n", MH(MH_OPT, "Home/End"));
+    printf("  %s                               Filter (regex search) in focused panel\n\n", MH(MH_OPT, "/"));
 
     milk_help_section("Sorting", mh_color);
-    printf("  %s, %s                        Change sort column / mode\n", MH(MH_OPT, "</>"), MH(MH_OPT, "S/s"));
-    printf("  %s                               Toggle sort direction\n\n", MH(MH_OPT, "["));
+    printf("  %s, %s                        Cycle sort column backward/forward\n", MH(MH_OPT, "<"), MH(MH_OPT, ">/]"));
+    printf("  %s                               Sort by Name\n", MH(MH_OPT, "s"));
+    printf("  %s                               Sort by Frequency/Status\n", MH(MH_OPT, "S"));
+    printf("  %s                               Sort by Ancestry/Topology\n", MH(MH_OPT, "A"));
+    printf("  %s                               Toggle sort direction (Ascending/Descending)\n\n", MH(MH_OPT, "["));
 
-    milk_help_section("Display", mh_color);
-    printf("  %s                             Adjust scan rate\n", MH(MH_OPT, "+/-"));
-    printf("  %s                               Toggle detail pane\n", MH(MH_OPT, "D"));
-    printf("  %s                               Toggle lineage mode\n", MH(MH_OPT, "L"));
-    printf("  %s                               Pause/resume display\n", MH(MH_OPT, "p"));
-    printf("  %s                           Freeze selection highlight\n", MH(MH_OPT, "SPACE"));
-    printf("  %s                               Filter (regex search)\n", MH(MH_OPT, "/"));
-    printf("  %s                               Export snapshot to file\n", MH(MH_OPT, "W"));
-    printf("  %s                               Toggle command log panel\n", MH(MH_OPT, "G"));
-    printf("  %s                               Help overlay\n\n", MH(MH_OPT, "h"));
+    milk_help_section("Display & Layout", mh_color);
+    printf("  %s                             Adjust scan rate (increase/decrease speed)\n", MH(MH_OPT, "+/-"));
+    printf("  %s                         Toggle detail pane / Graph jump (on selected item)\n", MH(MH_OPT, "ENTER/D"));
+    printf("  %s                               Cycle graph lineage mode (on Graph view)\n", MH(MH_OPT, "L"));
+    printf("  %s                               Pause/resume display updates\n", MH(MH_OPT, "F"));
+    printf("  %s                           Freeze selection highlight (prevent jumping)\n", MH(MH_OPT, "SPACE"));
+    printf("  %s                               Export current snapshot to file\n", MH(MH_OPT, "W"));
+    printf("  %s                               Toggle command log panel visibility\n", MH(MH_OPT, "G"));
+    printf("  %s                               Spawn interactive CLI diagnostic tool\n", MH(MH_OPT, "i"));
+    printf("  %s                               Show help overlay\n\n", MH(MH_OPT, "h"));
 
-    milk_help_section("Control mode (c to toggle)", mh_color);
-    printf("  FPS:   %s=run  %s=conf  %s=remove\n", MH(MH_OPT, "r"), MH(MH_OPT, "s"), MH(MH_OPT, "e"));
-    printf("  PROCS: %s=remove selected entry\n", MH(MH_OPT, "e"));
-    printf("  STRM:  %s=delete stream\n\n", MH(MH_OPT, "d"));
-
-    milk_help_section("Process signals (PROCS & FPS panels)", mh_color);
-    printf("  %s                               Graceful kill (SIGTERM)\n", MH(MH_OPT, "k"));
-    printf("  %s                               Immediate kill (SIGKILL)\n", MH(MH_OPT, "K"));
-    printf("  %s                               Pause/resume (SIGSTOP/SIGCONT)\n", MH(MH_OPT, "x"));
-    printf("  %s                               Cleanup dead/stopped procs (PROCS panel)\n\n", MH(MH_OPT, "C"));
-
-    milk_help_section("Detail View (ENTER or D) and Inspection (i)", mh_color);
-    printf("  %s                         Toggles detail pane for selected item\n", MH(MH_OPT, "ENTER/D"));
-    printf("  %s                               Spawn interactive CLI diagnostic tool\n\n", MH(MH_OPT, "i"));
+    milk_help_section("Control Mode Actions (press 'c' to toggle mode)", mh_color);
+    printf("  Global: %s=Delete selected (STRM/FPS/PROC)\n", MH(MH_OPT, "CTRL+e"));
+    printf("  STRM:   %s=Delete stream\n", MH(MH_OPT, "DEL"));
+    printf("  PROCS:  %s=Kill %s=SIGKILL %s=Ctrl(-1) %s=Ctrl(2) %s=Ctrl(3) %s=Zero %s=Cleanup\n", 
+           MH(MH_OPT, "k"), MH(MH_OPT, "K"), MH(MH_OPT, "p"), MH(MH_OPT, "^s"), MH(MH_OPT, "e"), MH(MH_OPT, "z"), MH(MH_OPT, "C"));
+    printf("  FPS:    %s=SIGTERM %s=SIGKILL %s=Pause %s=Run %s=Conf\n\n", 
+           MH(MH_OPT, "k"), MH(MH_OPT, "K"), MH(MH_OPT, "x"), MH(MH_OPT, "r"), MH(MH_OPT, "s"));
 
     milk_help_section("Columns", mh_color);
-    printf("  STREAMS: MB/s throughput, total in panel footer\n");
-    printf("  PROCS:   DUTY%% (exec/iter), CPU%%, MEM (RSS)\n");
-    printf("  FPS:     MEM (RSS)\n\n");
+    printf("  STREAMS: NAME/ANCESTRY, TYP, SIZE, Hz, MB/s, INODE, OWNER, COUNT, SEMS, WPID, RPID\n");
+    printf("  PROCS:   NAME/ANCESTRY, PID, STAT, Hz, TRG, trig-strm, exec, DUTY, LOOPCNT, MEM, MISSED, PRIO\n");
+    printf("  FPS:     NAME/ANCESTRY, CPID, RPID, STR, MEM, DESCRIPTION, STATUS\n\n");
 
     milk_help_section("Mouse", mh_color);
     printf("  Click=select  DblClick=detail\n");

--- a/src/cli/overview/overview_data_sys.c
+++ b/src/cli/overview/overview_data_sys.c
@@ -153,7 +153,7 @@ int pid_get_cpu_ticks(
      * cmajflt utime stime */
     int rc = fscanf(fp,
         "%*d %*s %*c %*d %*d %*d %*d %*d "
-        "%*u %*lu %*lu %*lu %*lu %lu %lu",
+        "%*u %*u %*u %*u %*u %lu %lu",
         utime, stime);
     fclose(fp);
 

--- a/src/cli/streamCTRL/milk-streamCTRL.c
+++ b/src/cli/streamCTRL/milk-streamCTRL.c
@@ -40,42 +40,28 @@ static void print_help(const char *progname, int mh_color)
 {
     milk_help_banner(progname, "interactive stream monitor TUI", mh_color);
     milk_help_section("Usage", mh_color);
-    printf("  %s%s%s [%soptions%s]\n\n",
-           mh_color ? MH_CMD : "", progname, mh_color ? MH_RST : "",
-           mh_color ? MH_OPT : "", mh_color ? MH_RST : "");
+    printf("  $ %s [%s]\n\n", progname, MH(MH_OPT, "options"));
 
     milk_help_section("Description", mh_color);
     printf("  Launches the interactive Terminal User Interface (TUI) for monitoring and\n"
            "  managing shared memory streams in real-time.\n\n");
 
     milk_help_section("Options", mh_color);
-    printf("  %s%-25s%s %s\n",
-           mh_color ? MH_OPT : "", "-d DIR",
-           mh_color ? MH_RST : "", "Override SHM directory (default: /dev/shm)");
-    printf("  %s%-25s%s %s\n",
-           mh_color ? MH_OPT : "", "-w, --wave",
-           mh_color ? MH_RST : "", "Enable wave background animation");
-    printf("  %s%-25s%s %s\n",
-           mh_color ? MH_OPT : "", "-h, --help",
-           mh_color ? MH_RST : "", "Show this help and exit");
-    printf("  %s%-25s%s %s\n",
-           mh_color ? MH_OPT : "", "-h1, --help-oneline",
-           mh_color ? MH_RST : "", "One-line description and exit");
-    printf("  %s%-25s%s %s\n",
-           mh_color ? MH_OPT : "", "-h2, --help-description",
-           mh_color ? MH_RST : "", "Verbose description and exit");
-    printf("  %s%-25s%s %s\n\n",
-           mh_color ? MH_OPT : "", "-hm, --help-mono",
-           mh_color ? MH_RST : "", "Full help, no ANSI color");
+    printf("  %s %s                   Override SHM directory (default: /dev/shm)\n", MH(MH_OPT, "-d"), MH(MH_ARG, "DIR"));
+    printf("  %s             Enable wave background animation\n", MH(MH_OPT, "-w, --wave"));
+    printf("  %s             Show this help and exit\n", MH(MH_OPT, "-h, --help"));
+    printf("  %s             One-line description and exit\n", MH(MH_OPT, "-h1, --help-oneline"));
+    printf("  %s             Verbose description and exit\n", MH(MH_OPT, "-h2, --help-description"));
+    printf("  %s             Full help, no ANSI color\n\n", MH(MH_OPT, "-hm, --help-mono"));
 
     milk_help_section("Interactive Commands", mh_color);
-    printf("  %s%-12s%s %s\n", mh_color ? MH_CMD : "", "x", mh_color ? MH_RST : "", "Exit");
-    printf("  %s%-12s%s %s\n", mh_color ? MH_CMD : "", "h", mh_color ? MH_RST : "", "Help screen");
-    printf("  %s%-12s%s %s\n", mh_color ? MH_CMD : "", "F2-F6", mh_color ? MH_RST : "", "Switch tabs");
-    printf("  %s%-12s%s %s\n", mh_color ? MH_CMD : "", "UP/DOWN", mh_color ? MH_RST : "", "Navigate streams");
-    printf("  %s%-12s%s %s\n", mh_color ? MH_CMD : "", "CTRL+e", mh_color ? MH_RST : "", "Erase selected stream");
-    printf("  %s%-12s%s %s\n", mh_color ? MH_CMD : "", "+/-", mh_color ? MH_RST : "", "Increase/decrease display rate");
-    printf("  %s%-12s%s %s\n\n", mh_color ? MH_CMD : "", "{/}", mh_color ? MH_RST : "", "Decrease/increase scan rate");
+    printf("  %s                               Exit\n", MH(MH_CMD, "x"));
+    printf("  %s                               Help screen\n", MH(MH_CMD, "h"));
+    printf("  %s                           Switch tabs\n", MH(MH_CMD, "F2-F6"));
+    printf("  %s                         Navigate streams\n", MH(MH_CMD, "UP/DOWN"));
+    printf("  %s                          Erase selected stream\n", MH(MH_CMD, "CTRL+e"));
+    printf("  %s                             Increase/decrease display rate\n", MH(MH_CMD, "+/-"));
+    printf("  %s                             Decrease/increase scan rate\n\n", MH(MH_CMD, "{/}"));
 
     const char *see_also[] = {
         "milk-stream-info", "milk-stream-list", "milk-streamCTRL-cli"

--- a/src/engine/libprocessinfo/procCTRL/milk-procCTRL.c
+++ b/src/engine/libprocessinfo/procCTRL/milk-procCTRL.c
@@ -13,78 +13,90 @@
 #include "processinfo.h"
 #include "procCTRL_TUI.h"
 
+#include "milk_help.h"
+
 // Prototypes for functions defined in other procCTRL files
 errno_t processinfo_CTRLscreen();
 
-void print_help(const char *progname) {
-    printf("Usage: %s [options]\n", progname);
-    printf("\n");
-    printf("MILK Process Control Tool (procCTRL)\n");
-    printf("====================================\n");
-    printf("This tool monitors and controls real-time loop processes in the MILK environment.\n");
-    printf("It provides a Text User Interface (TUI) to inspect process status, CPU usage,\n");
-    printf("scheduling, and shared memory links. It also allows sending control signals\n");
-    printf("to processes (pause, step, exit) and managing their affinity.\n");
-    printf("\n");
-    printf("  File Operations:\n");
-    printf("    READS:        processinfo.list.shm (Global Process List)\n");
-    printf("                  - Reads PID, name, and active status of all registered processes.\n");
-    printf("    READS/WRITES: proc.<process_name>.<PID>.shm (Process Control Block)\n");
-    printf("                  - Reads detailed status (loopstat), counters, timing, and triggers.\n");
-    printf("                  - Writes control signals (CTRLval) to Pause/Resume/Step/Exit.\n");
-    printf("\n");
-    printf("Options:\n");
-    printf("  -h, --help           Show this help message and exit.\n");
-    printf("  -d, --debug          Enable debug output to stdout (disables TUI).\n");
-    printf("  -c, --check-scan     Check if milk-procCTRL-scan is running and print its PID.\n");
-    printf("\n");
-    printf("Key Bindings (Interactive Mode):\n");
-    printf("--------------------------------\n");
-    printf("  F2  : Switch to CONTROL view (default)\n");
-    printf("  F3  : Switch to RESOURCES view (CPU/Memory)\n");
-    printf("  F4  : Switch to TRIGGERING view\n");
-    printf("  F5  : Switch to TIMING view\n");
-    printf("  F6  : Switch to PROCINFO parameters summary view\n");
-    printf("  h   : Show in-app Help screen\n");
-    printf("  f   : Freeze/Unfreeze display updates\n");
-    printf("  s   : Sort process list by currently highlighted column\n");
-    printf("  S   : Apply current sort criteria to all tabs/modes\n");
-    printf("  + - : Increase/Decrease update frequency\n");
-    printf("  x   : Exit milk-procCTRL\n");
-    printf("\n");
-    printf("Navigation & Column Control:\n");
-    printf("  UP/DN     : Move process selection cursor\n");
-    printf("  LEFT/RGHT : Move column highlight cursor\n");
-    printf("  1-9       : Toggle visibility of specific columns (mode-specific)\n");
-    printf("  CTRL + L/R: Cycle through display modes/tabs\n");
-    printf("\n");
-    printf("Process Control (on selection or current process):\n");
-    printf("  SPACE : Select/Unselect current process\n");
-    printf("  u     : Unselect all processes\n");
-    printf("  p     : Pause/Resume (Writes CTRLval)\n");
-    printf("  CTRL+S: Step (Writes CTRLval)\n");
-    printf("  e     : Request clean exit (Writes CTRLval)\n");
-    printf("  T     : Send SIGTERM\n");
-    printf("  K     : Send SIGKILL\n");
-    printf("  I     : Send SIGINT\n");
-    printf("  r / R : Remove log for selected / all inactive process(es)\n");
-    printf("  z / Z : Zero counter for selected / all process(es)\n");
-    printf("\n");
-    printf("For more details, press 'h' inside the tool.\n");
+static void print_help(const char *progname, int mh_color) {
+    milk_help_banner(progname, "interactive TUI for monitoring and controlling milk processes", mh_color);
+
+    milk_help_section("Usage", mh_color);
+    printf("  $ %s [%s]\n\n", progname, MH(MH_OPT, "options"));
+
+    milk_help_section("Description", mh_color);
+    printf("  This tool monitors and controls real-time loop processes in the MILK environment.\n"
+           "  It provides a Text User Interface (TUI) to inspect process status, CPU usage,\n"
+           "  scheduling, and shared memory links. It also allows sending control signals\n"
+           "  to processes (pause, step, exit) and managing their affinity.\n"
+           "\n"
+           "  File Operations:\n"
+           "  - READS:        %s (Global Process List)\n"
+           "                  Reads PID, name, and active status of all registered processes.\n"
+           "  - READS/WRITES: %s (Process Control Block)\n"
+           "                  Reads detailed status (loopstat), counters, timing, and triggers.\n"
+           "                  Writes control signals (CTRLval) to Pause/Resume/Step/Exit.\n\n",
+           MH(MH_BOLD, "processinfo.list.shm"),
+           MH(MH_BOLD, "proc.<process_name>.<PID>.shm"));
+
+    milk_help_section("Options", mh_color);
+    printf("  %s             Show this help message and exit\n", MH(MH_OPT, "-h, --help"));
+    printf("  %s             One-line description and exit\n", MH(MH_OPT, "-h1, --help-oneline"));
+    printf("  %s             Full help, forced monochrome\n", MH(MH_OPT, "-hm, --help-mono"));
+    printf("  %s             Enable debug output to stdout (disables TUI)\n", MH(MH_OPT, "-d, --debug"));
+    printf("  %s             Check if milk-procCTRL-scan is running and print its PID\n", MH(MH_OPT, "-c, --check-scan"));
+    printf("  %s %s                   Log output to specified file\n\n", MH(MH_OPT, "-l, --log"), MH(MH_ARG, "FILE"));
+
+    milk_help_section("Key Bindings (Interactive Mode)", mh_color);
+    printf("  %s                              Switch to CONTROL view (default)\n", MH(MH_CMD, "F2"));
+    printf("  %s                              Switch to RESOURCES view (CPU/Memory)\n", MH(MH_CMD, "F3"));
+    printf("  %s                              Switch to TRIGGERING view\n", MH(MH_CMD, "F4"));
+    printf("  %s                              Switch to TIMING view\n", MH(MH_CMD, "F5"));
+    printf("  %s                              Switch to PROCINFO parameters summary view\n", MH(MH_CMD, "F6"));
+    printf("  %s                               Show in-app Help screen\n", MH(MH_CMD, "h"));
+    printf("  %s                               Freeze/Unfreeze display updates\n", MH(MH_CMD, "f"));
+    printf("  %s                               Sort process list by currently highlighted column\n", MH(MH_CMD, "s"));
+    printf("  %s                               Apply current sort criteria to all tabs/modes\n", MH(MH_CMD, "S"));
+    printf("  %s                             Increase/Decrease update frequency\n", MH(MH_CMD, "+ -"));
+    printf("  %s                               Exit milk-procCTRL\n\n", MH(MH_CMD, "x"));
+
+    milk_help_section("Navigation & Column Control", mh_color);
+    printf("  %s                           Move process selection cursor\n", MH(MH_CMD, "UP/DN"));
+    printf("  %s                       Move column highlight cursor\n", MH(MH_CMD, "LEFT/RGHT"));
+    printf("  %s                             Toggle visibility of specific columns (mode-specific)\n", MH(MH_CMD, "1-9"));
+    printf("  %s                      Cycle through display modes/tabs\n\n", MH(MH_CMD, "CTRL + L/R"));
+
+    milk_help_section("Process Control (on selection or current process)", mh_color);
+    printf("  %s                           Select/Unselect current process\n", MH(MH_CMD, "SPACE"));
+    printf("  %s                               Unselect all processes\n", MH(MH_CMD, "u"));
+    printf("  %s                               Pause/Resume (Writes CTRLval)\n", MH(MH_CMD, "p"));
+    printf("  %s                          Step (Writes CTRLval)\n", MH(MH_CMD, "CTRL+S"));
+    printf("  %s                               Request clean exit (Writes CTRLval)\n", MH(MH_CMD, "e"));
+    printf("  %s                               Send SIGTERM\n", MH(MH_CMD, "T"));
+    printf("  %s                               Send SIGKILL\n", MH(MH_CMD, "K"));
+    printf("  %s                               Send SIGINT\n", MH(MH_CMD, "I"));
+    printf("  %s                           Remove log for selected / all inactive process(es)\n", MH(MH_CMD, "r / R"));
+    printf("  %s                           Zero counter for selected / all process(es)\n\n", MH(MH_CMD, "z / Z"));
 }
 
 int main(int argc, char *argv[])
 {
-    /* Handle -h1/--help-oneline before getopt so "-h1" is not
-     * parsed as "-h" (flag) + "1" (unknown). */
-    if (argc >= 2 &&
-        (strcmp(argv[1], "-h1") == 0 ||
-         strcmp(argv[1], "--help-oneline") == 0))
+    int action = milk_help_init(argc, argv,
+                                "interactive TUI for monitoring and controlling milk processes",
+                                "This tool monitors and controls real-time loop processes in the MILK environment.");
+    
+    if (action == MH_ACTION_H1 || action == MH_ACTION_H2)
     {
-        printf("interactive TUI for monitoring and controlling milk processes\n");
         return 0;
     }
 
+    int mh_color = (action == MH_ACTION_HELP);
+
+    if (action == MH_ACTION_HELP || action == MH_ACTION_MONO)
+    {
+        print_help(argv[0], mh_color);
+        return 0;
+    }
 
     int opt;
 
@@ -104,7 +116,7 @@ int main(int argc, char *argv[])
     while ((opt = getopt_long(argc, argv, "hdcl:", long_options, NULL)) != -1) {
         switch (opt) {
             case 'h':
-                print_help(argv[0]);
+                // Handled by milk_help_init
                 return 0;
             case 'd':
                 procCTRL_debug_mode = 1;
@@ -162,7 +174,7 @@ int main(int argc, char *argv[])
             case '?':
             default:
                 printf("\n\033[1;31mERROR\033[0m: Invalid option.\n\n");
-                print_help(argv[0]);
+                print_help(argv[0], 1);
                 return 1;
         }
     }


### PR DESCRIPTION
## Summary

Standardizes the help documentation for the `milkCTRL`, `milk-procCTRL`, and `milk-streamCTRL` diagnostic tools to ensure compliance with the MILK framework's project-wide help infrastructure.

## Changes

### milkCTRL
- Refactored `print_help` in `src/cli/overview/milkCTRL.c` to use `milk_help_banner`, `milk_help_section`, and `MH` macros for compliant, colorized ANSI output.
- Expanded the help documentation to include a detailed overview of the dashboard layout (F2-F6 views).
- Added comprehensive lists of key bindings and navigation commands (including `SHIFT+UP/DN`), and corrected column descriptions that now accurately reflect the TUI implementation.

### milk-procCTRL & milk-streamCTRL
- Refactored `print_help` and argument handling to use the standardized `milk_help` infrastructure, ensuring consistent ANSI color usage across the diagnostic suite.

### Bug Fixes
- Fixed `fscanf` format specifier warning in `src/cli/overview/overview_data_sys.c`.

## Verification

- [x] Build passes (`make -j && cmake --install . --prefix _install`)
- [x] Verified `milkCTRL -h1` output and help menus.
- [x] Evaluated interactive TUI commands corresponding to updated help text.

## Prompt Summary

The user requested that the help documentation for the `milkCTRL` diagnostic tool be standardized, adding colors and a more detailed description of its features (missing commands, columns descriptions, dashboard architecture). They also noted that the `milk-procCTRL` and `milk-streamCTRL` help messages were non-compliant (missing colors) and asked for them to be updated.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None