### PR TITLE
fix: interactive UI controls, split resizing, and tmux robustness

### DIFF
--- a/src/cli/overview/milkCTRL.c
+++ b/src/cli/overview/milkCTRL.c
@@ -180,6 +180,9 @@ static void print_help(const char *prog, int mh_color)
     printf("  %s                               Toggle sort direction (Ascending/Descending)\n\n", MH(MH_OPT, "["));
 
     milk_help_section("Display & Layout", mh_color);
+    printf("  %s, %s                        Adjust F5:FPS vertical split panel size\n", MH(MH_OPT, "{"), MH(MH_OPT, "}"));
+    printf("  %s, %s                        Adjust F2:Dashboard vertical split\n", MH(MH_OPT, "{"), MH(MH_OPT, "}"));
+    printf("  %s, %s                        Adjust F2:Dashboard horizontal split\n", MH(MH_OPT, "("), MH(MH_OPT, ")"));
     printf("  %s                             Adjust scan rate (increase/decrease speed)\n", MH(MH_OPT, "+/-"));
     printf("  %s                         Toggle detail pane / Graph jump (on selected item)\n", MH(MH_OPT, "ENTER/D"));
     printf("  %s                               Cycle graph lineage mode (on Graph view)\n", MH(MH_OPT, "L"));
@@ -308,6 +311,12 @@ int main(int argc, char *argv[])
     lay.focus = OV_FOCUS_STREAMS;
     lay.cmdlog_rows = 4;
     lay.param_sel = -1;
+    lay.fps_split_ratio = 0.4f;
+    lay.fps_split_dragging = 0;
+    lay.dash_split_v_ratio = 0.5f;
+    lay.dash_split_h_ratio = 0.5f;
+    lay.dash_split_v_dragging = 0;
+    lay.dash_split_h_dragging = 0;
 
     /* --- Main TUI loop (~10 fps) --- */
     /* Clear screen once on startup */

--- a/src/cli/overview/overview_ansi.h
+++ b/src/cli/overview/overview_ansi.h
@@ -49,6 +49,8 @@
 #define OV_KEY_MOUSE_CLICK  281
 #define OV_KEY_MOUSE_UP     282
 #define OV_KEY_MOUSE_DOWN   283
+#define OV_KEY_MOUSE_DRAG   287
+#define OV_KEY_MOUSE_RELEASE 288
 
 extern int ov_mouse_row;
 extern int ov_mouse_col;
@@ -82,7 +84,7 @@ static inline void ov_raw_mode_enter(void)
     int flags = fcntl(STDIN_FILENO, F_GETFL, 0);
     fcntl(STDIN_FILENO, F_SETFL, flags | O_NONBLOCK);
 
-    const char seq[] = "\033[?1049h\033[?25l\033[?7l\033[?1000h\033[?1006h";
+    const char seq[] = "\033[?1049h\033[?25l\033[?7l\033[?1002h\033[?1006h";
     if (write(STDOUT_FILENO, seq, sizeof(seq) - 1) < 0) {}
     ov__raw_active = 1;
 }
@@ -90,7 +92,7 @@ static inline void ov_raw_mode_enter(void)
 static inline void ov_raw_mode_exit(void)
 {
     if (!ov__raw_active) return;
-    const char seq[] = "\033[?1006l\033[?1000l\033[?25h\033[?7h\033[0m\033[?1049l";
+    const char seq[] = "\033[?1006l\033[?1002l\033[?25h\033[?7h\033[0m\033[?1049l";
     if (write(STDOUT_FILENO, seq, sizeof(seq) - 1) < 0) {}
     tcsetattr(STDIN_FILENO, TCSAFLUSH, &ov__orig_termios);
     ov__raw_active = 0;
@@ -572,7 +574,9 @@ static inline int ov_get_key(void)
 
                         if (mb == 64) return OV_KEY_MOUSE_UP;
                         if (mb == 65) return OV_KEY_MOUSE_DOWN;
+                        if ((mb & 32) && press) return OV_KEY_MOUSE_DRAG;
                         if (mb == 0 && press) return OV_KEY_MOUSE_CLICK;
+                        if (!press) return OV_KEY_MOUSE_RELEASE;
                         return OV_KEY_NONE;
                     }
                     return OV_KEY_NONE;

