### PR TITLE
fix: milk-CTRL interactivity, UI layout refinements, and robust FPS lifecycle dispatch

### DIFF
--- a/src/cli/overview/milkCTRL.c
+++ b/src/cli/overview/milkCTRL.c
@@ -208,7 +208,10 @@ static void print_help(const char *prog, int mh_color)
 
     milk_help_section("Mouse", mh_color);
     printf("  Click=select  DblClick=detail\n");
-    printf("  Scroll wheel=navigate list\n\n");
+    printf("  Scroll wheel=navigate list\n");
+    printf("  Click column headers to sort\n");
+    printf("  Click dashboard tabs to switch views\n");
+    printf("  Drag panel borders to resize\n\n");
     printf("  %s                               Quit\n", MH(MH_OPT, "q"));
 }
 

--- a/src/cli/overview/overview_ctrl.c
+++ b/src/cli/overview/overview_ctrl.c
@@ -127,7 +127,7 @@ void ov_ctrl_fps_run_toggle(
         ov_cmdlog_push(log,
                        rc == 0 ? OV_CMDLOG_OK
                                : OV_CMDLOG_FAIL,
-                       "FPS \"%s\" — %s",
+                       "⚙️ FPS \"%s\" — %s",
                        f->name, action);
     }
 }
@@ -158,7 +158,7 @@ void ov_ctrl_fps_conf_toggle(
         ov_cmdlog_push(log,
                        rc == 0 ? OV_CMDLOG_OK
                                : OV_CMDLOG_FAIL,
-                       "FPS \"%s\" — %s",
+                       "⚙️ FPS \"%s\" — %s",
                        f->name, action);
     }
 }
@@ -185,7 +185,7 @@ void ov_ctrl_stream_delete(
         if (log != NULL)
         {
             ov_cmdlog_push(log, OV_CMDLOG_FAIL,
-                           "Stream \"%s\" — delete"
+                           "🚫 Stream \"%s\" — delete"
                            " failed (open)",
                            s->name);
         }
@@ -209,7 +209,7 @@ void ov_ctrl_stream_delete(
         if (log != NULL)
         {
             ov_cmdlog_push(log, OV_CMDLOG_FAIL,
-                           "Stream \"%s\" — delete"
+                           "🚫 Stream \"%s\" — delete"
                            " failed (unlink)",
                            s->name);
         }
@@ -219,7 +219,7 @@ void ov_ctrl_stream_delete(
     if (log != NULL)
     {
         ov_cmdlog_push(log, OV_CMDLOG_OK,
-                       "Stream \"%s\" — deleted 🗑",
+                       "🗑️ Stream \"%s\" — deleted",
                        s->name);
     }
 }
@@ -244,7 +244,7 @@ void ov_ctrl_proc_kill(
         ov_cmdlog_push(log,
                        rc == 0 ? OV_CMDLOG_OK
                                : OV_CMDLOG_FAIL,
-                       "Process \"%s\" (PID %d)"
+                       "💀 Process \"%s\" (PID %d)"
                        " — SIGTERM",
                        p->name, p->PID);
     }
@@ -303,7 +303,7 @@ void ov_ctrl_proc_set_ctrlval(
         if (log != NULL)
         {
             ov_cmdlog_push(log, OV_CMDLOG_FAIL,
-                           "Process \"%s\" — ctrl failed (open)", p->name);
+                           "🚫 Process \"%s\" — ctrl failed (open)", p->name);
         }
         return;
     }
@@ -315,7 +315,7 @@ void ov_ctrl_proc_set_ctrlval(
         if (log != NULL)
         {
             ov_cmdlog_push(log, OV_CMDLOG_FAIL,
-                           "Process \"%s\" — ctrl failed (stat)", p->name);
+                           "🚫 Process \"%s\" — ctrl failed (stat)", p->name);
         }
         return;
     }
@@ -328,7 +328,7 @@ void ov_ctrl_proc_set_ctrlval(
         if (log != NULL)
         {
             ov_cmdlog_push(log, OV_CMDLOG_FAIL,
-                           "Process \"%s\" — ctrl failed (mmap)", p->name);
+                           "🚫 Process \"%s\" — ctrl failed (mmap)", p->name);
         }
         return;
     }
@@ -350,7 +350,7 @@ void ov_ctrl_proc_set_ctrlval(
         else action = "CTRLval updated";
 
         ov_cmdlog_push(log, OV_CMDLOG_OK,
-                       "Process \"%s\" — %s", p->name, action);
+                       "⚡ Process \"%s\" — %s", p->name, action);
     }
 }
 
@@ -378,7 +378,7 @@ void ov_ctrl_proc_zero_counters(
         if (log != NULL)
         {
             ov_cmdlog_push(log, OV_CMDLOG_FAIL,
-                           "Process \"%s\" — zero failed (open)", p->name);
+                           "🚫 Process \"%s\" — zero failed (open)", p->name);
         }
         return;
     }
@@ -390,7 +390,7 @@ void ov_ctrl_proc_zero_counters(
         if (log != NULL)
         {
             ov_cmdlog_push(log, OV_CMDLOG_FAIL,
-                           "Process \"%s\" — zero failed (stat)", p->name);
+                           "🚫 Process \"%s\" — zero failed (stat)", p->name);
         }
         return;
     }
@@ -403,7 +403,7 @@ void ov_ctrl_proc_zero_counters(
         if (log != NULL)
         {
             ov_cmdlog_push(log, OV_CMDLOG_FAIL,
-                           "Process \"%s\" — zero failed (mmap)", p->name);
+                           "🚫 Process \"%s\" — zero failed (mmap)", p->name);
         }
         return;
     }
@@ -416,7 +416,7 @@ void ov_ctrl_proc_zero_counters(
     if (log != NULL)
     {
         ov_cmdlog_push(log, OV_CMDLOG_OK,
-                       "Process \"%s\" — Counters zeroed", p->name);
+                       "0️⃣ Process \"%s\" — Counters zeroed", p->name);
     }
 }
 
@@ -440,7 +440,7 @@ void ov_ctrl_proc_remove(
         {
             ov_cmdlog_push(log,
                            OV_CMDLOG_FAIL,
-                           "Process \"%s\" (PID %d) is still alive",
+                           "🚫 Process \"%s\" (PID %d) is still alive",
                            p->name, p->PID);
         }
         return;
@@ -679,7 +679,7 @@ void ov_ctrl_fps_remove(
     if (log != NULL)
     {
         ov_cmdlog_push(log, OV_CMDLOG_OK,
-                       "FPS \"%s\" — erased 🗑",
+                       "🗑️ FPS \"%s\" — erased",
                        f->name);
     }
 }
@@ -697,7 +697,7 @@ void ov_ctrl_procs_cleanup(
     {
         ov_cmdlog_push(log,
                        rc == 0 ? OV_CMDLOG_OK : OV_CMDLOG_FAIL,
-                       "Process cleanup requested");
+                       "🧹 Process cleanup requested");
     }
 }
 

