### PR TITLE
refactor: make EXECUTE_SYSTEM_COMMAND default-checked

### DIFF
--- a/.agents/rules/error-handling-practices.md
+++ b/.agents/rules/error-handling-practices.md
@@ -71,13 +71,13 @@ display).
   your desired format string) to ensure the error log
   retains the required file/line/function context.
 - **Execution:** When executing shell commands via
-  `system()`, do not check the return code manually.
-  Instead, use `EXECUTE_SYSTEM_COMMAND_ERRCHECK(format,
-  ...)` which wraps the execution and error logging
-  automatically. (The bare `EXECUTE_SYSTEM_COMMAND`
-  macro silently discards the return value and is
-  treated as deprecated — see
-  `library-vs-application-error-handling.md` §3.)
+  `system()`, use `EXECUTE_SYSTEM_COMMAND(format, ...)`
+  which wraps the call, checks the exit status, and
+  logs failures via `PRINT_ERROR`. The opt-in
+  `EXECUTE_SYSTEM_COMMAND_NOCHECK` variant silently
+  discards the return value and must only be used when
+  ignoring the exit status is justified by a comment
+  (see `library-vs-application-error-handling.md` §3).
 
 ## 5. Transition Strategy
 

--- a/.agents/rules/library-vs-application-error-handling.md
+++ b/.agents/rules/library-vs-application-error-handling.md
@@ -90,23 +90,21 @@ that return them must still be declared `errno_t`,
 and the codes must satisfy
 `code >= IMAGESTREAMIO_FAILURE`.
 
-## 3. `EXECUTE_SYSTEM_COMMAND` — Intended Default
+## 3. `EXECUTE_SYSTEM_COMMAND` — Default Is Checked
 
