### PR TITLE
refactor: replace perror() with PRINT_ERROR across src/

### DIFF
--- a/src/cli/CLIcore/CLIcore.c
+++ b/src/cli/CLIcore/CLIcore.c
@@ -322,7 +322,7 @@ int cli_fifo_open(const char *path)
         O_RDWR | O_NONBLOCK);
     if(data.fifofd == -1)
     {
-        perror("open");
+        PRINT_ERROR("open: %s", strerror(errno));
         printf("File name : %s\n",
                data.fifoname);
         return -1;
@@ -610,7 +610,7 @@ static int handle_fifo_input(const char *prompt)
             }
             else
             {
-                perror("read");
+                PRINT_ERROR("read: %s", strerror(errno));
                 return -1; /* signal error */
             }
         }
@@ -1011,7 +1011,7 @@ errno_t runCLI(int argc, char *argv[], char *promptstring)
                 }
                 else
                 {
-                    perror("select");
+                    PRINT_ERROR("select: %s", strerror(errno));
                     DEBUG_TRACE_FEXIT();
                     return EXIT_FAILURE;
                 }

--- a/src/cli/CLIcore/CLIcore/CLIcore_UI_builtins.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI_builtins.c
@@ -717,7 +717,7 @@ errno_t cli_pwd(void)
     }
     else
     {
-        perror("pwd");
+        PRINT_ERROR("pwd: %s", strerror(errno));
         return RETURN_FAILURE;
     }
 }

--- a/src/cli/CLIcore/milk-fuzzy-match.c
+++ b/src/cli/CLIcore/milk-fuzzy-match.c
@@ -22,10 +22,12 @@
  */
 
 #include <ctype.h>
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include "libmilkcommon/milkDebugTools.h"
 #include "milk_help.h"
 
 #define FM_ONELINE "fuzzy-match lines against a query using bigram (Dice) similarity"
@@ -247,7 +249,8 @@ int main(int argc, char **argv)
     if (filename != NULL) {
         fp = fopen(filename, "r");
         if (fp == NULL) {
-            perror(filename);
+            PRINT_ERROR("fopen(%s): %s",
+                        filename, strerror(errno));
             return 1;
         }
     }

--- a/src/cli/libmilkscript/CLIcore_signals.c
+++ b/src/cli/libmilkscript/CLIcore_signals.c
@@ -76,7 +76,7 @@ static void set_terminal_echo_on()
     struct termios termInfo;
     if(tcgetattr(0, &termInfo) == -1)
     {
-        perror("tcgetattr");
+        PRINT_ERROR("tcgetattr: %s", strerror(errno));
         exit(1);
     }
     termInfo.c_lflag |= ECHO; /* turn on ECHO */