--- a/src/cli/overview/overview_data.h
+++ b/src/cli/overview/overview_data.h
@@ -401,6 +401,12 @@ void ov_model_full_scan(OV_MODEL *model);
 int ov_scan_has_new_data(void);
 
 /**
+ * ov_scan_force_update - interrupt sleep to force an immediate scan.
+ */
+void ov_scan_force_update(void);
+
+
+/**
  * ov_scan_cache_cleanup - release all persistent
  * SHM mappings held by the scan caches.
  *

--- a/src/cli/overview/overview_input.c
+++ b/src/cli/overview/overview_input.c
@@ -479,12 +479,23 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
 
         if (lay->view == OV_VIEW_DASHBOARD)
         {
-            /* Check for dashboard horizontal split drag */
-            int h_split_row = lay->r_streams.row + lay->r_streams.height;
+            /* Check for dashboard horizontal split drag.
+             * The split border is at h_split_row, which
+             * coincides with r_graph.row (the tab header
+             * row of the bottom-right panel).  Only start
+             * a drag when the click is in the LEFT half
+             * (under streams/fps); clicks on the RIGHT
+             * half fall through so tab labels remain
+             * clickable. */
+            int h_split_row =
+                lay->r_streams.row + lay->r_streams.height;
             if (mr == h_split_row - 1 || mr == h_split_row)
             {
-                lay->dash_split_h_dragging = 1;
-                return 1;
+                if (mc < lay->r_graph.col)
+                {
+                    lay->dash_split_h_dragging = 1;
+                    return 1;
+                }
             }
             /* Check for dashboard vertical split drag */
             int v_split_col = lay->r_streams.width;

--- a/src/cli/overview/overview_input.c
+++ b/src/cli/overview/overview_input.c
@@ -53,6 +53,39 @@ extern int ov_help_toggle_at(
     OV_LAYOUT *lay, int vis_row);
 
 /**
+ * hit_panel_tab - detect which tab label was clicked.
+ * @mc:       mouse column (1-based)
+ * @panel_col: panel left column
+ * @tabs:     tab label array
+ * @num_tabs: number of tabs
+ *
+ * Uses the same layout as ov_draw_panel_tabs: tabs start
+ * at panel_col+2, each rendered as " LABEL " with 1-space
+ * gap between tabs.
+ *
+ * Return: tab index [0..num_tabs-1], or -1 if no tab hit.
+ */
+static int hit_panel_tab(
+    int         mc,
+    int         panel_col,
+    const char **tabs,
+    int         num_tabs)
+{
+    int cur = panel_col + 2;
+    for (int ii = 0; ii < num_tabs; ii++)
+    {
+        /* Tab text is " LABEL ", so width = strlen + 2 */
+        int tw = (int) strlen(tabs[ii]) + 2;
+        if (mc >= cur && mc < cur + tw)
+        {
+            return ii;
+        }
+        cur += tw + 1; /* +1 for gap between tabs */
+    }
+    return -1;
+}
+
+/**
  * ov_handle_key - process one key event.
  * @key: keycode from ov_get_key()
  * @lay: mutable layout state
@@ -477,40 +510,75 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
                  && INSIDE(lay->r_graph, mr, mc))
         {
             lay->focus = OV_FOCUS_GRAPH;
-            int body_row =
-                mr - lay->r_graph.row - 2;
-            if (body_row >= 0)
+
+            /* Tab header click */
+            if (mr == lay->r_graph.row)
             {
-                int idx =
-                    lay->scroll_graph + body_row;
-                if (idx < m->nb_edges)
+                const char *dtabs[] = {
+                    "CONNECTIONS",
+                    "DETAILS",
+                    "RESOURCES"
+                };
+                int ti = hit_panel_tab(
+                    mc, lay->r_graph.col,
+                    dtabs, 3);
+                if (ti >= 0)
                 {
-                    lay->sel_graph = idx;
-                    if (is_dbl)
+                    lay->graph_tab_mode = ti;
+                }
+            }
+            else
+            {
+                int body_row =
+                    mr - lay->r_graph.row - 2;
+                if (body_row >= 0)
+                {
+                    int idx =
+                        lay->scroll_graph
+                        + body_row;
+                    if (idx < m->nb_edges)
                     {
-                        const OV_EDGE *edge =
-                            &m->edges[idx];
-                        const OV_NODE *node =
-                            &m->nodes[edge->src_node];
-                        if (node->type == OV_NODE_STREAM)
+                        lay->sel_graph = idx;
+                        if (is_dbl)
                         {
-                            lay->focus = OV_FOCUS_STREAMS;
-                            lay->sel_stream = node->index;
-                            lay->sel_name_stream[0] = '\0';
+                            const OV_EDGE *edge =
+                                &m->edges[idx];
+                            const OV_NODE *node =
+                                &m->nodes[
+                                    edge->src_node];
+                            if (node->type
+                                == OV_NODE_STREAM)
+                            {
+                                lay->focus =
+                                    OV_FOCUS_STREAMS;
+                                lay->sel_stream =
+                                    node->index;
+                                lay->sel_name_stream
+                                    [0] = '\0';
+                            }
+                            else if (node->type
+                                == OV_NODE_PROC)
+                            {
+                                lay->focus =
+                                    OV_FOCUS_PROCS;
+                                lay->sel_proc =
+                                    node->index;
+                                lay->sel_name_proc
+                                    [0] = '\0';
+                            }
+                            else if (node->type
+                                == OV_NODE_FPS)
+                            {
+                                lay->focus =
+                                    OV_FOCUS_FPS;
+                                lay->sel_fps =
+                                    node->index;
+                                lay->sel_name_fps
+                                    [0] = '\0';
+                            }
+                            lay->view =
+                                OV_VIEW_DASHBOARD;
                         }
-                        else if (node->type == OV_NODE_PROC)
-                        {
-                            lay->focus = OV_FOCUS_PROCS;
-                            lay->sel_proc = node->index;
-                            lay->sel_name_proc[0] = '\0';
-                        }
-                        else if (node->type == OV_NODE_FPS)
-                        {
-                            lay->focus = OV_FOCUS_FPS;
-                            lay->sel_fps = node->index;
-                            lay->sel_name_fps[0] = '\0';
-                        }
-                        lay->view = OV_VIEW_DASHBOARD;
                     }
                 }
             }
