### PR TITLE
refactor: purge exit() from libfps

### DIFF
--- a/src/engine/libfps/fps_ID.c
+++ b/src/engine/libfps/fps_ID.c
@@ -73,10 +73,11 @@ long next_avail_fps_ID()
 
     if(ID == -1)
     {
-        printf("ERROR: ran out of FPS IDs - cannot allocate new ID\n");
-        printf("NB_FPS_MAX should be increased above current value (%d)\n",
-               NB_FPS_MAX);
-        exit(0);
+        PRINT_ERROR(
+            "ran out of FPS IDs - cannot allocate new ID; "
+            "NB_FPS_MAX should be increased above current "
+            "value (%d)",
+            NB_FPS_MAX);
     }
 
     return ID;

--- a/src/engine/libfps/fps_add_entry.c
+++ b/src/engine/libfps/fps_add_entry.c
@@ -102,12 +102,10 @@ errno_t function_parameter_add_entry(FPS *fps,
             }
             else
             {
-                printf("ERROR [%s line %d]: NBparamMAX %ld limit reached and realloc failed\n",
-                       __FILE__,
-                       __LINE__,
-                       NBparamMAX);
-                fflush(stdout);
-                exit(0);
+                FUNC_RETURN_FAILURE(
+                    "NBparamMAX %ld limit reached and "
+                    "realloc failed",
+                    NBparamMAX);
             }
         }
 

--- a/src/engine/libfps/fps_connect.c
+++ b/src/engine/libfps/fps_connect.c
@@ -7,6 +7,8 @@
 #include <sys/mman.h> // mmap
 #include <sys/stat.h> // fstat
 #include <unistd.h>   // for close
+#include <string.h>   // for strerror
+#include <errno.h>
 
 #include "fps.h"
 #include "fps_internal.h"
@@ -139,10 +141,9 @@ long fps_connect(
               0);
     if(fps->md == MAP_FAILED)
     {
+        PRINT_ERROR("mmap failed: %s", strerror(errno));
         close(SM_fd);
-        perror("Error mmapping the file");
-        fflush(stdout);
-        exit(EXIT_FAILURE);
+        return -1;
     }
 
     DEBUG_TRACEPOINT("File: %s - attempting connect\n", SM_fname);

--- a/src/engine/libfps/fps_loadstream.c
+++ b/src/engine/libfps/fps_loadstream.c
@@ -60,7 +60,7 @@ imageID functionparameter_LoadStream(
         printf("\033[1;31mFAILURE\033[0m:"
                " invalid stream modifier "
                "prefix in \"%s\"\n", rawname);
-        exit(EXIT_FAILURE);
+        return -1;
     }
     /* Apply location modifier to flags */
     uint64_t saved_flags =
@@ -100,7 +100,7 @@ imageID functionparameter_LoadStream(
                    sp.name, (long) probeID);
             fps->parray[pindex].fpflag =
                 saved_flags;
-            exit(EXIT_FAILURE);
+            return -1;
         }
     }
 
@@ -168,7 +168,7 @@ imageID functionparameter_LoadStream(
                "stream \"%s\" is in shared"
                " memory, not local\n",
                sp.name);
-        exit(EXIT_FAILURE);
+        return -1;
     }
     if (sp.loc == 'S' && ID >= 0 &&
         imLOC == STREAM_LOAD_SOURCE_LOCALMEM)
@@ -178,7 +178,7 @@ imageID functionparameter_LoadStream(
                "stream \"%s\" is in local"
                " memory, not shared\n",
                sp.name);
-        exit(EXIT_FAILURE);
+        return -1;
     }
 
     /* must-exist check */
@@ -189,7 +189,7 @@ imageID functionparameter_LoadStream(
                "stream \"%s\""
                " not found\n",
                sp.name);
