### PR TITLE
refactor: decouple 69 pure compute plugins from CLIcore.h

### DIFF
--- a/plugins/milk-extra-src/ZernikePolyn/ZernikePolyn_fit.c
+++ b/plugins/milk-extra-src/ZernikePolyn/ZernikePolyn_fit.c
@@ -13,8 +13,22 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
 
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_arith/COREMOD_arith.h"
 #include "COREMOD_iofits/COREMOD_iofits.h"
 #include "COREMOD_memory/COREMOD_memory.h"

--- a/plugins/milk-extra-src/ZernikePolyn/zernike_value.c
+++ b/plugins/milk-extra-src/ZernikePolyn/zernike_value.c
@@ -13,7 +13,22 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "zernike.h"
 

--- a/plugins/milk-extra-src/clustering/CFmeminit.c
+++ b/plugins/milk-extra-src/clustering/CFmeminit.c
@@ -3,7 +3,22 @@
  * @brief Cfmeminit module
  */
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "clustering_defs.h"
 

--- a/plugins/milk-extra-src/clustering/CFtree_rebuild.c
+++ b/plugins/milk-extra-src/clustering/CFtree_rebuild.c
@@ -5,7 +5,22 @@
 
 #include <math.h>
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "clustering_defs.h"
 

--- a/plugins/milk-extra-src/clustering/addCF_to_CF.c
+++ b/plugins/milk-extra-src/clustering/addCF_to_CF.c
@@ -1,5 +1,20 @@
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "clustering_defs.h"
 

--- a/plugins/milk-extra-src/clustering/compute_imdistance_double.c
+++ b/plugins/milk-extra-src/clustering/compute_imdistance_double.c
@@ -3,7 +3,22 @@
  * @brief Compute imdistance double module
  */
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "clustering_defs.h"
 

--- a/plugins/milk-extra-src/clustering/condense.c
+++ b/plugins/milk-extra-src/clustering/condense.c
@@ -1,4 +1,19 @@
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "clustering_defs.h"
 

--- a/plugins/milk-extra-src/clustering/create_new_leaf.c
+++ b/plugins/milk-extra-src/clustering/create_new_leaf.c
@@ -1,5 +1,20 @@
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "clustering_defs.h"
 

--- a/plugins/milk-extra-src/clustering/ctree_init.c
+++ b/plugins/milk-extra-src/clustering/ctree_init.c
@@ -1,4 +1,19 @@
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "clustering_defs.h"
 

--- a/plugins/milk-extra-src/clustering/ctree_memallocate.c
+++ b/plugins/milk-extra-src/clustering/ctree_memallocate.c
@@ -4,7 +4,22 @@
  */
 
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "clustering_defs.h"
 

--- a/plugins/milk-extra-src/clustering/ctree_memfree.c
+++ b/plugins/milk-extra-src/clustering/ctree_memfree.c
@@ -4,7 +4,22 @@
  */
 
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "clustering_defs.h"
 

--- a/plugins/milk-extra-src/clustering/droptree.c
+++ b/plugins/milk-extra-src/clustering/droptree.c
@@ -3,7 +3,22 @@
  * @brief Droptree module
  */
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "clustering_defs.h"
 

--- a/plugins/milk-extra-src/clustering/get_availableCFindex.c
+++ b/plugins/milk-extra-src/clustering/get_availableCFindex.c
@@ -3,7 +3,22 @@
  * @brief Get availablecfindex module
  */
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "clustering_defs.h"
 

--- a/plugins/milk-extra-src/clustering/leaf_addentry.c
+++ b/plugins/milk-extra-src/clustering/leaf_addentry.c
@@ -4,7 +4,22 @@
  */
 
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "clustering_defs.h"
 

--- a/plugins/milk-extra-src/clustering/leafnode_attachleaf.c
+++ b/plugins/milk-extra-src/clustering/leafnode_attachleaf.c
@@ -1,5 +1,20 @@
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "clustering_defs.h"
 

--- a/plugins/milk-extra-src/clustering/node_attachnode.c
+++ b/plugins/milk-extra-src/clustering/node_attachnode.c
@@ -3,7 +3,22 @@
  * @brief attach node CFindex to CFindexupnode
  */
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "clustering_defs.h"
 

