### PR TITLE
docs: tighten error-handling rules and add library/app boundary

### DIFF
--- a/.agents/rules/error-handling-practices.md
+++ b/.agents/rules/error-handling-practices.md
@@ -5,33 +5,244 @@ description: Standardized error handling and logging
 
 # Error Handling Practices
 
-The `milk` project standardizes its error handling and logging via macros defined in `src/engine/libmilkdata/milkDebugTools.h`. To ensure consistency, robustness, and ease of debugging across the codebase, all C source code must adhere to the following practices.
+The `milk` project standardizes its error handling and
+logging via macros defined in
+`src/engine/libmilkcommon/milkDebugTools.h`. To ensure
+consistency, robustness, and ease of debugging across
+the codebase, all C source code must adhere to the
+following practices.
+
+See also: `library-vs-application-error-handling.md`
+(library/application boundary, return-type discipline,
+`EXECUTE_SYSTEM_COMMAND` default, standalone CLI exit
+codes); `cli-error-help.md` (CLIcore arg-parse error
+display).
 
 ## 1. Unified Logging Macros
-- **Do not use** raw `printf()`, `fprintf(stderr, ...)`, or `perror()` for error logging.
-- **Always use** the standard logging macros from `milkDebugTools.h`:
+
+- **Do not use** raw `printf()`, `fprintf(stderr, ...)`,
+  or `perror()` for error logging.
+- **Always use** the standard logging macros from
+  `milkDebugTools.h`:
   - `PRINT_ERROR(format, ...)`: Logs an error message.
   - `PRINT_WARNING(format, ...)`: Logs a warning message.
-  - `PRINT_INFO(format, ...)`: Logs an informational message.
-- These macros automatically append the `__FILE__`, `__LINE__`, and `__func__`, ensuring that the log outputs are highly traceable.
+  - `PRINT_INFO(format, ...)`: Logs an informational
+    message.
+- These macros automatically append the `__FILE__`,
+  `__LINE__`, and `__func__`, ensuring that the log
+  outputs are highly traceable.
 
 ## 2. Standardized Return Codes
-- **Standard values:** Functions that return a status code must use `RETURN_SUCCESS` (`0`) and `RETURN_FAILURE` (`1`), which are defined in `milkDebugTools.h`.
+
+- **Standard values:** Functions that return a status
+  code must use `RETURN_SUCCESS` (`0`) and
+  `RETURN_FAILURE` (`1`), which are defined in
+  `milkDebugTools.h`.
 - **Helper macros:**
-  - Opt for `FUNC_RETURN_SUCCESS()` when successfully returning from a function.
-  - Opt for `FUNC_RETURN_FAILURE(format, ...)` when returning an error state from a function; this will internally call `PRINT_ERROR` and then return `RETURN_FAILURE`.
+  - Opt for `FUNC_RETURN_SUCCESS()` when successfully
+    returning from a function.
+  - Opt for `FUNC_RETURN_FAILURE(format, ...)` when
+    returning an error state from a function; this will
+    internally call `PRINT_ERROR` and then return
+    `RETURN_FAILURE`.
 
 ## 3. Propagation and Boilerplate Reduction
-- **Avoid** manual `if (err != RETURN_SUCCESS)` blocks when simply propagating an error code.
+
+- **Avoid** manual `if (err != RETURN_SUCCESS)` blocks
+  when simply propagating an error code.
 - **Use:**
-  - `FUNC_CHECK_RETURN(ret)`: Evaluates the return code and silently returns it if it is not `RETURN_SUCCESS`.
-  - `FUNC_CHECK_RETURN_PRINT(ret, format, ...)`: Evaluates the return code, logs an error via `PRINT_ERROR` if it fails, and then returns the code.
+  - `FUNC_CHECK_RETURN(ret)`: Evaluates the return code
+    and silently returns it if it is not
+    `RETURN_SUCCESS`.
+  - `FUNC_CHECK_RETURN_PRINT(ret, format, ...)`:
+    Evaluates the return code, logs an error via
+    `PRINT_ERROR` if it fails, and then returns the
+    code.
+- Use the non-`PRINT` form for propagation between
+  internal layers; the printing form is reserved for
+  the layer that adds context (see §7 below).
 
 ## 4. System Calls and `errno`
