### PR TITLE
feat(milkCTRL): add FPS parameter tree navigation in F5 tab

### DIFF
--- a/src/cli/CLIcore/CMakeLists.txt
+++ b/src/cli/CLIcore/CMakeLists.txt
@@ -241,6 +241,8 @@ add_executable(milkCTRL
     ../overview/overview_render_cmdlog.c
     ../overview/overview_input.c
     ../overview/overview_ctrl.c
+    ../overview/overview_fps_edit.c
+    ../overview/overview_render_fps_params.c
     ../overview/stream_graph.c
 )
 target_include_directories(milkCTRL PRIVATE

--- a/src/cli/overview/milkCTRL.c
+++ b/src/cli/overview/milkCTRL.c
@@ -306,6 +306,7 @@ int main(int argc, char *argv[])
     lay.view  = OV_VIEW_DASHBOARD;
     lay.focus = OV_FOCUS_STREAMS;
     lay.cmdlog_rows = 4;
+    lay.param_sel = -1;
 
     /* --- Main TUI loop (~10 fps) --- */
     /* Clear screen once on startup */

--- a/src/cli/overview/overview_data.h
+++ b/src/cli/overview/overview_data.h
@@ -205,16 +205,27 @@ typedef struct
     uint64_t stream_param_flags[OV_FPS_MAX_STREAM_PARAMS];
 
 #define OV_FPS_MAX_DISP_PARAMS 100
-    /* display parameters (read-only list) */
+    /* display parameters */
     int      nb_disp_params;
     char     disp_param_name[OV_FPS_MAX_DISP_PARAMS]
              [FUNCTION_PARAMETER_STRMAXLEN];
     char     disp_param_value[OV_FPS_MAX_DISP_PARAMS]
              [FUNCTION_PARAMETER_STRMAXLEN];
+    uint32_t disp_param_type[OV_FPS_MAX_DISP_PARAMS];
+    uint64_t disp_param_flags[OV_FPS_MAX_DISP_PARAMS];
 
     /* graph node index */
     int      node_idx;
 } OV_FPS;
+
+typedef struct {
+    char name[80];
+    int is_dir;
+    int param_idx;
+} fps_tree_item_t;
+
+int ov_get_fps_tree_items(const OV_FPS *fps, const char *path, fps_tree_item_t *items, int max_items);
+
 
 
 /* =========================================================

--- a/src/cli/overview/overview_data_cache.c
+++ b/src/cli/overview/overview_data_cache.c
@@ -112,4 +112,45 @@ void pcache_evict(int ci)
     }
 }
 
+/* =========================================================
+ * FPS cache public accessors
+ * ========================================================= */
 
+/**
+ * ov_fcache_get_fps - return raw FPS pointer by name.
+ *
+ * Returns the memory-mapped FPS struct from the cache,
+ * or NULL if the FPS is not currently cached.
+ */
+FPS *ov_fcache_get_fps(const char *name)
+{
+    int ci = fcache_find(name);
+    if (ci < 0)
+    {
+        return NULL;
+    }
+    return &s_fcache[ci].fps;
+}
+
+/**
+ * ov_fcache_get_param_index - map display index to
+ *     raw FPS parameter array index.
+ *
+ * @fps_name: FPS name to look up in cache
+ * @disp_idx: display parameter index (0..nb_disp_params-1)
+ *
+ * Return: raw parray index, or -1 on error.
+ */
+int ov_fcache_get_param_index(
+    const char *fps_name,
+    int         disp_idx)
+{
+    int ci = fcache_find(fps_name);
+    if (ci < 0
+        || disp_idx < 0
+        || disp_idx >= s_fcache[ci].dparam_nb)
+    {
+        return -1;
+    }
+    return s_fcache[ci].dparam_idx[disp_idx];
+}

--- a/src/cli/overview/overview_data_internal.h
+++ b/src/cli/overview/overview_data_internal.h
@@ -95,4 +95,12 @@ void fcache_evict(int ci);
 int pcache_find_pid(pid_t pid);
 void pcache_evict(int ci);
 
+/** Get cached FPS pointer for direct parameter access */
+FPS *ov_fcache_get_fps(const char *name);
+
+/** Get raw parameter index by display index */
+int ov_fcache_get_param_index(
+    const char *fps_name,
+    int         disp_idx);
+
 #endif // OVERVIEW_DATA_INTERNAL_H

--- a/src/cli/overview/overview_data_scan.c
+++ b/src/cli/overview/overview_data_scan.c
@@ -543,6 +543,8 @@ static void fill_fps_from_struct(
             break;
         }
         strncpy(f->disp_param_value[dp], valstr, FUNCTION_PARAMETER_STRMAXLEN - 1);
+        f->disp_param_type[dp]  = fp->type;
+        f->disp_param_flags[dp] = fp->fpflag;
     }
     f->nb_disp_params = ce->dparam_nb;
 

