### PR TITLE
fix: propagate libprocessinfo failures instead of exit(0)

### DIFF
--- a/src/cli/libmilkscript/CLIcore_script_cmd_builtins.c
+++ b/src/cli/libmilkscript/CLIcore_script_cmd_builtins.c
@@ -581,6 +581,14 @@ int cli_handle_shell_builtins(void)
                             processinfo_shm_create(
                                 pname,
                                 PROCESSINFO_CTRLVAL_RUN);
+                        if (procinfo == NULL)
+                        {
+                            PRINT_WARNING(
+                                "processinfo_shm_create(%s) "
+                                "failed; continuing without "
+                                "process tracking",
+                                pname);
+                        }
                     }
 
                     int iter = 0;
@@ -833,6 +841,14 @@ int cli_handle_shell_builtins(void)
                             processinfo_shm_create(
                                 pname,
                                 PROCESSINFO_CTRLVAL_RUN);
+                        if (procinfo == NULL)
+                        {
+                            PRINT_WARNING(
+                                "processinfo_shm_create(%s) "
+                                "failed; continuing without "
+                                "process tracking",
+                                pname);
+                        }
                     }
 
                     char prev[256];

--- a/src/engine/libprocessinfo/procCTRL/milk-procCTRL-scan.c
+++ b/src/engine/libprocessinfo/procCTRL/milk-procCTRL-scan.c
@@ -244,9 +244,15 @@ int main(int argc, char *argv[]) {
     }
 
     // 1. Create/Open Process List SHM