--- a/src/cli/overview/overview_ctrl.c
+++ b/src/cli/overview/overview_ctrl.c
@@ -30,7 +30,9 @@
 /* fps_types.h for FPS and FPSCMDCODE_* */
 #include "fps_types.h"
 
+errno_t functionparameter_CONFstart(FPS *fps);
 errno_t functionparameter_CONFstop(FPS *fps);
+errno_t functionparameter_RUNstart(FPS *fps);
 errno_t functionparameter_RUNstop(FPS *fps);
 errno_t functionparameter_FPSremove(FPS *fps);
 
@@ -46,24 +48,22 @@ int fps_disconnect(
     FPS *fps);
 
 /* =========================================================
- * Internal FPS SHM signal helper
+ * Internal FPS action helper
  * ========================================================= */
 
 /**
- * ov_ctrl_fps_signal - write a command code into
- * the FPS SHM.
+ * ov_ctrl_fps_action - perform an FPS function parameter action
  * @fps_name: FPS instance name
- * @cmd:      FPSCMDCODE_* value to OR into md->signal
+ * @action:   Function to execute
  *
- * Opens the FPS in simple (read/write) mode, ORs the
- * command, and immediately disconnects.
+ * Opens the FPS in simple mode, runs the action, and disconnects.
+ * Suppresses stderr to prevent tmux errors from corrupting TUI.
  *
- * Return: 0 on success, -1 if the SHM could not be
- * opened.
+ * Return: 0 on success, -1 if the SHM could not be opened.
  */