-- **Avoid** calling `perror()` after a failed system or standard library call.
-- **Use:** Instead, use `PRINT_ERROR("... failed: %s", strerror(errno))` (or your desired format string) to ensure the error log retains the required file/line/function context.
-- **Execution:** When executing shell commands via `system()`, do not check the return code manually. Instead, use `EXECUTE_SYSTEM_COMMAND_ERRCHECK(format, ...)` which wraps the execution and error logging automatically.
+
+- **Avoid** calling `perror()` after a failed system or
+  standard library call.
+- **Use:** Instead, use
+  `PRINT_ERROR("... failed: %s", strerror(errno))` (or
+  your desired format string) to ensure the error log
+  retains the required file/line/function context.
+- **Execution:** When executing shell commands via
+  `system()`, do not check the return code manually.
+  Instead, use `EXECUTE_SYSTEM_COMMAND_ERRCHECK(format,
+  ...)` which wraps the execution and error logging
+  automatically. (The bare `EXECUTE_SYSTEM_COMMAND`
+  macro silently discards the return value and is
+  treated as deprecated — see
+  `library-vs-application-error-handling.md` §3.)
 
 ## 5. Transition Strategy
-- **New Code:** All newly written or refactored C code must strictly use these macros.
-- **Migration:** When editing existing files that currently use `fprintf(stderr, ...)`, progressively refactor those specific lines or functions to use `PRINT_ERROR(...)`.
+
+- **New Code:** All newly written or refactored C code
+  must strictly use these macros.
+- **Migration:** When editing existing files that
+  currently use `fprintf(stderr, ...)`, progressively
+  refactor those specific lines or functions to use
+  `PRINT_ERROR(...)`.
+
+## 6. Mandatory-Check Syscalls
+
+The following calls MUST have their return inspected.
+Minimum reaction is
+`PRINT_ERROR("<call> failed: %s", strerror(errno))`
+(or the equivalent diagnostic) plus propagating
+failure to the caller. A bare `(void)` cast is
+forbidden; if the return genuinely does not matter,
+write a one-line comment justifying it.
+
+**Required-check list:**
+`open`, `close`, `read`, `write`, `lseek`,
+`ftruncate`, `mmap`, `munmap`, `shm_open`,
+`shm_unlink`, `sem_init`, `sem_post`, `sem_wait`,
+`sem_trywait`, `pthread_create`, `pthread_join`,
+`pthread_mutex_*`, `ImageStreamIO_*`, `fps_connect`,
+`fps_disconnect`, all `processinfo_*` lifecycle calls.
+
+```c
+/* WRONG — return discarded */
+sem_post(sem);
+ImageStreamIO_openIm(&img, name);
+
+/* RIGHT */
+if (sem_post(sem) != 0)
+{
+    PRINT_WARNING("sem_post failed: %s",
+                  strerror(errno));
+}
+errno_t isio_ret =
+    ImageStreamIO_openIm(&img, name);
+FUNC_CHECK_RETURN_PRINT(isio_ret,
+    "ImageStreamIO_openIm(%s) failed", name);
+```
+
+## 7. Print-Once Policy
+
+Errors propagate up the call stack; reports do not.
+Convention:
+
+- **Innermost layer** (the syscall site): print with
+  `PRINT_ERROR` — it owns `errno`, the path, and the
+  parameters — then return failure.
+- **Intermediate propagation layers:** use
+  `FUNC_CHECK_RETURN(ret)` (silent). Do **not** use the
+  `_PRINT` variant here; it produces double / triple
+  log lines for the same root cause.
+- **Top-level boundary** (CLIcore command function,
+  `main()`, signal handler, FPS RUN entry, fpsexec
+  callbacks): MAY add one user-facing `PRINT_ERROR`
+  summarising what the user was trying to do, or push
+  to a TUI feedback channel such as `OV_CMDLOG`.
+
+```c
+/* GOOD — single print at the layer with context */
+errno_t low(void)
+{
+    FUNC_RETURN_FAILURE("open: %s", strerror(errno));
+}
+
+errno_t mid(void)
+{
+    FUNC_CHECK_RETURN(low());   /* silent */
+    return RETURN_SUCCESS;
+}
+
+errno_t top(void)
+{
+    FUNC_CHECK_RETURN_PRINT(mid(),
+        "could not initialize stream");
+    return RETURN_SUCCESS;
+}
+```
+
+## 8. `ERRMODE_*` for Query-Style Functions
+
+`ERRMODE_NULL` / `ERRMODE_WARN` / `ERRMODE_FAIL` /
+`ERRMODE_ABORT` (defined in `milkDebugTools.h`
+lines 41–44) is the established convention for
+query-style functions whose caller knows whether a
+missing result is fatal — pioneered by `resolveIMGID()`
+(see `src/coremods/COREMOD_memory/imageID.h`) and used
+at ~223 call sites across the codebase.
+
+- New library functions MAY adopt the `ERRMODE_*`
+  parameter when caller failure tolerance is genuinely
+  caller-specific.
+- Do NOT mass-add it to existing `errno_t` functions —
+  return codes remain the default.
+- **Caller responsibility:** do not pass
+  `ERRMODE_ABORT` from a long-running supervisory loop
+  (FPS RUN, real-time control). `ERRMODE_ABORT` means
+  what it says — the function will call `abort()`.
+  Pass `ERRMODE_FAIL` instead and handle the failure
+  in your loop.
+
+## 9. Cleanup with `goto fail;`
+
+When a function holds two or more resources (file
+descriptors, memory mappings, allocations, locks) and
+may fail mid-acquisition, use the single-label
+`goto fail;` cleanup pattern with reverse-order
+release at the bottom. Initialise each resource
+handle to its sentinel value (`-1`, `NULL`,
+`MAP_FAILED`) before any `goto`, so the `fail:` block
+can release unconditionally.
+
+This is the **only approved use of `goto`** in the
+codebase, matching Linux kernel convention (already
+cited as the project style baseline in
+`code-style-guide.md`).
+
+```c
+errno_t example_function(const char *path, size_t sz)
+{
+    errno_t  rv  = RETURN_FAILURE;
+    int      fd  = -1;
+    void    *map = MAP_FAILED;
+    char    *buf = NULL;
+
+    fd = open(path, O_RDWR | O_CREAT, 0644);
+    if (fd == -1)
+    {
+        PRINT_ERROR("open(%s) failed: %s",
+                    path, strerror(errno));
+        goto fail;
+    }
+    if (ftruncate(fd, sz) != 0)
+    {
+        PRINT_ERROR("ftruncate failed: %s",
+                    strerror(errno));
+        goto fail;
+    }
+    map = mmap(NULL, sz, PROT_READ | PROT_WRITE,
+               MAP_SHARED, fd, 0);
+    if (map == MAP_FAILED)
+    {
+        PRINT_ERROR("mmap failed: %s",
+                    strerror(errno));
+        goto fail;
+    }
+    buf = malloc(sz);
+    if (buf == NULL)
+    {
+        PRINT_ERROR("malloc(%zu) failed", sz);
+        goto fail;
+    }
+
+    /* ... use resources ... */
+    rv = RETURN_SUCCESS;
+
+fail:
+    if (buf != NULL)       { free(buf); }
+    if (map != MAP_FAILED) { munmap(map, sz); }
+    if (fd  != -1)         { close(fd); }
+    return rv;
+}
+```