-    if (processinfo_shm_list_create() == -1) {
-        fprintf(stderr, "Error connecting to process list shared memory\n");
-        return 1;
+    {
+        long pindex_unused;
+        if (processinfo_shm_list_create(&pindex_unused)
+            != RETURN_SUCCESS)
+        {
+            PRINT_ERROR(
+                "Error connecting to process list shared memory");
+            return 1;
+        }
     }
 
     char procdname[STRINGMAXLEN_DIRNAME];

--- a/src/engine/libprocessinfo/procCTRL/procCTRL_TUI.c
+++ b/src/engine/libprocessinfo/procCTRL/procCTRL_TUI.c
@@ -241,10 +241,14 @@ static errno_t procctrl_init(procctrl_context_t *ctx) {
     int NBCPUset __attribute__((unused)) = processinfo_CPUsets_List(ctx->CPUsetList, ctx->procinfoproc->has_cset);
 
     if (ctx->flog) { fprintf(ctx->flog, "Connecting to process list...\n"); fflush(ctx->flog); }
-    if(processinfo_shm_list_create() == -1) {
-        printf("==== ERROR: CANNOT ACCESS PROCESS LIST ====\n");
-        if (ctx->flog) fclose(ctx->flog);
-        return RETURN_FAILURE;
+    {
+        long pindex_unused;
+        if(processinfo_shm_list_create(&pindex_unused)
+           != RETURN_SUCCESS) {
+            printf("==== ERROR: CANNOT ACCESS PROCESS LIST ====\n");
+            if (ctx->flog) fclose(ctx->flog);
+            return RETURN_FAILURE;
+        }
     }
     ctx->procinfoproc->pinfolist = pinfolist;
     

--- a/src/engine/libprocessinfo/processinfo_setup.c
+++ b/src/engine/libprocessinfo/processinfo_setup.c
@@ -73,6 +73,13 @@ PROCESSINFO *processinfo_setup(
         DEBUG_TRACEPOINT(" ");
 
         processinfo = processinfo_shm_create(pinfoname0, 0);
+        if (processinfo == NULL)
+        {
+            PRINT_ERROR(
+                "processinfo_shm_create(%s) failed", pinfoname0);
+            DEBUG_TRACE_FEXIT();
+            return NULL;
+        }
 
         DEBUG_TRACEPOINT(" ");
     }

--- a/src/engine/libprocessinfo/processinfo_shm_create.c
+++ b/src/engine/libprocessinfo/processinfo_shm_create.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 #include <time.h>
 #include <string.h>
+#include <errno.h>
 
 #include "processinfo_internal.h"
 #include "processinfo.h"
@@ -42,9 +43,10 @@ PROCESSINFO *processinfo_shm_create(
 {
     DEBUG_TRACE_FSTART();
 
-    size_t       sharedsize = 0; // shared memory size in bytes
-    int          SM_fd;          // shared memory file descriptor
-    PROCESSINFO *pinfo = NULL;
+    size_t       sharedsize = 0;
+    int          SM_fd      = -1;
+    PROCESSINFO *pinfo      = NULL;
+    long         pindex     = 0;
 
     static int LogFileCreated __attribute__((unused)) = 0;
     // toggles to 1 when created. To avoid re-creating file on same process
@@ -57,8 +59,11 @@ PROCESSINFO *processinfo_shm_create(
     PID = getpid();
 
     DEBUG_TRACEPOINT("create/update pinfolist");
-    long pindex;
-    pindex = processinfo_shm_list_create();
+    if (processinfo_shm_list_create(&pindex) != RETURN_SUCCESS)
+    {
+        PRINT_ERROR("processinfo_shm_list_create failed");
+        goto fail;
+    }
 
     DEBUG_TRACEPOINT("index = %ld", pindex);
 
@@ -87,34 +92,32 @@ PROCESSINFO *processinfo_shm_create(
     SM_fd = open(SM_fname, O_RDWR | O_CREAT | O_TRUNC, (mode_t) FILEMODE);
     if(SM_fd == -1)
     {
-        perror("Error opening file for writing");
-        exit(0);
+        PRINT_ERROR("open(%s) failed: %s",
+                    SM_fname, strerror(errno));
+        goto fail;
     }
 
-    int result;
-    result = lseek(SM_fd, sharedsize - 1, SEEK_SET);
-    if(result == -1)
+    if(lseek(SM_fd, sharedsize - 1, SEEK_SET) == -1)
     {
-        close(SM_fd);
-        fprintf(stderr, "Error calling lseek() to 'stretch' the file");
-        exit(0);
+        PRINT_ERROR("lseek failed: %s", strerror(errno));
+        goto fail;
     }
 
-    result = write(SM_fd, "", 1);
-    if(result != 1)
+    if(write(SM_fd, "", 1) != 1)
     {
-        close(SM_fd);
-        perror("Error writing last byte of the file");
-        exit(0);
+        PRINT_ERROR("write last byte failed: %s",
+                    strerror(errno));
+        goto fail;
     }
 
     pinfo = (PROCESSINFO *)
             mmap(0, sharedsize, PROT_READ | PROT_WRITE, MAP_SHARED, SM_fd, 0);
     if(pinfo == MAP_FAILED)
     {
-        close(SM_fd);
-        perror("Error mmapping the file");
-        exit(0);
+        PRINT_ERROR("mmap(%s) failed: %s",
+                    SM_fname, strerror(errno));
+        pinfo = NULL;
+        goto fail;
     }
 
     DEBUG_TRACEPOINT("created processinfo entry at %s\n", SM_fname);
@@ -130,7 +133,7 @@ PROCESSINFO *processinfo_shm_create(
 
     pinfolist->active[pindex] = 1;
 
-    int tmuxnamestrlen = 100;
+    enum { tmuxnamestrlen = 100 };
     char  tmuxname[tmuxnamestrlen];
     FILE *fpout;
     int   notmux = 0;
@@ -243,5 +246,17 @@ PROCESSINFO *processinfo_shm_create(
 
     DEBUG_TRACE_FEXIT();
 
+    if (SM_fd != -1)
+    {
+        close(SM_fd);
+    }
     return pinfo;
+
+fail:
+    if (SM_fd != -1)
+    {
+        close(SM_fd);
+    }
+    DEBUG_TRACE_FEXIT();
+    return NULL;
 }

--- a/src/engine/libprocessinfo/processinfo_shm_list_create.c
+++ b/src/engine/libprocessinfo/processinfo_shm_list_create.c
@@ -9,82 +9,98 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <errno.h>
 
 #include "processinfo_internal.h"
 #include "processinfo.h"
 #include "processinfo_procdirname.h"
 #include "processinfo_shm_link.h"
+#include "processinfo_shm_list_create.h"
 
 #define FILEMODE 0666
 
 extern PROCESSINFOLIST *pinfolist;
 
 
-long processinfo_shm_list_create()
+/**
+ * @brief Create or attach to the processinfo list SHM and reserve a slot.
+ *
+ * If the list file does not exist, create it and zero its `active` flags.
+ * Otherwise, link to the existing file and find the first inactive slot.
+ *
+ * @param pindex_out  On success, receives the reserved slot index. Must
+ *                    not be NULL.
+ *
+ * @return RETURN_SUCCESS on success, RETURN_FAILURE on any error
+ *         (open/lseek/write/mmap failure, link failure, list full).
+ */
+errno_t processinfo_shm_list_create(long *pindex_out)
 {
-    char SM_fname[STRINGMAXLEN_FULLFILENAME];
-    long pindex = 0;
+    errno_t rv     = RETURN_FAILURE;
+    int     SM_fd  = -1;
+    long    pindex = 0;
 
+    if (pindex_out == NULL)
+    {
+        FUNC_RETURN_FAILURE("pindex_out is NULL");
+    }
+
+    char SM_fname[STRINGMAXLEN_FULLFILENAME];
     char procdname[STRINGMAXLEN_DIRNAME];
     processinfo_procdirname(procdname);
 
     WRITE_FULLFILENAME(SM_fname, "%s/processinfo.list.shm", procdname);
 
-    /*
-    * Check if a file exist using stat() function.
-    * return 1 if the file exist otherwise return 0.
-    */
+    /* Check whether the list file already exists. */
     struct stat buffer;
     int         exists = stat(SM_fname, &buffer);
 
-    if(exists == -1)
+    if (exists == -1)
     {
         printf("CREATING PROCESSINFO LIST\n");
 
-        size_t sharedsize = 0; // shared memory size in bytes
-        int    SM_fd;          // shared memory file descriptor
-
-        sharedsize = sizeof(PROCESSINFOLIST);
+        size_t sharedsize = sizeof(PROCESSINFOLIST);
         umask(0);
-        SM_fd = open(SM_fname, O_RDWR | O_CREAT | O_TRUNC, (mode_t) FILEMODE);
-        if(SM_fd == -1)
+        SM_fd = open(SM_fname,
+                     O_RDWR | O_CREAT | O_TRUNC,
+                     (mode_t) FILEMODE);
+        if (SM_fd == -1)
         {
-            perror("Error opening file for writing");
-            return -1;
+            PRINT_ERROR("open(%s) failed: %s",
+                        SM_fname, strerror(errno));
+            goto fail;
         }
 
-        int result;
-        result = lseek(SM_fd, sharedsize - 1, SEEK_SET);
-        if(result == -1)
+        if (lseek(SM_fd, sharedsize - 1, SEEK_SET) == -1)
         {
-            close(SM_fd);
-            fprintf(stderr, "Error calling lseek() to 'stretch' the file");
-            return -1;
+            PRINT_ERROR("lseek failed: %s", strerror(errno));
+            goto fail;
         }
 
-        result = write(SM_fd, "", 1);
-        if(result != 1)
+        if (write(SM_fd, "", 1) != 1)
         {
-            close(SM_fd);
-            perror("Error writing last byte of the file");
-            return -1;
+            PRINT_ERROR("write last byte failed: %s",
+                        strerror(errno));
+            goto fail;
         }
 
-        pinfolist = (PROCESSINFOLIST *) \
+        pinfolist = (PROCESSINFOLIST *)
                     mmap(0,
-                        sharedsize,
-                        PROT_READ | PROT_WRITE,
-                        MAP_SHARED,
-                        SM_fd,
-                        0);
-        if(pinfolist == MAP_FAILED)
+                         sharedsize,
+                         PROT_READ | PROT_WRITE,
+                         MAP_SHARED,
+                         SM_fd,
+                         0);
+        if (pinfolist == MAP_FAILED)
         {
-            close(SM_fd);
-            perror("Error mmapping the file");
-            return -1;
+            PRINT_ERROR("mmap(%s) failed: %s",
+                        SM_fname, strerror(errno));
+            pinfolist = NULL;
+            goto fail;
         }
 
-        for(pindex = 0; pindex < PROCESSINFOLISTSIZE; pindex++)
+        for (pindex = 0; pindex < PROCESSINFOLISTSIZE; pindex++)
         {
             pinfolist->active[pindex] = 0;
         }
@@ -93,29 +109,37 @@ long processinfo_shm_list_create()
     }
     else
     {
-        int SM_fd;
-        //struct stat file_stat;
+        int link_fd;
 
-        pinfolist = (PROCESSINFOLIST *) processinfo_shm_link(SM_fname, &SM_fd);
-        if(pinfolist == MAP_FAILED)
+        pinfolist = (PROCESSINFOLIST *)
+                    processinfo_shm_link(SM_fname, &link_fd);
+        if (pinfolist == MAP_FAILED)
         {
-            return -1;
+            FUNC_RETURN_FAILURE(
+                "processinfo_shm_link(%s) failed", SM_fname);
         }
 
-        while((pinfolist->active[pindex] != 0) &&
-                (pindex < PROCESSINFOLISTSIZE))
+        while ((pinfolist->active[pindex] != 0) &&
+               (pindex < PROCESSINFOLISTSIZE))
         {
             pindex++;
         }
 
-        if(pindex == PROCESSINFOLISTSIZE)
+        if (pindex == PROCESSINFOLISTSIZE)
         {
-            fprintf(stderr, "ERROR: pindex reaches max value\n");
-            return -1;
+            FUNC_RETURN_FAILURE(
+                "pindex reached max value (%d)",
+                PROCESSINFOLISTSIZE);
         }
     }
 
-    // printf("pindex = %ld\n", pindex);
+    *pindex_out = pindex;
+    rv = RETURN_SUCCESS;
 
-    return pindex;
+fail:
+    if (SM_fd != -1)
+    {
+        close(SM_fd);
+    }
+    return rv;
 }

--- a/src/engine/libprocessinfo/processinfo_shm_list_create.h
+++ b/src/engine/libprocessinfo/processinfo_shm_list_create.h
@@ -6,6 +6,6 @@
 #ifndef _PROCESSINFO_SHM_LIST_CREATE_H
 #define _PROCESSINFO_SHM_LIST_CREATE_H
 
-long processinfo_shm_list_create();
+errno_t processinfo_shm_list_create(long *pindex_out);
 
 #endif


### PR DESCRIPTION
## Summary

Implements PR 1 of the error-handling migration roadmap. Bundles
two correctness fixes in `src/engine/libprocessinfo/`:

- **Item #1** — `processinfo_shm_create` previously called
  `exit(0)` on four shared-memory failure paths (open / lseek /
  write / mmap), terminating the host process *while reporting
  success*. Now returns `NULL` via the canonical `goto fail;`
  cleanup pattern from `error-handling-practices.md` §9.
- **Item #3** — `processinfo_shm_list_create` previously
  returned `long pindex` *or* `-1`, conflating valid index with
  error sentinel. Signature changed to
  `errno_t f(long *pindex_out)` per the return-type discipline
  in `library-vs-application-error-handling.md` §2.

Both functions and their six direct callers updated.

## Changes

### libprocessinfo
- `processinfo_shm_create.c` — four `exit(0)` sites replaced
  with `PRINT_ERROR` + `goto fail;`. Function now returns
  `NULL` on failure; `SM_fd` is closed unconditionally
  (incidentally fixes a pre-existing fd leak on the success
  path). The local `tmuxname` VLA was converted to an enum-sized
  fixed array because C forbids `goto` jumping into VLA scope.
- `processinfo_shm_list_create.c/.h` — new signature
  `errno_t f(long *pindex_out)`. Five `return -1;` sites become
  `FUNC_RETURN_FAILURE` / `goto fail;` + `PRINT_ERROR`. Also
  fixes the same fd leak via the `goto fail;` pattern.

### Caller updates (6 sites)
- `processinfo_shm_create` callers — propagate the NULL:
  - `processinfo_setup.c:75` returns NULL on failure to avoid
    dereferencing NULL on the next line (would have segfaulted
    instead of silent-killing, but still bad).
  - `CLIcore_script_cmd_builtins.c:580, 833` —
    `PRINT_WARNING` and continue (best-effort process tracking;
    the `if (procinfo != NULL)` checks downstream already
    handle a missing handle).
- `processinfo_shm_list_create` callers — use new out-param:
  - `milk-procCTRL-scan.c:247` (already checked == -1)
  - `procCTRL_TUI.c:244` (already checked == -1)
  - `processinfo_shm_create.c:61` (was silent; now fails fast)

### Logging
The four `perror`/`fprintf` calls inside the rewritten functions
became `PRINT_ERROR` per the migration policy in
`error-handling-practices.md` §5 (\"refactor logging in functions
you are already touching\"). The broader `perror`/`fprintf`
sweeps remain scoped to PR 5 / PR 6 of the roadmap.

## Verification

- [x] `cmake --build` — clean (0 warnings introduced)
- [x] `ctest --output-on-failure` — 38/38 pass
- [ ] Manual smoke test of FPS lifecycle (deferred to reviewer
      since it requires a running system)

## Prompt Summary

Approved migration roadmap (rules-only PR #329 introduced the
contract). User asked to start the multi-PR migration; this is
PR 1 of 6 — the highest-value bug fix bundled with the related
sentinel-collision fix because both live in the same module.

## AI Authorship

- **Model**: Claude Sonnet 4.6 (1M context)
- **User edits**: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)