@@ -581,40 +649,75 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
             else if (INSIDE(lay->r_graph, mr, mc))
             {
                 lay->focus = OV_FOCUS_GRAPH;
-                int body_row =
-                    mr - lay->r_graph.row - 2;
-                if (body_row >= 0)
+
+                /* Tab header click */
+                if (mr == lay->r_graph.row)
                 {
-                    int idx =
-                        lay->scroll_graph + body_row;
-                    if (idx < m->nb_edges)
+                    const char *dtabs[] = {
+                        "CONNECTIONS",
+                        "DETAILS",
+                        "RESOURCES"
+                    };
+                    int ti = hit_panel_tab(
+                        mc, lay->r_graph.col,
+                        dtabs, 3);
+                    if (ti >= 0)
                     {
-                        lay->sel_graph = idx;
-                        if (is_dbl)
+                        lay->graph_tab_mode = ti;
+                    }
+                }
+                else
+                {
+                    int body_row =
+                        mr - lay->r_graph.row - 2;
+                    if (body_row >= 0)
+                    {
+                        int idx =
+                            lay->scroll_graph
+                            + body_row;
+                        if (idx < m->nb_edges)
                         {
-                            const OV_EDGE *edge =
-                                &m->edges[idx];
-                            const OV_NODE *node =
-                                &m->nodes[edge->src_node];
-                            if (node->type == OV_NODE_STREAM)
+                            lay->sel_graph = idx;
+                            if (is_dbl)
                             {
-                                lay->focus = OV_FOCUS_STREAMS;
-                                lay->sel_stream = node->index;
-                                lay->sel_name_stream[0] = '\0';
+                                const OV_EDGE *edge =
+                                    &m->edges[idx];
+                                const OV_NODE *node =
+                                    &m->nodes[
+                                        edge->src_node];
+                                if (node->type
+                                    == OV_NODE_STREAM)
+                                {
+                                    lay->focus =
+                                        OV_FOCUS_STREAMS;
+                                    lay->sel_stream =
+                                        node->index;
+                                    lay->sel_name_stream
+                                        [0] = '\0';
+                                }
+                                else if (node->type
+                                    == OV_NODE_PROC)
+                                {
+                                    lay->focus =
+                                        OV_FOCUS_PROCS;
+                                    lay->sel_proc =
+                                        node->index;
+                                    lay->sel_name_proc
+                                        [0] = '\0';
+                                }
+                                else if (node->type
+                                    == OV_NODE_FPS)
+                                {
+                                    lay->focus =
+                                        OV_FOCUS_FPS;
+                                    lay->sel_fps =
+                                        node->index;
+                                    lay->sel_name_fps
+                                        [0] = '\0';
+                                }
+                                lay->view =
+                                    OV_VIEW_DASHBOARD;
                             }
-                            else if (node->type == OV_NODE_PROC)
-                            {
-                                lay->focus = OV_FOCUS_PROCS;
-                                lay->sel_proc = node->index;
-                                lay->sel_name_proc[0] = '\0';
-                            }
-                            else if (node->type == OV_NODE_FPS)
-                            {
-                                lay->focus = OV_FOCUS_FPS;
-                                lay->sel_fps = node->index;
-                                lay->sel_name_fps[0] = '\0';
-                            }
-                            lay->view = OV_VIEW_DASHBOARD;
                         }
                     }
                 }

--- a/src/cli/overview/overview_input.c
+++ b/src/cli/overview/overview_input.c
@@ -210,6 +210,88 @@ static const OV_FPS *ov_input_get_sel_fps(
     const OV_LAYOUT *lay,
     const OV_MODEL  *m);
 
+static int ov_input_get_filtered_count(int focus, const OV_LAYOUT *lay, const OV_MODEL *m)
+{
+    int count = 0;
+    if (focus == OV_FOCUS_STREAMS) {
+        count = m->nb_streams;
+        if (lay->filter_stream[0] != '\0') {
+            const char *names[OV_MAX_STREAMS];
+            for (int i = 0; i < count; i++) names[i] = m->streams[i].name;
+            int fidx[OV_MAX_STREAMS];
+            count = ov_filter_build(lay->filter_stream, names, count, fidx, OV_MAX_STREAMS);
+        }
+    } else if (focus == OV_FOCUS_PROCS) {
+        count = m->nb_procs;
+        if (lay->filter_proc[0] != '\0') {
+            const char *names[OV_MAX_PROCS];
+            for (int i = 0; i < count; i++) names[i] = m->procs[i].name;
+            int fidx[OV_MAX_PROCS];
+            count = ov_filter_build(lay->filter_proc, names, count, fidx, OV_MAX_PROCS);
+        }
+    } else if (focus == OV_FOCUS_FPS) {
+        count = m->nb_fps;
+        if (lay->filter_fps[0] != '\0') {
+            const char *names[OV_MAX_FPS];
+            for (int i = 0; i < count; i++) names[i] = m->fps[i].name;
+            int fidx[OV_MAX_FPS];
+            count = ov_filter_build(lay->filter_fps, names, count, fidx, OV_MAX_FPS);
+        }
+    }
+    return count;
+}
+
+static void ov_input__streams_header_click(OV_LAYOUT *lay, int mc)
+{
+    int c = mc - lay->r_streams.col - 5 + lay->hscroll_stream;
+    if (c < 0) return;
+    int col_idx = -1;
+    if (c < 15) col_idx = (lay->sort_key_stream == 7) ? 7 : 0;
+    else if (c < 20) col_idx = 1;
+    else if (c < 32) col_idx = 2;
+    else if (c < 39) col_idx = 3;
+    else if (c < 47) col_idx = 4;
+    else if (c < 58) col_idx = 5;
+    else if (c >= 66 && c < 77) col_idx = 6;
+    
+    if (col_idx >= 0) {
+        if (lay->sort_key_stream == col_idx) lay->sort_dir_stream = !lay->sort_dir_stream;
+        else { lay->sort_key_stream = col_idx; lay->sort_dir_stream = 0; }
+    }
+}
+
+static void ov_input__procs_header_click(OV_LAYOUT *lay, int mc)
+{
+    int c = mc - lay->r_procs.col - 5 + lay->hscroll_proc;
+    if (c < 0) return;
+    int col_idx = -1;
+    if (c < 15) col_idx = (lay->sort_key_proc == 5) ? 5 : 0;
+    else if (c < 23) col_idx = 1;
+    else if (c < 29) col_idx = 2;
+    else if (c < 36) col_idx = 3;
+    else if (c >= 84 && c < 90) col_idx = 4;
+    
+    if (col_idx >= 0) {
+        if (lay->sort_key_proc == col_idx) lay->sort_dir_proc = !lay->sort_dir_proc;
+        else { lay->sort_key_proc = col_idx; lay->sort_dir_proc = 0; }
+    }
+}
+
+static void ov_input__fps_header_click(OV_LAYOUT *lay, int mc)
+{
+    int c = mc - lay->r_fps.col - 5 + lay->hscroll_fps;
+    if (c < 0) return;
+    int col_idx = -1;
+    if (c < 19) col_idx = (lay->sort_key_fps == 3) ? 3 : 0;
+    else if (c >= 23 && c < 31) col_idx = 1;
+    else if (c >= 43 && c < 49) col_idx = 2;
+    
+    if (col_idx >= 0) {
+        if (lay->sort_key_fps == col_idx) lay->sort_dir_fps = !lay->sort_dir_fps;
+        else { lay->sort_key_fps = col_idx; lay->sort_dir_fps = 0; }
+    }
+}
+
 static void ov_input__exec_preview_btn(
     int              btn_id,
     OV_LAYOUT       *lay,
@@ -302,6 +384,8 @@ static void ov_input__exec_preview_btn(
     default:
         break;
     }
+    
+    ov_scan_force_update();
 }
 
 static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
@@ -389,9 +473,10 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
          * for non-active panels all overlap the full
          * screen, so we must check the view first and
          * route directly to the correct handler.
-         * On the Dashboard all four rects are distinct
+         * on the Dashboard all four rects are distinct
          * so the cascade works normally.
          */
+
         if (lay->view == OV_VIEW_DASHBOARD)
         {
             /* Check for dashboard horizontal split drag */
@@ -442,7 +527,11 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
                 lay->fps_param_focus = 0;
                 int body_row =
                     mr - lay->r_fps.row - 2;
-                if (body_row >= 0)
+                if (body_row == -1)
+                {
+                    ov_input__fps_header_click(lay, mc);
+                }
+                else if (body_row >= 0)
                 {
                     int idx =
                         lay->scroll_fps + body_row;
@@ -470,7 +559,11 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
             lay->focus = OV_FOCUS_STREAMS;
             int body_row =
                 mr - lay->r_streams.row - 2;
-            if (body_row >= 0)
+            if (body_row == -1)
+            {
+                ov_input__streams_header_click(lay, mc);
+            }
+            else if (body_row >= 0)
             {
                 int idx =
                     lay->scroll_stream + body_row;
@@ -491,7 +584,11 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
             lay->focus = OV_FOCUS_PROCS;
             int body_row =
                 mr - lay->r_procs.row - 2;
-            if (body_row >= 0)
+            if (body_row == -1)
+            {
+                ov_input__procs_header_click(lay, mc);
+            }
+            else if (body_row >= 0)
             {
                 int idx =
                     lay->scroll_proc + body_row;
@@ -591,7 +688,11 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
                 lay->focus = OV_FOCUS_STREAMS;
                 int body_row =
                     mr - lay->r_streams.row - 2;
-                if (body_row >= 0)
+                if (body_row == -1)
+                {
+                    ov_input__streams_header_click(lay, mc);
+                }
+                else if (body_row >= 0)
                 {
                     int idx =
                         lay->scroll_stream + body_row;
@@ -611,7 +712,11 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
                 lay->focus = OV_FOCUS_PROCS;
                 int body_row =
                     mr - lay->r_procs.row - 2;
-                if (body_row >= 0)
+                if (body_row == -1)
+                {
+                    ov_input__procs_header_click(lay, mc);
+                }
+                else if (body_row >= 0)
                 {
                     int idx =
                         lay->scroll_proc + body_row;
@@ -631,7 +736,11 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
                 lay->focus = OV_FOCUS_FPS;
                 int body_row =
                     mr - lay->r_fps.row - 2;
-                if (body_row >= 0)
+                if (body_row == -1)
+                {
+                    ov_input__fps_header_click(lay, mc);
+                }
+                else if (body_row >= 0)
                 {
                     int idx =
                         lay->scroll_fps + body_row;
@@ -725,10 +834,12 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
         }
         
         /* Check if clicking on cmdlog border to start dragging */
-        int log_top = (lay->cmdlog_rows > 0) ? (lay->term_rows - lay->cmdlog_rows) : lay->term_rows;
-        if (mr == log_top - 1)
         {
-            lay->cmdlog_dragging = 1;
+            int cmdlog_top = (lay->cmdlog_rows > 0) ? (lay->term_rows - lay->cmdlog_rows) : lay->term_rows;
+            if (mr == cmdlog_top - 1 || mr == cmdlog_top)
+            {
+                lay->cmdlog_dragging = 1;
+            }
         }
         
         return 1;
@@ -749,8 +860,8 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
         int mc = ov_mouse_col;
 
         /* Global: Command log panel height drag */
-        int log_top = (lay->cmdlog_rows > 0) ? (lay->term_rows - lay->cmdlog_rows) : lay->term_rows;
-        if (lay->cmdlog_dragging || (mr == log_top - 1))
+        int cmdlog_top = (lay->cmdlog_rows > 0) ? (lay->term_rows - lay->cmdlog_rows) : lay->term_rows;
+        if (lay->cmdlog_dragging || (mr == cmdlog_top - 1 || mr == cmdlog_top))
         {
             lay->cmdlog_dragging = 1;
             int new_h = lay->term_rows - 1 - mr;
@@ -834,7 +945,7 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
             {
                 sel    = &lay->sel_fps;
                 scroll = &lay->scroll_fps;
-                count  = m->nb_fps;
+                count  = ov_input_get_filtered_count(OV_FOCUS_FPS, lay, m);
                 page_h = lay->r_fps.height - 3;
             }
         }
@@ -842,14 +953,14 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
         {
             sel    = &lay->sel_stream;
             scroll = &lay->scroll_stream;
-            count  = m->nb_streams;
+            count  = ov_input_get_filtered_count(OV_FOCUS_STREAMS, lay, m);
             page_h = lay->r_streams.height - 3;
         }
         else if (lay->view == OV_VIEW_PROCS)
         {
             sel    = &lay->sel_proc;
             scroll = &lay->scroll_proc;
-            count  = m->nb_procs;
+            count  = ov_input_get_filtered_count(OV_FOCUS_PROCS, lay, m);
             page_h = lay->r_procs.height - 3;
         }
         else if (lay->view == OV_VIEW_GRAPH)
@@ -906,21 +1017,21 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
             {
                 sel    = &lay->sel_stream;
                 scroll = &lay->scroll_stream;
-                count  = m->nb_streams;
+                count  = ov_input_get_filtered_count(OV_FOCUS_STREAMS, lay, m);
                 page_h = lay->r_streams.height - 3;
             }
             else if (INSIDE(lay->r_procs, mr, mc))
             {
                 sel    = &lay->sel_proc;
                 scroll = &lay->scroll_proc;
-                count  = m->nb_procs;
+                count  = ov_input_get_filtered_count(OV_FOCUS_PROCS, lay, m);
                 page_h = lay->r_procs.height - 3;
             }
             else if (INSIDE(lay->r_fps, mr, mc))
             {
                 sel    = &lay->sel_fps;
                 scroll = &lay->scroll_fps;
-                count  = m->nb_fps;
+                count  = ov_input_get_filtered_count(OV_FOCUS_FPS, lay, m);
                 page_h = lay->r_fps.height - 3;
             }
             else if (INSIDE(lay->r_graph, mr, mc))
@@ -975,12 +1086,22 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
 
         if (sel != NULL && scroll != NULL)
         {
+            *scroll += dir;
+            if (*scroll < 0) *scroll = 0;
+            if (page_h > 0 && *scroll > count - page_h) {
+                *scroll = count - page_h;
+                if (*scroll < 0) *scroll = 0;
+            }
+
             *sel += dir;
-            if (*sel < 0) *sel = 0;
+            if (*sel < *scroll) *sel = *scroll;
+            if (page_h > 0 && *sel >= *scroll + page_h) *sel = *scroll + page_h - 1;
             if (*sel >= count) *sel = count - 1;
             if (*sel < 0) *sel = 0;
-            if (*sel < *scroll) *scroll = *sel;
-            if (page_h > 0 && *sel >= *scroll + page_h) *scroll = *sel - page_h + 1;
+
+            if (sel == &lay->sel_stream) lay->sel_name_stream[0] = '\0';
+            else if (sel == &lay->sel_proc) lay->sel_name_proc[0] = '\0';
+            else if (sel == &lay->sel_fps) lay->sel_name_fps[0] = '\0';
         }
         return 1;
     }
@@ -1392,6 +1513,7 @@ static int ov_input__handle_actions(int key, OV_LAYOUT *lay, const OV_MODEL *m)
             const OV_STREAM *s = ov_input_get_sel_stream(lay, m);
             if (s) ov_ctrl_stream_delete(s, log);
         }
+        ov_scan_force_update();
         return 1;
     }
 
@@ -1487,6 +1609,10 @@ static int ov_input__handle_actions(int key, OV_LAYOUT *lay, const OV_MODEL *m)
             else snprintf(keyname, sizeof(keyname), "'%c'", key);
             
             ov_cmdlog_push(log, OV_CMDLOG_WARN, "%s requires CONTROL mode (press c to toggle CTRL mode ON/OFF)", keyname);
+        }
+        else
+        {
+            ov_scan_force_update();
         }
         return 1;
     }

--- a/src/cli/overview/overview_input.c
+++ b/src/cli/overview/overview_input.c
@@ -241,54 +241,137 @@ static int ov_input_get_filtered_count(int focus, const OV_LAYOUT *lay, const OV
     return count;
 }
 
-static void ov_input__streams_header_click(OV_LAYOUT *lay, int mc)
+static const char *stream_col_names[] = {
+    "NAME", "TYP", "SIZE", "Hz",
+    "MB/s", "INODE", "COUNT", "ANCESTRY"
+};
+
+static void ov_input__streams_header_click(
+    OV_LAYOUT *lay, int mc)
 {
-    int c = mc - lay->r_streams.col - 5 + lay->hscroll_stream;
-    if (c < 0) return;
+    int c = mc - lay->r_streams.col - 5
+            + lay->hscroll_stream;
+    if (c < 0)
+    {
+        return;
+    }
     int col_idx = -1;
-    if (c < 15) col_idx = (lay->sort_key_stream == 7) ? 7 : 0;
-    else if (c < 20) col_idx = 1;
-    else if (c < 32) col_idx = 2;
-    else if (c < 39) col_idx = 3;
-    else if (c < 47) col_idx = 4;
-    else if (c < 58) col_idx = 5;
-    else if (c >= 66 && c < 77) col_idx = 6;
-    
-    if (col_idx >= 0) {
-        if (lay->sort_key_stream == col_idx) lay->sort_dir_stream = !lay->sort_dir_stream;
-        else { lay->sort_key_stream = col_idx; lay->sort_dir_stream = 0; }
+    if (c < 15)
+    {
+        col_idx = (lay->sort_key_stream == 7) ? 7 : 0;
+    }
+    else if (c < 20) { col_idx = 1; }
+    else if (c < 32) { col_idx = 2; }
+    else if (c < 39) { col_idx = 3; }
+    else if (c < 47) { col_idx = 4; }
+    else if (c < 58) { col_idx = 5; }
+    else if (c >= 66 && c < 77) { col_idx = 6; }
+
+    if (col_idx >= 0)
+    {
+        if (lay->sort_key_stream == col_idx)
+        {
+            lay->sort_dir_stream =
+                !lay->sort_dir_stream;
+        }
+        else
+        {
+            lay->sort_key_stream = col_idx;
+            lay->sort_dir_stream = 0;
+        }
+        ov_cmdlog_push(
+            &lay->cmdlog, OV_CMDLOG_INFO,
+            "Sort STREAMS by %s %s",
+            stream_col_names[col_idx],
+            lay->sort_dir_stream ? "▼" : "▲");
+        ov_scan_force_update();
     }
 }
 
-static void ov_input__procs_header_click(OV_LAYOUT *lay, int mc)
+static const char *proc_col_names[] = {
+    "NAME", "PID", "STAT", "Hz",
+    "MEM", "ANCESTRY"
+};
+
+static void ov_input__procs_header_click(
+    OV_LAYOUT *lay, int mc)
 {
-    int c = mc - lay->r_procs.col - 5 + lay->hscroll_proc;
-    if (c < 0) return;
+    int c = mc - lay->r_procs.col - 5
+            + lay->hscroll_proc;
+    if (c < 0)
+    {
+        return;
+    }
     int col_idx = -1;
-    if (c < 15) col_idx = (lay->sort_key_proc == 5) ? 5 : 0;
-    else if (c < 23) col_idx = 1;
-    else if (c < 29) col_idx = 2;
-    else if (c < 36) col_idx = 3;
-    else if (c >= 84 && c < 90) col_idx = 4;
-    
-    if (col_idx >= 0) {
-        if (lay->sort_key_proc == col_idx) lay->sort_dir_proc = !lay->sort_dir_proc;
-        else { lay->sort_key_proc = col_idx; lay->sort_dir_proc = 0; }
+    if (c < 15)
+    {
+        col_idx = (lay->sort_key_proc == 5) ? 5 : 0;
+    }
+    else if (c < 23) { col_idx = 1; }
+    else if (c < 29) { col_idx = 2; }
+    else if (c < 36) { col_idx = 3; }
+    else if (c >= 84 && c < 90) { col_idx = 4; }
+
+    if (col_idx >= 0)
+    {
+        if (lay->sort_key_proc == col_idx)
+        {
+            lay->sort_dir_proc =
+                !lay->sort_dir_proc;
+        }
+        else
+        {
+            lay->sort_key_proc = col_idx;
+            lay->sort_dir_proc = 0;
+        }
+        ov_cmdlog_push(
+            &lay->cmdlog, OV_CMDLOG_INFO,
+            "Sort PROCS by %s %s",
+            proc_col_names[col_idx],
+            lay->sort_dir_proc ? "▼" : "▲");
+        ov_scan_force_update();
     }
 }
 
-static void ov_input__fps_header_click(OV_LAYOUT *lay, int mc)
+static const char *fps_col_names[] = {
+    "NAME", "STATUS", "MEM", "ANCESTRY"
+};
+
+static void ov_input__fps_header_click(
+    OV_LAYOUT *lay, int mc)
 {
-    int c = mc - lay->r_fps.col - 5 + lay->hscroll_fps;
-    if (c < 0) return;
+    int c = mc - lay->r_fps.col - 5
+            + lay->hscroll_fps;
+    if (c < 0)
+    {
+        return;
+    }
     int col_idx = -1;
-    if (c < 19) col_idx = (lay->sort_key_fps == 3) ? 3 : 0;
-    else if (c >= 23 && c < 31) col_idx = 1;
-    else if (c >= 43 && c < 49) col_idx = 2;
-    
-    if (col_idx >= 0) {
-        if (lay->sort_key_fps == col_idx) lay->sort_dir_fps = !lay->sort_dir_fps;
-        else { lay->sort_key_fps = col_idx; lay->sort_dir_fps = 0; }
+    if (c < 19)
+    {
+        col_idx = (lay->sort_key_fps == 3) ? 3 : 0;
+    }
+    else if (c >= 23 && c < 31) { col_idx = 1; }
+    else if (c >= 43 && c < 49) { col_idx = 2; }
+
+    if (col_idx >= 0)
+    {
+        if (lay->sort_key_fps == col_idx)
+        {
+            lay->sort_dir_fps =
+                !lay->sort_dir_fps;
+        }
+        else
+        {
+            lay->sort_key_fps = col_idx;
+            lay->sort_dir_fps = 0;
+        }
+        ov_cmdlog_push(
+            &lay->cmdlog, OV_CMDLOG_INFO,
+            "Sort FPS by %s %s",
+            fps_col_names[col_idx],
+            lay->sort_dir_fps ? "▼" : "▲");
+        ov_scan_force_update();
     }
 }
 

--- a/src/cli/overview/overview_input.c
+++ b/src/cli/overview/overview_input.c
@@ -620,6 +620,14 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
                 }
             }
         }
+        
+        /* Check if clicking on cmdlog border to start dragging */
+        int log_top = (lay->cmdlog_rows > 0) ? (lay->term_rows - lay->cmdlog_rows) : lay->term_rows;
+        if (mr == log_top - 1)
+        {
+            lay->cmdlog_dragging = 1;
+        }
+        
         return 1;
     }
 
@@ -628,6 +636,7 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
         lay->fps_split_dragging = 0;
         lay->dash_split_v_dragging = 0;
         lay->dash_split_h_dragging = 0;
+        lay->cmdlog_dragging = 0;
         return 1;
     }
 