--- a/.agents/rules/library-vs-application-error-handling.md
+++ b/.agents/rules/library-vs-application-error-handling.md
@@ -1,0 +1,149 @@
+---
+description: Architectural error-handling boundary —
+  library code returns failures; only application
+  entry points may terminate the process.
+---
+
+# Library vs. Application Error Handling
+
+This rule complements `error-handling-practices.md`
+(logging macros, return codes, cleanup) and
+`cli-error-help.md` (CLIcore arg-parse error display).
+Where those documents cover *how* to report and
+propagate errors, this one covers *who* may end the
+process and *what* a function's signature must look
+like.
+
+## 1. The Boundary: Who May Call `exit()` / `abort()`
+
+- **Library code MUST NOT call `exit()` or `abort()`.**
+  This includes everything under `src/coremods/`,
+  `src/engine/lib*/`, `ImageStreamIO/`, and any
+  function reachable from a CLIcore command.
+  Failures must propagate as return codes.
+- `exit()` is permitted only inside `main()` of
+  standalone binaries, or in a function called
+  exclusively from `main()` whose name makes its
+  terminal nature explicit (e.g. `usage_exit()`).
+- `abort()` is permitted only as the body of an
+  internal-invariant assertion that should crash a
+  debug build. Wrap it in `#ifndef NDEBUG`, or use the
+  forthcoming `MILK_BUG(fmt, ...)` macro (§5 below).
+
+```c
+/* WRONG — library code (processinfo_shm_create.c) */
+SM_fd = open(SM_fname,
+             O_RDWR | O_CREAT | O_TRUNC, FILEMODE);
+if (SM_fd == -1)
+{
+    perror("Error opening file for writing");
+    exit(0);    /* kills caller; reports SUCCESS */
+}
+
+/* RIGHT — propagate via the shared cleanup label */
+SM_fd = open(SM_fname,
+             O_RDWR | O_CREAT | O_TRUNC, FILEMODE);
+if (SM_fd == -1)
+{
+    PRINT_ERROR("open(%s) failed: %s",
+                SM_fname, strerror(errno));
+    goto fail;
+}
+```
+
+The `exit(0)` form is the worst possible variant: it
+terminates the host process while reporting success
+to whatever launched it. Library code that does this
+silently breaks every supervisor and every CI runner.
+
+## 2. Return-Type Discipline
+
+Three approved function shapes:
+
+1. **Status-only:** `errno_t f(...)` returning
+   `RETURN_SUCCESS` / `RETURN_FAILURE`. The default
+   for procedural functions.
+2. **Value-or-error:** the out-parameter idiom —
+   `errno_t f(int input, long *out)`. **Required**
+   when the natural return type can collide with an
+   error sentinel. Functions that return
+   `long pindex` or `-1` from the same return slot
+   (today's `processinfo_shm_list_create()` is the
+   canonical counter-example) violate this rule.
+3. **Pointer-returning:** MAY return `NULL` on
+   failure; the function MUST call `PRINT_ERROR`
+   itself before returning `NULL` (the caller has no
+   other channel for context).
+
+```c
+/* GOOD — value and error are separate */
+errno_t processinfo_shm_list_create(long *pindex_out);
+
+/* DISCOURAGED — sentinel collision risk */
+long processinfo_shm_list_create(void);
+/* returns -1 on error */
+```
+
+`IMAGESTREAMIO_*` codes (in `ImageStreamIO/`) are
+grandfathered as a richer error taxonomy. Functions
+that return them must still be declared `errno_t`,
+and the codes must satisfy
+`code >= IMAGESTREAMIO_FAILURE`.
+
+## 3. `EXECUTE_SYSTEM_COMMAND` — Intended Default
+
+- **Today:** `EXECUTE_SYSTEM_COMMAND` is silent — its
+  expansion casts the `system()` return to `(void)`.
+  `EXECUTE_SYSTEM_COMMAND_ERRCHECK` is the safe
+  variant. Adoption is inverted: ~82 silent callers
+  vs. ~4 checked.
+- **Rule for new code:** always use
+  `EXECUTE_SYSTEM_COMMAND_ERRCHECK`.
+- **Documented intent (not yet implemented):** a
+  future macro change will swap the names —
+  `EXECUTE_SYSTEM_COMMAND` will become the checked
+  variant; the silent path will be renamed
+  `EXECUTE_SYSTEM_COMMAND_NOCHECK` and require an
+  explanatory comment per call site. Until that
+  lands, treat the bare `EXECUTE_SYSTEM_COMMAND` as
+  deprecated.
+
+## 4. Standalone CLI Exit Codes
+
+For executables with their own `main()` (`milkCTRL`,
+`milk-stream-graph`, `milk-stream-info`,
+`milk-procinfo-info`, `milk-fps-*` wrappers,
+`milk-streamCTRL`, `milk-fpsCTRL`, `milk-procCTRL`):
+
+| Code | Meaning                                      |
+|------|----------------------------------------------|
+| `0`  | Success                                      |
+| `1`  | Runtime error (file not found, IPC failure) |
+| `2`  | Usage error (bad args, missing required)    |
+
+Codes ≥3 may carry program-specific meaning,
+documented in the binary's `--help` output.
+
+CLIcore commands continue to use the codes from
+`cli-error-help.md` (`RETURN_CLICHECKARGARRAY_*`).
+This rule applies only to standalone binaries with
+their own `main()`.
+
+## 5. `MILK_BUG(fmt, ...)` — Intended Invariant Macro
+
+- **Today:** none — `abort()` is used directly at
+  ~10 sites across `ImageStreamIO.c` and
+  `processinfo_exec_end.c`, with no documented
+  contract about when it is allowed.
+- **Documented intent (not yet implemented):**
+  introduce `MILK_BUG(fmt, ...)` that expands to
+  `PRINT_ERROR(...) + abort()` in debug builds and
+  `PRINT_ERROR(...) + return RETURN_FAILURE` (or
+  `goto fail;`-style propagation) in release builds.
+  When introduced it will replace every current
+  `abort()` site.
+- **Rule until it lands:** new code uses neither
+  `abort()` nor `assert()`. If you find yourself
+  reaching for one, return through
+  `FUNC_RETURN_FAILURE` instead and document the
+  invariant in a code comment above the check.