--- a/plugins/milk-extra-src/clustering/printCFtree.c
+++ b/plugins/milk-extra-src/clustering/printCFtree.c
@@ -5,7 +5,22 @@
 
 #include <math.h>
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 
 #include "clustering_defs.h"

--- a/plugins/milk-extra-src/clustering/split_CF_node.c
+++ b/plugins/milk-extra-src/clustering/split_CF_node.c
@@ -1,5 +1,20 @@
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "clustering_defs.h"
 

--- a/plugins/milk-extra-src/clustering/update_level.c
+++ b/plugins/milk-extra-src/clustering/update_level.c
@@ -4,7 +4,22 @@
  */
 
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "clustering_defs.h"
 

--- a/plugins/milk-extra-src/clustering/write_clustCFave.c
+++ b/plugins/milk-extra-src/clustering/write_clustCFave.c
@@ -5,7 +5,22 @@
 
 #include <math.h>
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "COREMOD_iofits/COREMOD_iofits.h"
 

--- a/plugins/milk-extra-src/clustering/write_clustCFdat.c
+++ b/plugins/milk-extra-src/clustering/write_clustCFdat.c
@@ -5,7 +5,22 @@
 
 #include <math.h>
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "COREMOD_iofits/COREMOD_iofits.h"
 

--- a/plugins/milk-extra-src/clustering/write_clustleafsummary.c
+++ b/plugins/milk-extra-src/clustering/write_clustleafsummary.c
@@ -5,7 +5,22 @@
 
 #include <math.h>
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "COREMOD_iofits/COREMOD_iofits.h"
 

--- a/plugins/milk-extra-src/fft/DFT.c
+++ b/plugins/milk-extra-src/fft/DFT.c
@@ -3,10 +3,21 @@
 
 #include <math.h>
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
 #ifdef MILK_NO_CLI
 #include "CLIcore_standalone.h"
 #else
-#include "CLIcore.h"
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
 #endif
 
 #include "COREMOD_iofits/COREMOD_iofits.h"

--- a/plugins/milk-extra-src/fft/dofft_internal.h
+++ b/plugins/milk-extra-src/fft/dofft_internal.h
@@ -13,10 +13,21 @@
 
 #include "dofft.h"
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
 #ifdef MILK_NO_CLI
 #include "CLIcore_standalone.h"
 #else
-#include "CLIcore.h"
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
 #endif
 
 #include "COREMOD_memory/COREMOD_memory.h"

--- a/plugins/milk-extra-src/fft/fft_autocorrelation.c
+++ b/plugins/milk-extra-src/fft/fft_autocorrelation.c
@@ -7,10 +7,21 @@
 
 #include <math.h>
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
 #ifdef MILK_NO_CLI
 #include "CLIcore_standalone.h"
 #else
-#include "CLIcore.h"
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
 #endif
 
 #include "COREMOD_arith/COREMOD_arith.h"

--- a/plugins/milk-extra-src/fft/fft_structure_function.c
+++ b/plugins/milk-extra-src/fft/fft_structure_function.c
@@ -7,10 +7,21 @@
 
 #include <math.h>
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
 #ifdef MILK_NO_CLI
 #include "CLIcore_standalone.h"
 #else
-#include "CLIcore.h"
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
 #endif
 
 #include "COREMOD_memory/COREMOD_memory.h"

--- a/plugins/milk-extra-src/fft/fftzoom.c
+++ b/plugins/milk-extra-src/fft/fftzoom.c
@@ -6,10 +6,21 @@
 /** @file fftzoom.c
  */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
 #ifdef MILK_NO_CLI
 #include "CLIcore_standalone.h"
 #else
-#include "CLIcore.h"
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
 #endif
 
 #include "COREMOD_memory/COREMOD_memory.h"

--- a/plugins/milk-extra-src/fft/wisdom.c
+++ b/plugins/milk-extra-src/fft/wisdom.c
@@ -11,7 +11,22 @@
 #include "CLIcore_standalone.h"
 #include "COREMOD_memory/COREMOD_memory.h"
 #else
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #endif
 
 errno_t import_wisdom()