@@ -635,6 +644,18 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
     {
         int mr = ov_mouse_row;
         int mc = ov_mouse_col;
+
+        /* Global: Command log panel height drag */
+        int log_top = (lay->cmdlog_rows > 0) ? (lay->term_rows - lay->cmdlog_rows) : lay->term_rows;
+        if (lay->cmdlog_dragging || (mr == log_top - 1))
+        {
+            lay->cmdlog_dragging = 1;
+            int new_h = lay->term_rows - 1 - mr;
+            if (new_h < 0) new_h = 0;
+            if (new_h > lay->term_rows / 2) new_h = lay->term_rows / 2;
+            lay->cmdlog_rows = new_h;
+            return 1;
+        }
 
         if (lay->view == OV_VIEW_FPS)
         {
@@ -941,6 +962,21 @@ static int ov_input__handle_misc_toggles(int key, OV_LAYOUT *lay, const OV_MODEL
     if (key == 'L')
     {
         lay->lineage_mode = (lay->lineage_mode + 1) % 3;
+        return 1;
+    }
+    if (key == 'v' || key == 'V')
+    {
+        int step = (key == 'v') ? -1 : 1;
+        if (lay->cmdlog_rows == 0 && step > 0)
+        {
+            lay->cmdlog_rows = 4;
+        }
+        else
+        {
+            lay->cmdlog_rows += step;
+        }
+        if (lay->cmdlog_rows < 0) lay->cmdlog_rows = 0;
+        if (lay->cmdlog_rows > lay->term_rows / 2) lay->cmdlog_rows = lay->term_rows / 2;
         return 1;
     }
     if (key == '{' || key == '}')
@@ -2106,7 +2142,7 @@ int ov_handle_key(
         char ctrl_str[128] = "";
 
         // Base keys always available
-        snprintf(keys_str, sizeof(keys_str), "Keys: q c h G ? TAB D L F W i <>[]sS +-= F2-F6 / ESC");
+        snprintf(keys_str, sizeof(keys_str), "Keys: q c h G v V ? TAB D L F W i <>[]sS +-= F2-F6 / ESC");
 
         if (lay->ctrl_mode)
         {

--- a/src/cli/overview/overview_input.c
+++ b/src/cli/overview/overview_input.c
@@ -284,6 +284,7 @@ static void ov_input__streams_header_click(
             "Sort STREAMS by %s %s",
             stream_col_names[col_idx],
             lay->sort_dir_stream ? "▼" : "▲");
+        lay->sort_pending = 1;
         ov_scan_force_update();
     }
 }
@@ -329,6 +330,7 @@ static void ov_input__procs_header_click(
             "Sort PROCS by %s %s",
             proc_col_names[col_idx],
             lay->sort_dir_proc ? "▼" : "▲");
+        lay->sort_pending = 1;
         ov_scan_force_update();
     }
 }
@@ -371,6 +373,7 @@ static void ov_input__fps_header_click(
             "Sort FPS by %s %s",
             fps_col_names[col_idx],
             lay->sort_dir_fps ? "▼" : "▲");
+        lay->sort_pending = 1;
         ov_scan_force_update();
     }
 }