--- a/src/cli/overview/overview_fps_edit.c
+++ b/src/cli/overview/overview_fps_edit.c
@@ -1,0 +1,356 @@
+/**
+ * @file overview_fps_edit.c
+ * @brief Inline FPS parameter editing for milkCTRL
+ *
+ * Implements an inline parameter edit bar at the bottom
+ * of the terminal, modeled on fpsCTRL_inline_edit_param.
+ * Uses direct ANSI writes that bypass the double-buffer
+ * for the edit prompt (only the prompt row is affected).
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "overview_ansi.h"
+#include "overview_layout.h"
+#include "overview_data.h"
+#include "overview_data_internal.h"
+
+/* libfps headers after overview headers to
+ * avoid macro redefinition warnings */
+#include "fps_types.h"
+#include "fps_paramvalue.h"
+#include "fps_printparameter_valuestring.h"
+#include "fps_WriteParameterToDisk.h"
+#include "fps_save2disk.h"
+
+/**
+ * ov_fps_type_short_label - return a short type label.
+ *
+ * @type: FPS parameter type code
+ *
+ * Return: static string like "INT64", "FLOAT", etc.
+ */
+static const char *ov_fps_type_short_label(
+    uint32_t type)
+{
+    if (type == FPTYPE_INT64 || type == FPTYPE_INT32)
+    {
+        return "INT";
+    }
+    if (type == FPTYPE_UINT64 || type == FPTYPE_UINT32)
+    {
+        return "UINT";
+    }
+    if (type == FPTYPE_FLOAT64 || type == FPTYPE_FLOAT32)
+    {
+        return "FLT";
+    }
+    if (type == FPTYPE_ONOFF)
+    {
+        return "ON/OFF";
+    }
+    if (type == FPTYPE_STREAMNAME)
+    {
+        return "STRM";
+    }
+    if (FPTYPE_IS_STRING(type))
+    {
+        return "STR";
+    }
+    if (type == FPTYPE_PID)
+    {
+        return "PID";
+    }
+    if (type == FPTYPE_TIMESPEC)
+    {
+        return "TIME";
+    }
+    return "???";
+}
+
+/**
+ * ov_fps_inline_edit - edit an FPS parameter inline.
+ *
+ * Draws an edit prompt on the bottom terminal row,
+ * reads character input, and applies the new value
+ * to the FPS shared memory on ENTER.
+ *
+ * The edit bar uses direct ANSI writes (bypassing
+ * the shadow buffer) because it is a modal overlay.
+ * After editing, the shadow front buffer is cleared
+ * to force a full repaint on the next frame.
+ *
+ * @lay:       layout state
+ * @fps_name:  name of the FPS to edit
+ * @disp_idx:  display parameter index
+ *
+ * Return: 0 on success/abort, -1 on error
+ */
+int ov_fps_inline_edit(
+    OV_LAYOUT  *lay,
+    const char *fps_name,
+    int         disp_idx)
+{
+    (void) lay;
+
+    FPS *fps = ov_fcache_get_fps(fps_name);
+    if (fps == NULL || fps->md == NULL)
+    {
+        return -1;
+    }
+
+    int pindex = ov_fcache_get_param_index(
+        fps_name, disp_idx);
+    if (pindex < 0)
+    {
+        return -1;
+    }
+
+    FPS_PARAM *fp = &fps->parray[pindex];
+
+    /* Get current value as string */
+    char curval[200];
+    functionparameter_GetParamValueString(
+        fp, curval, (int) sizeof(curval));
+
+    /* Short type label */
+    const char *tlabel =
+        ov_fps_type_short_label(fp->type);
+
+    /* Strip FPS name prefix from keyword */
+    const char *display_kw = fp->keywordfull;
+    int prefix_len = (int) strlen(fps->md->name);
+    if (strncmp(display_kw,
+                fps->md->name,
+                (size_t) prefix_len) == 0
+        && display_kw[prefix_len] == '.')
+    {
+        display_kw += prefix_len + 1;
+    }
+
+    /* Get terminal size */
+    int trows, tcols;
+    ov_get_terminal_size(&trows, &tcols);
+
+    /* Show cursor */
+    if (write(STDOUT_FILENO,
+              "\033[?25h", 6) < 0) {}
+
+    /* Position at bottom row and clear it */
+    {
+        char posbuf[32];
+        int n = snprintf(posbuf, sizeof(posbuf),
+            "\033[%d;1H\033[2K", trows);
+        if (n > 0)
+        {
+            if (write(STDOUT_FILENO,
+                      posbuf, (size_t) n) < 0) {}
+        }
+    }
+
+    /* Check writability */
+    if (!(fp->fpflag & FPFLAG_WRITESTATUS))
+    {
+        char prompt[512];
+        int n = snprintf(prompt, sizeof(prompt),
+            "\033[1;31m"
+            " [%s] %s = %s  (read-only)"
+            "\033[0m",
+            tlabel, display_kw, curval);
+        if (n > 0)
+        {
+            if (write(STDOUT_FILENO,
+                      prompt, (size_t) n) < 0) {}
+        }
+        usleep(800000);
+        /* Drain buffered keys */
+        while (ov_get_key() != OV_KEY_NONE) {}
+        /* Hide cursor */
+        if (write(STDOUT_FILENO,
+                  "\033[?25l", 6) < 0) {}
+        /* Force full repaint */
+        ov_buf_force_clear();
+        return 0;
+    }
+
+    /* ONOFF: toggle immediately, no text input */
+    if (fp->type == FPTYPE_ONOFF)
+    {
+        int64_t newval = fp->val.i64[0] ? 0 : 1;
+        fp->val.i64[0] = newval;
+
+        fps->md->signal |=
+            FUNCTION_PARAMETER_STRUCT_SIGNAL_UPDATE;
+
+        if (fp->fpflag & FPFLAG_SAVEONCHANGE)
+        {
+            functionparameter_WriteParameterToDisk(
+                fps, pindex,
+                "setval", "milkCTRL_toggle");
+            functionparameter_SaveFPS2disk(fps);
+        }
+
+        /* Brief flash */
+        {
+            char msg[256];
+            int n = snprintf(msg, sizeof(msg),
+                "\033[1;32m"
+                " [ON/OFF] %s => %s"
+                "\033[0m",
+                display_kw,
+                newval ? "ON" : "OFF");
+            if (n > 0)
+            {
+                if (write(STDOUT_FILENO,
+                          msg, (size_t) n)
+                    < 0) {}
+            }
+        }
+        usleep(300000);
+        while (ov_get_key() != OV_KEY_NONE) {}
+        if (write(STDOUT_FILENO,
+                  "\033[?25l", 6) < 0) {}
+        ov_buf_force_clear();
+        return 0;
+    }
+
+    /* Text input mode: show prompt */
+    {
+        char prompt[512];
+        int n = snprintf(prompt, sizeof(prompt),
+            "\033[1;36m"
+            " [%s] %s"
+            "\033[0m"
+            " (was: "
+            "\033[33m%s\033[0m"
+            ") new value: ",
+            tlabel, display_kw, curval);
+        if (n > 0)
+        {
+            if (write(STDOUT_FILENO,
+                      prompt, (size_t) n) < 0) {}
+        }
+    }
+
+    /* Character-by-character input loop */
+    char buf[200];
+    int  bufpos  = 0;
+    int  maxlen  = (int) sizeof(buf) - 1;
+    int  aborted = 0;
+
+    for (;;)
+    {
+        usleep(10000);
+        int key = ov_get_key();
+
+        if (key == OV_KEY_NONE)
+        {
+            continue;
+        }
+
+        /* ESC — abort */
+        if (key == OV_KEY_ESC)
+        {
+            aborted = 1;
+            break;
+        }
+
+        /* ENTER — confirm */
+        if (key == OV_KEY_ENTER
+            || key == 13)
+        {
+            break;
+        }
+
+        /* Backspace (127 or ctrl-h) */
+        if (key == 127 || key == 8)
+        {
+            if (bufpos > 0)
+            {
+                bufpos--;
+                if (write(STDOUT_FILENO,
+                          "\b \b", 3) < 0) {}
+            }
+            continue;
+        }
+
+        /* Ctrl+U — clear input */
+        if (key == ctrl('u'))
+        {
+            while (bufpos > 0)
+            {
+                bufpos--;
+                if (write(STDOUT_FILENO,
+                          "\b \b", 3) < 0) {}
+            }
+            continue;
+        }
+
+        /* Ignore non-printable / special keys */
+        if (key < 32 || key > 126)
+        {
+            continue;
+        }
+
+        /* Printable character */
+        if (bufpos < maxlen)
+        {
+            buf[bufpos++] = (char) key;
+            char echo = (char) key;
+            if (write(STDOUT_FILENO,
+                      &echo, 1) < 0) {}
+        }
+    }
+    buf[bufpos] = '\0';
+
+    /* Hide cursor */
+    if (write(STDOUT_FILENO,
+              "\033[?25l", 6) < 0) {}
+
+    if (!aborted && bufpos > 0)
+    {
+        if (functionparameter_SetParamValue_fromString(
+                fps, pindex, buf) != 0)
+        {
+            /* Show error briefly */
+            const char errmsg[] =
+                "\033[1;31m  ERROR: invalid value"
+                "\033[0m";
+            if (write(STDOUT_FILENO,
+                      errmsg, sizeof(errmsg) - 1)
+                < 0) {}
+            usleep(500000);
+        }
+        else
+        {
+            /* Signal update */
+            fps->md->signal |=
+                FUNCTION_PARAMETER_STRUCT_SIGNAL_UPDATE;
+
+            /* Processinfo change tracking */
+            if (strncmp(
+                    fp->keywordfull,
+                    ".procinfo.", 10) == 0)
+            {
+                fps->md->processinfo_change_cnt++;
+            }
+
+            /* Save to disk if flagged */
+            if (fp->fpflag & FPFLAG_SAVEONCHANGE)
+            {
+                functionparameter_WriteParameterToDisk(
+                    fps, pindex,
+                    "setval",
+                    "milkCTRL_SetParamValue");
+                functionparameter_SaveFPS2disk(fps);
+            }
+        }
+    }
+
+    /* Force full repaint */
+    ov_buf_force_clear();
+    return 0;
+}

--- a/src/cli/overview/overview_fps_edit.h
+++ b/src/cli/overview/overview_fps_edit.h
@@ -1,0 +1,25 @@
+/**
+ * @file overview_fps_edit.h
+ * @brief Inline FPS parameter editing for milkCTRL
+ */
+
+#ifndef OVERVIEW_FPS_EDIT_H
+#define OVERVIEW_FPS_EDIT_H
+
+#include "overview_layout.h"
+
+/**
+ * ov_fps_inline_edit - edit an FPS parameter inline.
+ *
+ * @lay:       layout state
+ * @fps_name:  name of the FPS to edit
+ * @disp_idx:  display parameter index
+ *
+ * Return: 0 on success/abort, -1 on error
+ */
+int ov_fps_inline_edit(
+    OV_LAYOUT  *lay,
+    const char *fps_name,
+    int         disp_idx);
+
+#endif /* OVERVIEW_FPS_EDIT_H */

--- a/src/cli/overview/overview_input.c
+++ b/src/cli/overview/overview_input.c
@@ -11,6 +11,7 @@
 #include "overview_data.h"
 #include "overview_layout.h"
 #include "overview_ctrl.h"
+#include "overview_fps_edit.h"
 #include "stream_graph.h"
 
 static int get_graph_start_node(const OV_LAYOUT *lay, const OV_MODEL *m)
@@ -194,9 +195,19 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
         /* Check for header tab clicks */
         if (mr == lay->r_header.row && mc >= 1)
         {
-            int tab_widths[] = {10, 10, 10, 9, 10};
+            /* Tab widths must match the renderer in ov_render_header():
+             * each tab renders as " [" + " Fn:LABEL " + "] " (inactive)
+             * or " " + ← + " Fn:LABEL " + → + " " (active),
+             * both totalling strlen(label) + 9 visible columns. */
+            static const char *vlabels[] =
+                {"DASH", "STRM", "PROC", "FPS", "CONN"};
+            int tab_widths[OV_VIEW_COUNT];
             int tabs_total_width = 0;
-            for (int v = 0; v < OV_VIEW_COUNT; v++) tabs_total_width += tab_widths[v];
+            for (int v = 0; v < OV_VIEW_COUNT; v++)
+            {
+                tab_widths[v] = (int) strlen(vlabels[v]) + 9;
+                tabs_total_width += tab_widths[v];
+            }
             
             int x = lay->term_cols - tabs_total_width + 1;
             if (mc >= x)
@@ -213,66 +224,232 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
             }
         }
 
-        if (INSIDE(lay->r_streams, mr, mc))
+        /* --- View-aware panel dispatch ---
+         * In single-panel views (F3–F6) the panel rects
+         * for non-active panels all overlap the full
+         * screen, so we must check the view first and
+         * route directly to the correct handler.
+         * On the Dashboard all four rects are distinct
+         * so the cascade works normally.
+         */
+        if (lay->view == OV_VIEW_FPS)
+        {
+            /* F5: left = fps list, right = params */
+            if (INSIDE(lay->r_fps_params, mr, mc))
+            {
+                lay->focus = OV_FOCUS_FPS;
+                lay->fps_param_focus = 1;
+                int body_row =
+                    mr - lay->r_fps_params.row - 2;
+                if (body_row >= 0)
+                {
+                    int idx =
+                        lay->fps_param_scroll + body_row;
+                    lay->fps_param_sel = idx;
+                }
+            }
+            else if (INSIDE(lay->r_fps, mr, mc))
+            {
+                lay->focus = OV_FOCUS_FPS;
+                lay->fps_param_focus = 0;
+                int body_row =
+                    mr - lay->r_fps.row - 2;
+                if (body_row >= 0)
+                {
+                    int idx =
+                        lay->scroll_fps + body_row;
+                    if (idx < m->nb_fps)
+                    {
+                        if (lay->sel_fps != idx)
+                        {
+                            lay->sel_fps = idx;
+                            lay->sel_name_fps[0] = '\0';
+                            lay->fps_param_path[0] = '\0';
+                            lay->fps_param_sel = 0;
+                            lay->fps_param_scroll = 0;
+                        }
+                        if (is_dbl)
+                        {
+                            lay->graph_tab_mode = 1;
+                        }
+                    }
+                }
+            }
+        }
+        else if (lay->view == OV_VIEW_STREAMS
+                 && INSIDE(lay->r_streams, mr, mc))
         {
             lay->focus = OV_FOCUS_STREAMS;
-            int body_row = mr - lay->r_streams.row - 2;
+            int body_row =
+                mr - lay->r_streams.row - 2;
             if (body_row >= 0)
             {
-                int idx = lay->scroll_stream + body_row;
+                int idx =
+                    lay->scroll_stream + body_row;
                 if (idx < m->nb_streams)
                 {
                     lay->sel_stream = idx;
-                    if (is_dbl) lay->graph_tab_mode = 1;
+                    if (is_dbl)
+                    {
+                        lay->graph_tab_mode = 1;
+                    }
                 }
             }
         }