-- **Today:** `EXECUTE_SYSTEM_COMMAND` is silent — its
-  expansion casts the `system()` return to `(void)`.
-  `EXECUTE_SYSTEM_COMMAND_ERRCHECK` is the safe
-  variant. Adoption is inverted: ~82 silent callers
-  vs. ~4 checked.
-- **Rule for new code:** always use
-  `EXECUTE_SYSTEM_COMMAND_ERRCHECK`.
-- **Documented intent (not yet implemented):** a
-  future macro change will swap the names —
-  `EXECUTE_SYSTEM_COMMAND` will become the checked
-  variant; the silent path will be renamed
-  `EXECUTE_SYSTEM_COMMAND_NOCHECK` and require an
-  explanatory comment per call site. Until that
-  lands, treat the bare `EXECUTE_SYSTEM_COMMAND` as
-  deprecated.
+- `EXECUTE_SYSTEM_COMMAND(format, ...)` checks the
+  `system()` return and logs failures via
+  `PRINT_ERROR`. Use this by default.
+- `EXECUTE_SYSTEM_COMMAND_NOCHECK(format, ...)` is the
+  opt-in silent variant. Use it only when the exit
+  status genuinely doesn't matter (e.g. a `tmux
+  kill-session` whose absence is expected) and document
+  the reason in a one-line comment above the call.
+- New code reaches for the checked default. Existing
+  `_NOCHECK` call sites should be audited
+  opportunistically: convert to the checked default if
+  failure is meaningful, leave the `_NOCHECK` form with
+  a justifying comment otherwise.
 
 ## 4. Standalone CLI Exit Codes
 

--- a/plugins/milk-extra-src/fft/wisdom.c
+++ b/plugins/milk-extra-src/fft/wisdom.c
@@ -119,7 +119,7 @@ errno_t export_wisdom()
     char  wisdom_file_single[STRINGMAXLEN_FULLFILENAME];
     char  wisdom_file_double[STRINGMAXLEN_FULLFILENAME];
 
-    EXECUTE_SYSTEM_COMMAND("mkdir -p %s", FFTCONFIGDIR);
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("mkdir -p %s", FFTCONFIGDIR);
 
 #ifdef FFTWMT
     WRITE_FULLFILENAME(wisdom_file_single,

--- a/plugins/milk-extra-src/image_basic/image_basic_utils.c
+++ b/plugins/milk-extra-src/image_basic/image_basic_utils.c
@@ -205,7 +205,7 @@ long load_fitsimages(
     char fname1[STRINGMAXLEN_FILENAME];
     FILE *fp;
 
-	EXECUTE_SYSTEM_COMMAND("ls %s.fits > flist.tmp\n", strfilter);
+	EXECUTE_SYSTEM_COMMAND_NOCHECK("ls %s.fits > flist.tmp\n", strfilter);
 
 
     if((fp = fopen("flist.tmp", "r")) == NULL)
@@ -228,7 +228,7 @@ long load_fitsimages(
 
     fclose(fp);
 
-    EXECUTE_SYSTEM_COMMAND("rm flist.tmp");
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("rm flist.tmp");
 
     printf("%ld images loaded\n", cnt);
 
@@ -442,7 +442,7 @@ long basic_addimagesfiles(
     imageID ID;
     int init = 0; // becomes 1 when first image encountered
 
-	EXECUTE_SYSTEM_COMMAND("ls %s.fits > flist.tmp\n", strfilter);
+	EXECUTE_SYSTEM_COMMAND_NOCHECK("ls %s.fits > flist.tmp\n", strfilter);
 
 
     if((fp = fopen("flist.tmp", "r")) == NULL)
@@ -474,7 +474,7 @@ long basic_addimagesfiles(
 
     fclose(fp);
 
-    EXECUTE_SYSTEM_COMMAND("rm flist.tmp");
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("rm flist.tmp");
 
     printf("%ld images coadded (stored in variable imcnt) -> %s\n", cnt, outname);
     create_variable_ID("imcnt", 1.0 * cnt);

--- a/plugins/milk-extra-src/image_basic/loadfitsimgcube.c
+++ b/plugins/milk-extra-src/image_basic/loadfitsimgcube.c
@@ -112,7 +112,7 @@ long load_fitsimages_cube(
 
     printf("Filter = %s\n", strfilter);
 
-    EXECUTE_SYSTEM_COMMAND(
+    EXECUTE_SYSTEM_COMMAND_NOCHECK(
         "ls %s > flist.tmp\n", strfilter);
 
     xsize = 0;

--- a/plugins/milk-extra-src/image_format/CR2toFITS.c
+++ b/plugins/milk-extra-src/image_format/CR2toFITS.c
@@ -121,7 +121,7 @@ imageID CR2toFITS(const char *__restrict fnameCR2,
     long    xsize, ysize;
     long    ii;
 
-    EXECUTE_SYSTEM_COMMAND("dcraw -t 0 -D -4 -c %s > _tmppgm.pgm", fnameCR2);
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("dcraw -t 0 -D -4 -c %s > _tmppgm.pgm", fnameCR2);
 
     ID = read_PGMimage("_tmppgm.pgm", "tmpfits1");
     if(system("rm _tmppgm.pgm") != 0)
@@ -131,7 +131,7 @@ imageID CR2toFITS(const char *__restrict fnameCR2,
 
     if(CR2toFITS_NORM == 1)
     {
-        EXECUTE_SYSTEM_COMMAND(
+        EXECUTE_SYSTEM_COMMAND_NOCHECK(
             "dcraw -i -v %s | grep \"ISO speed\"| awk '{print $3}' > "
             "iso_tmp.txt",
             fnameCR2);
@@ -153,7 +153,7 @@ imageID CR2toFITS(const char *__restrict fnameCR2,
 
         printf("iso = %f\n", iso);
 
-        EXECUTE_SYSTEM_COMMAND(
+        EXECUTE_SYSTEM_COMMAND_NOCHECK(
             "dcraw -i -v %s | grep \"Shutter\"| awk '{print $2}' > "
             "shutter_tmp.txt",
             fnameCR2);
@@ -175,7 +175,7 @@ imageID CR2toFITS(const char *__restrict fnameCR2,
         }
         printf("shutter = %f\n", shutter);
 
-        EXECUTE_SYSTEM_COMMAND(
+        EXECUTE_SYSTEM_COMMAND_NOCHECK(
             "dcraw -i -v %s | grep \"Aperture\"| awk '{print $2}' > "
             "aperture_tmp.txt",
             fnameCR2);

--- a/plugins/milk-extra-src/image_format/CR2tomov.c
+++ b/plugins/milk-extra-src/image_format/CR2tomov.c
@@ -247,7 +247,7 @@ errno_t CR2tomov()
         load_fits("badpix.fits", "badpix", 1, NULL);
         load_fits("flat.fits", "flat", 1, NULL);
 
-        EXECUTE_SYSTEM_COMMAND("ls ./CR2/*.CR2 > flist.tmp");
+        EXECUTE_SYSTEM_COMMAND_NOCHECK("ls ./CR2/*.CR2 > flist.tmp");
 
         if((fp = fopen("flist.tmp", "r")) == NULL)
         {
@@ -931,11 +931,11 @@ errno_t CR2tomov()
                         delete_image_ID("imb", DELETE_IMAGE_ERRMODE_WARNING);
                         //		  WRITE_FULLFILENAME(fnamejpg,"./JPEG/im%05ld.jpg",i);
 
-                        EXECUTE_SYSTEM_COMMAND(
+                        EXECUTE_SYSTEM_COMMAND_NOCHECK(
                             "bmptoppm imrgb.bmp | ppmtojpeg --quality 95 > "
                             "_tmpjpeg.jpg; mv _tmpjpeg.jpg %s",
                             fnamejpg);
-                        EXECUTE_SYSTEM_COMMAND("rm imrgb.bmp");
+                        EXECUTE_SYSTEM_COMMAND_NOCHECK("rm imrgb.bmp");
                     }
                     SKIPcnt_FITStoJPEG++;
                     if(SKIPcnt_FITStoJPEG > SKIP_FITStoJPEG - 1)

--- a/plugins/milk-extra-src/image_format/image_format.c
+++ b/plugins/milk-extra-src/image_format/image_format.c
@@ -296,7 +296,7 @@ imageID loadCR2(
 {
     imageID ID;
 
-    EXECUTE_SYSTEM_COMMAND("dcraw -t 0 -D -4 -c %s > _tmppgm.pgm", fnameCR2);
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("dcraw -t 0 -D -4 -c %s > _tmppgm.pgm", fnameCR2);
 
     ID = read_PGMimage("_tmppgm.pgm", IDname);
     if(system("rm _tmppgm.pgm") != 0)
@@ -322,7 +322,7 @@ long CR2toFITS_strfilter(
     char fname1[STRINGMAXLEN_FULLFILENAME];
     FILE *fp;
 
-    EXECUTE_SYSTEM_COMMAND("ls %s.CR2 > flist.tmp\n", strfilter);
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("ls %s.CR2 > flist.tmp\n", strfilter);
 
     fp = fopen("flist.tmp", "r");
     while(fgets(fname, STRINGMAXLEN_FULLFILENAME, fp) != NULL)
@@ -350,7 +350,7 @@ long CR2toFITS_strfilter(
 
     fclose(fp);
 
-    EXECUTE_SYSTEM_COMMAND("rm flist.tmp");
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("rm flist.tmp");
 
     printf("%ld files converted\n", cnt);
 

--- a/plugins/milk-extra-src/image_format/loadCR2toFITSRGB.c
+++ b/plugins/milk-extra-src/image_format/loadCR2toFITSRGB.c
@@ -117,7 +117,7 @@ errno_t loadCR2toFITSRGB(const char *__restrict fnameCR2,
                          const char *__restrict fnameFITSg,
                          const char *__restrict fnameFITSb)
 {
-    EXECUTE_SYSTEM_COMMAND("dcraw -t 0 -D -4 -c %s > _tmppgm.pgm", fnameCR2);
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("dcraw -t 0 -D -4 -c %s > _tmppgm.pgm", fnameCR2);
 
     read_PGMimage("_tmppgm.pgm", "tmpfits1");
     //  r = system("rm _tmppgm.pgm");
@@ -131,7 +131,7 @@ errno_t loadCR2toFITSRGB(const char *__restrict fnameCR2,
         //imageID ID;
         //long xsize,ysize;
 
-        EXECUTE_SYSTEM_COMMAND(
+        EXECUTE_SYSTEM_COMMAND_NOCHECK(
             "dcraw -i -v %s | grep \"ISO speed\"| awk '{print $3}' > "
             "iso_tmp.txt",
             fnameCR2);
@@ -152,7 +152,7 @@ errno_t loadCR2toFITSRGB(const char *__restrict fnameCR2,
         }
         printf("iso = %f\n", iso);
 
-        EXECUTE_SYSTEM_COMMAND(
+        EXECUTE_SYSTEM_COMMAND_NOCHECK(
             "dcraw -i -v %s | grep \"Shutter\"| awk '{print $2}' > "
             "shutter_tmp.txt",
             fnameCR2);
@@ -174,7 +174,7 @@ errno_t loadCR2toFITSRGB(const char *__restrict fnameCR2,
         }
         printf("shutter = %f\n", shutter);
 
-        EXECUTE_SYSTEM_COMMAND(
+        EXECUTE_SYSTEM_COMMAND_NOCHECK(
             "dcraw -i -v %s | grep \"Aperture\"| awk '{print $2}' > "
             "aperture_tmp.txt",
             fnameCR2);

--- a/src/cli/CLIcore/CLIcore.c
+++ b/src/cli/CLIcore/CLIcore.c
@@ -155,7 +155,7 @@ errno_t exitCLI()
 
     if(Listimfile == 1)
     {
-        EXECUTE_SYSTEM_COMMAND("rm imlist.txt");
+        EXECUTE_SYSTEM_COMMAND_NOCHECK("rm imlist.txt");
     }
 
     if(dcquiet == 0)
@@ -374,7 +374,7 @@ errno_t CLI_startup()
     {
         printf("        CLI PID = %d\n", (int) CLIPID);
 
-        EXECUTE_SYSTEM_COMMAND(
+        EXECUTE_SYSTEM_COMMAND_NOCHECK(
             "echo -n \"        \"; cat /proc/%d/status | grep "
             "Cpus_allowed_list",
             CLIPID);
@@ -878,11 +878,11 @@ errno_t runCLI(int argc, char *argv[], char *promptstring)
             }
             else if(data.fifoON == 1)
             {
-                EXECUTE_SYSTEM_COMMAND("file %s",
+                EXECUTE_SYSTEM_COMMAND_NOCHECK("file %s",
                                        CLIstartupfilename); //TEST
-                EXECUTE_SYSTEM_COMMAND("cat %s",
+                EXECUTE_SYSTEM_COMMAND_NOCHECK("cat %s",
                                        CLIstartupfilename); //TEST
-                EXECUTE_SYSTEM_COMMAND("cat %s > %s 2> /dev/null",
+                EXECUTE_SYSTEM_COMMAND_NOCHECK("cat %s > %s 2> /dev/null",
                                        CLIstartupfilename,
                                        data.fifoname);
 

--- a/src/cli/libmilkscript/CLIcore_UI_execute.c
+++ b/src/cli/libmilkscript/CLIcore_UI_execute.c
@@ -427,7 +427,7 @@ errno_t CLI_execute_line()
             if(fp == NULL)
             {
                 printf("ERROR: cannot log into file %s\n", data.CLIlogname);
-                EXECUTE_SYSTEM_COMMAND("mkdir -p %s/logdir/%04d%02d%02d\n",
+                EXECUTE_SYSTEM_COMMAND_NOCHECK("mkdir -p %s/logdir/%04d%02d%02d\n",
                                        getenv("HOME"),
                                        1900 + uttime->tm_year,
                                        1 + uttime->tm_mon,

--- a/src/cli/libmilkscript/CLIcore_help_command.c
+++ b/src/cli/libmilkscript/CLIcore_help_command.c
@@ -657,7 +657,7 @@ errno_t help()
 errno_t helpreadline()
 {
 
-    EXECUTE_SYSTEM_COMMAND(
+    EXECUTE_SYSTEM_COMMAND_NOCHECK(
         "more %s/src/CommandLineInterface/doc/helpreadline.md",
         dcsourcedir);
 

--- a/src/cli/streamCTRL/streamCTRL_TUI_input.c
+++ b/src/cli/streamCTRL/streamCTRL_TUI_input.c
@@ -225,7 +225,7 @@ errno_t streamCTRL_keyinput_process(
 
     case 'F': // set stream name filter string
         // TUI_exit();
-        EXECUTE_SYSTEM_COMMAND("clear");
+        EXECUTE_SYSTEM_COMMAND_NOCHECK("clear");
         printf("Enter string: ");
         fflush(stdout);
         stringindex = 0;

--- a/src/cli/streamCTRL/streamCTRL_defs.h
+++ b/src/cli/streamCTRL/streamCTRL_defs.h
@@ -9,7 +9,7 @@
  *   - SHAREDSHMDIR  — from $MILK_SHM_DIR env var or /dev/shm fallback
  *   - PRINT_ERROR   — thin stderr wrapper
  *   - DEBUG_TRACEPOINT — no-op (or stderr if VERBOSE defined)
- *   - EXECUTE_SYSTEM_COMMAND — inline system() wrapper
+ *   - EXECUTE_SYSTEM_COMMAND_NOCHECK — inline system() wrapper
  *   - WRITE_FULLFILENAME — inline snprintf wrapper
  *   - errno_t / imageID types if not already defined
  */
@@ -160,12 +160,12 @@ static inline const char *streamctrl_get_shmdir(void)
  * ========================================================= */
 
 /**
- * EXECUTE_SYSTEM_COMMAND - build and run a shell command.
+ * EXECUTE_SYSTEM_COMMAND_NOCHECK - build and run a shell command.
  *
  * Formats the command with snprintf, then passes it to system().
  * On failure, prints a warning but does not abort.
  */
-#define EXECUTE_SYSTEM_COMMAND(fmt, ...) \
+#define EXECUTE_SYSTEM_COMMAND_NOCHECK(fmt, ...) \
     do { \
         char _escmd_buf[STRINGMAXLEN_COMMAND]; \
         int  _escmd_n = snprintf(_escmd_buf, sizeof(_escmd_buf), \

--- a/src/cli/streamCTRL/streamCTRL_scan.c
+++ b/src/cli/streamCTRL/streamCTRL_scan.c
@@ -48,8 +48,8 @@ void *streamCTRL_scan(
 
     while(streaminfoproc->loop == 1)
     {
-        //EXECUTE_SYSTEM_COMMAND("echo \" \" >> IDlog.txt");
-        //EXECUTE_SYSTEM_COMMAND("echo \"[%ld] loopSTART\" >> IDlog.txt", scaniter);
+        //EXECUTE_SYSTEM_COMMAND_NOCHECK("echo \" \" >> IDlog.txt");
+        //EXECUTE_SYSTEM_COMMAND_NOCHECK("echo \"[%ld] loopSTART\" >> IDlog.txt", scaniter);
 
         long NBsindex = 0;
 
@@ -89,7 +89,7 @@ void *streamCTRL_scan(
          * "connecting" until the loop below sets them. */
         streaminfoproc->NBstream = NBsindex;
 
-        //EXECUTE_SYSTEM_COMMAND("echo \"NBsindex = %ld\" >> IDlog.txt", NBsindex);
+        //EXECUTE_SYSTEM_COMMAND_NOCHECK("echo \"NBsindex = %ld\" >> IDlog.txt", NBsindex);
 
         // write stream list to file if applicable
         // ususally used for debugging only
@@ -144,7 +144,7 @@ void *streamCTRL_scan(
             // Check if already in memory
             //
             ID = image_ID_from_images(images, streaminfo[sindex].sname);
-            /*EXECUTE_SYSTEM_COMMAND("echo \"  %ld %s : ID = %ld\" >> IDlog.txt",
+            /*EXECUTE_SYSTEM_COMMAND_NOCHECK("echo \"  %ld %s : ID = %ld\" >> IDlog.txt",
                                    sindex,
                                    streaminfo[sindex].sname,
                                    ID);*/
@@ -176,7 +176,7 @@ void *streamCTRL_scan(
                     {
                         return NULL;
                     }
-                    /*EXECUTE_SYSTEM_COMMAND("echo \"  %ld get ID = %ld\" >> IDlog.txt",
+                    /*EXECUTE_SYSTEM_COMMAND_NOCHECK("echo \"  %ld get ID = %ld\" >> IDlog.txt",
                                            sindex, ID);*/
 
 
@@ -214,7 +214,7 @@ void *streamCTRL_scan(
 
                 if(streaminfo[sindex].ISIOretval == IMAGESTREAMIO_SUCCESS)
                 {
-                    /*EXECUTE_SYSTEM_COMMAND("echo \"  %ld  ISIO OK\" >> IDlog.txt",
+                    /*EXECUTE_SYSTEM_COMMAND_NOCHECK("echo \"  %ld  ISIO OK\" >> IDlog.txt",
                                            sindex);*/
 
                     float gainv = 1.0;
@@ -234,7 +234,7 @@ void *streamCTRL_scan(
                 }
                 /*else
                 {
-                    EXECUTE_SYSTEM_COMMAND("echo \"  %ld  ISIO NOTOK\" >> IDlog.txt",
+                    EXECUTE_SYSTEM_COMMAND_NOCHECK("echo \"  %ld  ISIO NOTOK\" >> IDlog.txt",
                                            sindex);
                 }*/
             }
@@ -455,7 +455,7 @@ void *streamCTRL_scan(
         streaminfoproc->NBstream = NBsindex;
         streaminfoproc->loopcnt++;
 
-        //EXECUTE_SYSTEM_COMMAND("echo \"[%ld] loopEND\" >> IDlog.txt", scaniter);
+        //EXECUTE_SYSTEM_COMMAND_NOCHECK("echo \"[%ld] loopEND\" >> IDlog.txt", scaniter);
         scaniter++;
 
 

--- a/src/coremods/COREMOD_iofits/is_fits_file.c
+++ b/src/coremods/COREMOD_iofits/is_fits_file.c
@@ -44,7 +44,7 @@ int is_fits_file(const char *restrict file_name)
     {
         fitsfile *fptr;
 
-        EXECUTE_SYSTEM_COMMAND("touch fitscheck.%s", file_name);
+        EXECUTE_SYSTEM_COMMAND_NOCHECK("touch fitscheck.%s", file_name);
 
         if(!fits_open_file(&fptr,
                            file_name,

--- a/src/coremods/COREMOD_memory/delete_image.c
+++ b/src/coremods/COREMOD_memory/delete_image.c
@@ -250,7 +250,7 @@ errno_t delete_image(
 
             if(dcrmshm == 1)
             {
-                EXECUTE_SYSTEM_COMMAND(
+                EXECUTE_SYSTEM_COMMAND_NOCHECK(
                     "rm /dev/shm/sem.%s.%s_sem*",
                     dcshmsemdir,
                     img->name);
@@ -261,7 +261,7 @@ errno_t delete_image(
                     img->name);
                 remove(fname);
 
-                EXECUTE_SYSTEM_COMMAND(
+                EXECUTE_SYSTEM_COMMAND_NOCHECK(
                     "rm %s/%s.im.shm",
                     dcshmdir, img->name);
             }

--- a/src/coremods/COREMOD_memory/saveall.c
+++ b/src/coremods/COREMOD_memory/saveall.c
@@ -243,7 +243,7 @@ errno_t COREMOD_MEMORY_SaveAll_snapshot(
         }
     }
 
-    EXECUTE_SYSTEM_COMMAND(
+    EXECUTE_SYSTEM_COMMAND_NOCHECK(
         "mkdir -p %s", dirname);
 
     for(i = 0; i < imcnt; i++)
@@ -327,7 +327,7 @@ errno_t COREMOD_MEMORY_SaveAll_sequ(
         (uint32_t *) malloc(
             sizeof(uint32_t) * imcnt);
 
-    EXECUTE_SYSTEM_COMMAND(
+    EXECUTE_SYSTEM_COMMAND_NOCHECK(
         "mkdir -p %s", dirname);
 
     {

--- a/src/coremods/COREMOD_tools/mvprocCPUset.c
+++ b/src/coremods/COREMOD_tools/mvprocCPUset.c
@@ -386,7 +386,7 @@ int COREMOD_TOOLS_mvProcRTPrio(const int rtprio)
              rtprio, getpid());
     printf("Executing command: %s\n", command);
 
-    EXECUTE_SYSTEM_COMMAND_ERRCHECK("%s", command);
+    EXECUTE_SYSTEM_COMMAND("%s", command);
 
     if(setresuid(dcruid, dcruid, dceuid) !=
             0) // Go back to normal privileges
@@ -434,7 +434,7 @@ int COREMOD_TOOLS_mvProcTsetExt(const int pid, const char *tsetspec)
              tsetspec, pid);
     printf("Executing command: %s\n", command);
 
-    EXECUTE_SYSTEM_COMMAND_ERRCHECK("%s", command);
+    EXECUTE_SYSTEM_COMMAND("%s", command);
 
     if(setresuid(dcruid, dcruid, dceuid) !=
             0) // Go back to normal privileges
@@ -489,7 +489,7 @@ int COREMOD_TOOLS_mvProcCPUsetExt(const int   pid,
     else
     {
         // Command does exist
-        EXECUTE_SYSTEM_COMMAND("%s", command);
+        EXECUTE_SYSTEM_COMMAND_NOCHECK("%s", command);
         if(dcretval != 0)
         {
             if(dcretval == 512)
@@ -514,7 +514,7 @@ int COREMOD_TOOLS_mvProcCPUsetExt(const int   pid,
                  rtprio, pid);
         printf("Executing command: %s\n", command);
 
-        EXECUTE_SYSTEM_COMMAND_ERRCHECK("%s", command);
+        EXECUTE_SYSTEM_COMMAND("%s", command);
     }
 
     if(setresuid(dcruid, dcruid, dceuid) !=

--- a/src/engine/libfps/fpsCTRL/fpsCTRL_TUI_process_user_key.c
+++ b/src/engine/libfps/fpsCTRL/fpsCTRL_TUI_process_user_key.c
@@ -738,8 +738,8 @@ int fpsCTRL_TUI_process_user_key(
                 else
                     snprintf(progexec, 1024, "%s-exec", selected_fps->md->callprogname);
                 
-                EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:run \" cd %s\" C-m", selected_fps->md->name, selected_fps->md->workdir);
-                EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:run \" %s %s:runstart\" C-m", selected_fps->md->name, progexec, selected_fps->md->name);
+                EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:run \" cd %s\" C-m", selected_fps->md->name, selected_fps->md->workdir);
+                EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:run \" %s %s:runstart\" C-m", selected_fps->md->name, progexec, selected_fps->md->name);
             }
             break;
 
@@ -772,8 +772,8 @@ int fpsCTRL_TUI_process_user_key(
                 else
                     snprintf(progexec, 1024, "%s-exec", selected_fps->md->callprogname);
                 
-                EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:conf \" cd %s\" C-m", selected_fps->md->name, selected_fps->md->workdir);
-                EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:conf \" %s %s:confstart\" C-m", selected_fps->md->name, progexec, selected_fps->md->name);
+                EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:conf \" cd %s\" C-m", selected_fps->md->name, selected_fps->md->workdir);
+                EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:conf \" %s %s:confstart\" C-m", selected_fps->md->name, progexec, selected_fps->md->name);
             }
             break;
 

--- a/src/engine/libfps/fps_CONFstart.c
+++ b/src/engine/libfps/fps_CONFstart.c
@@ -19,17 +19,17 @@ errno_t functionparameter_CONFstart(FPS *fps)
 {
     // Move to correct launch directory
     //
-    EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:conf \" cd %s\" C-m",
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:conf \" cd %s\" C-m",
                            fps->md->name,
                            fps->md->workdir);
 
     if (strstr(fps->md->execfullpath, "fpsexec") != NULL) {
-        EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:conf \" %s %s:confstart\" C-m",
+        EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:conf \" %s %s:confstart\" C-m",
                                fps->md->name,
                                fps->md->execfullpath,
                                fps->md->name);
     } else {
-        EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:conf \" fpsconfstart\" C-m",
+        EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:conf \" fpsconfstart\" C-m",
                                fps->md->name);
     }
 

--- a/src/engine/libfps/fps_FPSremove.c
+++ b/src/engine/libfps/fps_FPSremove.c
@@ -24,7 +24,7 @@ errno_t functionparameter_FPSremove(FPS *fps)
     WRITE_FULLFILENAME(fpsfname, "%s/%s.fps.shm", shmdname, fps->md->name);
 
     // delete sym links
-    EXECUTE_SYSTEM_COMMAND(
+    EXECUTE_SYSTEM_COMMAND_NOCHECK(
         "find %s -follow -type f -name \"fpslog.*%s\" -exec grep -q \"LOGSTART "
         "%s\" {} \\; -delete",
         shmdname,
@@ -84,29 +84,29 @@ errno_t functionparameter_FPSremove(FPS *fps)
                  fps->md->name);
         if (system(chkcmd) == 0)
         {
-            EXECUTE_SYSTEM_COMMAND(
+            EXECUTE_SYSTEM_COMMAND_NOCHECK(
                 "tmux send-keys -t %s:ctrl"
                 " \" exit\" C-m",
                 fps->md->name);
-            EXECUTE_SYSTEM_COMMAND(
+            EXECUTE_SYSTEM_COMMAND_NOCHECK(
                 "tmux send-keys -t %s:ctrl"
                 " \" exit\" C-m",
                 fps->md->name);
 
-            EXECUTE_SYSTEM_COMMAND(
+            EXECUTE_SYSTEM_COMMAND_NOCHECK(
                 "tmux send-keys -t %s:conf"
                 " \" exit\" C-m",
                 fps->md->name);
-            EXECUTE_SYSTEM_COMMAND(
+            EXECUTE_SYSTEM_COMMAND_NOCHECK(
                 "tmux send-keys -t %s:conf"
                 " \" exit\" C-m",
                 fps->md->name);
 
-            EXECUTE_SYSTEM_COMMAND(
+            EXECUTE_SYSTEM_COMMAND_NOCHECK(
                 "tmux send-keys -t %s:run"
                 " \" exit\" C-m",
                 fps->md->name);
-            EXECUTE_SYSTEM_COMMAND(
+            EXECUTE_SYSTEM_COMMAND_NOCHECK(
                 "tmux send-keys -t %s:run"
                 " \" exit\" C-m",
                 fps->md->name);

--- a/src/engine/libfps/fps_GetFileName.c
+++ b/src/engine/libfps/fps_GetFileName.c
@@ -24,7 +24,7 @@ int functionparameter_GetFileName(
     //char fpsdatadirname[STRINGMAXLEN_DIRNAME];
 
     WRITE_DIRNAME(ffname, "%s/%s/fps/", fps->md->workdir, fps->md->datadir);
-    EXECUTE_SYSTEM_COMMAND("mkdir -p %s", ffname);
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("mkdir -p %s", ffname);
 
     // build up directory name
     for(l = 0; l < fparam->keywordlevel - 1; l++)

--- a/src/engine/libfps/fps_RUNstart.c
+++ b/src/engine/libfps/fps_RUNstart.c
@@ -27,7 +27,7 @@ errno_t functionparameter_RUNstart(
         long pindex;
 
         // Move to correct launch directory
-        EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:run \" cd %s\" C-m",
+        EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:run \" cd %s\" C-m",
                                fps->md->name,
                                fps->md->workdir);
 
@@ -36,7 +36,7 @@ errno_t functionparameter_RUNstart(
         pindex = functionparameter_GetParamIndex(fps, ".procinfo.cset");
         if(pindex > -1)
         {
-            EXECUTE_SYSTEM_COMMAND(
+            EXECUTE_SYSTEM_COMMAND_NOCHECK(
                 "tmux send-keys -t %s:run \" export "
                 "TCSETCMDPREFIX=\\\"csetpmove %s;\\\"\" C-m",
                 fps->md->name,
@@ -44,7 +44,7 @@ errno_t functionparameter_RUNstart(
         }
         else
         {
-            EXECUTE_SYSTEM_COMMAND(
+            EXECUTE_SYSTEM_COMMAND_NOCHECK(
                 "tmux send-keys -t %s:run \" export "
                 "TCSETCMDPREFIX=\"\"\" C-m",
                 fps->md->name);
@@ -55,7 +55,7 @@ errno_t functionparameter_RUNstart(
         pindex = functionparameter_GetParamIndex(fps, ".procinfo.taskset");
         if(pindex > -1)
         {
-            EXECUTE_SYSTEM_COMMAND(
+            EXECUTE_SYSTEM_COMMAND_NOCHECK(
                 "tmux send-keys -t %s:run \" export "
                 "TCSETCMDPREFIX=\\\"\\${TCSETCMDPREFIX} tsetpmove "
                 "\\\\\\\"%s\\\\\\\";\\\"\" C-m",
@@ -64,7 +64,7 @@ errno_t functionparameter_RUNstart(
         }
         else
         {
-            EXECUTE_SYSTEM_COMMAND(
+            EXECUTE_SYSTEM_COMMAND_NOCHECK(
                 "tmux send-keys -t %s:run \" export "
                 "TCSETCMDPREFIX=\"\"\" C-m",
                 fps->md->name);
@@ -78,7 +78,7 @@ errno_t functionparameter_RUNstart(
             long NBthread =
                 functionparameter_GetParamValue_INT64(fps,
                         ".procinfo.NBthread");
-            EXECUTE_SYSTEM_COMMAND(
+            EXECUTE_SYSTEM_COMMAND_NOCHECK(
                 "tmux send-keys -t %s:run \" export "
                 "OMP_NUM_THREADS=%ld\" C-m",
                 fps->md->name,
@@ -100,19 +100,19 @@ errno_t functionparameter_RUNstart(
         }
 
         // create output directory if it does not already exit
-        EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:run \" mkdir %s\" C-m",
+        EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:run \" mkdir %s\" C-m",
                                fps->md->name,
                                fps->md->datadir);
 
         // Send run command
         //
         if (strstr(fps->md->execfullpath, "fpsexec") != NULL) {
-            EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:run \" %s %s:runstart\" C-m",
+            EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:run \" %s %s:runstart\" C-m",
                                    fps->md->name,
                                    fps->md->execfullpath,
                                    fps->md->name);
         } else {
-            EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:run \" fpsrunstart\" C-m",
+            EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:run \" fpsrunstart\" C-m",
                                    fps->md->name);
         }
 

--- a/src/engine/libfps/fps_RUNstop.c
+++ b/src/engine/libfps/fps_RUNstop.c
@@ -15,22 +15,22 @@ errno_t functionparameter_RUNstop(FPS *fps)
 {
     // Move to correct launch directory
     //
-    EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:ctrl \" cd %s\" C-m",
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:ctrl \" cd %s\" C-m",
                            fps->md->name,
                            fps->md->workdir);
 
     if (strstr(fps->md->execfullpath, "fpsexec") != NULL) {
-        EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:ctrl \" %s %s:runstop\" C-m",
+        EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:ctrl \" %s %s:runstop\" C-m",
                                fps->md->name,
                                fps->md->execfullpath,
                                fps->md->name);
     } else {
-        EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:ctrl \" fpsrunstop\" C-m",
+        EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:ctrl \" fpsrunstop\" C-m",
                                fps->md->name);
     }
 
     // Send C-c in case runstop command is not implemented
-    EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:run C-c &> /dev/null",
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:run C-c &> /dev/null",
                            fps->md->name);
 
     fps->md->status &= ~FUNCTION_PARAMETER_STRUCT_STATUS_CMDRUN;

--- a/src/engine/libfps/fps_lifecycle.c
+++ b/src/engine/libfps/fps_lifecycle.c
@@ -572,7 +572,7 @@ int fps_generic_runstop(const char *fps_name)
      * 2. Clear the CMDRUN status flag
      * 3. Signal the GUI to update
      */
-    EXECUTE_SYSTEM_COMMAND(
+    EXECUTE_SYSTEM_COMMAND_NOCHECK(
         "tmux send-keys -t %s:run C-c"
         " 2>/dev/null",
         fps.md->name);

--- a/src/engine/libfps/fps_processcmdline_interactive.c
+++ b/src/engine/libfps/fps_processcmdline_interactive.c
@@ -803,12 +803,12 @@ int functionparameter_FPSprocess_cmdline(
                 DEBUG_TRACEPOINT(" ");
                 if(fps[fpsindex].parray[pindex].type == FPTYPE_EXECFILENAME)
                 {
-                    EXECUTE_SYSTEM_COMMAND(
+                    EXECUTE_SYSTEM_COMMAND_NOCHECK(
                         "tmux send-keys -t %s:run \"cd %s\" "
                         "C-m",
                         fps[fpsindex].md->name,
                         fps[fpsindex].md->workdir);
-                    EXECUTE_SYSTEM_COMMAND(
+                    EXECUTE_SYSTEM_COMMAND_NOCHECK(
                         "tmux send-keys -t %s:run \"%s %s\" "
                         "C-m",
                         fps[fpsindex].md->name,

--- a/src/engine/libfps/fps_tmux.c
+++ b/src/engine/libfps/fps_tmux.c
@@ -23,17 +23,17 @@ int functionparameter_FPS_tmux_kill(
     FPS *fps
 )
 {
-    EXECUTE_SYSTEM_COMMAND(
+    EXECUTE_SYSTEM_COMMAND_NOCHECK(
         "tmux send-keys -t %s:ctrl C-c 2>/dev/null",
         fps->md->name);
-    EXECUTE_SYSTEM_COMMAND(
+    EXECUTE_SYSTEM_COMMAND_NOCHECK(
         "tmux send-keys -t %s:conf C-c 2>/dev/null",
         fps->md->name);
-    EXECUTE_SYSTEM_COMMAND(
+    EXECUTE_SYSTEM_COMMAND_NOCHECK(
         "tmux send-keys -t %s:run C-c 2>/dev/null",
         fps->md->name);
 
-    EXECUTE_SYSTEM_COMMAND(
+    EXECUTE_SYSTEM_COMMAND_NOCHECK(
         "tmux kill-session -t %s 2>/dev/null",
         fps->md->name);
 
@@ -46,7 +46,7 @@ int functionparameter_FPS_tmux_attach(
 {
     // This should hang until the tmux is detached,
     // and then return to the current fpsCTRL window.
-    EXECUTE_SYSTEM_COMMAND("tmux attach -t %s", fps->md->name);
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux attach -t %s", fps->md->name);
     return RETURN_SUCCESS;
 }
 
@@ -68,7 +68,7 @@ int functionparameter_FPS_tmux_init(
     functionparameter_FPS_tmux_kill(fps);
 
     // Create session with all 3 windows atomically
-    EXECUTE_SYSTEM_COMMAND(
+    EXECUTE_SYSTEM_COMMAND_NOCHECK(
         "tmux new-session -s %s -d -n ctrl \\;"
         " new-window -n conf \\;"
         " new-window -n run \\;"
@@ -117,29 +117,29 @@ int functionparameter_FPS_tmux_init(
                  "%s", mloadstringcp);
     }
 
-    EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:ctrl \" bash\" C-m",
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:ctrl \" bash\" C-m",
                            fps->md->name); // This spins a bash-in-bash.
-    EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:ctrl \" cd %s\" C-m",
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:ctrl \" cd %s\" C-m",
                            fps->md->name, fps->md->workdir);
 
     // source rootdir fpstmuxenv first
-    EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:ctrl \" source ../fpstmuxenv\" C-m",
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:ctrl \" source ../fpstmuxenv\" C-m",
                            fps->md->name);
     // then local fpstmuxenv
-    EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:ctrl \" source fpstmuxenv\" C-m",
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:ctrl \" source fpstmuxenv\" C-m",
                            fps->md->name);
 
 
     // confstart
     //
-    EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:conf \" bash\" C-m",
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:conf \" bash\" C-m",
                            fps->md->name); // This spins a bash-in-bash.
-    EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:conf \" cd %s\" C-m",
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:conf \" cd %s\" C-m",
                            fps->md->name, fps->md->workdir);
 
-    EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:conf \" source ../fpstmuxenv\" C-m",
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:conf \" source ../fpstmuxenv\" C-m",
                            fps->md->name);
-    EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:conf \" source  fpstmuxenv\" C-m",
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:conf \" source  fpstmuxenv\" C-m",
                            fps->md->name);
 
 
@@ -165,19 +165,19 @@ int functionparameter_FPS_tmux_init(
              fps->md->callfuncname,
              argstring);
 
-    EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:conf \" %s\" C-m",
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:conf \" %s\" C-m",
                            fps->md->name,
                            functionstring);
 
     // runstart
     //
-    EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:run \" bash\" C-m",
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:run \" bash\" C-m",
                            fps->md->name); // This spins a bash-in-bash.
-    EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:run \" cd %s\" C-m",
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:run \" cd %s\" C-m",
                            fps->md->name, fps->md->workdir);
-    EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:run \" source ../fpstmuxenv\" C-m",
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:run \" source ../fpstmuxenv\" C-m",
                            fps->md->name);
-    EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:run \" source fpstmuxenv\" C-m",
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:run \" source fpstmuxenv\" C-m",
                            fps->md->name);
 
     snprintf(functionstring,
@@ -193,7 +193,7 @@ int functionparameter_FPS_tmux_init(
              fps->md->callfuncname,
              argstring);
 
-    EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:run \"%s\" C-m",
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:run \"%s\" C-m",
                            fps->md->name,
                            functionstring);
 
@@ -211,7 +211,7 @@ int functionparameter_FPS_tmux_init(
              fps->md->callfuncname,
              argstring);
 
-    EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:run \"%s\" C-m",
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:run \"%s\" C-m",
                            fps->md->name,
                            functionstring);
 
@@ -251,7 +251,7 @@ int functionparameter_FPS_tmux_standalone_setup(
         return RETURN_SUCCESS;
     }
 
-    EXECUTE_SYSTEM_COMMAND(
+    EXECUTE_SYSTEM_COMMAND_NOCHECK(
         "tmux new-session -s %s -d -n ctrl \\;"
         " new-window -n conf \\;"
         " new-window -n run \\;"
@@ -269,7 +269,7 @@ int functionparameter_FPS_tmux_send(
     const char *cmd_str
 )
 {
-    EXECUTE_SYSTEM_COMMAND("tmux send-keys -t %s:%s \"%s\" C-m", fps_name, window, cmd_str);
+    EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:%s \"%s\" C-m", fps_name, window, cmd_str);
     return RETURN_SUCCESS;
 }
 

--- a/src/engine/libfpsseq/fpsseq_cmdexec.c
+++ b/src/engine/libfpsseq/fpsseq_cmdexec.c
@@ -1048,12 +1048,12 @@ int milkseq_exec_cmd(
                 DEBUG_TRACEPOINT(" ");
                 if(fps[fpsindex].parray[pindex].type == FPTYPE_EXECFILENAME)
                 {
-                    EXECUTE_SYSTEM_COMMAND(
+                    EXECUTE_SYSTEM_COMMAND_NOCHECK(
                         "tmux send-keys -t %s:run \"cd %s\" "
                         "C-m",
                         fps[fpsindex].md->name,
                         fps[fpsindex].md->workdir);
-                    EXECUTE_SYSTEM_COMMAND(
+                    EXECUTE_SYSTEM_COMMAND_NOCHECK(
                         "tmux send-keys -t %s:run \"%s %s\" "
                         "C-m",
                         fps[fpsindex].md->name,

--- a/src/engine/libmilkcommon/milkDebugTools.h
+++ b/src/engine/libmilkcommon/milkDebugTools.h
@@ -133,7 +133,7 @@ typedef long variableID;
         } \
     } while (0)
 
-#define EXECUTE_SYSTEM_COMMAND(format, ...) \
+#define EXECUTE_SYSTEM_COMMAND_NOCHECK(format, ...) \
     do \
     {\
         char syscommandstring[STRINGMAXLEN_COMMAND]; \
@@ -142,7 +142,7 @@ typedef long variableID;
         (void)_ret; \
     } while (0)
 
-#define EXECUTE_SYSTEM_COMMAND_ERRCHECK(format, ...) \
+#define EXECUTE_SYSTEM_COMMAND(format, ...) \
     do \
     {\
         char syscommandstring[STRINGMAXLEN_COMMAND]; \


### PR DESCRIPTION
## Summary

Implements PR 2 of the error-handling migration roadmap. Swaps
the two system() wrapper macros in `milkDebugTools.h` so the
safe variant is the default name — matching the "intended
direction" documented in `library-vs-application-error-handling.md`
§3 (now realised, not future).

| Old | New |
|---|---|
| `EXECUTE_SYSTEM_COMMAND` (silent) | renamed to `EXECUTE_SYSTEM_COMMAND_NOCHECK` (opt-in) |
| `EXECUTE_SYSTEM_COMMAND_ERRCHECK` (checked) | renamed to `EXECUTE_SYSTEM_COMMAND` (default) |

Three mechanical sed passes (using a `_TMPCHK` intermediate to
avoid the `_ERRCHECK` superstring problem) updated all call
sites across 28 .c/.h files in `src/` and `plugins/`. The
ImageStreamIO submodule has zero uses of either macro and is
untouched.

## Behaviour change

**None.** Existing call sites preserve their exact current
behaviour: 101 previously-silent sites are now spelled
`EXECUTE_SYSTEM_COMMAND_NOCHECK` and continue to discard the
`system()` return; the 3 `_ERRCHECK` sites in
`mvprocCPUset.c` become bare `EXECUTE_SYSTEM_COMMAND` (now
equivalent to the old `_ERRCHECK`).

The change is **forward-looking**: any future call site written
as `EXECUTE_SYSTEM_COMMAND(...)` automatically gets the safe
checked default, instead of silently swallowing failures. The
101 `_NOCHECK` sites can be audited individually in follow-up
PRs (PR 4 — libfps exit() purge — naturally picks up the libfps
subset).

## Documentation

- `error-handling-practices.md` §4 — now points callers at the
  bare `EXECUTE_SYSTEM_COMMAND` and describes `_NOCHECK` as the
  opt-in escape hatch.
- `library-vs-application-error-handling.md` §3 — retitled
  "Default Is Checked"; replaces "future intent" wording with
  the current contract.

## Verification

- [x] `cmake --build` — clean, 0 warnings introduced
- [x] `ctest --output-on-failure` — 38/38 pass
- [x] Post-sweep grep confirms zero remaining `_ERRCHECK` /
      `_TMPCHK` stragglers; counts add up (102 `_NOCHECK`
      = 101 callers + macro def; 4 bare `EXECUTE_SYSTEM_COMMAND`
      = 3 callers + macro def).

## Prompt Summary

PR 2 of 6 from the approved migration roadmap. The aggressive
rename approach was confirmed in the earlier design Q&A: single
mechanical commit, forces per-site review on next touch through
the `_NOCHECK` marker.

## AI Authorship

- **Model**: Claude Sonnet 4.6 (1M context)
- **User edits**: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)