### PR DESCRIPTION
## Summary

Tightens the existing `error-handling-practices.md` rule and adds a
companion `library-vs-application-error-handling.md` covering the
library/application boundary, return-type discipline, the intended
`EXECUTE_SYSTEM_COMMAND` default flip, standalone-CLI exit codes, and
the future `MILK_BUG()` macro.

Documentation only — no source-tree edits, no macro changes. Migration
of the ~200+ violation sites surfaced during the review is scoped as
separate follow-up PRs.

## Changes

### `.agents/rules/error-handling-practices.md`
- Fix stale macro-source path (`libmilkdata` → `libmilkcommon`).
- Add cross-references to the new companion and `cli-error-help.md`.
- Clarify §3 on the print-once propagation contract.
- **§6 Mandatory-check syscalls** — explicit list (`open`/`close`/
  `read`/`write`/`mmap`/`sem_*`/`pthread_*`/`ImageStreamIO_*`/
  `fps_connect`/...) with worked example.
- **§7 Print-once policy** — innermost prints with `PRINT_ERROR`,
  intermediate layers propagate silently with `FUNC_CHECK_RETURN`,
  top-level boundary may add one user-facing summary.
- **§8 `ERRMODE_*` documentation** — formalises the ~223-site
  convention pioneered by `resolveIMGID()`; calls out the
  long-running-loop caveat for `ERRMODE_ABORT`.