--- a/plugins/milk-extra-src/image_basic/extrapolate_nearestpixel.c
+++ b/plugins/milk-extra-src/image_basic/extrapolate_nearestpixel.c
@@ -6,10 +6,21 @@
 /** @file extrapolate_nearestpixel.c
  */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
 #ifdef MILK_NO_CLI
 #include "CLIcore_standalone.h"
 #else
-#include "CLIcore.h"
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
 #endif
 
 #include "COREMOD_memory/COREMOD_memory.h"

--- a/plugins/milk-extra-src/image_basic/image_basic_utils.c
+++ b/plugins/milk-extra-src/image_basic/image_basic_utils.c
@@ -9,7 +9,22 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_arith/COREMOD_arith.h"
 #include "COREMOD_iofits/COREMOD_iofits.h"
 #include "COREMOD_memory/COREMOD_memory.h"

--- a/plugins/milk-extra-src/image_basic/imstretch.c
+++ b/plugins/milk-extra-src/image_basic/imstretch.c
@@ -8,10 +8,21 @@
 
 #include <math.h>
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
 #ifdef MILK_NO_CLI
 #include "CLIcore_standalone.h"
 #else
-#include "CLIcore.h"
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
 #endif
 
 #include "COREMOD_arith/COREMOD_arith.h"

--- a/plugins/milk-extra-src/image_basic/measure_transl.c
+++ b/plugins/milk-extra-src/image_basic/measure_transl.c
@@ -6,10 +6,21 @@
 /** @file measure_transl.c
  */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
 #ifdef MILK_NO_CLI
 #include "CLIcore_standalone.h"
 #else
-#include "CLIcore.h"
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
 #endif
 
 #include "COREMOD_arith/COREMOD_arith.h"

--- a/plugins/milk-extra-src/image_basic/naninf2zero.c
+++ b/plugins/milk-extra-src/image_basic/naninf2zero.c
@@ -8,10 +8,21 @@
 
 #include <math.h>
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
 #ifdef MILK_NO_CLI
 #include "CLIcore_standalone.h"
 #else
-#include "CLIcore.h"
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
 #endif
 
 #include "COREMOD_memory/COREMOD_memory.h"

--- a/plugins/milk-extra-src/image_basic/tableto2Dim.c
+++ b/plugins/milk-extra-src/image_basic/tableto2Dim.c
@@ -8,10 +8,21 @@
 
 #include <math.h>
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
 #ifdef MILK_NO_CLI
 #include "CLIcore_standalone.h"
 #else
-#include "CLIcore.h"
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
 #endif
 
 #include "COREMOD_iofits/COREMOD_iofits.h"

--- a/plugins/milk-extra-src/image_filter/cubepercentile.c
+++ b/plugins/milk-extra-src/image_filter/cubepercentile.c
@@ -6,10 +6,21 @@
 /** @file cubepercentile.c
  */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
 #ifdef MILK_NO_CLI
 #include "CLIcore_standalone.h"
 #else
-#include "CLIcore.h"
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
 #endif
 
 #include "COREMOD_memory/COREMOD_memory.h"

--- a/plugins/milk-extra-src/image_filter/fit1D.c
+++ b/plugins/milk-extra-src/image_filter/fit1D.c
@@ -12,7 +12,22 @@
 #include "CLIcore_standalone.h"
 #include "COREMOD_memory/COREMOD_memory.h"
 #else
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #endif
 #include "statistic/statistic.h"
 

--- a/plugins/milk-extra-src/image_filter/fit2DcosKernel.c
+++ b/plugins/milk-extra-src/image_filter/fit2DcosKernel.c
@@ -8,10 +8,21 @@
 
 #include <math.h>
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
 #ifdef MILK_NO_CLI
 #include "CLIcore_standalone.h"
 #else
-#include "CLIcore.h"
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
 #endif
 
 #include "COREMOD_iofits/COREMOD_iofits.h"

--- a/plugins/milk-extra-src/image_filter/fit2Dcossin.c
+++ b/plugins/milk-extra-src/image_filter/fit2Dcossin.c
@@ -8,10 +8,21 @@
 
 #include <math.h>
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
 #ifdef MILK_NO_CLI
 #include "CLIcore_standalone.h"
 #else
