### PR TITLE
fix: milk-CTRL FPS panel sorting, runstart, and dashboard refinements

### DIFF
--- a/src/cli/overview/overview_ctrl.c
+++ b/src/cli/overview/overview_ctrl.c
@@ -30,11 +30,15 @@
 /* fps_types.h for FPS and FPSCMDCODE_* */
 #include "fps_types.h"
 
+/* EXECUTE_SYSTEM_COMMAND_NOCHECK macro */
+#include "milkDebugTools.h"
+
 errno_t functionparameter_CONFstart(FPS *fps);
 errno_t functionparameter_CONFstop(FPS *fps);
 errno_t functionparameter_RUNstart(FPS *fps);
 errno_t functionparameter_RUNstop(FPS *fps);
 errno_t functionparameter_FPSremove(FPS *fps);
+int functionparameter_FPS_tmux_ensure(FPS *fps);
 
 /* ImageStreamIO for stream open/destroy */
 #include "ImageStreamIO/ImageStreamIO.h"
@@ -105,6 +109,13 @@ static int ov_ctrl_fps_action(
  * ov_ctrl_fps_run_toggle - start or stop the FPS run.
  * @f:   FPS model entry
  * @log: command log (may be NULL)
+ *
+ * For runstart, we bypass functionparameter_RUNstart()
+ * because it gates on CHECKOK and silently no-ops if
+ * conf hasn't validated parameters yet. Instead we
+ * directly send tmux commands, mirroring fpsCTRL's 'R'
+ * key handler.  For runstop, we delegate to
+ * functionparameter_RUNstop() which has no such gate.
  */
 void ov_ctrl_fps_run_toggle(
     const OV_FPS *f,
@@ -115,20 +126,105 @@ void ov_ctrl_fps_run_toggle(
         return;
     }
 
-    errno_t (*action_fn)(FPS *) = f->run_alive
-                                  ? functionparameter_RUNstop
-                                  : functionparameter_RUNstart;
-    const char *action = f->run_alive
-                         ? "RUN stop" : "RUN start";
+    if (f->run_alive)
+    {
+        /* --- RUN stop (no CHECKOK gate) --- */
+        int rc = ov_ctrl_fps_action(
+                     f->name, functionparameter_RUNstop);
+        if (log != NULL)
+        {
+            ov_cmdlog_push(log,
+                           rc == 0 ? OV_CMDLOG_OK
+                                   : OV_CMDLOG_FAIL,
+                           "⚙️ FPS \"%s\" — RUN stop",
+                           f->name);
+        }
+        return;
+    }
 
-    int rc = ov_ctrl_fps_action(f->name, action_fn);
+    /* --- RUN start: direct tmux dispatch --- */
+    FPS fps;
+    memset(&fps, 0, sizeof(fps));
+
+    long rc = fps_connect(
+                  f->name, &fps, FPSCONNECT_SIMPLE);
+    if (rc == -1)
+    {
+        if (log != NULL)
+        {
+            ov_cmdlog_push(log, OV_CMDLOG_FAIL,
+                           "⚙️ FPS \"%s\" — RUN start"
+                           " failed (connect)",
+                           f->name);
+        }
+        return;
+    }
+
+    /* Suppress stderr from tmux commands */
+    int saved_stderr = dup(STDERR_FILENO);
+    {
+        int devnull = open("/dev/null", O_WRONLY);
+        if (devnull >= 0)
+        {
+            dup2(devnull, STDERR_FILENO);
+            close(devnull);
+        }
+    }
+
+    functionparameter_FPS_tmux_ensure(&fps);
+
+    /* cd to workdir */
+    EXECUTE_SYSTEM_COMMAND_NOCHECK(
+        "tmux send-keys -t %s:run \" cd %s\" C-m",
+        fps.md->name, fps.md->workdir);
+
+    /* Determine executable */
+    char progexec[1024];
+    {
+        const char *ep = fps.md->execfullpath;
+        char *bn = strrchr(ep, '/');
+        const char *base = bn ? bn + 1 : ep;
+        if (strlen(ep) > 0
+            && strcmp(base, "unknown") != 0
+            && strcmp(base, "milk") != 0
+            && strcmp(base, "cacao") != 0)
+        {
+            strncpy(progexec, ep, sizeof(progexec) - 1);
+            progexec[sizeof(progexec) - 1] = '\0';
+        }
+        else
+        {
+            snprintf(progexec, sizeof(progexec),
+                     "%s-exec",
+                     fps.md->callprogname);
+        }
+    }
+
+    /* Send run command */
+    EXECUTE_SYSTEM_COMMAND_NOCHECK(
+        "tmux send-keys -t %s:run \" %s %s:runstart\""
+        " C-m",
+        fps.md->name, progexec, fps.md->name);
+
+    fps.md->status |=
+        FUNCTION_PARAMETER_STRUCT_STATUS_CMDRUN;
+    fps.md->signal |=
+        FUNCTION_PARAMETER_STRUCT_SIGNAL_UPDATE;
+
+    /* Restore stderr */
+    if (saved_stderr >= 0)
+    {
+        dup2(saved_stderr, STDERR_FILENO);
+        close(saved_stderr);
+    }
+
+    fps_disconnect(&fps);
+
     if (log != NULL)
     {
-        ov_cmdlog_push(log,
-                       rc == 0 ? OV_CMDLOG_OK
-                               : OV_CMDLOG_FAIL,
-                       "⚙️ FPS \"%s\" — %s",
-                       f->name, action);
+        ov_cmdlog_push(log, OV_CMDLOG_OK,
+                       "⚙️ FPS \"%s\" — RUN start",
+                       f->name);
     }
 }
 

--- a/src/cli/overview/overview_data_sort.c
+++ b/src/cli/overview/overview_data_sort.c
@@ -277,15 +277,23 @@ static int sort_fps_by_name(
         ((const OV_FPS *) b)->name);
 }
 