- **§9 `goto fail;` cleanup pattern** — designated as the only
  approved use of `goto`, with a worked `open + ftruncate + mmap +
  malloc` example.

### `.agents/rules/library-vs-application-error-handling.md` (new)
- **§1 The boundary** — library code MUST NOT call `exit()` /
  `abort()`. Worked example uses `processinfo_shm_create.c:91` (the
  `exit(0)` on failure bug) refactored to `goto fail;` +
  `FUNC_RETURN_FAILURE`.
- **§2 Return-type discipline** — three approved shapes
  (`errno_t` status, value-or-error out-parameter, pointer-or-NULL);
  `processinfo_shm_list_create()` cited as the canonical
  sentinel-collision counter-example.
- **§3 `EXECUTE_SYSTEM_COMMAND` intended default** — bare macro
  deprecated; current adoption is inverted (~82 silent vs. ~4
  checked); names will swap in a future macro change.
- **§4 Standalone CLI exit codes** — 0 success, 1 runtime, 2 usage;
  ≥3 program-specific.
- **§5 `MILK_BUG(fmt, ...)` intended invariant macro** — debug
  aborts, release returns; replaces the ~10 raw `abort()` sites once
  introduced.

## Verification

- [x] Both files render as valid markdown.
- [x] All lines ≤80 characters (project code-style limit).
- [x] `cli-error-help.md` cross-linked from both new entry points;
      file itself left untouched.
- [x] No source code changes — \`compile-test\` workflow does not apply.

## Prompt Summary

User asked for a review of error-handling practices and a uniform rule
set if current implementation was inappropriate. Investigation found
the macros and existing rule were good, but practice diverged sharply
(228 \`fprintf\` vs. 233 \`PRINT_ERROR\`; 82 unchecked \`system()\` vs. 4
checked; library code calling \`exit(0)\` on failure; mixed return-type
conventions; silent shared-memory failures) and the rules had several
gaps (no library/app boundary, no syscall-check requirement, no
cleanup pattern, no standalone-CLI exit codes).

Scope chosen after design Q&A: rules-only PR (deliverable = guidance);
ranked migration list captured separately as follow-up. User-confirmed
decisions: aggressive \`EXECUTE_SYSTEM_COMMAND\` rename (intent only,
not implemented here); \`MILK_BUG\` with debug-abort / release-return
semantics (intent only); \`ERRMODE_ABORT\` documented as caller-trust
(no behaviour change).

## AI Authorship

- **Model**: Claude Sonnet 4.6 (1M context)
- **User edits**: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)