-#include "CLIcore.h"
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
 #endif
 
 #include "COREMOD_iofits/COREMOD_iofits.h"

--- a/plugins/milk-extra-src/image_filter/gaussfilter.c
+++ b/plugins/milk-extra-src/image_filter/gaussfilter.c
@@ -10,10 +10,21 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
 #ifdef MILK_NO_CLI
 #include "CLIcore_standalone.h"
 #else
-#include "CLIcore.h"
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
 #endif
 #include "gaussfilter.h"
 #include "fps.h"

--- a/plugins/milk-extra-src/image_filter/medianfilter.c
+++ b/plugins/milk-extra-src/image_filter/medianfilter.c
@@ -6,10 +6,21 @@
 /** @file medianfilter.c
  */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
 #ifdef MILK_NO_CLI
 #include "CLIcore_standalone.h"
 #else
-#include "CLIcore.h"
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
 #endif
 
 #include "COREMOD_iofits/COREMOD_iofits.h"

--- a/plugins/milk-extra-src/image_filter/percentile_interpolation.c
+++ b/plugins/milk-extra-src/image_filter/percentile_interpolation.c
@@ -6,10 +6,21 @@
 /** @file percentile_interpolation.c
  */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
 #ifdef MILK_NO_CLI
 #include "CLIcore_standalone.h"
 #else
-#include "CLIcore.h"
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
 #endif
 
 #include "COREMOD_memory/COREMOD_memory.h"

--- a/plugins/milk-extra-src/image_format/CR2tomov.c
+++ b/plugins/milk-extra-src/image_format/CR2tomov.c
@@ -8,8 +8,22 @@
 
 #include <math.h>
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
 
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_iofits/COREMOD_iofits.h"
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "COREMOD_tools/COREMOD_tools.h"

--- a/plugins/milk-extra-src/image_format/FITStorgbFITSsimple.c
+++ b/plugins/milk-extra-src/image_format/FITStorgbFITSsimple.c
@@ -8,8 +8,22 @@
 
 #include <math.h>
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
 
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 
 static float FLUXFACTOR = 1.0;

--- a/plugins/milk-extra-src/image_format/readPGM.c
+++ b/plugins/milk-extra-src/image_format/readPGM.c
@@ -6,8 +6,22 @@
 /** @file readPGM.c
  */
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
 
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 
 /**

--- a/plugins/milk-extra-src/image_gen/image_gen_basic_shapes.c
+++ b/plugins/milk-extra-src/image_gen/image_gen_basic_shapes.c
@@ -1,4 +1,19 @@
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_iofits/COREMOD_iofits.h"
 #include "COREMOD_arith/COREMOD_arith.h"
 #include "fps.h"

--- a/plugins/milk-extra-src/image_gen/image_gen_complex.c
+++ b/plugins/milk-extra-src/image_gen/image_gen_complex.c
@@ -1,4 +1,19 @@
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_iofits/COREMOD_iofits.h"
 #include "COREMOD_arith/COREMOD_arith.h"
 #include "fps.h"

--- a/plugins/milk-extra-src/image_gen/image_gen_internal.h
+++ b/plugins/milk-extra-src/image_gen/image_gen_internal.h
@@ -15,10 +15,21 @@
 #include <fitsio.h>
 #endif
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
 #ifdef MILK_NO_CLI
 #include "CLIcore_standalone.h"
 #else
-#include "CLIcore.h"
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
 #endif
 
 #include "COREMOD_arith/COREMOD_arith.h"

--- a/plugins/milk-extra-src/image_gen/image_gen_polygons.c
+++ b/plugins/milk-extra-src/image_gen/image_gen_polygons.c
@@ -1,4 +1,19 @@
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_iofits/COREMOD_iofits.h"
 #include "COREMOD_arith/COREMOD_arith.h"
 #include "fps.h"

--- a/plugins/milk-extra-src/image_gen/image_gen_profiles.c
+++ b/plugins/milk-extra-src/image_gen/image_gen_profiles.c
@@ -1,4 +1,19 @@
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_iofits/COREMOD_iofits.h"
 #include "COREMOD_arith/COREMOD_arith.h"
 #include "fps.h"

--- a/plugins/milk-extra-src/img_reduce/img_reduce_internal.h
+++ b/plugins/milk-extra-src/img_reduce/img_reduce_internal.h
@@ -20,7 +20,22 @@
 #include <fitsio.h>
 
 #ifndef MILK_NO_CLI
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #else
 #include "CLIcore_standalone.h"
 #endif

--- a/plugins/milk-extra-src/info/kbdhit.c
+++ b/plugins/milk-extra-src/info/kbdhit.c
@@ -10,7 +10,22 @@
 #include <termios.h>
 #include <unistd.h>
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 
 errno_t kbdhit(void)

--- a/plugins/milk-extra-src/info/percentile.c
+++ b/plugins/milk-extra-src/info/percentile.c
@@ -6,8 +6,22 @@
 /** @file percentile.c
  */
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
 
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "COREMOD_tools/COREMOD_tools.h"
 

