### PR TITLE
Remove SUID privileges from milk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,7 +292,7 @@ set(PROGRAM_PERMISSIONS_DEFAULT
 
 install(TARGETS milk
       DESTINATION bin
-      PERMISSIONS ${PROGRAM_PERMISSIONS_DEFAULT} SETUID)
+      PERMISSIONS ${PROGRAM_PERMISSIONS_DEFAULT})
 
 
 
@@ -397,7 +397,7 @@ install(PROGRAMS
       						scripts/milk-fpslist-addentry
       						scripts/milk-fpsCTRL
       						scripts/milk-cr2tofits
-      			
+
 			scripts/milk-FITS2shm
       scripts/milk-fitsheader
 			scripts/milk-fpsmkcmd

--- a/doc/templatemodule/templatemodule.c
+++ b/doc/templatemodule/templatemodule.c
@@ -314,15 +314,12 @@ int templatemodule_examplefunc00(int mode)
 /**
  * ## Purpose
  *
- * This function demonstrates use of seteuid, sched_setscheduler \n
- * Note that fields "Use", "return", "not" and "warning" are optional
+ * This function demonstrates priority escalation with the milk API.
  *
  * ## Arguments
  *
  * Brief description of arguments is in .h file \n
  * A more detailed description of arguments in provided here \n
- *
- *
  *
  * ## Use
  *
@@ -355,33 +352,10 @@ int templatemodule_examplefunc01(const char *namein,
     ///
     int Niteration;
 
-    int RT_priority =
-        95; // any number from 0-99. Higher number = higher priority
-    struct sched_param schedpar;
-
+    int RT_priority = 95; // any number from 0-99. Higher number = higher priority
     int retval;
 
-    schedpar.sched_priority = RT_priority;
-
-    /// ## Set up priviledges
-
-    iretval = seteuid(euid_called); //This goes up to maximum privileges
-    if(retval != 0)
-        printERROR(__FILE__,
-                   __func__,
-                   __LINE__,
-                   "seteuid() returns non-zero value");
-
-    sched_setscheduler(0,
-                       SCHED_FIFO,
-                       &schedpar); //other option is SCHED_RR, might be faster
-
-    retval = seteuid(euid_real); //Go back to normal privileges
-    if(retval != 0)
-        printERROR(__FILE__,
-                   __func__,
-                   __LINE__,
-                   "seteuid() returns non-zero value");
+    COREMOD_TOOLS_mvProcRTPrio(RT_priority);
 
     /// ## Execute loop
 

--- a/plugins/milk-extra-src/image_basic/streamfeed.c
+++ b/plugins/milk-extra-src/image_basic/streamfeed.c
@@ -6,6 +6,7 @@
 #include "CommandLineInterface/CLIcore.h"
 
 #include "COREMOD_memory/COREMOD_memory.h"
+#include "COREMOD_tools/mvprocCPUset.h"
 
 // ==========================================
 // Forward declaration(s)
@@ -63,25 +64,13 @@ long IMAGE_BASIC_streamfeed(const char *__restrict IDname,
     long               k;
     long               tdelay;
     int                RT_priority = 95; //any number from 0-99
-    struct sched_param schedpar;
     int                semval;
     const char        *ptr0;
     const char        *ptr1;
     int                loopOK;
     long               ii;
 
-    schedpar.sched_priority = RT_priority;
-    if(seteuid(data.euid) != 0)  //This goes up to maximum privileges
-    {
-        PRINT_ERROR("seteuid error");
-    }
-    sched_setscheduler(0,
-                       SCHED_FIFO,
-                       &schedpar); //other option is SCHED_RR, might be faster
-    if(seteuid(data.ruid) != 0)    //Go back to normal privileges
-    {
-        PRINT_ERROR("seteuid error");
-    }
+    COREMOD_TOOLS_mvProcRTPrio(RT_priority);
 
     ID     = image_ID(IDname);
     xsize  = data.image[ID].md[0].size[0];
@@ -176,10 +165,10 @@ long IMAGE_BASIC_streamfeed(const char *__restrict IDname,
     }
     if(data.image[IDs].md[0].sem > 0)
     {
-        semval = ImageStreamIO_semvalue(data.image+IDs, 0);
+        semval = ImageStreamIO_semvalue(data.image + IDs, 0);
         if(semval < SEMAPHORE_MAXVAL)
         {
-            ImageStreamIO_sempost(data.image+IDs, 0);
+            ImageStreamIO_sempost(data.image + IDs, 0);
         }
     }
     data.image[IDs].md[0].write = 0;

--- a/scripts/milk-makecsetandrt
+++ b/scripts/milk-makecsetandrt
@@ -21,7 +21,4 @@ fi
 pname="$0-$1-$2"
 echo "$pname"
 
-milk -n $pname << EOF
-csetandprioext $1 $2 $3
-exit
-EOF
+milk-rtsched -c $2 -p $3 $1

--- a/src/COREMOD_memory/logshmim.c
+++ b/src/COREMOD_memory/logshmim.c
@@ -31,6 +31,7 @@
 #include "stream_sem.h"
 
 #include "shmimlog_types.h"
+#include "COREMOD_tools/mvprocCPUset.h"
 
 #define likely(x)   __builtin_expect(!!(x), 1)
 #define unlikely(x) __builtin_expect(!!(x), 0)
@@ -287,21 +288,7 @@ static void *save_telemetry_fits_function(
     // Set save function to RT priority 0
     // This is meant to be lower priority than the data collection into buffers
     //
-    int                RT_priority = tmsg->writerRTprio;
-    struct sched_param schedpar;
-
-    schedpar.sched_priority = RT_priority;
-    if(seteuid(data.euid) != 0)  //This goes up to maximum privileges
-    {
-        PRINT_ERROR("seteuid error");
-    }
-    sched_setscheduler(0,
-                       SCHED_FIFO,
-                       &schedpar); //other option is SCHED_RR, might be faster
-    if(seteuid(data.ruid) != 0)    //Go back to normal privileges
-    {
-        PRINT_ERROR("seteuid error");
-    }
+    COREMOD_TOOLS_mvProcRTPrio(tmsg->writerRTprio);
 
     // Add custom keywords
     int            NBcustomKW = 9;

--- a/src/COREMOD_memory/stream_TCP.c
+++ b/src/COREMOD_memory/stream_TCP.c
@@ -15,6 +15,7 @@
 #include "list_image.h"
 #include "read_shmim.h"
 #include "stream_sem.h"
+#include "COREMOD_tools/mvprocCPUset.h"
 
 // set to 1 if transfering keywords
 static int TCPTRANSFERKW = 1;
@@ -606,7 +607,7 @@ imageID COREMOD_MEMORY_image_NETWORKtransmit(
  * mode = 1, force counter to be used for synchronization, ignore semaphores if they exist
  */
 
-imageID COREMOD_MEMORY_image_NETWORKreceive(int                         port,
+imageID COREMOD_MEMORY_image_NETWORKreceive(int port,
         __attribute__((unused)) int mode,
         int RT_priority)
 {
@@ -683,18 +684,7 @@ imageID COREMOD_MEMORY_image_NETWORKreceive(int                         port,
         printf("\nCan't catch a requested signal (TERM, INT, ABRT, BUS, SEGV, HUP, PIPE)\n");
     }
 
-    schedpar.sched_priority = RT_priority;
-    if(seteuid(data.euid) != 0)  //This goes up to maximum privileges
-    {
-        PRINT_ERROR("seteuid error");
-    }
-    sched_setscheduler(0,
-                       SCHED_FIFO,
-                       &schedpar); //other option is SCHED_RR, might be faster
-    if(seteuid(data.ruid) != 0)    //Go back to normal privileges
-    {
-        PRINT_ERROR("seteuid error");
-    }
+    COREMOD_TOOLS_mvProcRTPrio(RT_priority);
 
     // create TCP socket
     if((fds_server = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP)) == -1)

--- a/src/COREMOD_memory/stream_UDP.c
+++ b/src/COREMOD_memory/stream_UDP.c
@@ -15,6 +15,7 @@
 #include "list_image.h"
 #include "read_shmim.h"
 #include "stream_sem.h"
+#include "COREMOD_tools/mvprocCPUset.h"
 
 // set to 1 if transfering keywords
 static int TCPTRANSFERKW = 1;
@@ -555,16 +556,7 @@ imageID COREMOD_MEMORY_image_NETUDPreceive(
         }
     }
 
-    schedpar.sched_priority = RT_priority;
-    if(seteuid(data.euid) != 0)  //This goes up to maximum privileges
-    {
-        PRINT_ERROR("seteuid error");
-    }
-    sched_setscheduler(0, SCHED_FIFO, &schedpar);
-    if(seteuid(data.ruid) != 0)    //Go back to normal privileges
-    {
-        PRINT_ERROR("seteuid error");
-    }
+    COREMOD_TOOLS_mvProcRTPrio(RT_priority);
 
     // create UDP socket
     if((fds_server = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0)

--- a/src/COREMOD_tools/CMakeLists.txt
+++ b/src/COREMOD_tools/CMakeLists.txt
@@ -81,3 +81,12 @@ target_link_libraries(${LIBNAME} PUBLIC ${CFITSIO_LIBRARIES})
 
 install(TARGETS ${LIBNAME} EXPORT milkTargets DESTINATION lib)
 install(FILES ${INCLUDEFILES} DESTINATION include/${SRCNAME})
+
+# Standalone SUID-root helper: escalate/drop privileges for RT scheduling
+add_executable(milk-rtsched exec_mvprovCPUset.c)
+target_include_directories(milk-rtsched PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/..> $<INSTALL_INTERFACE:include>)
+install(TARGETS milk-rtsched DESTINATION bin
+    PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                GROUP_READ             GROUP_EXECUTE
+                WORLD_READ             WORLD_EXECUTE
+                SETUID)

--- a/src/COREMOD_tools/exec_mvprovCPUset.c
+++ b/src/COREMOD_tools/exec_mvprovCPUset.c
@@ -1,0 +1,188 @@
+#define _GNU_SOURCE // Needed for get/set resuid
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <sched.h>
+#include <errno.h>
+#include <dirent.h>
+
+#include "CommandLineInterface/CLIcore.h"
+#include "CommandLineInterface/milkDebugTools.h"
+
+
+DATA data = {0}; // Lot of macros rely on it
+
+
+// Real UID of the invoking user (saved at startup, never changes)
+static uid_t STARTUP_RUID = (uid_t) -1;
+// Effective UID granted by the SUID bit (0 = root when compiled SUID root)
+static uid_t STARTUP_EUID = (uid_t) -1;
+
+// Restore effective UID to root (requires SUID-root binary).
+// Returns 0 on success, -1 on failure.
+int upscale_privileges()
+{
+    if(setresuid(STARTUP_EUID, STARTUP_EUID, STARTUP_EUID) != 0)
+    {
+        PRINT_ERROR("seteuid to root failed");
+        return -1;
+    }
+    return 0;
+}
+
+// Drop effective UID back to the invoking user.
+// Returns 0 on success, -1 on failure.
+int downscale_privileges()
+{
+    if(setresuid(STARTUP_RUID, STARTUP_RUID, STARTUP_EUID) != 0)
+    {
+        PRINT_ERROR("seteuid to user failed");
+        return -1;
+    }
+    return 0;
+}
+
+static void usage(const char *prog)
+{
+    fprintf(stderr,
+            "Usage: %s [-p <rtprio>] [-t <tsetspec>] [-c <csetname>] <pid>\n"
+            "  -p <rtprio>   Set SCHED_FIFO real-time priority for <pid>\n"
+            "  -t <tsetspec> Assign CPU affinity (taskset) to <pid>\n"
+            "  -c <csetname> Move <pid> to named cpuset\n"
+            "  <pid>         Target process ID (required positional, must be last)\n",
+            prog);
+}
+
+int main(int argc, char **argv)
+{
+    STARTUP_RUID = getuid();  // unprivileged invoking user
+    STARTUP_EUID = geteuid(); // root (0) when binary is SUID root
+
+    // Drop to user immediately; escalate only for the privileged operations.
+    if(seteuid(STARTUP_RUID) != 0)
+    {
+        PRINT_ERROR("initial seteuid drop failed");
+        return EXIT_FAILURE;
+    }
+
+    int   rtprio  = -1;
+    char  tsetspec[256] = "";
+    char  csetname[256] = "";
+
+    int opt;
+    while((opt = getopt(argc, argv, "p:t:c:")) != -1)
+    {
+        switch(opt)
+        {
+        case 'p':
+            rtprio = atoi(optarg);
+            break;
+        case 't':
+            strncpy(tsetspec, optarg, sizeof(tsetspec) - 1);
+            break;
+        case 'c':
+            strncpy(csetname, optarg, sizeof(csetname) - 1);
+            break;
+        default:
+            usage(argv[0]);
+            return EXIT_FAILURE;
+        }
+    }
+
+    if(optind >= argc)
+    {
+        fprintf(stderr, "Error: PID argument required\n");
+        usage(argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    pid_t pid = (pid_t)atoi(argv[optind]);
+
+    if(upscale_privileges() != 0)
+    {
+        return EXIT_FAILURE;
+    }
+
+    int ret = EXIT_SUCCESS;
+
+    if(csetname[0] != '\0')
+    {
+        // cgroups v1: write each TID individually — "tasks" accepts only one TID
+        // at a time and does not move sibling threads automatically.
+        // cgroups v2: write the TGID once to "cgroup.procs" — the kernel moves
+        // all threads atomically, equivalent to cset proc --threads.
+        char taskfile[512];
+        snprintf(taskfile, sizeof(taskfile),
+                 "/sys/fs/cgroup/cpuset/%s/tasks", csetname);
+        FILE *f = fopen(taskfile, "w");
+        if(f != NULL)
+        {
+            // v1 path: iterate /proc/<pid>/task/ to move every thread
+            char taskdir[64];
+            snprintf(taskdir, sizeof(taskdir), "/proc/%d/task", (int)pid);
+            DIR *d = opendir(taskdir);
+            if(d != NULL)
+            {
+                struct dirent *ent;
+                while((ent = readdir(d)) != NULL)
+                {
+                    if(ent->d_name[0] == '.')
+                    {
+                        continue;
+                    }
+                    fprintf(f, "%s\n", ent->d_name);
+                }
+                closedir(d);
+            }
+            else
+            {
+                // /proc/<pid>/task not readable — fall back to main thread only
+                fprintf(f, "%d\n", (int)pid);
+            }
+            fclose(f);
+        }
+        else
+        {
+            // v2 path: writing TGID to cgroup.procs moves all threads atomically
+            snprintf(taskfile, sizeof(taskfile),
+                     "/sys/fs/cgroup/%s/cgroup.procs", csetname);
+            f = fopen(taskfile, "w");
+            if(f != NULL)
+            {
+                fprintf(f, "%d\n", (int)pid);
+                fclose(f);
+            }
+            else
+            {
+                PRINT_ERROR("cannot open cpuset tasks file for '%s': %s",
+                            csetname, strerror(errno));
+                ret = EXIT_FAILURE;
+            }
+        }
+    }
+
+    if(tsetspec[0] != '\0')
+    {
+        // taskset -pc accepts a CPU list (e.g. "0-3", "1,3") or hex mask.
+        EXECUTE_SYSTEM_COMMAND("taskset -pc %s %d", tsetspec, (int)pid);
+    }
+
+    if(rtprio >= 0)
+    {
+        struct sched_param param;
+        param.sched_priority = rtprio;
+        if(sched_setscheduler(pid, (rtprio > 0) ? SCHED_FIFO : SCHED_OTHER,
+                              &param) != 0)
+        {
+            PRINT_ERROR("sched_setscheduler %s prio %d for pid %d: %s",
+                        (rtprio > 0) ? "SCHED_FIFO" : "SCHED_OTHER",
+                        rtprio, (int)pid, strerror(errno));
+            ret = EXIT_FAILURE;
+        }
+    }
+
+    downscale_privileges();
+    return ret;
+}

--- a/src/COREMOD_tools/mvprocCPUset.c
+++ b/src/COREMOD_tools/mvprocCPUset.c
@@ -11,18 +11,13 @@
 // Forward declaration(s)
 // ==========================================
 
-int COREMOD_TOOLS_mvProcRTPrio(const int rtprio);
-
-int COREMOD_TOOLS_mvProcTset(const char *tsetspec);
-
 int COREMOD_TOOLS_mvProcTsetExt(const int pid, const char *tsetspec);
-
-int COREMOD_TOOLS_mvProcCPUset(const char *csetname);
-
-
 int COREMOD_TOOLS_mvProcCPUsetExt(const int   pid,
                                   const char *csetname,
                                   const int   rtprio);
+int COREMOD_TOOLS_mvProcTset(const char *tsetspec);
+int COREMOD_TOOLS_mvProcRTPrio(const int rtprio);
+int COREMOD_TOOLS_mvProcCPUset(const char *csetname);
 
 // ==========================================
 // Command line interface wrapper function(s)
@@ -158,28 +153,7 @@ int COREMOD_TOOLS_mvProcRTPrio(const int rtprio)
         return RETURN_SUCCESS;
     }
 
-    char command[200];
-
-    if(seteuid(data.euid) != 0 ||
-            setuid(data.euid) != 0) // This goes up to maximum privileges
-    {
-        PRINT_ERROR("seteuid/setuid error");
-        return RETURN_FAILURE;
-    }
-
-    sprintf(command, "chrt -f -p %d %d\n", rtprio, getpid());
-    printf("Executing command: %s\n", command);
-
-    EXECUTE_SYSTEM_COMMAND_ERRCHECK("%s", command);
-
-    if(setresuid(data.ruid, data.ruid, data.euid) !=
-            0) // Go back to normal privileges
-    {
-        PRINT_ERROR("seteuid error after executing chrt");
-        //TODO probably should force a quit here... since we're remaining
-        //TODO at elevated privileges and we really shoudn't.
-        return RETURN_FAILURE;
-    }
+    EXECUTE_SYSTEM_COMMAND_ERRCHECK("milk-rtsched -p %d %d", rtprio, getpid());
 
     return RETURN_SUCCESS;
 }
@@ -192,38 +166,8 @@ int COREMOD_TOOLS_mvProcTset(const char *tsetspec)
 
 int COREMOD_TOOLS_mvProcTsetExt(const int pid, const char *tsetspec)
 {
-    char command[200];
-
-    // Must make TWO calls
-    // First call: promote the EUID to root,
-    // Second call: setuid promote the RUID to root
-    // Which is what we need for the cset call to pass without a sudo password prompt.
-
-    /* FOR DEBUG - WARNING data.euid and data.ruid are NOT what they say
-    PRINT_ERROR("(data) EUID %d - (data) RUID %d ", data.euid, data.ruid);
-    int euid, suid, ruid;
-    getresuid(&ruid, &euid, &suid);
-    PRINT_ERROR("AC EUID %d - SUID %d - RUID %d ", euid, suid, ruid);
-    //*/
-
-    if(seteuid(data.euid) != 0 ||
-            setuid(data.euid) != 0) // This goes up to maximum privileges
-    {
-        PRINT_ERROR("seteuid/setuid error");
-    }
-
-    sprintf(command, "taskset -pc %s %d\n", tsetspec, pid);
-    printf("Executing command: %s\n", command);
-
-    EXECUTE_SYSTEM_COMMAND_ERRCHECK("%s", command);
-
-    if(setresuid(data.ruid, data.ruid, data.euid) !=
-            0) // Go back to normal privileges
-    {
-        PRINT_ERROR("seteuid error");
-    }
-
-    return (0);
+    EXECUTE_SYSTEM_COMMAND("milk-rtsched -t %s %d", tsetspec, pid);
+    return 0;
 }
 
 
@@ -238,66 +182,14 @@ int COREMOD_TOOLS_mvProcCPUsetExt(const int   pid,
                                   const char *csetname,
                                   const int   rtprio)
 {
-    char command[STRINGMAXLEN_COMMAND];
-
-    /* FOR DEBUG - WARNING data.euid and data.ruid are NOT what they say
-    PRINT_ERROR("(data) EUID %d - (data) RUID %d ", data.euid, data.ruid);
-    int euid, suid, ruid;
-    getresuid(&ruid, &euid, &suid);
-    PRINT_ERROR("AC EUID %d - SUID %d - RUID %d ", euid, suid, ruid);
-    //*/
-
-    // Must make TWO calls - see COREMOD_TOOLS_mvProcTset
-    if(seteuid(data.euid) != 0 ||
-            setuid(data.euid) != 0) // This goes up to maximum privileges
+    if(rtprio > 0)
     {
-        PRINT_ERROR("seteuid/setuid error");
-    }
-
-    sprintf(command,
-            "cset proc --threads --force -m -p %d -t %s\n",
-            pid,
-            csetname);
-    printf("Executing command: %s\n", command);
-
-    if(system("which cset > /dev/null 2>&1"))
-    {
-        // Command doesn't exist...
-        printf("Error: cset command is not installed\n");
+        EXECUTE_SYSTEM_COMMAND("milk-rtsched -c %s -p %d %d", csetname, rtprio, pid);
     }
     else
     {
-        // Command does exist
-        EXECUTE_SYSTEM_COMMAND("%s", command);
-        if(data.retvalue != 0)
-        {
-            if(data.retvalue == 512)
-            {
-                PRINT_ERROR("Error: cset-proc returns error 512 - cpuset %s does not exist.\n",
-                            csetname);
-            }
-            else
-            {
-                // Re-raise as would EXECUTE_SYTEM_COMMAND_ERRCHECK
-                PRINT_ERROR("Error: cset-proc returns error %d.", data.retvalue);
-                abort();
-            }
-        }
+        EXECUTE_SYSTEM_COMMAND("milk-rtsched -c %s %d", csetname, pid);
     }
 
-    if(rtprio > 0)
-    {
-        sprintf(command, "chrt -f -p %d %d\n", rtprio, pid);
-        printf("Executing command: %s\n", command);
-
-        EXECUTE_SYSTEM_COMMAND_ERRCHECK("%s", command);
-    }
-
-    if(setresuid(data.ruid, data.ruid, data.euid) !=
-            0) // Go back to normal privileges
-    {
-        PRINT_ERROR("seteuid error");
-    }
-
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/src/CommandLineInterface/CLIcore.c
+++ b/src/CommandLineInterface/CLIcore.c
@@ -39,7 +39,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <sys/prctl.h>
-#include <sched.h>
 #include <signal.h>
 
 #include <readline/history.h>
@@ -66,6 +65,7 @@
 #include "COREMOD_arith/COREMOD_arith.h"
 #include "COREMOD_iofits/COREMOD_iofits.h"
 #include "COREMOD_memory/COREMOD_memory.h"
+#include "COREMOD_tools/mvprocCPUset.h"
 
 #include "CommandLineInterface/CLIcore/CLIcore_UI.h"
 #include "CommandLineInterface/CLIcore/CLIcore_checkargs.h"
@@ -334,16 +334,6 @@ errno_t CLI_startup()
             openACC_devtype);
     }
 #endif
-
-    // to take advantage of kernel priority:
-    // owner=root mode=4755
-
-    getresuid(&data.ruid, &data.euid, &data.suid);
-    //This sets it to the privileges of the normal user
-    if(seteuid(data.ruid) != 0)
-    {
-        PRINT_ERROR("seteuid error");
-    }
 
     // Initialize random-number generator
     //
@@ -1079,7 +1069,6 @@ void fnExit1(void)
 static int command_line_process_options(int argc, char **argv)
 {
     int                option_index = 0;
-    struct sched_param schedpar;
     char               command[STRINGMAXLEN_COMMAND];
 
     static struct option long_options[] =
@@ -1203,22 +1192,10 @@ static int command_line_process_options(int argc, char **argv)
             break;
 
         case 'p':
-            schedpar.sched_priority = atoi(optarg);
-            printf("RUNNING WITH RT PRIORITY = %d\n", schedpar.sched_priority);
+            printf("RUNNING WITH RT PRIORITY = %d\n", atoi(optarg));
 
-            if(seteuid(data.euid) != 0)  //This goes up to maximum privileges
-            {
-                PRINT_ERROR("seteuid() returns non-zero value");
-            }
-            sched_setscheduler(
-                0,
-                SCHED_FIFO,
-                &schedpar); //other option is SCHED_RR, might be faster
+            COREMOD_TOOLS_mvProcRTPrio(atoi(optarg));
 
-            if(seteuid(data.ruid) != 0)  //Go back to normal privileges
-            {
-                PRINT_ERROR("seteuid() returns non-zero value");
-            }
             break;
 
         case 'f':

--- a/src/CommandLineInterface/doc/templatemodule/templatemodule.c
+++ b/src/CommandLineInterface/doc/templatemodule/templatemodule.c
@@ -314,15 +314,12 @@ int templatemodule_examplefunc00(int mode)
 /**
  * ## Purpose
  *
- * This function demonstrates use of seteuid, sched_setscheduler \n
- * Note that fields "Use", "return", "not" and "warning" are optional
+ * This function demonstrates priority escalation with the milk API.
  *
  * ## Arguments
  *
  * Brief description of arguments is in .h file \n
  * A more detailed description of arguments in provided here \n
- *
- *
  *
  * ## Use
  *
@@ -355,33 +352,10 @@ int templatemodule_examplefunc01(const char *namein,
     ///
     int Niteration;
 
-    int RT_priority =
-        95; // any number from 0-99. Higher number = higher priority
-    struct sched_param schedpar;
-
+    int RT_priority = 95; // any number from 0-99. Higher number = higher priority
     int retval;
 
-    schedpar.sched_priority = RT_priority;
-
-    /// ## Set up priviledges
-
-    iretval = seteuid(euid_called); //This goes up to maximum privileges
-    if(retval != 0)
-        printERROR(__FILE__,
-                   __func__,
-                   __LINE__,
-                   "seteuid() returns non-zero value");
-
-    sched_setscheduler(0,
-                       SCHED_FIFO,
-                       &schedpar); //other option is SCHED_RR, might be faster
-
-    retval = seteuid(euid_real); //Go back to normal privileges
-    if(retval != 0)
-        printERROR(__FILE__,
-                   __func__,
-                   __LINE__,
-                   "seteuid() returns non-zero value");
+    COREMOD_TOOLS_mvProcRTPrio(RT_priority);
 
     /// ## Execute loop
 

--- a/src/CommandLineInterface/procCTRL/procCTRL_TUI.c
+++ b/src/CommandLineInterface/procCTRL/procCTRL_TUI.c
@@ -139,7 +139,9 @@ int processinfo_compute_status(PROCESSINFO *processinfo)
  *
  * ## Description
  *
- * Uses command: cset set -l
+ * Reads cpuset names and CPU lists directly from the cgroup filesystem.
+ * Supports both cgroups v1 (/sys/fs/cgroup/cpuset/) and
+ * cgroups v2 (/sys/fs/cgroup/).
  *
  *
  */
@@ -157,9 +159,70 @@ static int processinfo_CPUsets_List(STRINGLISTENTRY *CPUsetList)
     char fname[STRINGMAXLEN_FILENAME];
     WRITE_FILENAME(fname, "%s/.csetlist.%ld", SHAREDPROCDIR, (long) getpid());
 
-    EXECUTE_SYSTEM_COMMAND(
-        "cset set -l | awk '/root/{stop=1} stop==1{print $0}' > %s",
-        fname);
+    // Detect cgroup version and enumerate cpusets directly from the filesystem.
+    // Writes "name cpu-list" lines to fname — same format sscanf() expects below.
+    {
+        // v1: cpuset controller is a separate mount with a root "tasks" file.
+        // v2: unified hierarchy; cpuset dirs carry "cpuset.cpus.effective".
+        const char *v1root  = "/sys/fs/cgroup/cpuset";
+        const char *v2root  = "/sys/fs/cgroup";
+        char        probe[256];
+        snprintf(probe, sizeof(probe), "%s/tasks", v1root);
+        FILE *test = fopen(probe, "r");
+        int   is_v2;
+        const char *cgroot;
+        if(test != NULL)
+        {
+            fclose(test);
+            cgroot = v1root;
+            is_v2  = 0;
+        }
+        else
+        {
+            cgroot = v2root;
+            is_v2  = 1;
+        }
+
+        FILE *fw = fopen(fname, "w");
+        if(fw != NULL)
+        {
+            DIR *d = opendir(cgroot);
+            if(d != NULL)
+            {
+                struct dirent *ent;
+                while((ent = readdir(d)) != NULL)
+                {
+                    if(ent->d_name[0] == '.')
+                    {
+                        continue;
+                    }
+
+                    // Presence of the CPU list file identifies a cpuset dir.
+                    char cpufile[512];
+                    snprintf(cpufile, sizeof(cpufile), "%s/%s/%s",
+                             cgroot, ent->d_name,
+                             is_v2 ? "cpuset.cpus.effective" : "cpuset.cpus");
+
+                    FILE *fc = fopen(cpufile, "r");
+                    if(fc == NULL)
+                    {
+                        continue;    // not a cpuset directory
+                    }
+
+                    char cpus[64] = "-";
+                    if(fgets(cpus, sizeof(cpus), fc) != NULL)
+                    {
+                        cpus[strcspn(cpus, "\n")] = '\0';
+                    }
+                    fclose(fc);
+
+                    fprintf(fw, "%s %s\n", ent->d_name, cpus);
+                }
+                closedir(d);
+            }
+            fclose(fw);
+        }
+    }
 
     // first scan: get number of entries
     fp = fopen(fname, "r");
@@ -226,7 +289,7 @@ static int processinfo_SelectFromList(STRINGLISTENTRY *StringList, int NBelem)
 
         int  stringindex = 0;
         char c;
-        while(((c = getchar()) != 13) && (stringindex < strlenmax - 1))
+        while(((c = getchar()) != '\n') && (c != '\r') && (stringindex < strlenmax - 1))
         {
             buff[stringindex] = c;
             if(c == 127)  // delete key
@@ -968,10 +1031,12 @@ errno_t processinfo_CTRLscreen()
                 printf("CURRENT cpu set : %s\n",
                        procinfoproc.pinfodisp[pindex].cpuset);
                 listindex = processinfo_SelectFromList(CPUsetList, NBCPUset);
-
-                EXECUTE_SYSTEM_COMMAND("sudo cset proc -m %d %s",
-                                       pinfolist->PIDarray[pindex],
-                                       CPUsetList[listindex].name);
+                printf("I'm here A!!\n");
+                fflush(stdout);
+                COREMOD_TOOLS_mvProcCPUsetExt(pinfolist->PIDarray[pindex],
+                                              CPUsetList[listindex].name, -1);
+                printf("I'm here!!\n");
+                fflush(stdout);
 
                 TUI_init_terminal(&wrow, &wcol);
             }
@@ -982,14 +1047,8 @@ errno_t processinfo_CTRLscreen()
             if(pinfolist->active[pindex] == 1)
             {
                 TUI_exit();
-
-                EXECUTE_SYSTEM_COMMAND("sudo cset proc -m %d root &> /dev/null",
-                                       pinfolist->PIDarray[pindex]);
-                EXECUTE_SYSTEM_COMMAND(
-                    "sudo cset proc --force -m %d %s &> /dev/null",
-                    pinfolist->PIDarray[pindex],
-                    procinfoproc.pinfodisp[pindex].cpuset);
-
+                COREMOD_TOOLS_mvProcCPUsetExt(pinfolist->PIDarray[pindex],
+                                              procinfoproc.pinfodisp[pindex].cpuset, -1);
                 TUI_init_terminal(&wrow, &wcol);
             }
             break;

--- a/src/CommandLineInterface/processinfo/processinfo_setup.c
+++ b/src/CommandLineInterface/processinfo/processinfo_setup.c
@@ -2,6 +2,7 @@
 
 #include "CLIcore.h"
 #include <processtools.h>
+#include "COREMOD_tools/mvprocCPUset.h"
 
 
 // High level processinfo function
@@ -96,24 +97,7 @@ errno_t processinfo_loopstart(PROCESSINFO *processinfo)
 
     if(processinfo->RT_priority > -1)
     {
-        struct sched_param schedpar;
-        // ===========================
-        // Set realtime priority
-        // ===========================
-        schedpar.sched_priority = processinfo->RT_priority;
-
-        if(seteuid(data.euid) != 0)  //This goes up to maximum privileges
-        {
-            PRINT_ERROR("seteuid error");
-        }
-        sched_setscheduler(
-            0,
-            SCHED_FIFO,
-            &schedpar);              //other option is SCHED_RR, might be faster
-        if(seteuid(data.ruid) != 0)  //Go back to normal privileges
-        {
-            PRINT_ERROR("seteuid error");
-        }
+        COREMOD_TOOLS_mvProcRTPrio(processinfo->RT_priority);
     }
 
     return RETURN_SUCCESS;


### PR DESCRIPTION
bin/milk is no longer SUID

A single executable milk-rtsched is SUID and handles commands for CPUset, taskset, SCHED_FIFO.

Internal CLI commands csetpmove, csetandprioext, etc are maintained, as well as the previous script entrypoint `milk-makecsetandrt` (but which will now call milk-rtsched instead of invoking a milk shell to call a command to spawn another executable...)