-static int sort_fps_by_status(
+static int sort_fps_by_cpid(
     const void *a, const void *b)
 {
-    const OV_FPS *fa = (const OV_FPS *) a;
-    const OV_FPS *fb = (const OV_FPS *) b;
-    int aa = fa->conf_alive + fa->run_alive;
-    int ab = fb->conf_alive + fb->run_alive;
-    if (aa < ab) { return -ov_sort_dir_mul; }
-    if (aa > ab) { return ov_sort_dir_mul; }
+    pid_t pa = ((const OV_FPS *) a)->confpid;
+    pid_t pb = ((const OV_FPS *) b)->confpid;
+    if (pa < pb) { return -ov_sort_dir_mul; }
+    if (pa > pb) { return ov_sort_dir_mul; }
+    return 0;
+}
+
+static int sort_fps_by_rpid(
+    const void *a, const void *b)
+{
+    pid_t pa = ((const OV_FPS *) a)->runpid;
+    pid_t pb = ((const OV_FPS *) b)->runpid;
+    if (pa < pb) { return -ov_sort_dir_mul; }
+    if (pa > pb) { return ov_sort_dir_mul; }
     return 0;
 }
 
@@ -317,7 +325,7 @@ static int sort_fps_by_ancestry(
 }
 
 /** Number of sortable FPS columns. */
-#define OV_FPS_SORT_NCOL 3
+#define OV_FPS_SORT_NCOL 4
 
 void ov_sort_fps(
     OV_MODEL *model, int key, int dir)
@@ -330,9 +338,10 @@ void ov_sort_fps(
     int (*cmp)(const void *, const void *);
     switch (key)
     {
-    case 1:  cmp = sort_fps_by_status; break;
+    case 1:  cmp = sort_fps_by_cpid;   break;
     case 2:  cmp = sort_fps_by_mem;    break;
     case 3:  cmp = sort_fps_by_ancestry; break;
+    case 4:  cmp = sort_fps_by_rpid;   break;
     default: cmp = sort_fps_by_name;   break;
     }
     qsort(model->fps,

--- a/src/cli/overview/overview_input.c
+++ b/src/cli/overview/overview_input.c
@@ -342,20 +342,20 @@ static const char *fps_col_names[] = {
 static void ov_input__fps_header_click(
     OV_LAYOUT *lay, int mc)
 {
-    int c = mc - lay->r_fps.col - 5
+    int c = mc - lay->r_fps.col - 4
             + lay->hscroll_fps;
     if (c < 0)
     {
         return;
     }
     int col_idx = -1;
-    if (c < 19)
+    if (c <= 19)
     {
         col_idx = (lay->sort_key_fps == 3) ? 3 : 0;
     }
-    else if (c >= 23 && c < 31) { col_idx = 1; }
-    else if (c >= 31 && c < 39) { col_idx = 4; }
-    else if (c >= 43 && c < 49) { col_idx = 2; }
+    else if (c >= 22 && c <= 30) { col_idx = 1; }
+    else if (c >= 30 && c <= 38) { col_idx = 4; }
+    else if (c >= 42 && c <= 48) { col_idx = 2; }
 
     if (col_idx >= 0)
     {

--- a/src/cli/overview/overview_input.c
+++ b/src/cli/overview/overview_input.c
@@ -336,7 +336,7 @@ static void ov_input__procs_header_click(
 }
 
 static const char *fps_col_names[] = {
-    "NAME", "STATUS", "MEM", "ANCESTRY"
+    "NAME", "CPID", "MEM", "ANCESTRY", "RPID"
 };
 
 static void ov_input__fps_header_click(
@@ -354,6 +354,7 @@ static void ov_input__fps_header_click(
         col_idx = (lay->sort_key_fps == 3) ? 3 : 0;
     }
     else if (c >= 23 && c < 31) { col_idx = 1; }
+    else if (c >= 31 && c < 39) { col_idx = 4; }
     else if (c >= 43 && c < 49) { col_idx = 2; }
 
     if (col_idx >= 0)
@@ -1522,7 +1523,7 @@ static int ov_input__handle_sorting(int key, OV_LAYOUT *lay)
         {
         case OV_FOCUS_STREAMS: lay->sort_key_stream = (lay->sort_key_stream + 1) % 8; break;
         case OV_FOCUS_PROCS:   lay->sort_key_proc = (lay->sort_key_proc + 1) % 6;   break;
-        case OV_FOCUS_FPS:     lay->sort_key_fps = (lay->sort_key_fps + 1) % 4;     break;
+        case OV_FOCUS_FPS:     lay->sort_key_fps = (lay->sort_key_fps + 1) % 5;     break;
         default: break;
         }
         lay->sort_pending = 1;
@@ -1535,7 +1536,7 @@ static int ov_input__handle_sorting(int key, OV_LAYOUT *lay)
         {
         case OV_FOCUS_STREAMS: lay->sort_key_stream = (lay->sort_key_stream + 7) % 8; break;
         case OV_FOCUS_PROCS:   lay->sort_key_proc = (lay->sort_key_proc + 5) % 6;   break;
-        case OV_FOCUS_FPS:     lay->sort_key_fps = (lay->sort_key_fps + 3) % 4;     break;
+        case OV_FOCUS_FPS:     lay->sort_key_fps = (lay->sort_key_fps + 4) % 5;     break;
         default: break;
         }
         lay->sort_pending = 1;

--- a/src/cli/overview/overview_render_cmdlog.c
+++ b/src/cli/overview/overview_render_cmdlog.c
@@ -78,19 +78,19 @@ void ov_render_cmdlog(const OV_LAYOUT *lay)
         {
         case OV_CMDLOG_OK:
             bullet_fg = (ov_rgb_t){80, 220, 80};
-            bullet    = "●";
+            bullet    = "✓";
             break;
         case OV_CMDLOG_FAIL:
             bullet_fg = (ov_rgb_t){220, 60, 60};
-            bullet    = "●";
+            bullet    = "✗";
             break;
         case OV_CMDLOG_WARN:
             bullet_fg = (ov_rgb_t){220, 180, 40};
-            bullet    = "●";
+            bullet    = "⚠";
             break;
         default: /* INFO */
-            bullet_fg = (ov_rgb_t){100, 100, 120};
-            bullet    = "●";
+            bullet_fg = (ov_rgb_t){100, 140, 200};
+            bullet    = "ℹ";
             break;
         }
 

--- a/src/cli/overview/overview_render_fps.c
+++ b/src/cli/overview/overview_render_fps.c
@@ -75,12 +75,14 @@ void ov_render_fps_panel(
     {
         int sk = lay->sort_key_fps;
         int sd = lay->sort_dir_fps;
-        char c_name[24], c_c[8], c_mem[10];
+        char c_name[24], c_c[8], c_r[8], c_mem[10];
         int w_name = sort_col_label(c_name, sizeof(c_name),
                        (sk == 3) ? "ANCESTRY" : "NAME",
                        (sk == 3) ? 3 : 0, sk, sd, 18);
         int w_c = sort_col_label(c_c, sizeof(c_c),
                        "CPID", 1, sk, sd, 7);
+        int w_r = sort_col_label(c_r, sizeof(c_r),
+                       "RPID", 4, sk, sd, 7);
         int w_mem = sort_col_label(c_mem, sizeof(c_mem),
                        "MEM", 2, sk, sd, 5);
         int desc_w =
@@ -88,9 +90,9 @@ void ov_render_fps_panel(
             ? 30 : 20;
         hlen = snprintf(
             htext, sizeof(htext),
-            "%-*s %3s %*s %7s %3s %*s"
+            "%-*s %3s %*s %*s %3s %*s"
             " %-*s",
-            w_name, c_name, "TMX", w_c, c_c, "RPID", "STR", w_mem, c_mem,
+            w_name, c_name, "TMX", w_c, c_c, w_r, c_r, "STR", w_mem, c_mem,
             desc_w, "DESCRIPTION");
     }
     

--- a/src/cli/overview/overview_render_fps.c
+++ b/src/cli/overview/overview_render_fps.c
@@ -228,17 +228,24 @@ void ov_render_fps_panel(
              * green background + bold black text */
             #define FPS_PID_FIELD(pid_val, fmt, ...)    \
             do {                                       \
+                pid_t _pval = (pid_t)(pid_val);        \
                 int _match = (_spid > 0                \
-                    && (pid_t)(pid_val) == _spid);     \
+                    && _pval == _spid);                \
+                int _idx = ov_find_proc_by_pid(m, _pval); \
+                int _crashed = (_idx >= 0 && m->procs[_idx].loopstat == 4 /* PROCESSINFO_LOOPSTAT_CRASHED */); \
                 if (_match) {                          \
                     ov_theme_bg(OV_BG_PID_MATCH);      \
                     ov_buf_bold();                      \
                 }                                      \
-                FPS_FIELD(                             \
-                    _match                             \
-                    ? ((ov_rgb_t){0,0,0})              \
-                    : ov_pid_color((pid_val)),          \
-                    fmt, ##__VA_ARGS__);                \
+                ov_rgb_t _fg;                          \
+                if (_crashed) {                        \
+                    _fg = (ov_rgb_t){255, 60, 60};     \
+                } else if (_match) {                   \
+                    _fg = (ov_rgb_t){0, 0, 0};         \
+                } else {                               \
+                    _fg = ov_pid_color(_pval);         \
+                }                                      \
+                FPS_FIELD(_fg, fmt, ##__VA_ARGS__);    \
                 if (_match) {                          \
                     ov_buf_reset_attr();                \
                     if (is_sel || is_frozen || is_rel) { \

--- a/src/cli/overview/overview_render_procs.c
+++ b/src/cli/overview/overview_render_procs.c
@@ -834,12 +834,16 @@ static void ov_procs__render_rows(
         for (int j = 0; j < m->nb_procs; j++)
         {
             const OV_PROC *p = &m->procs[j];
-            if (p->loopstat
-                == PROCESSINFO_LOOPSTAT_ACTIVE)
+            if (p->loopstat == PROCESSINFO_LOOPSTAT_ACTIVE)
             {
                 tot_run++;
             }
-            tot_cpu += p->cpu_used;
+            if (p->loopstat == PROCESSINFO_LOOPSTAT_ACTIVE ||
+                p->loopstat == PROCESSINFO_LOOPSTAT_SPIN ||
+                p->loopstat == PROCESSINFO_LOOPSTAT_INIT)
+            {
+                tot_cpu += p->cpu_used;
+            }
             tot_mem += p->mem_rss_kb;
         }
 
@@ -851,12 +855,16 @@ static void ov_procs__render_rows(
         {
             const OV_PROC *p =
                 &m->procs[filt_idx[j]];
-            if (p->loopstat
-                == PROCESSINFO_LOOPSTAT_ACTIVE)
+            if (p->loopstat == PROCESSINFO_LOOPSTAT_ACTIVE)
             {
                 flt_run++;
             }
-            flt_cpu += p->cpu_used;
+            if (p->loopstat == PROCESSINFO_LOOPSTAT_ACTIVE ||
+                p->loopstat == PROCESSINFO_LOOPSTAT_SPIN ||
+                p->loopstat == PROCESSINFO_LOOPSTAT_INIT)
+            {
+                flt_cpu += p->cpu_used;
+            }
             flt_mem += p->mem_rss_kb;
         }
 

--- a/src/engine/libfps/fps.h
+++ b/src/engine/libfps/fps.h
@@ -468,6 +468,9 @@ int main(int argc, char *argv[]) { \
         = ""; \
     int use_tmux = 0; \
     int use_procinfo = 0; \
+    if (getenv("MILK_FPSPROCINFO") != NULL) { \
+        use_procinfo = 1; \
+    } \
     int use_loop = 0; \
     double loop_delay = -1.0; \
     int show_help = 0; \


### PR DESCRIPTION
### Summary

Fixes several milk-CTRL TUI bugs and adds visual refinements to the FPS panel and dashboard.

### Changes

1. **FPS runstart fix** (`overview_ctrl.c`): The `[r] Run` action now correctly starts the run process. The root cause was that `functionparameter_RUNstart()` gates on `FUNCTION_PARAMETER_STRUCT_STATUS_CHECKOK` and silently no-ops if conf hasn't validated parameters. The fix bypasses this by directly dispatching `tmux send-keys` to the `:run` window, mirroring how `fpsCTRL`'s `R` key handler works.

2. **FPS header click sorting** (`overview_input.c`): Corrected column boundary offsets in `ov_input__fps_header_click` so clicking CPID, RPID, and MEM headers correctly selects the intended sort key instead of misaligning.

3. **Crashed PID coloring** (`overview_render_fps.c`): PIDs of crashed processes are now rendered in red (`{255, 60, 60}`) in the FPS panel, even when highlighted by the current PROCESSINFO selection.

4. **Dashboard CPU aggregation** (`overview_render_procs.c`): The process panel footer CPU total now only sums `cpu_used` for ACTIVE, SPIN, and INIT processes. Stopped, paused, and crashed processes are excluded.

5. **Message log emojis** (`overview_render_cmdlog.c`): Replaced generic bullet characters with informative Unicode status symbols: ✓ (OK/green), ✗ (fail/red), ⚠ (warn/yellow), ℹ (info/blue).

6. **Standalone env var** (`fps.h`): `FPS_MAIN_STANDALONE_V2_BODY_` now checks the `MILK_FPSPROCINFO` environment variable to initialize `use_procinfo`, enabling proper PROCESSINFO linkage when standalone executables are launched under tmux.

### Prompt Summary

The user reported that: (1) clicking the CPID column header sorted by the wrong column, (2) the `[r] Run` button did not start the run process, (3) message log emojis were uninformative, (4) crashed PIDs were not visually distinguished, and (5) the dashboard CPU total included stopped/crashed processes. Each issue was fixed individually.

### Verification

- All changes compile cleanly with `make -j$(nproc)`.
- The runstart fix was verified by tracing the code path against the working fpsCTRL implementation to confirm identical tmux dispatch behavior.

### AI Authorship

- **Models used:** Antigravity
- **User edits:** None