--- a/plugins/milk-extra-src/info/print_header.c
+++ b/plugins/milk-extra-src/info/print_header.c
@@ -15,7 +15,22 @@
 #define A_BOLD 0
 #endif
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 
 extern int infoscreen_wcol;

--- a/plugins/milk-extra-src/info/stream-monproc-runner.c
+++ b/plugins/milk-extra-src/info/stream-monproc-runner.c
@@ -9,7 +9,22 @@
 #include <getopt.h>
 #include <string.h>
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "stream_monproc.h"
 

--- a/plugins/milk-extra-src/info/streamtiming_stats.c
+++ b/plugins/milk-extra-src/info/streamtiming_stats.c
@@ -18,8 +18,22 @@
 #endif
 #include <sched.h>
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
 
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "COREMOD_tools/COREMOD_tools.h"
 #include "timediff.h"

--- a/plugins/milk-extra-src/linARfilterPred/linARfilterPred_internal.h
+++ b/plugins/milk-extra-src/linARfilterPred/linARfilterPred_internal.h
@@ -26,7 +26,22 @@
 
 #include <time.h>
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "timeutils.h"
 
 #include "COREMOD_arith/COREMOD_arith.h"

--- a/plugins/milk-extra-src/linalgebra/GPU_SVD_computeControlMatrix.c
+++ b/plugins/milk-extra-src/linalgebra/GPU_SVD_computeControlMatrix.c
@@ -15,8 +15,22 @@
 #include <pthread.h>
 #endif
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
 
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_iofits/COREMOD_iofits.h"
 #include "COREMOD_memory/COREMOD_memory.h"
 

--- a/plugins/milk-extra-src/linalgebra/GPU_loop_MultMat_execute.c
+++ b/plugins/milk-extra-src/linalgebra/GPU_loop_MultMat_execute.c
@@ -13,7 +13,22 @@
 
 #include <cublas_v2.h>
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "timeutils.h"
 
 #include "COREMOD_memory/COREMOD_memory.h"

--- a/plugins/milk-extra-src/linalgebra/GPU_loop_MultMat_setup.c
+++ b/plugins/milk-extra-src/linalgebra/GPU_loop_MultMat_setup.c
@@ -12,8 +12,22 @@
 #include <fcntl.h>
 #include <pthread.h>
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
 
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 
 #include "GPU_loop_MultMat_free.h"

--- a/plugins/milk-extra-src/linalgebra/GPUloadCmat.c
+++ b/plugins/milk-extra-src/linalgebra/GPUloadCmat.c
@@ -10,7 +10,22 @@
 
 #include <cublas_v2.h>
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "linalgebra_types.h"
 

--- a/plugins/milk-extra-src/linalgebra/cublas_Coeff2Map_Loop.c
+++ b/plugins/milk-extra-src/linalgebra/cublas_Coeff2Map_Loop.c
@@ -12,8 +12,22 @@
 
 #include <cublas_v2.h>
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
 
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 
 extern int cuda_deviceCount;

--- a/plugins/milk-extra-src/linalgebra/cublas_linalgebratest.c
+++ b/plugins/milk-extra-src/linalgebra/cublas_linalgebratest.c
@@ -6,8 +6,22 @@
 /** @file linalgebratest.c
  */
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
 
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 
 #include "GPU_SVD_computeControlMatrix.h"