--- a/src/cli/streamCTRL/streamCTRL_find_streams.c
+++ b/src/cli/streamCTRL/streamCTRL_find_streams.c
@@ -73,7 +73,7 @@ int find_streams(
                 if(retv == -1)
                 {
                     printf("File \"%s\"", dir->d_name);
-                    perror("Error running lstat on file ");
+                    PRINT_ERROR("Error running lstat on file: %s", strerror(errno));
                     exit(EXIT_FAILURE);
                 }
 

--- a/src/cli/streamCTRL/streamCTRL_scan.c
+++ b/src/cli/streamCTRL/streamCTRL_scan.c
@@ -376,7 +376,7 @@ void *streamCTRL_scan(
 
                     if(system(command) == -1)
                     {
-                        perror("Command system() failed");
+                        PRINT_ERROR("Command system() failed: %s", strerror(errno));
                         exit(EXIT_FAILURE);
                     }
 

--- a/src/cli/streamCTRL/streamCTRL_utilfuncs.c
+++ b/src/cli/streamCTRL/streamCTRL_utilfuncs.c
@@ -133,7 +133,7 @@ int get_PIDmax()
     {
         if(ferror(fp))
         {
-            perror("fscanf");
+            PRINT_ERROR("fscanf: %s", strerror(errno));
         }
         else
         {

--- a/src/coremods/COREMOD_iofits/loadmemstream.c
+++ b/src/coremods/COREMOD_iofits/loadmemstream.c
@@ -273,7 +273,7 @@ imageID COREMOD_IOFITS_LoadMemStream(
                 {
                     if(ferror(fp))
                     {
-                        perror("fscanf");
+                        PRINT_ERROR("fscanf: %s", strerror(errno));
                         *imLOC = STREAM_LOAD_SOURCE_EXITFAILURE; // fail
                         if(MEMLOADREPORT == 1)
                         {
@@ -573,7 +573,7 @@ imageID COREMOD_IOFITS_LoadMemStream(
                 {
                     if(ferror(fp))
                     {
-                        perror("fscanf");
+                        PRINT_ERROR("fscanf: %s", strerror(errno));
                         *imLOC = STREAM_LOAD_SOURCE_EXITFAILURE; // fail
                         if(MEMLOADREPORT == 1)
                         {

--- a/src/coremods/COREMOD_memory/delete_image.c
+++ b/src/coremods/COREMOD_memory/delete_image.c
@@ -237,7 +237,7 @@ errno_t delete_image(
                     ID,
                     dcimg[ID].md,
                     dcimg[ID].memsize);
-                perror("Error un-mmapping the file");
+                PRINT_ERROR("Error un-mmapping the file: %s", strerror(errno));
             }
 
             close(dcimg[ID].shmfd);

--- a/src/coremods/COREMOD_memory/milk-shmimpurge.c
+++ b/src/coremods/COREMOD_memory/milk-shmimpurge.c
@@ -22,6 +22,8 @@
 #include <termios.h>
 #include <unistd.h>
 
+#include "libmilkcommon/milkDebugTools.h"
+
 #include "ImageStreamIO/ImageStreamIO.h"
 #include "milk_help.h"
 
@@ -177,7 +179,7 @@ static int is_stream_orphan(const char *fullpath, int verbose)
 
     DIR *proc = opendir("/proc");
     if (proc == NULL) {
-        perror("opendir(/proc)");
+        PRINT_ERROR("opendir(/proc): %s", strerror(errno));
         return 0; /* fail-safe: assume live */
     }
 

--- a/src/coremods/COREMOD_memory/milk-stream-rm.c
+++ b/src/coremods/COREMOD_memory/milk-stream-rm.c
@@ -4,12 +4,14 @@
 #include <unistd.h>
 #include <getopt.h>
 #include <dirent.h>
+#include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <termios.h>
 #include <regex.h>
 
 #include "libmilkcommon/multiselect_parse.h"
+#include "libmilkcommon/milkDebugTools.h"
 
 #include "ImageStreamIO/ImageStreamIO.h"
 #include "milk_help.h"
@@ -100,7 +102,7 @@ static int remove_single_stream(
                    sname);
         }
         if (unlink(fullpath) != 0) {
-            perror("unlink");
+            PRINT_ERROR("unlink: %s", strerror(errno));
             return 1;
         }
         printf("  Stream symlink '%s'"
@@ -138,7 +140,7 @@ static int remove_single_stream(
 
     /* Unlink the SHM file */
     if (unlink(fullpath) != 0) {
-        perror("unlink");
+        PRINT_ERROR("unlink: %s", strerror(errno));
         return 1;
     }
 

--- a/src/coremods/COREMOD_memory/read_shmim_size.c
+++ b/src/coremods/COREMOD_memory/read_shmim_size.c
@@ -133,9 +133,9 @@ imageID read_sharedmem_image_size(
             {
                 printf("unmapping %s\n",
                        SM_fname);
-                perror(
-                    "Error un-mmapping"
-                    " the file");
+                PRINT_ERROR(
+                    "Error un-mmapping the file: %s",
+                    strerror(errno));
             }
             close(SM_fd);
         }

--- a/src/coremods/COREMOD_memory/stream_TCP.c
+++ b/src/coremods/COREMOD_memory/stream_TCP.c
@@ -524,7 +524,7 @@ imageID COREMOD_MEMORY_image_NETWORKtransmit(
                    (struct sockaddr *) &sock_server,
                    sizeof(sock_server)) < 0)
         {
-            perror("Error  connect() failed ");
+            PRINT_ERROR("Error  connect() failed: %s", strerror(errno));
             printf("port = %d\n", port);
             processinfo_error(processinfo, "ERROR: connect() failed\n");
             loopOK = 0;
@@ -680,7 +680,7 @@ imageID COREMOD_MEMORY_image_NETWORKtransmit(
 
                 if(rs != framesizeall)
                 {
-                    perror("socket send error ");
+                    PRINT_ERROR("socket send error: %s", strerror(errno));
                     snprintf(errmsg,
                              200,
                              "ERROR: send() sent a different "

--- a/src/coremods/COREMOD_memory/stream_UDP.c
+++ b/src/coremods/COREMOD_memory/stream_UDP.c
@@ -483,7 +483,7 @@ imageID COREMOD_MEMORY_image_NETUDPtransmit(const char *IDname,
 
                 if(byte_sock_count != framesizeall + 2 * n_udp_dgrams)
                 {
-                    perror("socket send error ");
+                    PRINT_ERROR("socket send error: %s", strerror(errno));
                     snprintf(errmsg,
                              200,
                              "ERROR: send() sent a different "

--- a/src/coremods/COREMOD_memory/stream_net_common.h
+++ b/src/coremods/COREMOD_memory/stream_net_common.h
@@ -300,7 +300,7 @@ static inline int stream_net_sem_wait(
     struct timespec ts;
     if (clock_gettime(CLOCK_MILK, &ts) == -1)
     {
-        perror("clock_gettime");
+        PRINT_ERROR("clock_gettime: %s", strerror(errno));
         exit(EXIT_FAILURE);
     }
     ts.tv_sec += 2;

--- a/src/coremods/COREMOD_memory/stream_pixmapdecode.c
+++ b/src/coremods/COREMOD_memory/stream_pixmapdecode.c
@@ -353,7 +353,7 @@ imageID COREMOD_MEMORY_PixMapDecode_U(
         {
             if(ferror(fp))
             {
-                perror("fscanf");
+                PRINT_ERROR("fscanf: %s", strerror(errno));
             }
             else
             {
@@ -452,7 +452,7 @@ imageID COREMOD_MEMORY_PixMapDecode_U(
         {
             if(clock_gettime(CLOCK_MILK, &ts) == -1)
             {
-                perror("clock_gettime");
+                PRINT_ERROR("clock_gettime: %s", strerror(errno));
                 exit(EXIT_FAILURE);
             }
             ts.tv_sec += 1;

--- a/src/engine/libfps/fpsCTRL/fpsCTRL_TUI.c
+++ b/src/engine/libfps/fpsCTRL/fpsCTRL_TUI.c
@@ -391,7 +391,7 @@ errno_t functionparameter_CTRLscreen(
         // Create FIFO if it does not exist
         if (access(fpsCTRLvar.fpsCTRLfifoname, F_OK) == -1) {
             if (mkfifo(fpsCTRLvar.fpsCTRLfifoname, 0666) == -1) {
-                perror("mkfifo");
+                PRINT_ERROR("mkfifo: %s", strerror(errno));
             }
         }
         fpsCTRLvar.fpsCTRLfifofd = open(fpsCTRLvar.fpsCTRLfifoname, O_RDWR | O_NONBLOCK);

--- a/src/engine/libfps/fps_read_fpsCMD_fifo.c
+++ b/src/engine/libfps/fps_read_fpsCMD_fifo.c
@@ -63,7 +63,7 @@ int functionparameter_read_fpsCMD_fifo(
                 }
                 else // read 0 byte
                 {
-                    //perror("read 0 byte");
+                    //PRINT_ERROR("read 0 byte: %s", strerror(errno));
                     return cmdcnt;
                 }
             }

--- a/src/engine/libfps/fps_struct_create.c
+++ b/src/engine/libfps/fps_struct_create.c
@@ -229,7 +229,7 @@ errno_t function_parameter_struct_realloc(
     // 2. Resize file
     if(truncate(SM_fname, sharedsize_new) == -1)
     {
-        perror("Error truncating file for realloc");
+        PRINT_ERROR("Error truncating file for realloc: %s", strerror(errno));
         return RETURN_FAILURE;
     }
 
@@ -243,7 +243,7 @@ errno_t function_parameter_struct_realloc(
                   0);
     if(fps->md == MAP_FAILED)
     {
-        perror("Error re-mmapping the file");
+        PRINT_ERROR("Error re-mmapping the file: %s", strerror(errno));
         return RETURN_FAILURE;
     }
 

--- a/src/engine/libfpsseq/fpsseq_shm.c
+++ b/src/engine/libfpsseq/fpsseq_shm.c
@@ -11,9 +11,11 @@
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <errno.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <dirent.h>
+#include "milkDebugTools.h"
 #include "fpsseq.h"
 #include "fps_types.h"
 
@@ -42,12 +44,12 @@ MILKSEQ_STATE *milkseq_create(const char *name)
 
     int fd = shm_open(shm_name, O_CREAT | O_RDWR | O_EXCL, 0666);
     if (fd == -1) {
-        perror("shm_open milkseq");
+        PRINT_ERROR("shm_open milkseq: %s", strerror(errno));
         return NULL;
     }
 
     if (ftruncate(fd, sizeof(MILKSEQ_STATE)) == -1) {
-        perror("ftruncate milkseq");
+        PRINT_ERROR("ftruncate milkseq: %s", strerror(errno));
         close(fd);
         shm_unlink(shm_name);
         return NULL;
@@ -57,7 +59,7 @@ MILKSEQ_STATE *milkseq_create(const char *name)
     close(fd);
 
     if (state == MAP_FAILED) {
-        perror("mmap milkseq");
+        PRINT_ERROR("mmap milkseq: %s", strerror(errno));
         shm_unlink(shm_name);
         return NULL;
     }
@@ -79,7 +81,7 @@ MILKSEQ_STATE *milkseq_create(const char *name)
     build_fifo_name(state->fifo_path, sizeof(state->fifo_path), name);
     unlink(state->fifo_path); // remove stale
     if (mkfifo(state->fifo_path, 0666) == -1) {
-        perror("mkfifo milkseq");
+        PRINT_ERROR("mkfifo milkseq: %s", strerror(errno));
         // Non-fatal, but warn
     }
 
@@ -102,7 +104,7 @@ MILKSEQ_STATE *milkseq_connect(const char *name)
     close(fd);
 
     if (state == MAP_FAILED) {
-        perror("mmap milkseq connect");
+        PRINT_ERROR("mmap milkseq connect: %s", strerror(errno));
         return NULL;
     }
 

--- a/src/engine/libprocessinfo/milk-procinfo-rm.c
+++ b/src/engine/libprocessinfo/milk-procinfo-rm.c
@@ -141,7 +141,7 @@ int main(int argc, char *argv[])
 
     DIR *dir = opendir(procdname);
     if (!dir) {
-        perror("opendir");
+        PRINT_ERROR("opendir: %s", strerror(errno));
         return 1;
     }
 
@@ -245,7 +245,7 @@ int main(int argc, char *argv[])
         }
         else
         {
-            perror("unlink");
+            PRINT_ERROR("unlink: %s", strerror(errno));
         }
     }
     closedir(dir);

--- a/src/engine/libprocessinfo/procCTRL/milk-procinfo-list.c
+++ b/src/engine/libprocessinfo/procCTRL/milk-procinfo-list.c
@@ -135,7 +135,7 @@ int main(int argc, char *argv[])
     DIR *dir = opendir(procdname);
     if (dir == NULL)
     {
-        perror("opendir");
+        PRINT_ERROR("opendir: %s", strerror(errno));
         if (use_regex)
         {
             regfree(&regex);

--- a/src/engine/libprocessinfo/processinfo_setup.c
+++ b/src/engine/libprocessinfo/processinfo_setup.c
@@ -151,7 +151,7 @@ errno_t processinfo_loopstart(PROCESSINFO *processinfo)
         schedpar.sched_priority = processinfo->RT_priority;
 
         if (sched_setscheduler(0, SCHED_FIFO, &schedpar) != 0) {
-            // perror("sched_setscheduler");
+            // PRINT_ERROR("sched_setscheduler: %s", strerror(errno));
         }
     }
 

--- a/src/engine/libprocessinfo/processinfo_shm_close.c
+++ b/src/engine/libprocessinfo/processinfo_shm_close.c
@@ -15,7 +15,7 @@ int processinfo_shm_close(PROCESSINFO *pinfo, int fd)
 {
     if(munmap(pinfo, sizeof(PROCESSINFO)) == -1)
     {
-        perror("Error un-mmapping the file");
+        PRINT_ERROR("Error un-mmapping the file: %s", strerror(errno));
     }
     close(fd);
 

--- a/src/engine/libprocessinfo/processinfo_update_output_stream.c
+++ b/src/engine/libprocessinfo/processinfo_update_output_stream.c
@@ -33,7 +33,7 @@ errno_t processinfo_update_output_stream(
         struct timespec ts;
         if(clock_gettime(CLOCK_MILK, &ts) == -1)
         {
-            perror("clock_gettime");
+            PRINT_ERROR("clock_gettime: %s", strerror(errno));
             exit(EXIT_FAILURE);
         }
 

--- a/src/engine/libprocessinfo/processtools_trigger.c
+++ b/src/engine/libprocessinfo/processtools_trigger.c
@@ -289,7 +289,7 @@ errno_t processinfo_waitoninputstream(PROCESSINFO *processinfo)
         struct timespec ts;
         if(clock_gettime(CLOCK_MILK, &ts) == -1)
         {
-            perror("clock_gettime");
+            PRINT_ERROR("clock_gettime: %s", strerror(errno));
             exit(EXIT_FAILURE);
         }
 

--- a/src/perfbench/milk-perfbench.c
+++ b/src/perfbench/milk-perfbench.c
@@ -39,6 +39,7 @@
 #include <asm/unistd.h>
 #include <limits.h>
 
+#include "libmilkcommon/milkDebugTools.h"
 #include "processinfo.h"
 #include "ImageStreamIO/ImageStruct.h"
 
@@ -1268,7 +1269,7 @@ static void run_phase(
     pid_t child = fork();
     if (child < 0)
     {
-        perror("fork");
+        PRINT_ERROR("fork: %s", strerror(errno));
         *wall_ns = 0;
         phase->valid = 0;
         if (pi) pi->valid = 0;


### PR DESCRIPTION
## Summary

Implements PR 5 of the error-handling migration roadmap.
Mechanically sweeps every `perror()` call in `src/` and
replaces it with `PRINT_ERROR("X: %s", strerror(errno))` per
the rule that error logging must use the `milkDebugTools.h`
macros (which add file/line/function context).

The single ImageStreamIO submodule perror is out of scope
(separate repo). After this PR, `grep "perror(" src/` returns
**zero** active matches; the only residue is two commented-out
lines (whose comment text was renamed by the sweep so the
comment now documents the replacement pattern).

## Per-directory summary

| Directory | Sites | Files | Commit |
|---|---|---|---|
| `src/engine/` (excl. ImageStreamIO submodule) | 14 | 10 | 75f9e52 |
| `src/coremods/` | 13 | 9 | 6ddb09b |
| `src/cli/` | 9 | 7 | 92d160f |
| `src/perfbench/` | 1 | 1 | e57664e |
| **Total** | **37** | **27** | |

(Plan estimated 50; PR 1 and PR 4 already converted ~13 of
those during their own scope.)

## Conversion pattern

```c
perror("Error opening file");                    /* before */
PRINT_ERROR("Error opening file: %s", strerror(errno));  /* after */
```

Three special cases handled by hand:
1. **`read_shmim_size.c:136`** — multi-line `perror( ... );`
   call rewritten in place.
2. **`milk-fuzzy-match.c:250`** — `perror(filename)` (variable
   argument, not literal) rewritten as
   `PRINT_ERROR("fopen(%s): %s", filename, strerror(errno))`.
3. **`CLIcore_signals.c:79`** — `perror("tcgetattr")` lives in
   `set_terminal_echo_on()`, which is called during normal
   startup (not from a signal handler), so async-signal safety
   isn't required and the rewrite is safe.

## Includes added

Five files needed new `<errno.h>` and/or `milkDebugTools.h`
includes (they didn't transitively pull them in):

- `src/engine/libfpsseq/fpsseq_shm.c`
- `src/coremods/COREMOD_memory/milk-stream-rm.c`
- `src/coremods/COREMOD_memory/milk-shmimpurge.c`
- `src/cli/CLIcore/milk-fuzzy-match.c`
- `src/perfbench/milk-perfbench.c`

## Verification

- [x] `cmake --build` — clean (no new warnings introduced)
- [x] `ctest --output-on-failure` — 38/38 pass
- [x] `grep "perror(" src/` — zero active matches outside the
      ImageStreamIO submodule (the two commented-out lines were
      renamed by the sweep too, so they document the pattern).

## Prompt Summary

PR 5 of 6 from the approved migration roadmap.

## AI Authorship

- **Model**: Claude Sonnet 4.6 (1M context)
- **User edits**: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)