### PR TITLE
fix: rename milkCTRL to milk-CTRL for consistency

### DIFF
--- a/src/cli/CLIcore/CMakeLists.txt
+++ b/src/cli/CLIcore/CMakeLists.txt
@@ -217,7 +217,7 @@ target_include_directories(milk-termview PRIVATE $<BUILD_INTERFACE:${CMAKE_SOURC
 install(TARGETS milk-termview DESTINATION bin)
 
 # milkCTRL: unified system dashboard TUI
-add_executable(milkCTRL
+add_executable(milk-CTRL
     ../overview/milkCTRL.c
     ../overview/overview_data.c
     ../overview/overview_data_sys.c
@@ -245,15 +245,15 @@ add_executable(milkCTRL
     ../overview/overview_render_fps_params.c
     ../overview/stream_graph.c
 )
-target_include_directories(milkCTRL PRIVATE
+target_include_directories(milk-CTRL PRIVATE
     ${CMAKE_SOURCE_DIR}/src/engine/ImageStreamIO
     ${CMAKE_SOURCE_DIR}/src/engine/libprocessinfo
     ${CMAKE_SOURCE_DIR}/src/engine/libfps
     ${CMAKE_SOURCE_DIR}/src/cli/overview
 )
-target_link_libraries(milkCTRL PUBLIC
+target_link_libraries(milk-CTRL PUBLIC
     ImageStreamIO milkprocessinfo milkfps m rt pthread)
-install(TARGETS milkCTRL DESTINATION bin)
+install(TARGETS milk-CTRL DESTINATION bin)
 install(PROGRAMS ../overview/milk-setup-caps DESTINATION bin)
 
 # milk-stream-graph: stream dependency graph tool

--- a/src/cli/overview/README.md
+++ b/src/cli/overview/README.md
@@ -1,4 +1,4 @@
-# overview (milkCTRL)
+# overview (milk-CTRL)
 
 Unified TUI dashboard for monitoring and controlling
 milk processes, streams, and FPS entries. Provides
@@ -7,7 +7,7 @@ runtime environment.
 
 ## Purpose
 
-`milkCTRL` aggregates real-time data from shared memory
+`milk-CTRL` aggregates real-time data from shared memory
 (streams, FPS, processinfo) into a multi-panel ncurses
 interface with sorting, filtering, search, and
 interactive control.
@@ -25,7 +25,7 @@ interactive control.
 
 | File | Description |
 |------|-------------|
-| `milkCTRL.c` | Entry point and main loop |
+| `milk-CTRL.c` | Entry point and main loop |
 | `overview_data.c/.h` | Data scanning and model updates |
 | `overview_render.c` | Panel rendering (largest file) |
 | `overview_input.c` | Keyboard input handler |

--- a/src/cli/overview/milk-setup-caps
+++ b/src/cli/overview/milk-setup-caps
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-# milk-setup-caps: Helper script to grant CAP_PERFMON and CAP_SYS_ADMIN to milkCTRL
+# milk-setup-caps: Helper script to grant CAP_PERFMON and CAP_SYS_ADMIN to milk-CTRL
 # This is required to access hardware performance counters for cache misses and instruction counts.
 
 set -e
 
-TARGET=$(which milkCTRL 2>/dev/null) || true
+TARGET=$(which milk-CTRL 2>/dev/null) || true
 
 if [ -z "$TARGET" ]; then
-    echo "Error: milkCTRL not found in PATH."
+    echo "Error: milk-CTRL not found in PATH."
     exit 1
 fi
 

--- a/src/cli/overview/milkCTRL.c
+++ b/src/cli/overview/milkCTRL.c
@@ -1,6 +1,6 @@
 /**
- * @file milkCTRL.c
- * @brief Main entry point for milkCTRL TUI
+ * @file milk-CTRL.c
+ * @brief Main entry point for milk-CTRL TUI
  *
  * Standalone binary providing a unified dashboard of all
  * milk shared-memory components (streams, FPS, processes)
@@ -119,13 +119,13 @@ extern int ov_handle_key(
 
 static void print_help(const char *prog, int mh_color)
 {
-    milk_help_banner(prog, "unified system dashboard TUI (milkCTRL) for streams, FPS, and processes", mh_color);
+    milk_help_banner(prog, "unified system dashboard TUI (milk-CTRL) for streams, FPS, and processes", mh_color);
 
     milk_help_section("Usage", mh_color);
     printf("  $ %s [%s %s]\n\n", prog, MH(MH_OPT, "-d"), MH(MH_ARG, "DIR"));
 
     milk_help_section("Description", mh_color);
-    printf("  milkCTRL is the unified system dashboard TUI for the milk framework.\n"
+    printf("  milk-CTRL is the unified system dashboard TUI for the milk framework.\n"
            "  It provides a comprehensive, consolidated view of all shared-memory\n"
            "  components across the machine, including data streams, Function\n"
            "  Processing Systems (FPS), and active managed processes. Designed for\n"
@@ -221,7 +221,7 @@ int main(int argc, char *argv[])
 {
     /* --- Help handling --- */
     int action = milk_help_init(argc, argv,
-        "unified system dashboard TUI (milkCTRL) for streams, FPS, and processes",
+        "unified system dashboard TUI (milk-CTRL) for streams, FPS, and processes",
         NULL);
 
     if (action == MH_ACTION_H1 || action == MH_ACTION_H2)

--- a/src/cli/overview/overview_cmdlog.c
+++ b/src/cli/overview/overview_cmdlog.c
@@ -1,6 +1,6 @@
 /**
  * @file overview_cmdlog.c
- * @brief Command log ring buffer for milkCTRL
+ * @brief Command log ring buffer for milk-CTRL
  *
  * Provides a simple ring-buffer API for posting
  * timestamped, leveled log entries that the TUI

--- a/src/cli/overview/overview_ctrl.c
+++ b/src/cli/overview/overview_ctrl.c
@@ -1,6 +1,6 @@
 /**
  * @file overview_ctrl.c
- * @brief Control-mode actions for milkCTRL
+ * @brief Control-mode actions for milk-CTRL
  *
  * Implements write operations available when CONTROL mode is ON:
  *   - FPS: toggle run process (r key), toggle conf process (s key)

--- a/src/cli/overview/overview_ctrl.h
+++ b/src/cli/overview/overview_ctrl.h
@@ -1,6 +1,6 @@
 /**
  * @file overview_ctrl.h
- * @brief Control-mode actions for milkCTRL
+ * @brief Control-mode actions for milk-CTRL
  */
 
 #ifndef OVERVIEW_CTRL_H

--- a/src/cli/overview/overview_data.c
+++ b/src/cli/overview/overview_data.c
@@ -1,6 +1,6 @@
 /**
  * @file overview_data.c
- * @brief Scan and graph-building for milkCTRL
+ * @brief Scan and graph-building for milk-CTRL
  *
  * Implements the three scanners (streams, FPS, processes)
  * and the cross-referencing graph builder.
@@ -108,7 +108,7 @@ void ov_model_export_snapshot(const OV_MODEL *m)
     struct tm *tm_ptr = localtime(&now);
     char fname[128];
     strftime(fname, sizeof(fname),
-        "/tmp/milkCTRL_snapshot_%Y%m%d_%H%M%S.txt",
+        "/tmp/milk-CTRL_snapshot_%Y%m%d_%H%M%S.txt",
         tm_ptr);
 
     FILE *fp = fopen(fname, "w");
@@ -121,7 +121,7 @@ void ov_model_export_snapshot(const OV_MODEL *m)
     strftime(tstr, sizeof(tstr),
         "%Y-%m-%d %H:%M:%S", tm_ptr);
     fprintf(fp,
-        "# milkCTRL snapshot — %s\n"
+        "# milk-CTRL snapshot — %s\n"
         "# streams: %d  procs: %d  fps: %d"
         "  edges: %d\n\n",
         tstr, m->nb_streams, m->nb_procs,

--- a/src/cli/overview/overview_data.h
+++ b/src/cli/overview/overview_data.h
@@ -1,6 +1,6 @@
 /**
  * @file overview_data.h
- * @brief Unified data model for milkCTRL
+ * @brief Unified data model for milk-CTRL
  *
  * Aggregates stream, FPS, and processinfo data into
  * a single graph model with nodes and directed edges.
@@ -519,7 +519,7 @@ int ov_filter_build(
  * ov_model_export_snapshot - dump model to a text file.
  * @m: model to export
  *
- * Writes a timestamped snapshot to /tmp/milkCTRL_snapshot_*.txt
+ * Writes a timestamped snapshot to /tmp/milk-CTRL_snapshot_*.txt
  * containing all streams, processes, and FPS entries.
  */
 void ov_model_export_snapshot(const OV_MODEL *m);

--- a/src/cli/overview/overview_defs.h
+++ b/src/cli/overview/overview_defs.h
@@ -1,9 +1,9 @@
 /**
  * @file overview_defs.h
- * @brief Standalone definitions for milkCTRL TUI
+ * @brief Standalone definitions for milk-CTRL TUI
  *
  * Provides all standalone macros, types, and helpers
- * needed by milkCTRL without depending on CLIcore.
+ * needed by milk-CTRL without depending on CLIcore.
  * Mirrors the streamCTRL_defs.h pattern.
  */
 

--- a/src/cli/overview/overview_fps_edit.c
+++ b/src/cli/overview/overview_fps_edit.c
@@ -1,6 +1,6 @@
 /**
  * @file overview_fps_edit.c
- * @brief Inline FPS parameter editing for milkCTRL
+ * @brief Inline FPS parameter editing for milk-CTRL
  *
  * Implements an inline parameter edit bar at the bottom
  * of the terminal, modeled on fpsCTRL_inline_edit_param.
@@ -189,7 +189,7 @@ int ov_fps_inline_edit(
         {
             functionparameter_WriteParameterToDisk(
                 fps, pindex,
-                "setval", "milkCTRL_toggle");
+                "setval", "milk-CTRL_toggle");
             functionparameter_SaveFPS2disk(fps);
         }
 
@@ -344,7 +344,7 @@ int ov_fps_inline_edit(
                 functionparameter_WriteParameterToDisk(
                     fps, pindex,
                     "setval",
-                    "milkCTRL_SetParamValue");
+                    "milk-CTRL_SetParamValue");
                 functionparameter_SaveFPS2disk(fps);
             }
         }

--- a/src/cli/overview/overview_fps_edit.h
+++ b/src/cli/overview/overview_fps_edit.h
@@ -1,6 +1,6 @@
 /**
  * @file overview_fps_edit.h
- * @brief Inline FPS parameter editing for milkCTRL
+ * @brief Inline FPS parameter editing for milk-CTRL
  */
 
 #ifndef OVERVIEW_FPS_EDIT_H

--- a/src/cli/overview/overview_input.c
+++ b/src/cli/overview/overview_input.c
@@ -1,6 +1,6 @@
 /**
  * @file overview_input.c
- * @brief Keyboard input handler for milkCTRL
+ * @brief Keyboard input handler for milk-CTRL
  */
 
 #include <stdlib.h>

--- a/src/cli/overview/overview_layout.c
+++ b/src/cli/overview/overview_layout.c
@@ -1,6 +1,6 @@
 /**
  * @file overview_layout.c
- * @brief Panel layout computation for milkCTRL
+ * @brief Panel layout computation for milk-CTRL
  */
 
 #include "overview_defs.h"

--- a/src/cli/overview/overview_layout.h
+++ b/src/cli/overview/overview_layout.h
@@ -1,6 +1,6 @@
 /**
  * @file overview_layout.h
- * @brief Panel layout definitions for milkCTRL
+ * @brief Panel layout definitions for milk-CTRL
  */
 
 #ifndef OVERVIEW_LAYOUT_H

--- a/src/cli/overview/overview_render.c
+++ b/src/cli/overview/overview_render.c
@@ -1,7 +1,7 @@
 /**
  * @file    overview_render.c
  * @brief   Shared render utilities and orchestrator
- *          for milkCTRL
+ *          for milk-CTRL
  *
  * Panel-specific rendering lives in:
  *   - overview_render_streams.c
@@ -261,7 +261,7 @@ void ov_render_header(
 
     /* Gradient header text */
     ov_buf_bold();
-    ov_buf_printf_gradient(OV_GRAD_LO, OV_GRAD_HI, " %s milkCTRL ", OV_BULLET);
+    ov_buf_printf_gradient(OV_GRAD_LO, OV_GRAD_HI, " %s milk-CTRL ", OV_BULLET);
     ov_buf_reset_attr();
 
     /* LCARS-style rounded end cap (matching the gradient end) */
@@ -324,7 +324,7 @@ void ov_render_header(
     int c7 = snprintf(NULL, 0, "  BW: %4.1f kB/s", bw_kbs);
     ov_buf_printf("  BW: %4.1f kB/s", bw_kbs);
 
-    /* c1 visual length: 17 chars for " ● milkCTRL " */
+    /* c1 visual length: 17 chars for " ● milk-CTRL " */
     int chars_left = 17 + ctrl_w + c2 + c3 + c4 + c5 + c6 + c7;
 
     int tabs_width = 0;

--- a/src/cli/overview/overview_render_cmdlog.c
+++ b/src/cli/overview/overview_render_cmdlog.c
@@ -1,6 +1,6 @@
 /**
  * @file overview_render_cmdlog.c
- * @brief Render the command log strip for milkCTRL
+ * @brief Render the command log strip for milk-CTRL
  *
  * Draws the most recent N log entries in a strip
  * above the status bar.  Each entry shows a timestamp,

--- a/src/cli/overview/overview_render_fps.c
+++ b/src/cli/overview/overview_render_fps.c
@@ -1,6 +1,6 @@
 /**
  * @file    overview_render_fps.c
- * @brief   FPS panel + detail panel rendering for milkCTRL
+ * @brief   FPS panel + detail panel rendering for milk-CTRL
  *
  * Split from overview_render.c for navigability.
  */

--- a/src/cli/overview/overview_render_fps_params.c
+++ b/src/cli/overview/overview_render_fps_params.c
@@ -1,6 +1,6 @@
 /**
  * @file    overview_render_fps_params.c
- * @brief   FPS parameter tree panel for milkCTRL F5 view
+ * @brief   FPS parameter tree panel for milk-CTRL F5 view
  *
  * Renders the right-side parameter panel when the F5
  * (OV_VIEW_FPS) tab is active. Shows a scrollable flat

--- a/src/cli/overview/overview_render_fps_params.h
+++ b/src/cli/overview/overview_render_fps_params.h
@@ -1,6 +1,6 @@
 /**
  * @file    overview_render_fps_params.h
- * @brief   FPS parameter tree panel for milkCTRL F5 view
+ * @brief   FPS parameter tree panel for milk-CTRL F5 view
  */
 
 #ifndef OVERVIEW_RENDER_FPS_PARAMS_H

--- a/src/cli/overview/overview_render_help.c
+++ b/src/cli/overview/overview_render_help.c
@@ -1,6 +1,6 @@
 /**
  * @file    overview_render_help.c
- * @brief   Collapsible help overlay for milkCTRL
+ * @brief   Collapsible help overlay for milk-CTRL
  *
  * Organizes help into topic sections that the user
  * can navigate (UP/DOWN) and expand/collapse (ENTER).

--- a/src/cli/overview/overview_render_procs.c
+++ b/src/cli/overview/overview_render_procs.c
@@ -1,6 +1,6 @@
 /**
  * @file    overview_render_procs.c
- * @brief   PROCS panel rendering for milkCTRL
+ * @brief   PROCS panel rendering for milk-CTRL
  *
  * Split from overview_render.c for navigability.
  */

--- a/src/cli/overview/overview_render_streams.c
+++ b/src/cli/overview/overview_render_streams.c
@@ -1,6 +1,6 @@
 /**
  * @file    overview_render_streams.c
- * @brief   STREAMS panel rendering for milkCTRL
+ * @brief   STREAMS panel rendering for milk-CTRL
  *
  * Split from overview_render.c for navigability.
  */

--- a/src/cli/overview/overview_scan.c
+++ b/src/cli/overview/overview_scan.c
@@ -1,6 +1,6 @@
 /**
  * @file overview_scan.c
- * @brief Background scan thread for milkCTRL
+ * @brief Background scan thread for milk-CTRL
  *
  * Runs ov_model_full_scan() in a loop on a background
  * thread with a configurable sleep interval. Uses

--- a/src/cli/overview/overview_theme.h
+++ b/src/cli/overview/overview_theme.h
@@ -1,6 +1,6 @@
 /**
  * @file overview_theme.h
- * @brief btop-inspired dark theme for milkCTRL
+ * @brief btop-inspired dark theme for milk-CTRL
  *
  * Defines semantic color tokens used throughout the TUI.
  * Uses TrueColor (24-bit) RGB values and provides helpers

--- a/src/cli/overview/stream_graph.h
+++ b/src/cli/overview/stream_graph.h
@@ -8,7 +8,7 @@
  * detects cycles (loops) in the stream graph.
  *
  * Used by both the standalone milk-stream-graph tool
- * and the milkCTRL CONNECTIONS panel.
+ * and the milk-CTRL CONNECTIONS panel.
  *
  * Dependencies: overview_data.h (OV_MODEL)
  */

--- a/src/cli/streamCTRL/README.md
+++ b/src/cli/streamCTRL/README.md
@@ -9,7 +9,7 @@ process associations.
 
 `milk-streamCTRL` scans `/dev/shm/*.im.shm` and
 displays real-time telemetry for each stream. Unlike
-the broader `milkCTRL` dashboard, this tool focuses
+the broader `milk-CTRL` dashboard, this tool focuses
 exclusively on stream diagnostics with higher detail.
 
 ## Files

--- a/src/engine/libfps/milk-fps-info.c
+++ b/src/engine/libfps/milk-fps-info.c
@@ -198,7 +198,7 @@ static void print_connections(const char *fpsname)
     "Output columns: parameter key, type, current value, flags.\n" \
     "With -v, also shows limits, defaults, and FPS header metadata.\n" \
     "With -c, cross-references stream and process connections\n" \
-    "from the live system graph built by milkCTRL/overview."
+    "from the live system graph built by milk-CTRL/overview."
 
 static void print_help(const char *progname, int mh_color)
 {

--- a/src/engine/libfps/scripts/milk-demopipeline
+++ b/src/engine/libfps/scripts/milk-demopipeline
@@ -112,7 +112,7 @@ ${MH_HDR}Usage:${MH_RST}
 
 ${MH_HDR}Description:${MH_RST}
   This script sets up a 9-node image processing chain inside tmux,
-  creating a rich graph for milkCTRL:
+  creating a rich graph for milk-CTRL:
 
     random_in ──> blurred_out ──> truncated_out
                                        │
@@ -151,7 +151,7 @@ ${MH_HDR}Environment:${MH_RST}
   MILK_SHM_DIR         Directory for shared memory files (${MH_DFLT}default: /milk/shm${MH_RST}).
 
 ${MH_HDR}See Also:${MH_RST}
-  ${MH_CMD}milkCTRL${MH_RST}
+  ${MH_CMD}milk-CTRL${MH_RST}
 EOF
 }
 
@@ -172,7 +172,7 @@ while [ $# -gt 0 ]; do
                  "blur, truncation, resize, rotation, cropping," \
                  "averaging, monitoring)" \
                  "connected via shared-memory streams in tmux" \
-                 "sessions. Useful for testing milkCTRL," \
+                 "sessions. Useful for testing milk-CTRL," \
                  "stream-graph, and pipeline diagnostics."
             exit 0
             ;;
@@ -305,7 +305,7 @@ milk-fpsexec-info-strmonproc \
 
 echo ""
 echo "Pipeline started in tmux sessions."
-echo "Run 'milkCTRL' and press D on a stream"
+echo "Run 'milk-CTRL' and press D on a stream"
 echo "to see ancestors/descendants."
 echo ""
 echo "Run 'milk-demopipeline cleanup' to stop."


### PR DESCRIPTION
## Summary

This pull request renames the `milkCTRL` diagnostic tool to `milk-CTRL` to ensure it follows the project's `milk-*` naming convention for standalone executables. This fixes an issue where the tool was not being installed correctly as a standard system-level utility.

## Changes

### CLIcore
- Renamed the `milkCTRL` executable target to `milk-CTRL` in `CMakeLists.txt`.

### Overview module
- Updated all internal documentation, user-facing output messages, and variables referencing `milkCTRL` to `milk-CTRL` in `milkCTRL.c`, rendering logic, headers, and UI layout.
- Updated `milk-setup-caps` to reference the renamed binary.

### Scripts
- Updated `milk-demopipeline` documentation and help messages.
- Updated `streamCTRL/README.md`.
- Updated `libfps/milk-fps-info.c` help text.

## Verification

- [x] Build passes (`/compile-test` equivalent run)
- [x] Verified `milk-CTRL` is successfully built and installed into `_install2/milk-1.03.00/bin/` with correct permissions.
- [x] Tested execution and UI display for the renamed binary.

## Prompt Summary

The user requested to resolve an issue where the `milkCTRL` diagnostic interface was not being properly installed in the system. After identifying that it did not follow the standard `milk-*` prefix rule, the executable target and all corresponding documentation and scripts were systematically renamed to `milk-CTRL` to ensure proper installation and consistency.

## AI Authorship

- **Model**: Antigravity
- **User edits**: None