--- a/plugins/milk-extra-src/linalgebra/linalgebra_types.h
+++ b/plugins/milk-extra-src/linalgebra/linalgebra_types.h
@@ -13,8 +13,22 @@
 #include <cuda_runtime_api.h>
 #endif
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
 
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #ifdef HAVE_MAGMA
 
 /******************* CPU memory */

--- a/plugins/milk-extra-src/linalgebra/linalgebrainit.c
+++ b/plugins/milk-extra-src/linalgebra/linalgebrainit.c
@@ -6,8 +6,22 @@
 #include "magma_v2.h"
 #endif
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
 
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 
 #ifdef HAVE_CUDA

--- a/plugins/milk-extra-src/linalgebra/magma_MatMatMult_testPseudoInverse.c
+++ b/plugins/milk-extra-src/linalgebra/magma_MatMatMult_testPseudoInverse.c
@@ -11,8 +11,22 @@
 extern int           INIT_MAGMA;
 extern magma_queue_t magmaqueue;
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
 
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 
 #include "linalgebra_types.h"

--- a/plugins/milk-extra-src/linalgebra/magma_compute_SVDpseudoInverse.c
+++ b/plugins/milk-extra-src/linalgebra/magma_compute_SVDpseudoInverse.c
@@ -15,7 +15,22 @@
 #include "magma_lapack.h"
 #include "magma_v2.h"
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "timeutils.h"
 
 #include "COREMOD_iofits/COREMOD_iofits.h"

--- a/plugins/milk-extra-src/linalgebra/magma_compute_SVDpseudoInverse_SVD.c
+++ b/plugins/milk-extra-src/linalgebra/magma_compute_SVDpseudoInverse_SVD.c
@@ -12,8 +12,22 @@
 #include "magma_lapack.h"
 #include "magma_v2.h"
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
 
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 
 #ifndef max

--- a/plugins/milk-extra-src/linalgebra/printGPUMATMULTCONF.c
+++ b/plugins/milk-extra-src/linalgebra/printGPUMATMULTCONF.c
@@ -8,7 +8,22 @@
 
 #ifdef HAVE_CUDA
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 
 #include "linalgebra_types.h"

--- a/plugins/milk-extra-src/psf/psf_internal.h
+++ b/plugins/milk-extra-src/psf/psf_internal.h
@@ -12,7 +12,22 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "CLIcore.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#ifdef MILK_NO_CLI
+#include "CLIcore_standalone.h"
+#else
+#include "libmilkdata/milkdata.h"
+#include "milkDebugTools.h"
+#include "fps.h"
+#include "ImageStreamIO/ImageStreamIO.h"
+#endif
 #include "COREMOD_arith/COREMOD_arith.h"
 #include "COREMOD_iofits/COREMOD_iofits.h"
 #include "COREMOD_memory/COREMOD_memory.h"


### PR DESCRIPTION
## Summary
This pull request completely decouples 69 pure compute modules within the `milk-extra-src` plugins from the heavyweight `CLIcore.h` mega-header. This continues the Phase F architecture improvements by enforcing strict separation between mathematical computation and CLI registration logic in plugins.

## Changes
### `milk-extra-src` Plugins
- Replaced the `#include "CLIcore.h"` inclusions with targeted sub-headers (`libmilkdata/milkdata.h`, `milkDebugTools.h`, `fps.h`, `ImageStreamIO/ImageStreamIO.h`) across 69 pure compute source files in 12 plugins (`fft`, `linalgebra`, `image_gen`, `ZernikePolyn`, `clustering`, `image_basic`, `image_filter`, etc.).
- Explicitly added standard headers (`<stdio.h>`, `<stdlib.h>`, `<math.h>`, etc.) into the replacement block to guarantee strict inclusion compliance without implicit reliance on `CLIcore.h`.

## Verification
- [x] Build passes (`make -j`) perfectly on all tiers
- [x] Tests pass (`ctest` 100% success rate on 38 tests)

## Prompt Summary
The user requested to proceed with the next modernization phase, specifically selecting Phase 3.1: Plugin Library Decoupling. The goal was to remove the `CLIcore.h` mega-header dependency from pure compute modules in `milk-extra-src` plugins, reducing incremental build times and improving modularity.

## AI Authorship
- **Model**: Antigravity
- **User edits**: None