-        exit(EXIT_FAILURE);
+        return -1;
     }
 
     /* Required-stream enforcement: abort with a clear message
@@ -218,7 +218,7 @@ imageID functionparameter_LoadStream(
                     fps->parray[pindex].keywordfull);
         }
         fflush(stderr);
-        exit(EXIT_FAILURE);
+        return -1;
     }
 
     if (run_req && ID == -1)
@@ -245,7 +245,7 @@ imageID functionparameter_LoadStream(
                     fps->parray[pindex].keywordfull);
         }
         fflush(stderr);
-        exit(EXIT_FAILURE);
+        return -1;
     }
 
     return ID;

--- a/src/engine/libfps/fps_outlog.c
+++ b/src/engine/libfps/fps_outlog.c
@@ -148,8 +148,8 @@ errno_t functionparameter_outlog(
             fpout = fopen(logfname, "a");
             if(fpout == NULL)
             {
-                printf("ERROR: cannot open file\n");
-                exit(EXIT_FAILURE);
+                FUNC_RETURN_FAILURE(
+                    "fopen(%s, \"a\") failed", logfname);
             }
             LogOutOpen = 1;
         }

--- a/src/engine/libfps/fps_read_fpsCMD_fifo.c
+++ b/src/engine/libfps/fps_read_fpsCMD_fifo.c
@@ -96,11 +96,12 @@ int functionparameter_read_fpsCMD_fifo(
 
                 if(cmdindex == NB_FPSCTRL_TASK_MAX)
                 {
-                    printf(
-                        "ERROR: fpscmdarray is full, %d NB_FPSCTRL_TASK_MAX "
-                        "limit reached\n",
+                    PRINT_ERROR(
+                        "fpscmdarray is full, "
+                        "NB_FPSCTRL_TASK_MAX limit (%d) "
+                        "reached",
                         NB_FPSCTRL_TASK_MAX);
-                    exit(0);
+                    return cmdcnt;
                 }
 
                 DEBUG_TRACEPOINT(" ");

--- a/src/engine/libfps/fps_scan.c
+++ b/src/engine/libfps/fps_scan.c
@@ -5,6 +5,7 @@
 
 #include <dirent.h>
 #include <string.h>
+#include <errno.h>
 
 #include <libgen.h>   // basename
 #include <sys/stat.h> // fstat
@@ -211,10 +212,11 @@ errno_t functionparameter_scan_fps(
                 retv = lstat(fullname, &buf);
                 if(retv == -1)
                 {
-                    printf("File \"%s\"", dir->d_name);
-                    perror("Error running lstat on file ");
-                    fflush(stdout);
-                    exit(EXIT_FAILURE);
+                    PRINT_ERROR(
+                        "lstat(%s) failed: %s",
+                        fullname, strerror(errno));
+                    closedir(d);
+                    return RETURN_FAILURE;
                 }
 
                 if(S_ISLNK(buf.st_mode))  // resolve link name
@@ -589,9 +591,8 @@ errno_t functionparameter_scan_fps(
     {
         char shmdname[STRINGMAXLEN_SHMDIRNAME];
         function_parameter_struct_shmdirname(shmdname);
-        printf("ERROR: missing %s directory\n", shmdname);
-        fflush(stdout);
-        exit(EXIT_FAILURE);
+        FUNC_RETURN_FAILURE(
+            "missing SHM directory %s", shmdname);
     }
 
     if(verbose > 0)

--- a/src/engine/libfps/fps_shmdirname.c
+++ b/src/engine/libfps/fps_shmdirname.c
@@ -95,7 +95,10 @@ errno_t function_parameter_struct_shmdirname(char *shmdname)
             tmpdir = opendir("/tmp");
             if(!tmpdir)
             {
-                exit(EXIT_FAILURE);
+                FUNC_RETURN_FAILURE(
+                    "could not locate any usable SHM "
+                    "directory (last fallback /tmp also "
+                    "failed to open)");
             }
             else
             {

--- a/src/engine/libfps/fps_struct_create.c
+++ b/src/engine/libfps/fps_struct_create.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 
 #include "fps.h"
 #include "fps_internal.h"
@@ -26,16 +27,17 @@ errno_t function_parameter_struct_create(
     const char *name
 )
 {
-    char                     *mapv = NULL;
-    FPS fps = {0};
-
-    char   SM_fname[200];
-    size_t sharedsize = 0; // shared memory size in bytes
-    int    SM_fd;          // shared memory file descriptor
+    errno_t                   rv         = RETURN_FAILURE;
+    char                     *mapv       = NULL;
+    int                       SM_fd      = -1;
+    size_t                    sharedsize = 0;
+    FPS                       fps        = {0};
+    fps.md = MAP_FAILED;
 
     char shmdname[200];
     function_parameter_struct_shmdirname(shmdname);
 
+    char SM_fname[200];
     if(snprintf(SM_fname, 200, "%s/%s.fps.shm", shmdname, name) < 0)
     {
         PRINT_ERROR("snprintf error");
@@ -55,36 +57,33 @@ errno_t function_parameter_struct_create(
     SM_fd = open(SM_fname, O_RDWR | O_CREAT | O_TRUNC, (mode_t) 0600);
     if(SM_fd == -1)
     {
-        perror("Error opening file for writing");
-        exit(0);
+        PRINT_ERROR("open(%s) failed: %s",
+                    SM_fname, strerror(errno));
+        goto fail;
     }
 
     fps.SMfd = SM_fd;
 
-    int result;
-    result = lseek(SM_fd, sharedsize - 1, SEEK_SET);
-    if(result == -1)
+    if(lseek(SM_fd, sharedsize - 1, SEEK_SET) == -1)
     {
-        close(SM_fd);
-        fprintf(stderr, "Error calling lseek() to 'stretch' the file\n");
-        exit(0);
+        PRINT_ERROR("lseek failed: %s", strerror(errno));
+        goto fail;
     }
 
-    result = write(SM_fd, "", 1);
-    if(result != 1)
+    if(write(SM_fd, "", 1) != 1)
     {
-        close(SM_fd);
-        perror("Error writing last byte of the file");
-        exit(0);
+        PRINT_ERROR("write last byte failed: %s",
+                    strerror(errno));
+        goto fail;
     }
 
     fps.md = (FUNCTION_PARAMETER_STRUCT_MD *)
              mmap(0, sharedsize, PROT_READ | PROT_WRITE, MAP_SHARED, SM_fd, 0);
     if(fps.md == MAP_FAILED)
     {
-        close(SM_fd);
-        perror("Error mmapping the file");
-        exit(0);
+        PRINT_ERROR("mmap(%s) failed: %s",
+                    SM_fname, strerror(errno));
+        goto fail;
     }
 
     mapv = (char *) fps.md;
@@ -124,8 +123,8 @@ errno_t function_parameter_struct_create(
     }
     else
     {
-        perror("getcwd() error");
-        return 1;
+        PRINT_ERROR("getcwd failed: %s", strerror(errno));
+        goto fail;
     }
 
     strncpy(fps.md->sourcefname, "NULL", FPS_SRCDIR_STRLENMAX - 1);
@@ -197,9 +196,18 @@ errno_t function_parameter_struct_create(
     fps.cmdset.triggerdelayptr = NULL;
     fps.cmdset.triggertimeoutptr = NULL;
 
-    munmap(fps.md, sharedsize);
+    rv = RETURN_SUCCESS;
 
-    return 0;
+fail:
+    if (fps.md != MAP_FAILED)
+    {
+        munmap(fps.md, sharedsize);
+    }
+    if (SM_fd != -1)
+    {
+        close(SM_fd);
+    }
+    return rv;
 }
 
 errno_t function_parameter_struct_realloc(


### PR DESCRIPTION
## Summary

Implements PR 4 of the error-handling migration roadmap.
Removes all 19 `exit()` calls from `src/engine/libfps/`,
replacing each with the appropriate failure return per the
rule that library code must propagate failures rather than
terminate the host process.

One commit per file (9 commits total) so each conversion is
reviewable in isolation.

## Per-file summary

| File | Sites | Function return | Conversion |
|---|---|---|---|
| `fps_loadstream.c` | 7 | `imageID` (long) | each `exit()` → `return -1` (existing failure sentinel) |
| `fps_struct_create.c` | 4 | `errno_t` | full `goto fail;` rewrite (also fixes pre-existing fd + munmap leaks) |
| `fps_scan.c` | 2 | `errno_t` | `closedir(d) + RETURN_FAILURE` (line 217); `FUNC_RETURN_FAILURE` (line 594) |
| `fps_connect.c` | 1 | `long` | `close(SM_fd) + return -1` |
| `fps_shmdirname.c` | 1 | `errno_t` | `FUNC_RETURN_FAILURE` |
| `fps_outlog.c` | 1 | `errno_t` | `FUNC_RETURN_FAILURE` |
| `fps_read_fpsCMD_fifo.c` | 1 | `int cmdcnt` | `return cmdcnt` (return what was processed so far) |
| `fps_add_entry.c` | 1 | `errno_t` | `FUNC_RETURN_FAILURE` |
| `fps_ID.c` | 1 | `long` | drop the `exit()`; `return ID` already delivers `-1` |

The 20th match from the original survey
(`fps_GetParamIndex.c:38`) is **not** a real exit — it lives
inside a `/* ... */` comment block and is not compiled.

## Logging

Per the migration policy in `error-handling-practices.md` §5
("refactor logging in functions you are already touching"),
the `perror`/`fprintf`/`printf` error messages adjacent to the
removed `exit()` calls became `PRINT_ERROR` (or
`FUNC_RETURN_FAILURE`, which wraps it). The broader perror /
fprintf sweeps remain scoped to PR 5 and PR 6.

## Behaviour change & known follow-up

The immediate caller at `fps_connect.c:240` (the
`functionparameter_LoadStream` loop) discards LoadStream's
return today, so what was previously a process-killing exit
now returns `-1` silently while the user-visible printf is
still emitted. **Audit and propagate at fps_connect — and at
the few external `fps_connect` callers that don't already
check `== -1` — is deliberately deferred to a follow-up PR**
to keep this PR scoped to "remove the exit", which already
spans 9 files.

The same shape applies to `fps_struct_create`, `fps_scan`,
`fps_outlog`, `fps_add_entry`, `fps_shmdirname`, and
`fps_ID` — callers that ignored the return today silently
continue past failures instead of dying. The user-visible
PRINT_ERROR output makes the failure visible; the regression
in safety vs. the previous "exit-on-error" behaviour is
intentional under the rule.

## Verification

- [x] `cmake --build` — clean (no new warnings)
- [x] `ctest --output-on-failure` — 38/38 pass
- [x] `grep "exit(" src/engine/libfps/` — only the one
      commented-out site in `fps_GetParamIndex.c:38` remains

## Prompt Summary

PR 4 of 6 from the approved migration roadmap. The "one commit
per file" format was confirmed in the planning Q&A as the
review-friendly unit.

## AI Authorship

- **Model**: Claude Sonnet 4.6 (1M context)
- **User edits**: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)