@@ -387,7 +390,7 @@ static void ov_input__exec_preview_btn(
         ov_cmdlog_push(
             &lay->cmdlog,
             OV_CMDLOG_WARN,
-            "Action requires CONTROL mode (press c to toggle CTRL mode ON/OFF)");
+            "🚫 Action requires CONTROL mode (press c to toggle CTRL mode ON/OFF)");
         return;
     }
 
@@ -716,6 +719,7 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
                 if (ti >= 0)
                 {
                     lay->graph_tab_mode = ti;
+                    ov_scan_force_update();
                 }
             }
             else
@@ -867,6 +871,7 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
                     if (ti >= 0)
                     {
                         lay->graph_tab_mode = ti;
+                        ov_scan_force_update();
                     }
                 }
                 else
@@ -1350,9 +1355,9 @@ static int ov_input__handle_misc_toggles(int key, OV_LAYOUT *lay, const OV_MODEL
         lay->paused = !lay->paused;
         ov_cmdlog_push(&lay->cmdlog,
                        OV_CMDLOG_INFO,
-                       "Display %s",
-                       lay->paused
-                       ? "paused" : "resumed");
+                       "%s Display %s",
+                       lay->paused ? "⏸️" : "▶️",
+                       lay->paused ? "paused" : "resumed");
         return 1;
     }
     if (key == 'W')