-static int ov_ctrl_fps_signal(
+static int ov_ctrl_fps_action(
     const char *fps_name,
-    uint32_t    cmd)
+    errno_t (*action)(FPS *))
 {
     FPS fps;
     memset(&fps, 0, sizeof(fps));
@@ -75,9 +75,22 @@ static int ov_ctrl_fps_signal(
         return -1;
     }
 
-    if (fps.md != NULL)
+    /* Suppress stderr from tmux commands to avoid TUI corruption */
+    int saved_stderr = dup(STDERR_FILENO);
+    int devnull = open("/dev/null", O_WRONLY);
+    if (devnull >= 0)
     {
-        fps.md->signal |= (uint64_t) cmd;
+        dup2(devnull, STDERR_FILENO);
+        close(devnull);
+    }
+
+    action(&fps);
+
+    /* Restore stderr */
+    if (saved_stderr >= 0)
+    {
+        dup2(saved_stderr, STDERR_FILENO);
+        close(saved_stderr);
     }
 
     fps_disconnect(&fps);
@@ -102,13 +115,13 @@ void ov_ctrl_fps_run_toggle(
         return;
     }
 
-    uint32_t cmd = f->run_alive
-                   ? FPSCMDCODE_RUNSTOP
-                   : FPSCMDCODE_RUNSTART;
+    errno_t (*action_fn)(FPS *) = f->run_alive
+                                  ? functionparameter_RUNstop
+                                  : functionparameter_RUNstart;
     const char *action = f->run_alive
                          ? "RUN stop" : "RUN start";
 
-    int rc = ov_ctrl_fps_signal(f->name, cmd);
+    int rc = ov_ctrl_fps_action(f->name, action_fn);
     if (log != NULL)
     {
         ov_cmdlog_push(log,
@@ -133,13 +146,13 @@ void ov_ctrl_fps_conf_toggle(
         return;
     }
 
-    uint32_t cmd = f->conf_alive
-                   ? FPSCMDCODE_CONFSTOP
-                   : FPSCMDCODE_CONFSTART;
+    errno_t (*action_fn)(FPS *) = f->conf_alive
+                                  ? functionparameter_CONFstop
+                                  : functionparameter_CONFstart;
     const char *action = f->conf_alive
                          ? "CONF stop" : "CONF start";
 
-    int rc = ov_ctrl_fps_signal(f->name, cmd);
+    int rc = ov_ctrl_fps_action(f->name, action_fn);
     if (log != NULL)
     {
         ov_cmdlog_push(log,

--- a/src/cli/overview/overview_data.c
+++ b/src/cli/overview/overview_data.c
@@ -76,6 +76,7 @@ void ov_model_full_scan(OV_MODEL *model)
 
     ov_scan_streams(model);
     ov_scan_fps(model);
+    ov_scan_tmux_sessions(model);
     ov_scan_procs(model);
 
     ov_build_graph(model);

--- a/src/cli/overview/overview_data.h
+++ b/src/cli/overview/overview_data.h
@@ -196,6 +196,12 @@ typedef struct
     int      conf_alive;
     int      run_alive;
 
+    /* tmux tracking */
+    uint8_t  tmux_flags;
+#define OV_TMUX_CTRL 0x01
+#define OV_TMUX_CONF 0x02
+#define OV_TMUX_RUN  0x04
+
     /* stream-type parameters (for edges) */
     int      nb_stream_params;
     char     stream_param_name[OV_FPS_MAX_STREAM_PARAMS]
@@ -363,6 +369,15 @@ void ov_scan_fps(OV_MODEL *model);
  * Maps the processinfo list and reads active processes.
  */
 void ov_scan_procs(OV_MODEL *model);
+
+/**
+ * ov_scan_tmux_sessions - check for live FPS tmux sessions.
+ * @model: model to update
+ *
+ * Parses `tmux list-windows` to update the OV_TMUX_* flags
+ * on the scanned FPS entries.
+ */
+void ov_scan_tmux_sessions(OV_MODEL *model);
 
 /**
  * ov_build_graph - build node/edge graph from scan data.

--- a/src/cli/overview/overview_data_scan.c
+++ b/src/cli/overview/overview_data_scan.c
@@ -1076,6 +1076,76 @@ void ov_scan_procs(OV_MODEL *model)
 
 
 /* =========================================================
+ * tmux session scanning
+ * ========================================================= */
+
+void ov_scan_tmux_sessions(OV_MODEL *model)
+{
+    /* Reset all tmux flags */
+    for (int i = 0; i < model->nb_fps; i++)
+    {
+        model->fps[i].tmux_flags = 0;
+    }
+
+    if (model->nb_fps == 0)
+    {
+        return;
+    }
+
+    FILE *fp = popen("tmux list-windows -a -F \"#{session_name}:#{window_name}\" 2>/dev/null", "r");
+    if (fp == NULL)
+    {
+        return;
+    }
+
+    char line[256];
+    while (fgets(line, sizeof(line), fp) != NULL)
+    {
+        /* Strip newline */
+        int len = strlen(line);
+        while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r'))
+        {
+            line[--len] = '\0';
+        }
+
+        /* Find the colon */
+        char *colon = strchr(line, ':');
+        if (colon == NULL)
+        {
+            continue;
+        }
+
+        *colon = '\0';
+        const char *session_name = line;
+        const char *window_name  = colon + 1;
+
+        /* Find matching FPS in model */
+        for (int i = 0; i < model->nb_fps; i++)
+        {
+            if (strcmp(model->fps[i].name, session_name) == 0)
+            {
+                if (strcmp(window_name, "ctrl") == 0)
+                {
+                    model->fps[i].tmux_flags |= OV_TMUX_CTRL;
+                }
+                else if (strcmp(window_name, "conf") == 0)
+                {
+                    model->fps[i].tmux_flags |= OV_TMUX_CONF;
+                }
+                else if (strcmp(window_name, "run") == 0)
+                {
+                    model->fps[i].tmux_flags |= OV_TMUX_RUN;
+                }
+                break;
+            }
+        }
+    }
+
+    pclose(fp);
+}
+
+
+/* =========================================================
  * Cache cleanup (called from ov_scan_stop)
  * ========================================================= */
 

--- a/src/cli/overview/overview_input.c
+++ b/src/cli/overview/overview_input.c
@@ -184,6 +184,15 @@ static void ov_input__exec_preview_btn(
 {
     OV_CMDLOG *log = &lay->cmdlog;
 
+    if (!lay->ctrl_mode)
+    {
+        ov_cmdlog_push(
+            &lay->cmdlog,
+            OV_CMDLOG_WARN,
+            "Action requires CONTROL mode (press c to toggle CTRL mode ON/OFF)");
+        return;
+    }
+
     switch (btn_id)
     {
     case OV_BTN_PROC_PAUSE:
@@ -350,8 +359,36 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
          * On the Dashboard all four rects are distinct
          * so the cascade works normally.
          */
+        if (lay->view == OV_VIEW_DASHBOARD)
+        {
+            /* Check for dashboard horizontal split drag */
+            int h_split_row = lay->r_streams.row + lay->r_streams.height;
+            if (mr == h_split_row - 1 || mr == h_split_row)
+            {
+                lay->dash_split_h_dragging = 1;
+                return 1;
+            }
+            /* Check for dashboard vertical split drag */
+            int v_split_col = lay->r_streams.width;
+            if (mc == v_split_col || mc == v_split_col + 1)
+            {
+                if (mr >= lay->r_streams.row && mr < lay->r_streams.row + lay->r_streams.height + lay->r_fps.height)
+                {
+                    lay->dash_split_v_dragging = 1;
+                    return 1;
+                }
+            }
+        }
+
         if (lay->view == OV_VIEW_FPS)
         {
+            /* F5: Check for split drag */
+            if (mc == lay->r_fps_list.width || mc == lay->r_fps_list.width + 1)
+            {
+                lay->fps_split_dragging = 1;
+                return 1;
+            }
+
             /* F5: left = fps list, right = params */
             if (INSIDE(lay->r_fps_params, mr, mc))
             {
@@ -584,6 +621,65 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
             }
         }
         return 1;
+    }
+
+    if (key == OV_KEY_MOUSE_RELEASE)
+    {
+        lay->fps_split_dragging = 0;
+        lay->dash_split_v_dragging = 0;
+        lay->dash_split_h_dragging = 0;
+        return 1;
+    }
+
+    if (key == OV_KEY_MOUSE_DRAG)
+    {
+        int mr = ov_mouse_row;
+        int mc = ov_mouse_col;
+
+        if (lay->view == OV_VIEW_FPS)
+        {
+            if (lay->fps_split_dragging || (mc >= lay->r_fps_list.width - 1 && mc <= lay->r_fps_list.width + 2))
+            {
+                lay->fps_split_dragging = 1;
+                float ratio = (float)mc / lay->term_cols;
+                if (ratio < 0.1f) ratio = 0.1f;
+                if (ratio > 0.9f) ratio = 0.9f;
+                lay->fps_split_ratio = ratio;
+                return 1;
+            }
+        }
+        if (lay->view == OV_VIEW_DASHBOARD)
+        {
+            int h_split_row = lay->r_streams.row + lay->r_streams.height;
+            int v_split_col = lay->r_streams.width;
+
+            int handled = 0;
+            if (lay->dash_split_h_dragging || (mr >= h_split_row - 1 && mr <= h_split_row + 1))
+            {
+                lay->dash_split_h_dragging = 1;
+                int log_h = lay->cmdlog_rows;
+                if (log_h < 0) log_h = 0;
+                int body_top = 3;
+                int body_h = lay->term_rows - 3 - log_h;
+                if (body_h < 4) body_h = 4;
+                float ratio = (float)(mr - body_top) / body_h;
+                if (ratio < 0.1f) ratio = 0.1f;
+                if (ratio > 0.9f) ratio = 0.9f;
+                lay->dash_split_h_ratio = ratio;
+                handled = 1;
+            }
+            if (lay->dash_split_v_dragging || (mc >= v_split_col - 1 && mc <= v_split_col + 2))
+            {
+                lay->dash_split_v_dragging = 1;
+                float ratio = (float)mc / lay->term_cols;
+                if (ratio < 0.1f) ratio = 0.1f;
+                if (ratio > 0.9f) ratio = 0.9f;
+                lay->dash_split_v_ratio = ratio;
+                handled = 1;
+            }
+            if (handled) return 1;
+        }
+        return 0; /* Ignore other drags for now */
     }
 
     if (key == OV_KEY_MOUSE_UP || key == OV_KEY_MOUSE_DOWN)
@@ -847,6 +943,54 @@ static int ov_input__handle_misc_toggles(int key, OV_LAYOUT *lay, const OV_MODEL
         lay->lineage_mode = (lay->lineage_mode + 1) % 3;
         return 1;
     }
+    if (key == '{' || key == '}')
+    {
+        float step = (key == '{') ? -0.05f : 0.05f;
+        if (lay->view == OV_VIEW_FPS)
+        {
+            lay->fps_split_ratio += step;
+            if (lay->fps_split_ratio < 0.1f) lay->fps_split_ratio = 0.1f;
+            if (lay->fps_split_ratio > 0.9f) lay->fps_split_ratio = 0.9f;
+            return 1;
+        }
+        else if (lay->view == OV_VIEW_DASHBOARD)
+        {
+            lay->dash_split_v_ratio += step;
+            if (lay->dash_split_v_ratio < 0.1f) lay->dash_split_v_ratio = 0.1f;
+            if (lay->dash_split_v_ratio > 0.9f) lay->dash_split_v_ratio = 0.9f;
+            return 1;
+        }
+    }
+    if (key == '(' || key == ')')
+    {
+        float step = (key == '(') ? -0.05f : 0.05f;
+        if (lay->view == OV_VIEW_DASHBOARD)
+        {
+            lay->dash_split_h_ratio += step;
+            if (lay->dash_split_h_ratio < 0.1f) lay->dash_split_h_ratio = 0.1f;
+            if (lay->dash_split_h_ratio > 0.9f) lay->dash_split_h_ratio = 0.9f;
+            return 1;
+        }
+    }
+
+    if (key == '{' || key == '}')
+    {
+        float step = (key == '{') ? -0.05f : 0.05f;
+        if (lay->view == OV_VIEW_DASHBOARD)
+        {
+            lay->dash_split_v_ratio += step;
+            if (lay->dash_split_v_ratio < 0.1f) lay->dash_split_v_ratio = 0.1f;
+            if (lay->dash_split_v_ratio > 0.9f) lay->dash_split_v_ratio = 0.9f;
+            return 1;
+        }
+        else if (lay->view == OV_VIEW_FPS)
+        {
+            lay->fps_split_ratio += step;
+            if (lay->fps_split_ratio < 0.1f) lay->fps_split_ratio = 0.1f;
+            if (lay->fps_split_ratio > 0.9f) lay->fps_split_ratio = 0.9f;
+            return 1;
+        }
+    }
     if (key == 'F')
     {
         lay->paused = !lay->paused;
@@ -891,6 +1035,12 @@ static int ov_input__handle_misc_toggles(int key, OV_LAYOUT *lay, const OV_MODEL
     /* ENTER — open DETAILS for list panels; toggle when on graph */
     if ((key == 10 || key == 13) && m != NULL)
     {
+        /* In dedicated FPS view, ENTER is used to edit parameters */
+        if (lay->view == OV_VIEW_FPS)
+        {
+            return 0;
+        }
+
         if (lay->focus == OV_FOCUS_STREAMS
             || lay->focus == OV_FOCUS_PROCS
             || lay->focus == OV_FOCUS_FPS)
@@ -1084,7 +1234,7 @@ static int ov_input__handle_actions(int key, OV_LAYOUT *lay, const OV_MODEL *m)
     {
         if (!lay->ctrl_mode)
         {
-            ov_cmdlog_push(log, OV_CMDLOG_WARN, "CTRL+e requires CONTROL mode");
+            ov_cmdlog_push(log, OV_CMDLOG_WARN, "CTRL+e requires CONTROL mode (press c to toggle CTRL mode ON/OFF)");
             return 1;
         }
 
@@ -1197,7 +1347,7 @@ static int ov_input__handle_actions(int key, OV_LAYOUT *lay, const OV_MODEL *m)
             else if (key == OV_KEY_DEL) snprintf(keyname, sizeof(keyname), "DEL");
             else snprintf(keyname, sizeof(keyname), "'%c'", key);
             
-            ov_cmdlog_push(log, OV_CMDLOG_WARN, "%s requires CONTROL mode", keyname);
+            ov_cmdlog_push(log, OV_CMDLOG_WARN, "%s requires CONTROL mode (press c to toggle CTRL mode ON/OFF)", keyname);
         }
         return 1;
     }
@@ -1335,7 +1485,7 @@ static int ov_input__handle_navigation(int key, OV_LAYOUT *lay, const OV_MODEL *
 
         /* RIGHT from list → enter param panel */
         if (lay->fps_param_focus == 0
-            && (key == OV_KEY_RIGHT || key == OV_KEY_ENTER || key == '\r')
+            && (key == OV_KEY_RIGHT || key == OV_KEY_ENTER || key == '\r' || key == '\n')
             && has_params)
         {
             lay->fps_param_focus = 1;
@@ -1426,7 +1576,7 @@ static int ov_input__handle_navigation(int key, OV_LAYOUT *lay, const OV_MODEL *
                 }
                 return 1;
             }
-            if (key == OV_KEY_RIGHT || key == OV_KEY_ENTER || key == '\r')
+            if (key == OV_KEY_RIGHT || key == OV_KEY_ENTER || key == '\r' || key == '\n')
             {
                 if (lay->fps_param_sel >= 0 && lay->fps_param_sel < nitems)
                 {
@@ -1447,14 +1597,14 @@ static int ov_input__handle_navigation(int key, OV_LAYOUT *lay, const OV_MODEL *
                         lay->fps_param_sel = 0;
                         lay->fps_param_scroll = 0;
                     }
-                    else if (key == OV_KEY_ENTER || key == '\r')
+                    else if (key == OV_KEY_ENTER || key == '\r' || key == '\n')
                     {
                         if (!lay->ctrl_mode)
                         {
                             ov_cmdlog_push(
                                 &lay->cmdlog,
                                 OV_CMDLOG_WARN,
-                                "Edit requires CONTROL mode");
+                                "Edit requires CONTROL mode (press c to toggle CTRL mode ON/OFF)");
                         }
                         else
                         {
@@ -1589,7 +1739,7 @@ static int ov_input__handle_navigation(int key, OV_LAYOUT *lay, const OV_MODEL *
                     lay->param_sel = -1;
                 }
                 else if (key == OV_KEY_ENTER
-                         || key == '\r')
+                         || key == '\r' || key == '\n')
                 {
                     if (!lay->ctrl_mode)
                     {
@@ -1597,7 +1747,7 @@ static int ov_input__handle_navigation(int key, OV_LAYOUT *lay, const OV_MODEL *
                             &lay->cmdlog,
                             OV_CMDLOG_WARN,
                             "Edit requires "
-                            "CONTROL mode");
+                            "CONTROL mode (press c to toggle CTRL mode ON/OFF)");
                     }
                     else
                     {

--- a/src/cli/overview/overview_layout.c
+++ b/src/cli/overview/overview_layout.c
@@ -51,25 +51,43 @@ void ov_layout_compute(OV_LAYOUT *lay)
         {
             body_h = 4;
         }
-        /* 2x2 grid layout */
-        int half_w = W / 2;
-        int half_h = body_h / 2;
+        /* 2x2 grid layout using adjustable splits */
+        int dash_w = (int)(W * lay->dash_split_v_ratio);
+        int dash_h = (int)(body_h * lay->dash_split_h_ratio);
+
+        if (dash_w < 20)
+        {
+            dash_w = 20;
+        }
+        if (dash_w > W - 20)
+        {
+            dash_w = W - 20;
+        }
+
+        if (dash_h < 4)
+        {
+            dash_h = 4;
+        }
+        if (dash_h > body_h - 4)
+        {
+            dash_h = body_h - 4;
+        }
 
         lay->r_streams = (OV_RECT){
             body_top, 1,
-            half_h, half_w
+            dash_h, dash_w
         };
         lay->r_procs = (OV_RECT){
-            body_top, half_w + 1,
-            half_h, W - half_w
+            body_top, dash_w + 1,
+            dash_h, W - dash_w
         };
         lay->r_fps = (OV_RECT){
-            body_top + half_h, 1,
-            body_h - half_h, half_w
+            body_top + dash_h, 1,
+            body_h - dash_h, dash_w
         };
         lay->r_graph = (OV_RECT){
-            body_top + half_h, half_w + 1,
-            body_h - half_h, W - half_w
+            body_top + dash_h, dash_w + 1,
+            body_h - dash_h, W - dash_w
         };
     }
     else
@@ -88,13 +106,17 @@ void ov_layout_compute(OV_LAYOUT *lay)
         lay->r_fps     = lay->r_streams;
         lay->r_graph   = lay->r_streams;
 
-        /* F5 split: ~40% list, ~60% params */
+        /* F5 split */
         if (lay->view == OV_VIEW_FPS)
         {
-            int lw = (W * 2) / 5;
+            int lw = (int)(W * lay->fps_split_ratio);
             if (lw < 20)
             {
                 lw = 20;
+            }
+            if (lw > W - 20)
+            {
+                lw = W - 20;
             }
             lay->r_fps_list   = (OV_RECT){
                 body_top, 1, body_h, lw

--- a/src/cli/overview/overview_layout.h
+++ b/src/cli/overview/overview_layout.h
@@ -161,6 +161,14 @@ typedef struct {
         int id;    /* action ID: OV_BTN_* */
     }            preview_btns[4];
     int          nb_preview_btns;
+    /* F5 view drag state */
+    float        fps_split_ratio;
+    int          fps_split_dragging;
+    /* F2 dashboard view drag state */
+    float        dash_split_v_ratio;
+    float        dash_split_h_ratio;
+    int          dash_split_v_dragging;
+    int          dash_split_h_dragging;
 } OV_LAYOUT;
 
 void ov_layout_compute(OV_LAYOUT *lay);

--- a/src/cli/overview/overview_render_fps.c
+++ b/src/cli/overview/overview_render_fps.c
@@ -88,9 +88,9 @@ void ov_render_fps_panel(
             ? 30 : 20;
         hlen = snprintf(
             htext, sizeof(htext),
-            "%-*s %*s %7s %3s %*s"
+            "%-*s %3s %*s %7s %3s %*s"
             " %-*s",
-            w_name, c_name, w_c, c_c, "RPID", "STR", w_mem, c_mem,
+            w_name, c_name, "TMX", w_c, c_c, "RPID", "STR", w_mem, c_mem,
             desc_w, "DESCRIPTION");
     }
     
@@ -249,6 +249,15 @@ void ov_render_fps_panel(
                         ? rel->sel_pid : 0;
 
             FPS_FIELD(OV_FG_FPS, "%-18.18s ", f->name);
+
+            char tmx_str[4] = {
+                (f->tmux_flags & OV_TMUX_CTRL) ? 'c' : '-',
+                (f->tmux_flags & OV_TMUX_CONF) ? 'C' : '-',
+                (f->tmux_flags & OV_TMUX_RUN)  ? 'r' : '-',
+                '\0'
+            };
+            FPS_FIELD(OV_FG_DIM, "%3s ", tmx_str);
+
             if (f->confpid > 0) FPS_PID_FIELD(f->confpid, "%7d ", (int) f->confpid);
             else FPS_FIELD(OV_FG_DIM, "%7s ", "-");
             if (f->runpid > 0) FPS_PID_FIELD(f->runpid, "%7d ", (int) f->runpid);

--- a/src/cli/overview/overview_render_graph.c
+++ b/src/cli/overview/overview_render_graph.c
@@ -291,10 +291,18 @@ void ov_render_preview_line(
             for (int bi = 0; bi < nb; bi++)
             {
                 ov_buf_pos(2, col);
-                ov_buf_bg(btns[bi].bg.r,
-                          btns[bi].bg.g,
-                          btns[bi].bg.b);
-                ov_buf_fg(255, 255, 255);
+                if (!lay->ctrl_mode)
+                {
+                    ov_buf_bg(60, 60, 60);
+                    ov_buf_fg(180, 180, 180);
+                }
+                else
+                {
+                    ov_buf_bg(btns[bi].bg.r,
+                              btns[bi].bg.g,
+                              btns[bi].bg.b);
+                    ov_buf_fg(255, 255, 255);
+                }
                 ov_buf_bold();
                 ov_buf_printf("%s",
                     btns[bi].label);

--- a/src/engine/libfps/fps_CONFstart.c
+++ b/src/engine/libfps/fps_CONFstart.c
@@ -6,6 +6,7 @@
 #include "fps.h"
 #include "fps_internal.h"
 #include "fps_globals.h"
+#include "fps_tmux.h"
 
 /** @brief FPS start CONF process
  *
@@ -17,6 +18,8 @@
 
 errno_t functionparameter_CONFstart(FPS *fps)
 {
+    functionparameter_FPS_tmux_ensure(fps);
+
     // Move to correct launch directory
     //
     EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:conf \" cd %s\" C-m",

--- a/src/engine/libfps/fps_RUNstart.c
+++ b/src/engine/libfps/fps_RUNstart.c
@@ -7,6 +7,7 @@
 #include "fps_internal.h"
 #include "fps_globals.h"
 #include "timeutils.h"
+#include "fps_tmux.h"
 
 #include "fps_GetParamIndex.h"
 
@@ -21,6 +22,7 @@ errno_t functionparameter_RUNstart(
     FPS *fps
 )
 {
+    functionparameter_FPS_tmux_ensure(fps);
 
     if(fps->md->status & FUNCTION_PARAMETER_STRUCT_STATUS_CHECKOK)
     {


### PR DESCRIPTION
## Summary

Enhances the `milkCTRL` TUI with new interactivity and visual feedback while fixing robust dispatch execution under `tmux`.

## Changes

### src/cli/overview
- Enabled `ENTER` key handling for inline parameter editing inside the FPS tab.
- Integrated resizable split panels inside graph/streams/fps windows with mouse drag support.
- Added `{`/`}` and `(`/`)` keyboard shortcuts for manually resizing panels horizontally and vertically.
- Standardized the control feedback warning message, enforcing "requires CONTROL mode" with instructions to "press c to toggle CTRL mode ON/OFF".
- Dimmed action buttons (visual indication) when READONLY mode is active.
- Added `[cCr]` tmux health indicator columns inside the FPS tab.

### src/engine/libfps
- Orchestrated robust parameter starting by invoking `functionparameter_FPS_tmux_ensure` inside `fps_CONFstart.c` and `fps_RUNstart.c`.

## Verification

- [x] Build passes (`/compile-test`)
- [x] Manual verification of control dispatch via `tmux`
- [x] Tested adjustable panel interaction using mouse/keyboard

## Prompt Summary

The user requested enhancements to the `milkCTRL` diagnostic interface. The core goals were to: add support for the ENTER key to edit parameters in the FPS tab, ensure consistent warning messages for actions in READONLY mode with visual button dimming, implement draggable/resizable split panels via mouse and keyboard shortcuts (`{}`, `()`), fix silent failures with the `[s] conf` toggle by ensuring tmux session orchestration, and finally, display `[cCr]` status letters in the FPS tab to observe the underlying tmux sessions. This combination of usability and diagnostic patches was implemented and verified.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None