-        else if (INSIDE(lay->r_procs, mr, mc))
+        else if (lay->view == OV_VIEW_PROCS
+                 && INSIDE(lay->r_procs, mr, mc))
         {
             lay->focus = OV_FOCUS_PROCS;
-            int body_row = mr - lay->r_procs.row - 2;
+            int body_row =
+                mr - lay->r_procs.row - 2;
             if (body_row >= 0)
             {
-                int idx = lay->scroll_proc + body_row;
+                int idx =
+                    lay->scroll_proc + body_row;
                 if (idx < m->nb_procs)
                 {
                     lay->sel_proc = idx;
-                    if (is_dbl) lay->graph_tab_mode = 1;
+                    if (is_dbl)
+                    {
+                        lay->graph_tab_mode = 1;
+                    }
                 }
             }
         }
-        else if (INSIDE(lay->r_fps, mr, mc))
-        {
-            lay->focus = OV_FOCUS_FPS;
-            int body_row = mr - lay->r_fps.row - 2;
-            if (body_row >= 0)
-            {
-                int idx = lay->scroll_fps + body_row;
-                if (idx < m->nb_fps)
-                {
-                    lay->sel_fps = idx;
-                    if (is_dbl) lay->graph_tab_mode = 1;
-                }
-            }
-        }
-        else if (INSIDE(lay->r_graph, mr, mc))
+        else if (lay->view == OV_VIEW_GRAPH
+                 && INSIDE(lay->r_graph, mr, mc))
         {
             lay->focus = OV_FOCUS_GRAPH;
-            int body_row = mr - lay->r_graph.row - 2;
+            int body_row =
+                mr - lay->r_graph.row - 2;
             if (body_row >= 0)
             {
-                int idx = lay->scroll_graph + body_row;
+                int idx =
+                    lay->scroll_graph + body_row;
                 if (idx < m->nb_edges)
                 {
                     lay->sel_graph = idx;
                     if (is_dbl)
                     {
-                        const OV_EDGE *edge = &m->edges[idx];
-                        const OV_NODE *node = &m->nodes[edge->src_node];
-                        if (node->type == OV_NODE_STREAM) { lay->focus = OV_FOCUS_STREAMS; lay->sel_stream = node->index; }
-                        else if (node->type == OV_NODE_PROC) { lay->focus = OV_FOCUS_PROCS; lay->sel_proc = node->index; }
-                        else if (node->type == OV_NODE_FPS) { lay->focus = OV_FOCUS_FPS; lay->sel_fps = node->index; }
+                        const OV_EDGE *edge =
+                            &m->edges[idx];
+                        const OV_NODE *node =
+                            &m->nodes[edge->src_node];
+                        if (node->type == OV_NODE_STREAM)
+                        {
+                            lay->focus = OV_FOCUS_STREAMS;
+                            lay->sel_stream = node->index;
+                        }
+                        else if (node->type == OV_NODE_PROC)
+                        {
+                            lay->focus = OV_FOCUS_PROCS;
+                            lay->sel_proc = node->index;
+                        }
+                        else if (node->type == OV_NODE_FPS)
+                        {
+                            lay->focus = OV_FOCUS_FPS;
+                            lay->sel_fps = node->index;
+                        }
                         lay->view = OV_VIEW_DASHBOARD;
+                    }
+                }
+            }
+        }
+        else if (lay->view == OV_VIEW_DASHBOARD)
+        {
+            /* Dashboard: four non-overlapping rects */
+            if (INSIDE(lay->r_streams, mr, mc))
+            {
+                lay->focus = OV_FOCUS_STREAMS;
+                int body_row =
+                    mr - lay->r_streams.row - 2;
+                if (body_row >= 0)
+                {
+                    int idx =
+                        lay->scroll_stream + body_row;
+                    if (idx < m->nb_streams)
+                    {
+                        lay->sel_stream = idx;
+                        if (is_dbl)
+                        {
+                            lay->graph_tab_mode = 1;
+                        }
+                    }
+                }
+            }
+            else if (INSIDE(lay->r_procs, mr, mc))
+            {
+                lay->focus = OV_FOCUS_PROCS;
+                int body_row =
+                    mr - lay->r_procs.row - 2;
+                if (body_row >= 0)
+                {
+                    int idx =
+                        lay->scroll_proc + body_row;
+                    if (idx < m->nb_procs)
+                    {
+                        lay->sel_proc = idx;
+                        if (is_dbl)
+                        {
+                            lay->graph_tab_mode = 1;
+                        }
+                    }
+                }
+            }
+            else if (INSIDE(lay->r_fps, mr, mc))
+            {
+                lay->focus = OV_FOCUS_FPS;
+                int body_row =
+                    mr - lay->r_fps.row - 2;
+                if (body_row >= 0)
+                {
+                    int idx =
+                        lay->scroll_fps + body_row;
+                    if (idx < m->nb_fps)
+                    {
+                        lay->sel_fps = idx;
+                        if (is_dbl)
+                        {
+                            lay->graph_tab_mode = 1;
+                        }
+                    }
+                }
+            }
+            else if (INSIDE(lay->r_graph, mr, mc))
+            {
+                lay->focus = OV_FOCUS_GRAPH;
+                int body_row =
+                    mr - lay->r_graph.row - 2;
+                if (body_row >= 0)
+                {
+                    int idx =
+                        lay->scroll_graph + body_row;
+                    if (idx < m->nb_edges)
+                    {
+                        lay->sel_graph = idx;
+                        if (is_dbl)
+                        {
+                            const OV_EDGE *edge =
+                                &m->edges[idx];
+                            const OV_NODE *node =
+                                &m->nodes[edge->src_node];
+                            if (node->type == OV_NODE_STREAM)
+                            {
+                                lay->focus = OV_FOCUS_STREAMS;
+                                lay->sel_stream = node->index;
+                            }
+                            else if (node->type == OV_NODE_PROC)
+                            {
+                                lay->focus = OV_FOCUS_PROCS;
+                                lay->sel_proc = node->index;
+                            }
+                            else if (node->type == OV_NODE_FPS)
+                            {
+                                lay->focus = OV_FOCUS_FPS;
+                                lay->sel_fps = node->index;
+                            }
+                            lay->view = OV_VIEW_DASHBOARD;
+                        }
                     }
                 }
             }
@@ -291,38 +468,58 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
         int  count  = 0;
         int  page_h = 10;
 
-        if (INSIDE(lay->r_streams, mr, mc))
+        /* View-aware dispatch (same rationale as click
+         * handler — in single-panel views the panel
+         * rects overlap).
+         */
+        if (lay->view == OV_VIEW_FPS)
+        {
+            if (INSIDE(lay->r_fps_params, mr, mc))
+            {
+                sel    = &lay->fps_param_sel;
+                scroll = &lay->fps_param_scroll;
+                count  = 1000;
+                page_h = lay->r_fps_params.height - 3;
+            }
+            else if (INSIDE(lay->r_fps, mr, mc))
+            {
+                sel    = &lay->sel_fps;
+                scroll = &lay->scroll_fps;
+                count  = m->nb_fps;
+                page_h = lay->r_fps.height - 3;
+            }
+        }
+        else if (lay->view == OV_VIEW_STREAMS)
         {
             sel    = &lay->sel_stream;
             scroll = &lay->scroll_stream;
             count  = m->nb_streams;
             page_h = lay->r_streams.height - 3;
         }
-        else if (INSIDE(lay->r_procs, mr, mc))
+        else if (lay->view == OV_VIEW_PROCS)
         {
             sel    = &lay->sel_proc;
             scroll = &lay->scroll_proc;
             count  = m->nb_procs;
             page_h = lay->r_procs.height - 3;
         }
-        else if (INSIDE(lay->r_fps, mr, mc))
-        {
-            sel    = &lay->sel_fps;
-            scroll = &lay->scroll_fps;
-            count  = m->nb_fps;
-            page_h = lay->r_fps.height - 3;
-        }
-        else if (INSIDE(lay->r_graph, mr, mc))
+        else if (lay->view == OV_VIEW_GRAPH)
         {
             if (lay->graph_tab_mode == 0)
             {
                 sel    = &lay->sel_graph;
                 scroll = &lay->scroll_graph;
-                int start_node = get_graph_start_node(lay, m);
-                if (start_node >= 0) {
+                int start_node =
+                    get_graph_start_node(lay, m);
+                if (start_node >= 0)
+                {
                     SG_RENDER_NODE rnodes[OV_MAX_NODES];
-                    count = sg_compute_render_nodes(m, start_node, lay->lineage_mode, rnodes);
-                } else {
+                    count = sg_compute_render_nodes(
+                        m, start_node,
+                        lay->lineage_mode, rnodes);
+                }
+                else
+                {
                     count = m->nb_edges;
                 }
                 page_h = lay->r_graph.height - 3;
@@ -331,17 +528,99 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
             {
                 page_h = lay->r_graph.height - 3;
                 lay->scroll_detail += dir;
-                if (lay->scroll_detail < 0) lay->scroll_detail = 0;
-                if (lay->scroll_detail > lay->detail_total_lines - page_h) {
-                    lay->scroll_detail = lay->detail_total_lines - page_h;
+                if (lay->scroll_detail < 0)
+                {
+                    lay->scroll_detail = 0;
                 }
-                if (lay->scroll_detail < 0) lay->scroll_detail = 0;
+                if (lay->scroll_detail >
+                    lay->detail_total_lines - page_h)
+                {
+                    lay->scroll_detail =
+                        lay->detail_total_lines - page_h;
+                }
+                if (lay->scroll_detail < 0)
+                {
+                    lay->scroll_detail = 0;
+                }
                 return 1;
             }
-            else 
+            else
             {
                 /* RESOURCES panel */
                 return 1;
+            }
+        }
+        else if (lay->view == OV_VIEW_DASHBOARD)
+        {
+            /* Dashboard: non-overlapping rects */
+            if (INSIDE(lay->r_streams, mr, mc))
+            {
+                sel    = &lay->sel_stream;
+                scroll = &lay->scroll_stream;
+                count  = m->nb_streams;
+                page_h = lay->r_streams.height - 3;
+            }
+            else if (INSIDE(lay->r_procs, mr, mc))
+            {
+                sel    = &lay->sel_proc;
+                scroll = &lay->scroll_proc;
+                count  = m->nb_procs;
+                page_h = lay->r_procs.height - 3;
+            }
+            else if (INSIDE(lay->r_fps, mr, mc))
+            {
+                sel    = &lay->sel_fps;
+                scroll = &lay->scroll_fps;
+                count  = m->nb_fps;
+                page_h = lay->r_fps.height - 3;
+            }
+            else if (INSIDE(lay->r_graph, mr, mc))
+            {
+                if (lay->graph_tab_mode == 0)
+                {
+                    sel    = &lay->sel_graph;
+                    scroll = &lay->scroll_graph;
+                    int start_node =
+                        get_graph_start_node(lay, m);
+                    if (start_node >= 0)
+                    {
+                        SG_RENDER_NODE rnodes[OV_MAX_NODES];
+                        count = sg_compute_render_nodes(
+                            m, start_node,
+                            lay->lineage_mode, rnodes);
+                    }
+                    else
+                    {
+                        count = m->nb_edges;
+                    }
+                    page_h = lay->r_graph.height - 3;
+                }
+                else if (lay->graph_tab_mode == 1)
+                {
+                    page_h = lay->r_graph.height - 3;
+                    lay->scroll_detail += dir;
+                    if (lay->scroll_detail < 0)
+                    {
+                        lay->scroll_detail = 0;
+                    }
+                    if (lay->scroll_detail >
+                        lay->detail_total_lines - page_h)
+                    {
+                        lay->scroll_detail =
+                            lay->detail_total_lines
+                            - page_h;
+                    }
+                    if (lay->scroll_detail < 0)
+                    {
+                        lay->scroll_detail = 0;
+                    }
+                    return 1;
+                }
+                else
+                {
+                    /* RESOURCES panel */
+                    return 1;
+                }
             }
         }
 
@@ -480,10 +759,21 @@ static int ov_input__handle_misc_toggles(int key, OV_LAYOUT *lay, const OV_MODEL
         return 1;
     }
 
-    /* ENTER — toggle detail mode */
+    /* ENTER — open DETAILS for list panels; toggle when on graph */
     if ((key == 10 || key == 13) && m != NULL)
     {
-        lay->graph_tab_mode = (lay->graph_tab_mode == 1) ? 0 : 1;
+        if (lay->focus == OV_FOCUS_STREAMS
+            || lay->focus == OV_FOCUS_PROCS
+            || lay->focus == OV_FOCUS_FPS)
+        {
+            /* Always jump to DETAILS sub-tab */
+            lay->graph_tab_mode = 1;
+        }
+        else
+        {
+            lay->graph_tab_mode =
+                (lay->graph_tab_mode == 1) ? 0 : 1;
+        }
         return 1;
     }
 
@@ -512,6 +802,10 @@ static int ov_input__handle_misc_toggles(int key, OV_LAYOUT *lay, const OV_MODEL
          */
         if (lay->view != OV_VIEW_DASHBOARD)
         {
+            if (lay->view == OV_VIEW_FPS)
+            {
+                return 0; /* Let handle_navigation process it */
+            }
             return 1;
         }
 
@@ -524,12 +818,7 @@ static int ov_input__handle_misc_toggles(int key, OV_LAYOUT *lay, const OV_MODEL
             else if (lay->focus == OV_FOCUS_FPS)
                 lay->focus = OV_FOCUS_PROCS;
             else if (lay->focus == OV_FOCUS_GRAPH)
-            {
-                if (lay->graph_tab_mode == 0)
-                    lay->focus = OV_FOCUS_FPS;
-                else
-                    lay->focus = OV_FOCUS_STREAMS;
-            }
+                lay->focus = OV_FOCUS_FPS;
         }
         else
         {
@@ -877,6 +1166,9 @@ static int ov_input__handle_ancestry_nav(int key, OV_LAYOUT *lay, const OV_MODEL
         } else if (lay->focus == OV_FOCUS_FPS && tn->type == OV_NODE_FPS) {
             lay->sel_fps = tn->index;
             lay->sel_name_fps[0] = '\0';
+            lay->fps_param_sel = 0;
+            lay->fps_param_scroll = 0;
+            lay->fps_param_focus = 0;
         }
     }
     return 1;
@@ -888,6 +1180,167 @@ static int ov_input__handle_navigation(int key, OV_LAYOUT *lay, const OV_MODEL *
     int *scroll = NULL;
     int  count  = 0;
     int  page_h = 10;
+
+    /* -------------------------------------------------------
+     * F5 view (OV_VIEW_FPS) param-tree intercept.
+     *
+     * When fps_param_focus == 1 (right-side param panel
+     * is active), all navigation keys are consumed by the
+     * param tree. RIGHT / ENTER from the list side switch
+     * focus to the param panel.
+     * ------------------------------------------------------- */
+    if (lay->view == OV_VIEW_FPS)
+    {
+        int fsel = lay->sel_fps;
+        int has_params =
+            (fsel >= 0
+             && fsel < m->nb_fps
+             && m->fps[fsel].nb_disp_params > 0);
+
+        int nitems = 0;
+        fps_tree_item_t items[1024];
+        if (has_params)
+        {
+            nitems = ov_get_fps_tree_items(&m->fps[fsel], lay->fps_param_path, items, 1024);
+        }
+
+        /* RIGHT from list → enter param panel */
+        if (lay->fps_param_focus == 0
+            && (key == OV_KEY_RIGHT || key == OV_KEY_ENTER || key == '\r')
+            && has_params)
+        {
+            lay->fps_param_focus = 1;
+            lay->fps_param_sel   = 0;
+            lay->fps_param_scroll = 0;
+            return 1;
+        }
+
+        /* All nav/edit keys when param panel is focused */
+        if (lay->fps_param_focus == 1)
+        {
+            /* ESC / LEFT from param panel → back to list or ascend dir */
+            if (key == OV_KEY_LEFT || key == OV_KEY_ESC)
+            {
+                if (lay->fps_param_path[0] == '\0')
+                {
+                    lay->fps_param_focus = 0;
+                }
+                else
+                {
+                    /* Ascend directory */
+                    char *last_dot = strrchr(lay->fps_param_path, '.');
+                    if (last_dot)
+                    {
+                        *last_dot = '\0';
+                    }
+                    else
+                    {
+                        lay->fps_param_path[0] = '\0';
+                    }
+                    lay->fps_param_sel = 0;
+                    lay->fps_param_scroll = 0;
+                }
+                return 1;
+            }
+
+            int ph = lay->r_fps_params.height - 3;
+            if (ph < 1)
+            {
+                ph = 1;
+            }
+
+            if (key == OV_KEY_UP)
+            {
+                if (lay->fps_param_sel > 0)
+                {
+                    lay->fps_param_sel--;
+                }
+                return 1;
+            }
+            if (key == OV_KEY_DOWN)
+            {
+                if (lay->fps_param_sel < nitems - 1)
+                {
+                    lay->fps_param_sel++;
+                }
+                return 1;
+            }
+            if (key == OV_KEY_PGUP)
+            {
+                lay->fps_param_sel -= ph;
+                if (lay->fps_param_sel < 0)
+                {
+                    lay->fps_param_sel = 0;
+                }
+                return 1;
+            }
+            if (key == OV_KEY_PGDN)
+            {
+                lay->fps_param_sel += ph;
+                if (lay->fps_param_sel >= nitems)
+                {
+                    lay->fps_param_sel = nitems - 1;
+                }
+                return 1;
+            }
+            if (key == OV_KEY_HOME)
+            {
+                lay->fps_param_sel = 0;
+                return 1;
+            }
+            if (key == OV_KEY_END)
+            {
+                lay->fps_param_sel = nitems - 1;
+                if (lay->fps_param_sel < 0)
+                {
+                    lay->fps_param_sel = 0;
+                }
+                return 1;
+            }
+            if (key == OV_KEY_RIGHT || key == OV_KEY_ENTER || key == '\r')
+            {
+                if (lay->fps_param_sel >= 0 && lay->fps_param_sel < nitems)
+                {
+                    fps_tree_item_t *item = &items[lay->fps_param_sel];
+                    if (item->is_dir)
+                    {
+                        /* Descend directory */
+                        if (lay->fps_param_path[0] == '\0')
+                        {
+                            strncpy(lay->fps_param_path, item->name, sizeof(lay->fps_param_path) - 1);
+                        }
+                        else
+                        {
+                            char tmp[200];
+                            snprintf(tmp, sizeof(tmp), "%s.%s", lay->fps_param_path, item->name);
+                            strncpy(lay->fps_param_path, tmp, sizeof(lay->fps_param_path) - 1);
+                        }
+                        lay->fps_param_sel = 0;
+                        lay->fps_param_scroll = 0;
+                    }
+                    else if (key == OV_KEY_ENTER || key == '\r')
+                    {
+                        if (!lay->ctrl_mode)
+                        {
+                            ov_cmdlog_push(
+                                &lay->cmdlog,
+                                OV_CMDLOG_WARN,
+                                "Edit requires CONTROL mode");
+                        }
+                        else
+                        {
+                            ov_fps_inline_edit(
+                                lay,
+                                m->fps[fsel].name,
+                                item->param_idx);
+                        }
+                    }
+                }
+                return 1;
+            }
+            return 0; /* pass through unmapped keys */
+        }
+    } /* if OV_VIEW_FPS */
 
     switch (lay->focus)
     {
@@ -942,27 +1395,140 @@ static int ov_input__handle_navigation(int key, OV_LAYOUT *lay, const OV_MODEL *
             }
             page_h = lay->r_graph.height - 3;
         } else if (lay->graph_tab_mode == 1) {
+            /* DETAILS tab: param nav if FPS selected */
+            int fps_sel = lay->freeze
+                ? lay->freeze_sel_fps
+                : lay->sel_fps;
+            int has_fps_params =
+                (fps_sel >= 0
+                 && fps_sel < m->nb_fps
+                 && m->fps[fps_sel].nb_disp_params > 0);
+            int nparams = has_fps_params
+                ? m->fps[fps_sel].nb_disp_params : 0;
+
+            if (has_fps_params && lay->param_sel >= 0)
+            {
+                /* Navigate parameter cursor */
+                if (key == OV_KEY_UP)
+                {
+                    if (lay->param_sel > 0)
+                    {
+                        lay->param_sel--;
+                    }
+                }
+                else if (key == OV_KEY_DOWN)
+                {
+                    if (lay->param_sel
+                        < nparams - 1)
+                    {
+                        lay->param_sel++;
+                    }
+                }
+                else if (key == OV_KEY_PGUP)
+                {
+                    lay->param_sel -= page_h;
+                    if (lay->param_sel < 0)
+                    {
+                        lay->param_sel = 0;
+                    }
+                }
+                else if (key == OV_KEY_PGDN)
+                {
+                    lay->param_sel += page_h;
+                    if (lay->param_sel
+                        >= nparams)
+                    {
+                        lay->param_sel =
+                            nparams - 1;
+                    }
+                }
+                else if (key == OV_KEY_HOME)
+                {
+                    lay->param_sel = 0;
+                }
+                else if (key == OV_KEY_END)
+                {
+                    lay->param_sel =
+                        nparams - 1;
+                    if (lay->param_sel < 0)
+                    {
+                        lay->param_sel = 0;
+                    }
+                }
+                else if (key == OV_KEY_ESC)
+                {
+                    lay->param_sel = -1;
+                }
+                else if (key == OV_KEY_ENTER
+                         || key == '\r')
+                {
+                    if (!lay->ctrl_mode)
+                    {
+                        ov_cmdlog_push(
+                            &lay->cmdlog,
+                            OV_CMDLOG_WARN,
+                            "Edit requires "
+                            "CONTROL mode");
+                    }
+                    else
+                    {
+                        ov_fps_inline_edit(
+                            lay,
+                            m->fps[fps_sel].name,
+                            lay->param_sel);
+                    }
+                }
+                return 1;
+            }
+
+            /* Init param_sel on first nav key */
+            if (has_fps_params
+                && lay->param_sel < 0
+                && (key == OV_KEY_DOWN
+                    || key == OV_KEY_UP))
+            {
+                lay->param_sel = 0;
+                return 1;
+            }
+
+            /* Fallback: detail scroll */
             sel = NULL;
             scroll = NULL;
             count = lay->detail_total_lines;
             page_h = lay->r_graph.height - 3;
-            
+
             if (key == OV_KEY_UP) {
-                if (lay->scroll_detail > 0) lay->scroll_detail--;
+                if (lay->scroll_detail > 0)
+                    lay->scroll_detail--;
             } else if (key == OV_KEY_DOWN) {
-                if (lay->scroll_detail < lay->detail_total_lines - page_h) lay->scroll_detail++;
+                if (lay->scroll_detail
+                    < lay->detail_total_lines
+                      - page_h)
+                    lay->scroll_detail++;
             } else if (key == OV_KEY_PGUP) {
                 lay->scroll_detail -= page_h;
-                if (lay->scroll_detail < 0) lay->scroll_detail = 0;
+                if (lay->scroll_detail < 0)
+                    lay->scroll_detail = 0;
             } else if (key == OV_KEY_PGDN) {
                 lay->scroll_detail += page_h;
-                if (lay->scroll_detail > lay->detail_total_lines - page_h) lay->scroll_detail = lay->detail_total_lines - page_h;
-                if (lay->scroll_detail < 0) lay->scroll_detail = 0;
+                if (lay->scroll_detail
+                    > lay->detail_total_lines
+                      - page_h)
+                {
+                    lay->scroll_detail =
+                        lay->detail_total_lines
+                        - page_h;
+                }
+                if (lay->scroll_detail < 0)
+                    lay->scroll_detail = 0;
             } else if (key == OV_KEY_HOME) {
                 lay->scroll_detail = 0;
             } else if (key == OV_KEY_END) {
-                lay->scroll_detail = lay->detail_total_lines - page_h;
-                if (lay->scroll_detail < 0) lay->scroll_detail = 0;
+                lay->scroll_detail =
+                    lay->detail_total_lines
+                    - page_h;
+                if (lay->scroll_detail < 0)
+                    lay->scroll_detail = 0;
             }
             return 1;
         } else {
@@ -1025,7 +1591,17 @@ static int ov_input__handle_navigation(int key, OV_LAYOUT *lay, const OV_MODEL *
             {
                 if (lay->focus == OV_FOCUS_STREAMS) lay->sel_name_stream[0] = '\0';
                 else if (lay->focus == OV_FOCUS_PROCS) lay->sel_name_proc[0] = '\0';
-                else if (lay->focus == OV_FOCUS_FPS) lay->sel_name_fps[0] = '\0';
+                else if (lay->focus == OV_FOCUS_FPS)
+                {
+                    lay->sel_name_fps[0] = '\0';
+                    /* Reset param tree cursor when FPS selection moves */
+                    if (lay->view == OV_VIEW_FPS)
+                    {
+                        lay->fps_param_sel    = 0;
+                        lay->fps_param_scroll = 0;
+                        lay->fps_param_focus  = 0;
+                    }
+                }
 
                 if (lay->focus == OV_FOCUS_GRAPH && *sel != old_sel)
                 {

--- a/src/cli/overview/overview_layout.c
+++ b/src/cli/overview/overview_layout.c
@@ -87,5 +87,28 @@ void ov_layout_compute(OV_LAYOUT *lay)
         lay->r_procs   = lay->r_streams;
         lay->r_fps     = lay->r_streams;
         lay->r_graph   = lay->r_streams;
+
+        /* F5 split: ~40% list, ~60% params */
+        if (lay->view == OV_VIEW_FPS)
+        {
+            int lw = (W * 2) / 5;
+            if (lw < 20)
+            {
+                lw = 20;
+            }
+            lay->r_fps_list   = (OV_RECT){
+                body_top, 1, body_h, lw
+            };
+            lay->r_fps_params = (OV_RECT){
+                body_top, lw + 1, body_h, W - lw
+            };
+            /* Keep r_fps pointing to list for panel rendering */
+            lay->r_fps = lay->r_fps_list;
+        }
+        else
+        {
+            lay->r_fps_list   = lay->r_fps;
+            lay->r_fps_params = lay->r_fps;
+        }
     }
 }

--- a/src/cli/overview/overview_layout.h
+++ b/src/cli/overview/overview_layout.h
@@ -130,6 +130,20 @@ typedef struct {
     char         sel_name_stream[80];
     char         sel_name_proc[80];
     char         sel_name_fps[80];
+    /* FPS parameter navigation (detail panel) */
+    int          param_sel;        /* selected param (-1=none) */
+    int          param_scroll;     /* scroll offset */
+    int          param_editing;    /* 1 = inline edit active */
+    char         param_edit_buf[200];
+    int          param_edit_pos;   /* cursor in edit buffer */
+    /* FPS parameter tree state (F5 full-screen view) */
+    int          fps_param_focus;  /* 0=FPS list, 1=param tree */
+    char         fps_param_path[200]; /* Current tree path, e.g. "conf" or "conf.sub" */
+    int          fps_param_sel;    /* selected row in param tree */
+    int          fps_param_scroll; /* scroll offset in param tree */
+    /* F5 view split rects */
+    OV_RECT      r_fps_list;       /* left: FPS list  */
+    OV_RECT      r_fps_params;     /* right: param tree */
 } OV_LAYOUT;
 
 void ov_layout_compute(OV_LAYOUT *lay);

--- a/src/cli/overview/overview_render.c
+++ b/src/cli/overview/overview_render.c
@@ -686,6 +686,22 @@ void ov_render_frame(
             break;
         case OV_VIEW_FPS:
             ov_render_fps_panel(lay, m, &rel);
+            if (lay->sel_fps >= 0
+                && lay->sel_fps < m->nb_fps
+                && m->fps[lay->sel_fps].nb_disp_params > 0)
+            {
+                ov_render_fps_params_panel(lay, m);
+            }
+            else
+            {
+                /* No params: draw empty right panel */
+                ov_draw_panel_border(
+                    lay->r_fps_params.row,
+                    lay->r_fps_params.col,
+                    lay->r_fps_params.height,
+                    lay->r_fps_params.width,
+                    "PARAMS", OV_FG_DIM, 0, 0);
+            }
             break;
         default:
             break;

--- a/src/cli/overview/overview_render_detail.c
+++ b/src/cli/overview/overview_render_detail.c
@@ -1,4 +1,5 @@
 #include "overview_render_internal.h"
+#include "fps_types.h"
 
 #define skip_draw (line_idx < lay->scroll_detail || ri >= max_rows)
 
@@ -650,26 +651,187 @@ static int ov_fps__render_detail_fps(
         H_ov_theme_bg(OV_BG_PANEL);
         H_ov_theme_fg(OV_FG_TITLE);
         H_ov_buf_bold();
-        int n = snprintf(NULL, 0, " Parameters (%d):", f->nb_disp_params);
-        H_ov_buf_printf(" Parameters (%d):", f->nb_disp_params);
+        int n = snprintf(NULL, 0,
+            " Parameters (%d):",
+            f->nb_disp_params);
+        H_ov_buf_printf(
+            " Parameters (%d):",
+            f->nb_disp_params);
         H_ov_buf_reset_attr();
         H_ov_theme_bg(OV_BG_PANEL);
-        H_render_pad_spaces(n, r.width);
+
+        /* Hint: ↑↓ ENTER (only when graph focused) */
+        if (lay->focus == OV_FOCUS_GRAPH
+            && lay->graph_tab_mode == 1)
+        {
+            H_ov_theme_fg(OV_FG_DIM);
+            int h = snprintf(NULL, 0,
+                "  [↑↓ ENTER]");
+            H_ov_buf_printf("  [↑↓ ENTER]");
+            H_render_pad_spaces(n + h, r.width);
+        }
+        else
+        {
+            H_render_pad_spaces(n, r.width);
+        }
         if (!skip_draw) { ri++; }
         line_idx++;
 
-        for (int dp = 0; dp < f->nb_disp_params; dp++)
+        /* Clamp param_sel */
+        if (lay->param_sel >= f->nb_disp_params)
         {
+            lay->param_sel =
+                f->nb_disp_params - 1;
+        }
+
+        /* Auto-scroll to keep selection visible */
+        {
+            int vis_rows = max_rows - ri;
+            if (vis_rows < 1) { vis_rows = 1; }
+            if (lay->param_sel >= 0)
+            {
+                if (lay->param_sel
+                    < lay->param_scroll)
+                {
+                    lay->param_scroll =
+                        lay->param_sel;
+                }
+                if (lay->param_sel
+                    >= lay->param_scroll
+                       + vis_rows)
+                {
+                    lay->param_scroll =
+                        lay->param_sel
+                        - vis_rows + 1;
+                }
+            }
+            if (lay->param_scroll < 0)
+            {
+                lay->param_scroll = 0;
+            }
+        }
+
+        for (int dp = 0;
+             dp < f->nb_disp_params; dp++)
+        {
+            /* Skip rows above scroll window */
+            if (dp < lay->param_scroll)
+            {
+                line_idx++;
+                continue;
+            }
+
+            int is_sel = (dp == lay->param_sel
+                && lay->focus == OV_FOCUS_GRAPH
+                && lay->graph_tab_mode == 1);
+            ov_rgb_t row_bg = is_sel
+                ? OV_BG_SELECTED : OV_BG_PANEL;
+
             H_ov_buf_pos(row + ri, r.col + 1);
-            H_ov_theme_bg(OV_BG_PANEL);
-            H_ov_theme_fg(OV_FG_DIM);
-            H_ov_buf_printf("  ");
-            H_ov_theme_fg(OV_FG_CONN);
-            H_ov_buf_printf("%-24.24s", f->disp_param_name[dp]);
-            H_ov_theme_fg(OV_FG_TEXT);
-            int n2 = snprintf(NULL, 0, " = %s", f->disp_param_value[dp]);
-            H_ov_buf_printf(" = %s", f->disp_param_value[dp]);
-            H_render_pad_spaces(2 + 24 + n2, r.width);
+            H_ov_theme_bg(row_bg);
+
+            /* Writability indicator */
+            int writable =
+                (f->disp_param_flags[dp]
+                 & FPFLAG_WRITESTATUS) != 0;
+            if (is_sel)
+            {
+                H_ov_theme_fg(writable
+                    ? OV_FG_ACTIVE : OV_FG_DIM);
+                H_ov_buf_printf(
+                    writable ? " \xe2\x9c\x8e"
+                             : " \xf0\x9f\x94\x92");
+            }
+            else
+            {
+                H_ov_buf_printf("  ");
+            }
+
+            /* Type badge */
+            const char *tbadge = "???";
+            ov_rgb_t tcolor = OV_FG_DIM;
+            uint32_t pt = f->disp_param_type[dp];
+            if (pt == FPTYPE_INT64
+                || pt == FPTYPE_INT32)
+            {
+                tbadge = "INT";
+                tcolor = (ov_rgb_t){
+                    120, 180, 255};
+            }
+            else if (pt == FPTYPE_UINT64
+                || pt == FPTYPE_UINT32)
+            {
+                tbadge = "UINT";
+                tcolor = (ov_rgb_t){
+                    100, 160, 220};
+            }
+            else if (pt == FPTYPE_FLOAT64
+                || pt == FPTYPE_FLOAT32)
+            {
+                tbadge = "FLT";
+                tcolor = (ov_rgb_t){
+                    180, 200, 100};
+            }
+            else if (pt == FPTYPE_ONOFF)
+            {
+                tbadge = "ON/OFF";
+                tcolor = (ov_rgb_t){
+                    220, 180, 60};
+            }
+            else if (pt == FPTYPE_STREAMNAME)
+            {
+                tbadge = "STRM";
+                tcolor = OV_FG_STREAM;
+            }
+            else if (pt == FPTYPE_FPSNAME)
+            {
+                tbadge = "FPS";
+                tcolor = OV_FG_FPS;
+            }
+            else if (FPTYPE_IS_STRING(pt))
+            {
+                tbadge = "STR";
+                tcolor = (ov_rgb_t){
+                    200, 160, 120};
+            }
+            else if (pt == FPTYPE_PID)
+            {
+                tbadge = "PID";
+                tcolor = OV_FG_PROC;
+            }
+            else if (pt == FPTYPE_TIMESPEC)
+            {
+                tbadge = "TIME";
+                tcolor = (ov_rgb_t){
+                    160, 180, 200};
+            }
+
+            H_ov_theme_fg(tcolor);
+            H_ov_buf_printf("[%-6s]", tbadge);
+
+            /* Parameter name */
+            H_ov_theme_fg(is_sel
+                ? OV_FG_BRIGHT : OV_FG_CONN);
+            H_ov_buf_printf(
+                " %-20.20s",
+                f->disp_param_name[dp]);
+
+            /* Value */
+            H_ov_theme_fg(is_sel
+                ? OV_FG_BRIGHT : OV_FG_TEXT);
+            int n2 = snprintf(NULL, 0,
+                " = %s",
+                f->disp_param_value[dp]);
+            H_ov_buf_printf(
+                " = %s",
+                f->disp_param_value[dp]);
+
+            /* Pad remainder */
+            /* 2 (icon) + 8 (badge) + 1 (sp)
+             * + 20 (name) + n2 (val) */
+            H_render_pad_spaces(
+                2 + 8 + 1 + 20 + n2, r.width);
+
             if (!skip_draw) { ri++; }
             line_idx++;
         } // for disp_params
@@ -697,6 +859,7 @@ int ov_render_detail_panel(
     int psel = lay->freeze ? lay->freeze_sel_proc   : lay->sel_proc;
     int fsel = lay->freeze ? lay->freeze_sel_fps    : lay->sel_fps;
 
+    /* If a list panel is directly focused, show its item's details. */
     if (focus == OV_FOCUS_STREAMS && ssel >= 0 && ssel < m->nb_streams)
     {
         return ov_fps__render_detail_stream(lay, m, ssel, r, max_rows, row);
@@ -708,6 +871,23 @@ int ov_render_detail_panel(
     if (focus == OV_FOCUS_FPS && fsel >= 0 && fsel < m->nb_fps)
     {
         return ov_fps__render_detail_fps(lay, m, fsel, r, max_rows, row);
+    }
+
+    /* Focus is on the graph panel (or no focused list panel).
+     * Still render details for whatever list item is selected,
+     * so that clicking/tabbing into the graph panel does not
+     * make the panel jump to CONNECTIONS view. */
+    if (fsel >= 0 && fsel < m->nb_fps)
+    {
+        return ov_fps__render_detail_fps(lay, m, fsel, r, max_rows, row);
+    }
+    if (ssel >= 0 && ssel < m->nb_streams)
+    {
+        return ov_fps__render_detail_stream(lay, m, ssel, r, max_rows, row);
+    }
+    if (psel >= 0 && psel < m->nb_procs)
+    {
+        return ov_fps__render_detail_proc(lay, m, psel, r, max_rows, row);
     }
 
     return 0;

--- a/src/cli/overview/overview_render_fps_params.c
+++ b/src/cli/overview/overview_render_fps_params.c
@@ -1,0 +1,485 @@
+/**
+ * @file    overview_render_fps_params.c
+ * @brief   FPS parameter tree panel for milkCTRL F5 view
+ *
+ * Renders the right-side parameter panel when the F5
+ * (OV_VIEW_FPS) tab is active. Shows a scrollable flat
+ * list of all visible parameters for the selected FPS,
+ * with type badge, current value, and writability icon.
+ */
+
+#include <string.h>
+#include <stdint.h>
+
+#include "overview_render_internal.h"
+#include "fps_types.h"
+
+/* =========================================================
+ * Helpers
+ * ========================================================= */
+
+/**
+ * fps_param_type_badge - short type label for badge column.
+ * @type: FPS parameter type code
+ *
+ * Return: pointer to a static string like "INT", "FLT", etc.
+ */
+static const char *fps_param_type_badge(uint32_t type)
+{
+    if (type == FPTYPE_INT64 || type == FPTYPE_INT32)
+    {
+        return "INT ";
+    }
+    if (type == FPTYPE_UINT64 || type == FPTYPE_UINT32)
+    {
+        return "UINT";
+    }
+    if (type == FPTYPE_FLOAT64 || type == FPTYPE_FLOAT32)
+    {
+        return "FLT ";
+    }
+    if (type == FPTYPE_ONOFF)
+    {
+        return "ON/F";
+    }
+    if (type == FPTYPE_STREAMNAME)
+    {
+        return "STRM";
+    }
+    if (FPTYPE_IS_STRING(type))
+    {
+        return "STR ";
+    }
+    if (type == FPTYPE_PID)
+    {
+        return "PID ";
+    }
+    if (type == FPTYPE_TIMESPEC)
+    {
+        return "TIME";
+    }
+    return "??? ";
+}
+
+/**
+ * fps_param_type_color - color for a type badge.
+ * @type: FPS parameter type code
+ *
+ * Return: ov_rgb_t color value.
+ */
+static ov_rgb_t fps_param_type_color(uint32_t type)
+{
+    if (type == FPTYPE_INT64 || type == FPTYPE_INT32
+        || type == FPTYPE_UINT64 || type == FPTYPE_UINT32)
+    {
+        return (ov_rgb_t){80, 140, 220};    /* blue-ish  */
+    }
+    if (type == FPTYPE_FLOAT64 || type == FPTYPE_FLOAT32)
+    {
+        return (ov_rgb_t){80, 200, 140};    /* teal      */
+    }
+    if (type == FPTYPE_ONOFF)
+    {
+        return (ov_rgb_t){200, 150, 60};    /* amber     */
+    }
+    if (type == FPTYPE_STREAMNAME)
+    {
+        return (ov_rgb_t){160, 100, 220};   /* purple    */
+    }
+    return (ov_rgb_t){130, 130, 130};       /* dim grey  */
+}
+
+/**
+ * render_param_breadcrumb - draw the FPS name / param count
+ * header at the top of r_fps_params.
+ *
+ * @lay: layout state
+ * @fps: FPS data entry
+ * @r:   panel rectangle (r_fps_params)
+ */
+static void render_param_breadcrumb(
+    const OV_LAYOUT *lay,
+    const OV_FPS    *fps,
+    OV_RECT          r)
+{
+    int focused = (lay->fps_param_focus == 1);
+    ov_rgb_t border_fg = focused
+        ? OV_FG_FPS : OV_FG_DIM;
+
+    /* Draw border and title in one call */
+    char title[256];
+    if (lay->fps_param_path[0] != '\0')
+    {
+        snprintf(title, sizeof(title),
+                 "PARAMS  %s / %s", fps->name, lay->fps_param_path);
+    }
+    else
+    {
+        snprintf(title, sizeof(title),
+                 "PARAMS  %s", fps->name);
+    }
+    ov_draw_panel_border(
+        r.row, r.col, r.height, r.width,
+        title, border_fg, focused, 0);
+
+    /* Header row: col labels */
+    int hrow = r.row + 1;
+    ov_buf_pos(hrow, r.col + 1);
+    ov_theme_bg(OV_BG_HEADER);
+    ov_theme_fg(OV_FG_DIM);
+
+    int kw = r.width - 18;   /* keyword column width */
+    if (kw < 6)
+    {
+        kw = 6;
+    }
+    ov_buf_printf(" %-*s %4s  %-*s",
+                  kw, "PARAMETER",
+                  "TYPE",
+                  r.width - kw - 12, "VALUE");
+    ov_buf_reset_attr();
+}
+
+/* =========================================================
+ * Tree Helpers
+ * ========================================================= */
+
+int ov_get_fps_tree_items(const OV_FPS *fps, const char *path, fps_tree_item_t *items, int max_items)
+{
+    int count = 0;
+    int path_len = strlen(path);
+    
+    for (int i = 0; i < fps->nb_disp_params; i++)
+    {
+        const char *pname = fps->disp_param_name[i];
+        if (pname[0] == '.') pname++;
+        
+        if (path_len > 0)
+        {
+            if (strncmp(pname, path, path_len) != 0) continue;
+            if (pname[path_len] != '.') continue;
+            pname += path_len + 1;
+        }
+        
+        const char *next_dot = strchr(pname, '.');
+        char seg[80] = {0};
+        int is_dir = 0;
+        
+        if (next_dot)
+        {
+            int seg_len = next_dot - pname;
+            if (seg_len >= (int)sizeof(seg)) seg_len = sizeof(seg) - 1;
+            strncpy(seg, pname, seg_len);
+            is_dir = 1;
+        }
+        else
+        {
+            strncpy(seg, pname, sizeof(seg) - 1);
+            is_dir = 0;
+        }
+        
+        int dup = 0;
+        if (is_dir)
+        {
+            for (int k = 0; k < count; k++)
+            {
+                if (items[k].is_dir && strcmp(items[k].name, seg) == 0)
+                {
+                    dup = 1;
+                    break;
+                }
+            }
+        }
+        
+        if (!dup && count < max_items)
+        {
+            strncpy(items[count].name, seg, sizeof(items[count].name) - 1);
+            items[count].is_dir = is_dir;
+            items[count].param_idx = i;
+            count++;
+        }
+    }
+    
+    for (int i = 0; i < count - 1; i++) {
+        for (int j = i + 1; j < count; j++) {
+            int swap = 0;
+            if (items[i].is_dir != items[j].is_dir) {
+                if (items[j].is_dir) swap = 1;
+            } else {
+                if (strcasecmp(items[i].name, items[j].name) > 0) swap = 1;
+            }
+            if (swap) {
+                fps_tree_item_t tmp = items[i];
+                items[i] = items[j];
+                items[j] = tmp;
+            }
+        }
+    }
+    
+    return count;
+}
+
+/* =========================================================
+ * Public renderer
+ * ========================================================= */
+
+/**
+ * ov_render_fps_params_panel - draw parameter tree panel.
+ * @lay: layout state (fps_param_focus/sel/scroll used)
+ * @m:   data model
+ *
+ * Draws the right panel in the F5 split view. Shows all
+ * visible parameters for the currently selected FPS entry
+ * as a virtual hierarchical tree.
+ */
+void ov_render_fps_params_panel(
+    OV_LAYOUT       *lay,
+    const OV_MODEL  *m)
+{
+    OV_RECT r = lay->r_fps_params;
+
+    /* --- Guard: need a valid FPS selection with params --- */
+    int fsel = lay->sel_fps;
+    if (fsel < 0 || fsel >= m->nb_fps)
+    {
+        /* Draw empty border */
+        ov_draw_panel_border(
+            r.row, r.col, r.height, r.width,
+            "PARAMS", OV_FG_DIM, 0, 0);
+        return;
+    }
+
+    const OV_FPS *fps = &m->fps[fsel];
+
+    fps_tree_item_t items[1024];
+    int nitems = ov_get_fps_tree_items(fps, lay->fps_param_path, items, 1024);
+
+    render_param_breadcrumb(lay, fps, r);
+
+    if (nitems <= 0)
+    {
+        if (lay->fps_param_path[0] != '\0')
+        {
+            ov_buf_pos(r.row + 2, r.col + 2);
+            ov_theme_fg(OV_FG_DIM);
+            ov_buf_printf("(Empty directory)");
+        }
+        else
+        {
+            ov_buf_pos(r.row + 2, r.col + 2);
+            ov_theme_fg(OV_FG_DIM);
+            ov_buf_printf("(No params)");
+        }
+        return;
+    }
+
+    /* Clamp scroll */
+    int max_rows = r.height - 3;   /* header row + borders */
+    if (max_rows < 1)
+    {
+        max_rows = 1;
+    }
+
+    int scroll = lay->fps_param_scroll;
+    int psel   = lay->fps_param_sel;
+
+    /* Keep cursor visible */
+    if (psel < scroll)
+    {
+        scroll = psel;
+    }
+    if (psel >= scroll + max_rows)
+    {
+        scroll = psel - max_rows + 1;
+    }
+    if (scroll < 0)
+    {
+        scroll = 0;
+    }
+    if (scroll > nitems - max_rows)
+    {
+        scroll = nitems - max_rows;
+    }
+    if (scroll < 0)
+    {
+        scroll = 0;
+    }
+    lay->fps_param_scroll = scroll;
+
+    /* Keyword column width */
+    int kw = r.width / 2 - 2;
+    if (kw > 35)
+    {
+        kw = 35;
+    }
+    if (kw < 12)
+    {
+        kw = 12;
+    }
+
+    for (int i = 0; i < max_rows; i++)
+    {
+        int row = r.row + 2 + i;
+        int list_idx = scroll + i;
+
+        if (list_idx >= nitems)
+        {
+            clear_row(row, r.col + 1,
+                      r.width - 2, OV_BG_PANEL);
+            continue;
+        }
+
+        int is_sel = (lay->fps_param_focus == 1
+                      && list_idx == psel);
+
+        ov_rgb_t row_bg = is_sel
+            ? OV_BG_SELECTED : OV_BG_PANEL;
+
+        ov_buf_pos(row, r.col + 1);
+        ov_theme_bg(row_bg);
+
+        fps_tree_item_t *item = &items[list_idx];
+
+        if (item->is_dir)
+        {
+            /* Directory row */
+            ov_theme_fg(OV_FG_DIM);
+            ov_buf_printf("  "); /* no pencil */
+
+            ov_theme_fg(is_sel ? OV_FG_TEXT : (ov_rgb_t){220, 200, 100}); /* folder color */
+            ov_buf_printf("%-*.*s/", kw - 1, kw - 1, item->name);
+
+            ov_theme_fg(OV_FG_DIM);
+            ov_buf_printf("%4s  ", "DIR ");
+
+            int vw = r.width - kw - 12;
+            if (vw < 4) vw = 4;
+            ov_buf_printf("%-*s", vw, ""); /* no value */
+        }
+        else
+        {
+            /* Leaf parameter row */
+            int pi = item->param_idx;
+
+            /* Write-status badge: W (writable now) / C (conf only) / NW (locked)
+             * Mirrors the W /NW display in milk-fpsCTRL. Column is 3 chars wide. */
+            {
+                uint64_t fl = fps->disp_param_flags[pi];
+                int ws  = (fl & FPFLAG_WRITESTATUS)  != 0;
+                int wc  = (fl & FPFLAG_WRITECONF)    != 0;
+
+                if (ws)
+                {
+                    /* Currently writable — green "W " */
+                    ov_theme_fg(is_sel
+                        ? OV_FG_ACTIVE
+                        : (ov_rgb_t){80, 200, 80});
+                    ov_buf_printf("W ");
+                }
+                else if (wc)
+                {
+                    /* Writable in conf mode only — amber "C " */
+                    ov_theme_fg(is_sel
+                        ? OV_FG_TEXT
+                        : (ov_rgb_t){220, 180, 60});
+                    ov_buf_printf("C ");
+                }
+                else
+                {
+                    /* Not writable — dim red "NW" */
+                    ov_theme_fg(is_sel
+                        ? OV_FG_DIM
+                        : (ov_rgb_t){160, 60, 60});
+                    ov_buf_printf("NW");
+                }
+            }
+            ov_buf_printf(" "); /* separator after badge */
+
+            /* Parameter keyword */
+            ov_theme_fg(is_sel
+                ? OV_FG_TEXT
+                : OV_FG_FPS);
+            ov_buf_printf("%-*.*s ", kw, kw, item->name);
+
+            /* Type badge */
+            {
+                ov_rgb_t tc =
+                    fps_param_type_color(
+                        fps->disp_param_type[pi]);
+                if (is_sel)
+                {
+                    tc = OV_FG_TEXT;
+                }
+                ov_theme_fg(tc);
+                ov_buf_printf("%4s  ",
+                    fps_param_type_badge(
+                        fps->disp_param_type[pi]));
+            }
+
+            /* Value */
+            {
+                const char *val = fps->disp_param_value[pi];
+                /* budget: badge(3) + sep(1) + kw + 1 + typebadge(6) = kw + 11 */
+                int vw = r.width - kw - 14;
+                if (vw < 4)
+                {
+                    vw = 4;
+                }
+
+                /* ONOFF: color based on string value "ON" / "OFF" */
+                if (fps->disp_param_type[pi] == FPTYPE_ONOFF)
+                {
+                    int is_on = (val[0] == 'O' && val[1] == 'N');
+                    if (is_on)
+                    {
+                        ov_theme_fg(is_sel
+                            ? OV_FG_ACTIVE
+                            : (ov_rgb_t){60, 220, 60});
+                        ov_buf_printf("%-*s",
+                            vw, "ON");
+                    }
+                    else
+                    {
+                        ov_theme_fg(is_sel
+                            ? OV_FG_DIM
+                            : (ov_rgb_t){160, 60, 60});
+                        ov_buf_printf("%-*s",
+                            vw, "OFF");
+                    }
+                }
+                else
+                {
+                    ov_theme_fg(is_sel
+                        ? OV_FG_TEXT : OV_FG_DIM);
+                    ov_buf_printf("%-*.*s",
+                        vw, vw, val);
+                }
+            }
+        }
+
+        ov_buf_reset_attr();
+    } /* for each row */
+
+    render_scroll_indicators(
+        r, scroll, max_rows,
+        nitems, OV_FG_FPS);
+
+    /* Footer: item count */
+    {
+        char fbuf[48];
+        snprintf(fbuf, sizeof(fbuf),
+                 " %d/%d items ",
+                 psel + 1, nitems);
+        int flen = (int)strlen(fbuf);
+        int bcol = r.col + r.width - flen - 2;
+        if (bcol > r.col + 1)
+        {
+            ov_buf_pos(r.row + r.height - 1, bcol);
+            ov_theme_fg(OV_FG_DIM);
+            ov_theme_bg(OV_BG_PANEL);
+            ov_buf_printf("%s", fbuf);
+        }
+    }
+
+    ov_buf_reset_attr();
+}

--- a/src/cli/overview/overview_render_fps_params.h
+++ b/src/cli/overview/overview_render_fps_params.h
@@ -1,0 +1,24 @@
+/**
+ * @file    overview_render_fps_params.h
+ * @brief   FPS parameter tree panel for milkCTRL F5 view
+ */
+
+#ifndef OVERVIEW_RENDER_FPS_PARAMS_H
+#define OVERVIEW_RENDER_FPS_PARAMS_H
+
+#include "overview_layout.h"
+#include "overview_data.h"
+
+/**
+ * ov_render_fps_params_panel - draw FPS parameter tree panel.
+ * @lay: layout state (fps_param_focus/sel/scroll consumed)
+ * @m:   data model
+ *
+ * Renders into lay->r_fps_params. Call only when
+ * view == OV_VIEW_FPS.
+ */
+void ov_render_fps_params_panel(
+    OV_LAYOUT       *lay,
+    const OV_MODEL  *m);
+
+#endif /* OVERVIEW_RENDER_FPS_PARAMS_H */

--- a/src/cli/overview/overview_render_internal.h
+++ b/src/cli/overview/overview_render_internal.h
@@ -202,6 +202,10 @@ void ov_render_graph_panel(
     const OV_LAYOUT *lay,
     const OV_MODEL  *m);
 
+void ov_render_fps_params_panel(
+    OV_LAYOUT       *lay,
+    const OV_MODEL  *m);
+
 void ov_render_status(
     const OV_LAYOUT *lay,
     const OV_MODEL  *m);


### PR DESCRIPTION
## Summary

Add a full FPS parameter tree navigation and editing system to milkCTRL's F5:FPS tab, bringing feature parity with `milk-fpsCTRL`. Also fixes a critical mouse interaction bug that affected all single-panel views (F3–F6).

## Changes

### FPS Parameter Tree (new)
- Split-panel layout in F5 view: left panel lists FPS entries (~40% width), right panel shows parameter tree (~60% width)
- Virtual hierarchy navigation: `RIGHT`/`ENTER` descends into `conf.sub.param` folders, `LEFT`/`ESC` ascends
- Inline parameter editing via `ENTER` on leaf parameters (requires CONTROL mode)
- Writability badges: `W` (write-status), `C` (write-conf), `NW` (read-only)
- Type badges: `INT`, `FLT`, `STRM`, `FPS`, `ON/OFF`, `STR`, `PID`, `TIME`
- Mouse click and scroll wheel support for both panels

### Mouse Dispatch Fix (bug fix)
- **Root cause**: In single-panel views (F3–F6), the layout engine sets `r_streams`, `r_procs`, `r_fps`, and `r_graph` to the same full-screen rectangle. The `INSIDE(r_streams)` check always matched first, stealing clicks from the active panel.
- **Fix**: Made both click and scroll handlers view-aware — they now check the active view first and route directly to the correct panel, falling back to the `INSIDE` cascade only on Dashboard where all four rects are non-overlapping.

### Tab Click Alignment Fix (bug fix)
- Compute header tab click widths dynamically from label strings instead of hardcoded values, fixing click misalignment.

### New Files
- `overview_fps_edit.c/h` — inline parameter editing via ncurses dialog
- `overview_render_fps_params.c/h` — right-panel parameter tree renderer

## Verification

- [x] Build passes (`make -j$(nproc) && make install`)
- [x] milkCTRL launches and renders correctly
- [x] F5 tab: left panel click selects FPS entries
- [x] F5 tab: right panel shows parameter tree with folder navigation
- [x] Dashboard tab: mouse clicks still work correctly on all four panels

## Prompt Summary

User requested adding FPS parameter tree navigation to milkCTRL's F5 tab (mirroring `milk-fpsCTRL`), followed by several refinement passes: adjusting column widths, adding writability status badges, and fixing a bug where clicking the left panel caused the FPS selection to disappear. The selection-loss bug was traced to overlapping panel rectangles in single-panel view layouts.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None — all code changes were authored by the AI agent based on user direction.