@@ -1360,7 +1365,7 @@ static int ov_input__handle_misc_toggles(int key, OV_LAYOUT *lay, const OV_MODEL
         ov_model_export_snapshot(m);
         ov_cmdlog_push(&lay->cmdlog,
                        OV_CMDLOG_OK,
-                       "Snapshot exported");
+                       "📸 Snapshot exported");
         return 1;
     }
 
@@ -1588,7 +1593,7 @@ static int ov_input__handle_actions(int key, OV_LAYOUT *lay, const OV_MODEL *m)
     {
         if (!lay->ctrl_mode)
         {
-            ov_cmdlog_push(log, OV_CMDLOG_WARN, "CTRL+e requires CONTROL mode (press c to toggle CTRL mode ON/OFF)");
+            ov_cmdlog_push(log, OV_CMDLOG_WARN, "🚫 CTRL+e requires CONTROL mode (press c to toggle CTRL mode ON/OFF)");
             return 1;
         }
 
@@ -1702,7 +1707,7 @@ static int ov_input__handle_actions(int key, OV_LAYOUT *lay, const OV_MODEL *m)
             else if (key == OV_KEY_DEL) snprintf(keyname, sizeof(keyname), "DEL");
             else snprintf(keyname, sizeof(keyname), "'%c'", key);
             
-            ov_cmdlog_push(log, OV_CMDLOG_WARN, "%s requires CONTROL mode (press c to toggle CTRL mode ON/OFF)", keyname);
+            ov_cmdlog_push(log, OV_CMDLOG_WARN, "🚫 %s requires CONTROL mode (press c to toggle CTRL mode ON/OFF)", keyname);
         }
         else
         {
@@ -2477,15 +2482,15 @@ int ov_handle_key(
                 snprintf(ctrl_str, sizeof(ctrl_str), " | CTRL (STRM): DEL ^e");
         }
 
-        ov_cmdlog_push(&lay->cmdlog, OV_CMDLOG_INFO, "%s%s", keys_str, ctrl_str);
+        ov_cmdlog_push(&lay->cmdlog, OV_CMDLOG_INFO, "⌨️ %s%s", keys_str, ctrl_str);
         if (lay->cmdlog_rows == 0) lay->cmdlog_rows = 4;
         return 0;
     }
 
-    if (key >= 32 && key < 127) {
-        ov_cmdlog_push(&lay->cmdlog, OV_CMDLOG_WARN, "Unmapped key: '%c' (code %d)", key, key);
+    if (key >= 32 && key <= 126) {
+        ov_cmdlog_push(&lay->cmdlog, OV_CMDLOG_WARN, "❔ Unmapped key: '%c' (code %d)", key, key);
     } else {
-        ov_cmdlog_push(&lay->cmdlog, OV_CMDLOG_WARN, "Unmapped key code: %d", key);
+        ov_cmdlog_push(&lay->cmdlog, OV_CMDLOG_WARN, "❔ Unmapped key code: %d", key);
     }
     return 0;
 }

--- a/src/cli/overview/overview_layout.h
+++ b/src/cli/overview/overview_layout.h
@@ -169,6 +169,7 @@ typedef struct {
     float        dash_split_h_ratio;
     int          dash_split_v_dragging;
     int          dash_split_h_dragging;
+    int          cmdlog_dragging;
 } OV_LAYOUT;
 
 void ov_layout_compute(OV_LAYOUT *lay);

--- a/src/cli/overview/overview_render.c
+++ b/src/cli/overview/overview_render.c
@@ -534,7 +534,7 @@ void ov_render_frame(
         lay->sort_pending = 0;
         g_last_model = m;
     }
-    else if (m != g_last_model)
+    else
     {
         /* A new scan model arrived. Re-apply the saved order so items don't shuffle. */
         OV_MODEL *mm = (OV_MODEL *)(uintptr_t) m;

--- a/src/cli/overview/overview_render_cmdlog.c
+++ b/src/cli/overview/overview_render_cmdlog.c
@@ -78,19 +78,19 @@ void ov_render_cmdlog(const OV_LAYOUT *lay)
         {
         case OV_CMDLOG_OK:
             bullet_fg = (ov_rgb_t){80, 220, 80};
-            bullet    = "●";
+            bullet    = "✅";
             break;
         case OV_CMDLOG_FAIL:
             bullet_fg = (ov_rgb_t){220, 60, 60};
-            bullet    = "●";
+            bullet    = "❌";
             break;
         case OV_CMDLOG_WARN:
             bullet_fg = (ov_rgb_t){220, 180, 40};
-            bullet    = "●";
+            bullet    = "⚠️";
             break;
         default: /* INFO */
             bullet_fg = (ov_rgb_t){100, 100, 120};
-            bullet    = "·";
+            bullet    = "ℹ️";
             break;
         }
 
@@ -102,7 +102,7 @@ void ov_render_cmdlog(const OV_LAYOUT *lay)
         /* Status bullet */
         ov_buf_fg(bullet_fg.r, bullet_fg.g, bullet_fg.b);
         ov_buf_printf("%s ", bullet);
-        nw += 4; /* bullet(1) + space + 2 for UTF-8 */
+        nw += 3; /* emoji(approx 2 cols) + space */
 
         /* Message text */
         ov_buf_fg(180, 180, 200);

--- a/src/cli/overview/overview_render_cmdlog.c
+++ b/src/cli/overview/overview_render_cmdlog.c
@@ -78,19 +78,19 @@ void ov_render_cmdlog(const OV_LAYOUT *lay)
         {
         case OV_CMDLOG_OK:
             bullet_fg = (ov_rgb_t){80, 220, 80};
-            bullet    = "✅";
+            bullet    = "●";
             break;
         case OV_CMDLOG_FAIL:
             bullet_fg = (ov_rgb_t){220, 60, 60};
-            bullet    = "❌";
+            bullet    = "●";
             break;
         case OV_CMDLOG_WARN:
             bullet_fg = (ov_rgb_t){220, 180, 40};
-            bullet    = "⚠️";
+            bullet    = "●";
             break;
         default: /* INFO */
             bullet_fg = (ov_rgb_t){100, 100, 120};
-            bullet    = "ℹ️";
+            bullet    = "●";
             break;
         }
 
@@ -102,7 +102,7 @@ void ov_render_cmdlog(const OV_LAYOUT *lay)
         /* Status bullet */
         ov_buf_fg(bullet_fg.r, bullet_fg.g, bullet_fg.b);
         ov_buf_printf("%s ", bullet);
-        nw += 3; /* emoji(approx 2 cols) + space */
+        nw += 2; /* 1 col bullet + space */
 
         /* Message text */
         ov_buf_fg(180, 180, 200);

--- a/src/cli/overview/overview_render_fps.c
+++ b/src/cli/overview/overview_render_fps.c
@@ -371,7 +371,15 @@ void ov_render_fps_panel(
             " %d conf \u2502 %d run \u2502 %s ",
             tot_conf, tot_run, tmem);
         int rlen = (int) strlen(rbuf);
-        int rcol = r.col + r.width - rlen - 2;
+        int below = filt_n - lay->scroll_fps - max_rows;
+        int dw = 0;
+        if (below > 0)
+        {
+            dw = 3;
+            int tmp = below;
+            while (tmp > 0) { dw++; tmp /= 10; }
+        }
+        int rcol = r.col + r.width - rlen - dw - 4;
         if (rcol > r.col + 1)
         {
             ov_buf_pos(brow, rcol);

--- a/src/cli/overview/overview_render_help.c
+++ b/src/cli/overview/overview_render_help.c
@@ -69,6 +69,7 @@ static const help_line_t HELP[] =
     { "  /        Filter (regex search)",       HF_CHILD,   HS_DISPLAY },
     { "  W        Export snapshot to file",     HF_CHILD,   HS_DISPLAY },
     { "  G        Toggle command log panel",    HF_CHILD,   HS_DISPLAY },
+    { "  v/V      Resize command log panel",    HF_CHILD,   HS_DISPLAY },
     { "  h        Toggle this help",            HF_CHILD,   HS_DISPLAY },
     { "  q        Quit",                        HF_CHILD,   HS_DISPLAY },
     /* --- Control mode --- */

--- a/src/cli/overview/overview_render_help.c
+++ b/src/cli/overview/overview_render_help.c
@@ -99,6 +99,9 @@ static const help_line_t HELP[] =
     { "Mouse",                                  HF_SECTION, HS_MOUSE },
     { "  Click=select  DblClick=detail",        HF_CHILD,   HS_MOUSE },
     { "  Scroll wheel=navigate list",           HF_CHILD,   HS_MOUSE },
+    { "  Click column headers to sort",         HF_CHILD,   HS_MOUSE },
+    { "  Click dashboard tabs to switch",       HF_CHILD,   HS_MOUSE },
+    { "  Drag panel borders to resize",         HF_CHILD,   HS_MOUSE },
     /* --- Colors --- */
     { "Colors",                                 HF_SECTION, HS_COLORS },
     { "",                                       HF_CHILD | HF_COLORS,

--- a/src/cli/overview/overview_render_internal.h
+++ b/src/cli/overview/overview_render_internal.h
@@ -150,7 +150,7 @@ static inline int sort_col_label(
                  label,
                  desc ? "\xe2\x96\xbc"
                       : "\xe2\x96\xb2");
-        return visual_width + 2;
+        return visual_width + 4;
     }
     else
     {

--- a/src/cli/overview/overview_render_procs.c
+++ b/src/cli/overview/overview_render_procs.c
@@ -872,7 +872,15 @@ static void ov_procs__render_rows(
             " %d RUN \u2502 %.0f%% CPU \u2502 %s ",
             tot_run, (double) tot_cpu, tmem);
         int rlen = (int) strlen(rbuf);
-        int rcol = r.col + r.width - rlen - 2;
+        int below = filt_n - lay->scroll_proc - (r.height - 3);
+        int dw = 0;
+        if (below > 0)
+        {
+            dw = 3;
+            int tmp = below;
+            while (tmp > 0) { dw++; tmp /= 10; }
+        }
+        int rcol = r.col + r.width - rlen - dw - 4;
         if (rcol > r.col + 1)
         {
             ov_buf_pos(brow, rcol);

--- a/src/cli/overview/overview_render_status.c
+++ b/src/cli/overview/overview_render_status.c
@@ -148,10 +148,10 @@ void ov_render_status(
     }
 
     int n_hints = snprintf(NULL, 0,
-        "%s%s%s  +/- TAB D S/s / p c G h q",
+        "%s%s%s  +/- TAB D S/s / p c G h q  (Click headers/tabs)",
         ctrl_hint, sort_label, detail_label);
     ov_buf_printf(
-        "%s%s%s  +/- TAB D S/s / p c G h q",
+        "%s%s%s  +/- TAB D S/s / p c G h q  (Click headers/tabs)",
         ctrl_hint, sort_label, detail_label);
     n1 += n_hints;
 

--- a/src/cli/overview/overview_render_streams.c
+++ b/src/cli/overview/overview_render_streams.c
@@ -575,7 +575,15 @@ void ov_render_streams_panel(
                 total_all_mb);
         }
         int rlen = (int) strlen(rbuf);
-        int rcol = r.col + r.width - rlen - 2;
+        int below = filt_n - lay->scroll_stream - max_rows;
+        int dw = 0;
+        if (below > 0)
+        {
+            dw = 3;
+            int tmp = below;
+            while (tmp > 0) { dw++; tmp /= 10; }
+        }
+        int rcol = r.col + r.width - rlen - dw - 4;
         if (rcol > r.col + 1)
         {
             ov_buf_pos(brow, rcol);

--- a/src/cli/overview/overview_scan.c
+++ b/src/cli/overview/overview_scan.c
@@ -56,6 +56,7 @@ static pthread_mutex_t ov_model_mutex =
 static pthread_t      ov_scan_thread;
 static volatile int   ov_scan_running    = 0;
 static volatile float ov_scan_interval_s = 1.0f;
+static atomic_int     ov_force_update_flag = 0;
 
 /**
  * ov_scan_get_interval - get current scan interval.
@@ -134,8 +135,9 @@ static void *ov_scan_thread_func(
             int num_sleeps = (int)(interval / 0.01f);
             for (int i = 0; i < num_sleeps; i++)
             {
-                if (!ov_scan_running || OV_SIG_ANY_SET())
+                if (!ov_scan_running || OV_SIG_ANY_SET() || atomic_load_explicit(&ov_force_update_flag, memory_order_acquire))
                 {
+                    atomic_store_explicit(&ov_force_update_flag, 0, memory_order_release);
                     break;
                 }
                 nanosleep(&ts, NULL);
@@ -207,4 +209,12 @@ const OV_MODEL *ov_scan_get_model(void)
     pthread_mutex_unlock(&ov_model_mutex);
 
     return &ov_model_slots[ov_display_idx];
+}
+
+/**
+ * ov_scan_force_update - interrupt sleep to force an immediate scan.
+ */
+void ov_scan_force_update(void)
+{
+    atomic_store_explicit(&ov_force_update_flag, 1, memory_order_release);
 }

--- a/src/cli/overview/overview_theme.h
+++ b/src/cli/overview/overview_theme.h
@@ -482,6 +482,13 @@ static inline void ov_draw_panel_tabs(
         current_col += strlen(tab_text) + 1; // 1 space between tabs
     }
 
+    if (current_col + 15 < col + width) {
+        ov_buf_pos(row, current_col + 1);
+        ov_theme_fg(OV_FG_MUTED);
+        ov_theme_bg(OV_BG_TERMINAL);
+        ov_buf_printf("(Click tab)");
+    }
+
     /* sides */
     for (int r = row + 1; r < row + height - 1; r++)
     {

--- a/src/engine/libfps/fps_CONFstart.c
+++ b/src/engine/libfps/fps_CONFstart.c
@@ -26,7 +26,14 @@ errno_t functionparameter_CONFstart(FPS *fps)
                            fps->md->name,
                            fps->md->workdir);
 
-    if (strstr(fps->md->execfullpath, "fpsexec") != NULL) {
+    char * exec_basename = strrchr(fps->md->execfullpath, '/');
+    exec_basename = (exec_basename != NULL) ? exec_basename + 1 : fps->md->execfullpath;
+
+    if (strcmp(exec_basename, "milk") != 0 && 
+        strcmp(exec_basename, "cacao") != 0 && 
+        strlen(exec_basename) > 0 && 
+        strcmp(exec_basename, "unknown") != 0) 
+    {
         EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:conf \" %s %s:confstart\" C-m",
                                fps->md->name,
                                fps->md->execfullpath,

--- a/src/engine/libfps/fps_RUNstart.c
+++ b/src/engine/libfps/fps_RUNstart.c
@@ -108,7 +108,14 @@ errno_t functionparameter_RUNstart(
 
         // Send run command
         //
-        if (strstr(fps->md->execfullpath, "fpsexec") != NULL) {
+        char * exec_basename = strrchr(fps->md->execfullpath, '/');
+        exec_basename = (exec_basename != NULL) ? exec_basename + 1 : fps->md->execfullpath;
+
+        if (strcmp(exec_basename, "milk") != 0 && 
+            strcmp(exec_basename, "cacao") != 0 && 
+            strlen(exec_basename) > 0 && 
+            strcmp(exec_basename, "unknown") != 0) 
+        {
             EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:run \" %s %s:runstart\" C-m",
                                    fps->md->name,
                                    fps->md->execfullpath,

--- a/src/engine/libfps/fps_RUNstop.c
+++ b/src/engine/libfps/fps_RUNstop.c
@@ -19,7 +19,14 @@ errno_t functionparameter_RUNstop(FPS *fps)
                            fps->md->name,
                            fps->md->workdir);
 
-    if (strstr(fps->md->execfullpath, "fpsexec") != NULL) {
+    char * exec_basename = strrchr(fps->md->execfullpath, '/');
+    exec_basename = (exec_basename != NULL) ? exec_basename + 1 : fps->md->execfullpath;
+
+    if (strcmp(exec_basename, "milk") != 0 && 
+        strcmp(exec_basename, "cacao") != 0 && 
+        strlen(exec_basename) > 0 && 
+        strcmp(exec_basename, "unknown") != 0) 
+    {
         EXECUTE_SYSTEM_COMMAND_NOCHECK("tmux send-keys -t %s:ctrl \" %s %s:runstop\" C-m",
                                fps->md->name,
                                fps->md->execfullpath,


### PR DESCRIPTION
## Summary
This PR finalizes the interactive UI refinements for the `milk-CTRL` tool, including a resizable command log panel, clickable panel headers and tabs, and standardized emojis and symbols. It also refactors the FPS lifecycle tmux dispatch routines to securely identify executable basenames instead of brittle substring checks, preventing legacy shell functions from being wrongly executed.

## Changes

### `src/cli/overview` (milk-CTRL)
- Added interactive panel resizing (drag support and `v`/`V` keys).
- Made dashboard and graph tab headings clickable, and columns sortable via click.
- Standardized command log feedback and emojis (using `●` consistently).
- Fixed h-split drag intercepting graph panel tab clicks on the dashboard.
- Displayed UI visual hints such as "(Click tab)" to aid user discovery.

### `src/engine/libfps` (FPS Lifecycle)
- Updated `fps_CONFstart.c`, `fps_RUNstart.c`, and `fps_RUNstop.c`.
- Replaced `strstr("fpsexec")` checks with robust parsing of `execfullpath` to match executable basenames.
- Restricted generic shell dispatching to `milk` and `cacao` plugins only, allowing standalone executables to properly invoke their respective actions directly.

## Verification
- [x] Build passes (`/compile-test`)
- [x] TUI UI validated for visual clarity and input persistence.

## Prompt Summary
The user requested to finalize the `milkCTRL` TUI enhancements (resizable panels, clicks, visual standards) alongside addressing FPS lifecycle command stability. The core goal was to reliably dispatch tmux commands depending on the true binary name, rather than legacy string assumptions, and ensuring the interface is professional and clean.

## AI Authorship
- **Model**: Antigravity
- **User edits**: None
