### PR TITLE
fix: milk-CTRL TUI diagnostic polish and interactivity fixes

### DIFF
--- a/src/cli/overview/milkCTRL.c
+++ b/src/cli/overview/milkCTRL.c
@@ -40,6 +40,8 @@ int            ov__color_level = 0;
 int ov_mouse_row = 0;
 int ov_mouse_col = 0;
 int ov_mouse_btn = 0;
+int ov_hover_row = 0;
+int ov_hover_col = 0;
 
 char ov__screenbuf[OV_SCREENBUF_SIZE];
 int  ov__screenbuf_len = 0;

--- a/src/cli/overview/overview_ansi.h
+++ b/src/cli/overview/overview_ansi.h
@@ -53,10 +53,13 @@
 #define OV_KEY_MOUSE_RELEASE 288
 #define OV_KEY_CTRL_SCROLL_UP   289
 #define OV_KEY_CTRL_SCROLL_DOWN 290
+#define OV_KEY_MOUSE_MOVE   291
 
 extern int ov_mouse_row;
 extern int ov_mouse_col;
 extern int ov_mouse_btn;
+extern int ov_hover_row;
+extern int ov_hover_col;
 
 #ifndef ctrl
 #define ctrl(x) ((x) & 0x1f)
@@ -94,10 +97,21 @@ static inline void ov_raw_mode_enter(void)
 static inline void ov_raw_mode_exit(void)
 {
     if (!ov__raw_active) return;
-    const char seq[] = "\033[?1006l\033[?1002l\033[?25h\033[?7h\033[0m\033[?1049l";
+    const char seq[] = "\033[?1003l\033[?1006l\033[?1002l\033[?25h\033[?7h\033[0m\033[?1049l";
     if (write(STDOUT_FILENO, seq, sizeof(seq) - 1) < 0) {}
     tcsetattr(STDIN_FILENO, TCSAFLUSH, &ov__orig_termios);
     ov__raw_active = 0;
+}
+
+static inline void ov_set_mouse_hover(int enable)
+{
+    if (enable) {
+        const char seq[] = "\033[?1002l\033[?1003h";
+        if (write(STDOUT_FILENO, seq, sizeof(seq) - 1) < 0) {}
+    } else {
+        const char seq[] = "\033[?1003l\033[?1002h";
+        if (write(STDOUT_FILENO, seq, sizeof(seq) - 1) < 0) {}
+    }
 }
 
 static inline void ov_get_terminal_size(int *rows, int *cols)
@@ -579,6 +593,14 @@ static inline int ov_get_key(void)
                         /* Ctrl+scroll (#12) */
                         if (mb == 80) return OV_KEY_CTRL_SCROLL_UP;
                         if (mb == 81) return OV_KEY_CTRL_SCROLL_DOWN;
+                        
+                        /* Mouse move (passive) */
+                        if (mb == 35 && press) {
+                            ov_hover_col = mc;
+                            ov_hover_row = mr;
+                            return OV_KEY_MOUSE_MOVE;
+                        }
+
                         if ((mb & 32) && press) return OV_KEY_MOUSE_DRAG;
                         if (mb == 0 && press) return OV_KEY_MOUSE_CLICK;
                         if (!press) return OV_KEY_MOUSE_RELEASE;

--- a/src/cli/overview/overview_ctrl.c
+++ b/src/cli/overview/overview_ctrl.c
@@ -31,6 +31,10 @@
 #include "fps_types.h"
 
 /* EXECUTE_SYSTEM_COMMAND_NOCHECK macro */
+#undef STRINGMAXLEN_DIRNAME
+#undef STRINGMAXLEN_FULLFILENAME
+#undef STRINGMAXLEN_COMMAND
+#undef PRINT_ERROR
 #include "milkDebugTools.h"
 
 errno_t functionparameter_CONFstart(FPS *fps);

--- a/src/cli/overview/overview_fps_edit.c
+++ b/src/cli/overview/overview_fps_edit.c
@@ -20,6 +20,10 @@
 
 /* libfps headers after overview headers to
  * avoid macro redefinition warnings */
+#undef STRINGMAXLEN_DIRNAME
+#undef STRINGMAXLEN_FULLFILENAME
+#undef STRINGMAXLEN_COMMAND
+#undef PRINT_ERROR
 #include "fps_types.h"
 #include "fps_paramvalue.h"
 #include "fps_printparameter_valuestring.h"

--- a/src/cli/overview/overview_input.c
+++ b/src/cli/overview/overview_input.c
@@ -488,6 +488,271 @@ static void ov_input__exec_preview_btn(
     ov_scan_force_update();
 }
 
+void ov_hittest(OV_LAYOUT *lay, const OV_MODEL *m, int mr, int mc)
+{
+    lay->hover_view = -1;
+    lay->hover_idx = -1;
+    lay->hover_is_header = 0;
+    lay->hover_col_logical = mc;
+    lay->hover_tooltip[0] = '\0';
+    lay->fps_split_hover = 0;
+    lay->dash_split_v_hover = 0;
+    lay->dash_split_h_hover = 0;
+    lay->cmdlog_split_hover = 0;
+
+    if (!lay->mouse_hover)
+    {
+        return;
+    }
+
+    int cmdlog_top = (lay->cmdlog_rows > 0) ? (lay->term_rows - lay->cmdlog_rows) : lay->term_rows;
+    if (mr == cmdlog_top - 1 || mr == cmdlog_top)
+    {
+        lay->cmdlog_split_hover = 1;
+    }
+
+    if (lay->view == OV_VIEW_FPS)
+    {
+        if (mc >= lay->r_fps_list.width - 1 && mc <= lay->r_fps_list.width + 2)
+        {
+            lay->fps_split_hover = 1;
+        }
+    }
+    else if (lay->view == OV_VIEW_DASHBOARD)
+    {
+        int h_split_row = lay->r_streams.row + lay->r_streams.height;
+        int v_split_col = lay->r_streams.width;
+
+        if (mr >= h_split_row - 1 && mr <= h_split_row + 1)
+        {
+            lay->dash_split_h_hover = 1;
+        }
+        if (mc >= v_split_col - 1 && mc <= v_split_col + 2)
+        {
+            lay->dash_split_v_hover = 1;
+        }
+    }
+
+    if (lay->view == OV_VIEW_FPS)
+    {
+        if (INSIDE(lay->r_fps_params, mr, mc))
+        {
+            lay->hover_view = OV_FOCUS_FPS;
+        }
+        else if (INSIDE(lay->r_fps, mr, mc))
+        {
+            lay->hover_view = OV_FOCUS_FPS;
+            int body_row = mr - lay->r_fps.row - 3;
+            if (body_row == -1 || body_row == -2) { lay->hover_is_header = 1; }
+            else if (body_row >= 0)
+            {
+                int idx = lay->scroll_fps + body_row;
+                if (idx < m->nb_fps) { lay->hover_idx = idx; }
+            }
+        }
+    }
+    else if (lay->view == OV_VIEW_STREAMS && INSIDE(lay->r_streams, mr, mc))
+    {
+        lay->hover_view = OV_FOCUS_STREAMS;
+        int body_row = mr - lay->r_streams.row - 3;
+        if (body_row == -1) { lay->hover_is_header = 1; }
+        else if (body_row >= 0)
+        {
+            int idx = lay->scroll_stream + body_row;
+            if (idx < m->nb_streams) { lay->hover_idx = idx; }
+        }
+    }
+    else if (lay->view == OV_VIEW_PROCS && INSIDE(lay->r_procs, mr, mc))
+    {
+        lay->hover_view = OV_FOCUS_PROCS;
+        int body_row = mr - lay->r_procs.row - 3;
+        if (body_row == -1) { lay->hover_is_header = 1; }
+        else if (body_row >= 0)
+        {
+            int idx = lay->scroll_proc + body_row;
+            if (idx < m->nb_procs) { lay->hover_idx = idx; }
+        }
+    }
+    else if (lay->view == OV_VIEW_GRAPH && INSIDE(lay->r_graph, mr, mc))
+    {
+        lay->hover_view = OV_FOCUS_GRAPH;
+        int body_row = mr - lay->r_graph.row - 1;
+        if (body_row >= 0)
+        {
+            if (lay->graph_tab_mode == 0) {
+                int idx = lay->scroll_graph + body_row;
+                if (idx < m->nb_edges) { lay->hover_idx = idx; }
+            } else {
+                lay->hover_idx = body_row;
+            }
+        }
+    }
+    else if (lay->view == OV_VIEW_DASHBOARD)
+    {
+        if (INSIDE(lay->r_streams, mr, mc))
+        {
+            lay->hover_view = OV_FOCUS_STREAMS;
+            int body_row = mr - lay->r_streams.row - 3;
+            if (body_row == -1 || body_row == -2) { lay->hover_is_header = 1; }
+            else if (body_row >= 0)
+            {
+                int idx = lay->scroll_stream + body_row;
+                if (idx < m->nb_streams) { lay->hover_idx = idx; }
+            }
+        }
+        else if (INSIDE(lay->r_procs, mr, mc))
+        {
+            lay->hover_view = OV_FOCUS_PROCS;
+            int body_row = mr - lay->r_procs.row - 3;
+            if (body_row == -1 || body_row == -2) { lay->hover_is_header = 1; }
+            else if (body_row >= 0)
+            {
+                int idx = lay->scroll_proc + body_row;
+                if (idx < m->nb_procs) { lay->hover_idx = idx; }
+            }
+        }
+        else if (INSIDE(lay->r_fps, mr, mc))
+        {
+            lay->hover_view = OV_FOCUS_FPS;
+            int body_row = mr - lay->r_fps.row - 3;
+            if (body_row == -1 || body_row == -2) { lay->hover_is_header = 1; }
+            else if (body_row >= 0)
+            {
+                int idx = lay->scroll_fps + body_row;
+                if (idx < m->nb_fps) { lay->hover_idx = idx; }
+            }
+        }
+        else if (INSIDE(lay->r_graph, mr, mc))
+        {
+            lay->hover_view = OV_FOCUS_GRAPH;
+            int body_row = mr - lay->r_graph.row - 1;
+            if (body_row >= 0)
+            {
+                if (lay->graph_tab_mode == 0) {
+                    int idx = lay->scroll_graph + body_row;
+                    if (idx < m->nb_edges) { lay->hover_idx = idx; }
+                } else {
+                    lay->hover_idx = body_row;
+                }
+            }
+        }
+    }
+}
+
+void ov_hittest_resolve_globals(OV_LAYOUT *lay, const OV_MODEL *m)
+{
+    lay->hover_global_stream = -1;
+    lay->hover_global_proc = -1;
+    lay->hover_global_fps = -1;
+
+    if (!lay->mouse_hover || lay->hover_idx < 0) return;
+
+    if (lay->hover_view == OV_FOCUS_STREAMS) {
+        int count = m->nb_streams;
+        int fidx[OV_MAX_STREAMS];
+        for (int i = 0; i < count; i++) fidx[i] = i;
+        if (lay->filter_stream[0] != '\0') {
+            const char *names[OV_MAX_STREAMS];
+            for (int i = 0; i < count; i++) names[i] = m->streams[i].name;
+            count = ov_filter_build(lay->filter_stream, names, m->nb_streams, fidx, OV_MAX_STREAMS);
+        }
+        if (lay->hover_idx < count) lay->hover_global_stream = fidx[lay->hover_idx];
+    }
+    else if (lay->hover_view == OV_FOCUS_PROCS) {
+        int count = m->nb_procs;
+        int fidx[OV_MAX_PROCS];
+        for (int i = 0; i < count; i++) fidx[i] = i;
+        if (lay->filter_proc[0] != '\0') {
+            const char *names[OV_MAX_PROCS];
+            for (int i = 0; i < count; i++) names[i] = m->procs[i].name;
+            count = ov_filter_build(lay->filter_proc, names, m->nb_procs, fidx, OV_MAX_PROCS);
+        }
+        if (lay->hover_idx < count) lay->hover_global_proc = fidx[lay->hover_idx];
+    }
+    else if (lay->hover_view == OV_FOCUS_FPS) {
+        int count = m->nb_fps;
+        int fidx[OV_MAX_FPS];
+        for (int i = 0; i < count; i++) fidx[i] = i;
+        if (lay->filter_fps[0] != '\0') {
+            const char *names[OV_MAX_FPS];
+            for (int i = 0; i < count; i++) names[i] = m->fps[i].name;
+            count = ov_filter_build(lay->filter_fps, names, m->nb_fps, fidx, OV_MAX_FPS);
+        }
+        if (lay->hover_idx < count) lay->hover_global_fps = fidx[lay->hover_idx];
+    }
+    else if (lay->hover_view == OV_FOCUS_GRAPH) {
+        if (lay->graph_tab_mode == 0) {
+            int start_node = get_graph_start_node(lay, m);
+            if (start_node >= 0) {
+                SG_TREE_NODE rnodes[OV_MAX_NODES];
+                int nb_rnodes = sg_compute_render_tree(m, start_node, lay->lineage_mode, rnodes);
+                if (lay->hover_idx < nb_rnodes) {
+                    const SG_TREE_NODE *rn = &rnodes[lay->hover_idx];
+                    int proc_idx = -1;
+                    if (rn->writer_name[0] != '\0') {
+                        for (int i = 0; i < m->nb_procs; i++) {
+                            if (strcmp(m->procs[i].name, rn->writer_name) == 0) {
+                                proc_idx = i;
+                                break;
+                            }
+                        }
+                    }
+                
+                    int disp_len = 0;
+                    for (int i = 0; rn->tree_prefix[i] != '\0'; ) {
+                        disp_len++;
+                        i += utf8_char_length((unsigned char)rn->tree_prefix[i]);
+                    }
+                    if (rn->is_target) disp_len += 2;
+                    for (int i = 0; rn->name[i] != '\0'; ) {
+                        disp_len++;
+                        i += utf8_char_length((unsigned char)rn->name[i]);
+                    }
+                    
+                    int click_on_proc = 0;
+                    if (lay->hover_col_logical - lay->r_graph.col - 1 > disp_len + 1) {
+                        click_on_proc = 1;
+                    }
+                    
+                    if (click_on_proc && proc_idx >= 0) {
+                        lay->hover_global_proc = proc_idx;
+                    } else if (rn->stream_idx >= 0) {
+                        lay->hover_global_stream = rn->stream_idx;
+                    }
+                }
+            }
+        }
+        else if (lay->graph_tab_mode == 1) {
+            ov_focus_t focus = lay->freeze ? lay->freeze_focus : lay->focus;
+            int fsel = lay->freeze ? lay->freeze_sel_fps : lay->sel_fps;
+            
+            int active_fps = -1;
+            if (focus == OV_FOCUS_FPS && fsel >= 0 && fsel < m->nb_fps) {
+                active_fps = fsel;
+            } else if (focus != OV_FOCUS_STREAMS && focus != OV_FOCUS_PROCS) {
+                if (fsel >= 0 && fsel < m->nb_fps) active_fps = fsel;
+            }
+            
+            if (active_fps >= 0) {
+                const OV_FPS *f = &m->fps[active_fps];
+                if (f->nb_disp_params > 0) {
+                    int header_rows = 3 + (f->description[0] != '\0' ? 1 : 0);
+                    int param_row = lay->hover_idx - header_rows;
+                    if (param_row >= 0) {
+                        int dp = lay->param_scroll + param_row;
+                        if (dp >= 0 && dp < f->nb_disp_params) {
+                            if (f->disp_param_type[dp] == FPTYPE_STREAMNAME) {
+                                int si = ov_find_stream_by_name(m, f->disp_param_value[dp]);
+                                if (si >= 0) lay->hover_global_stream = si;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
 {
     if (key == OV_KEY_MOUSE_CLICK)
@@ -529,9 +794,30 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
                 lay->ctrl_mode = !lay->ctrl_mode;
                 ov_cmdlog_push(&lay->cmdlog,
                                OV_CMDLOG_INFO,
-                               "Control mode %s",
+                               "🎛️ Control mode %s",
                                lay->ctrl_mode
-                               ? "ON" : "OFF");
+                               ? "✓ ON" : "✗ OFF");
+                return 1;
+            }
+
+            /* Check for HOVER mode toggle click */
+            int hover_badge_start = badge_start + badge_w + 1;
+            int hover_badge_w = lay->mouse_hover ? 14 : 15;
+            if (mc >= hover_badge_start && mc < hover_badge_start + hover_badge_w)
+            {
+                lay->mouse_hover = !lay->mouse_hover;
+                ov_set_mouse_hover(lay->mouse_hover);
+                ov_cmdlog_push(&lay->cmdlog,
+                               OV_CMDLOG_INFO,
+                               "🖱️ Mouse hover %s",
+                               lay->mouse_hover
+                               ? "✓ ON" : "✗ OFF");
+                if (lay->mouse_hover)
+                {
+                    ov_cmdlog_push(&lay->cmdlog,
+                                   OV_CMDLOG_WARN,
+                                   "⚠️ Warning: Hover uses more CPU & character BW on slow connections");
+                }
                 return 1;
             }
 
@@ -578,6 +864,73 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
                         lay->preview_btns[bi].id,
                         lay, m);
                     return 1;
+                }
+            }
+        }
+
+        /* --- Quick Action Buttons (Hover) --- */
+        if (lay->mouse_hover && lay->hover_idx >= 0)
+        {
+            if (lay->hover_view == OV_FOCUS_STREAMS && lay->hover_idx < m->nb_streams)
+            {
+                if (mr >= lay->r_streams.row + 3 && mr < lay->r_streams.row + lay->r_streams.height)
+                {
+                    int idx = lay->scroll_stream + (mr - lay->r_streams.row - 3);
+                    if (idx == lay->hover_idx)
+                    {
+                        if (mc >= lay->r_streams.col + lay->r_streams.width - 10 && mc < lay->r_streams.col + lay->r_streams.width)
+                        {
+                            ov_ctrl_stream_delete(&m->streams[idx], &lay->cmdlog);
+                            return 1;
+                        }
+                    }
+                }
+            }
+            else if (lay->hover_view == OV_FOCUS_PROCS && lay->hover_idx < m->nb_procs)
+            {
+                if (mr >= lay->r_procs.row + 3 && mr < lay->r_procs.row + lay->r_procs.height)
+                {
+                    int idx = lay->scroll_proc + (mr - lay->r_procs.row - 3);
+                    if (idx == lay->hover_idx)
+                    {
+                        if (mc >= lay->r_procs.col + lay->r_procs.width - 8 && mc < lay->r_procs.col + lay->r_procs.width)
+                        {
+                            ov_ctrl_proc_kill(&m->procs[idx], &lay->cmdlog);
+                            return 1;
+                        }
+                    }
+                }
+            }
+            else if (lay->hover_view == OV_FOCUS_FPS && lay->hover_idx < m->nb_fps)
+            {
+                if (mr >= lay->r_fps.row + 3 && mr < lay->r_fps.row + lay->r_fps.height)
+                {
+                    int idx = lay->scroll_fps + (mr - lay->r_fps.row - 3);
+                    if (idx == lay->hover_idx)
+                    {
+                        int right = lay->r_fps.col + lay->r_fps.width;
+                        if (mc >= right - 8 && mc < right)
+                        {
+                            ov_ctrl_fps_conf_toggle(&m->fps[idx], &lay->cmdlog);
+                            return 1;
+                        }
+                        else if (mc >= right - 16 && mc < right - 8)
+                        {
+                            if (m->fps[idx].run_alive)
+                            {
+                                ov_ctrl_fps_run_toggle(&m->fps[idx], &lay->cmdlog);
+                            }
+                            return 1;
+                        }
+                        else if (mc >= right - 24 && mc < right - 16)
+                        {
+                            if (!m->fps[idx].run_alive)
+                            {
+                                ov_ctrl_fps_run_toggle(&m->fps[idx], &lay->cmdlog);
+                            }
+                            return 1;
+                        }
+                    }
                 }
             }
         }
@@ -651,8 +1004,8 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
                 lay->focus = OV_FOCUS_FPS;
                 lay->fps_param_focus = 0;
                 int body_row =
-                    mr - lay->r_fps.row - 2;
-                if (body_row == -1)
+                    mr - lay->r_fps.row - 3;
+                if (body_row == -1 || body_row == -2)
                 {
                     ov_input__fps_header_click(lay, mc);
                 }
@@ -683,8 +1036,8 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
         {
             lay->focus = OV_FOCUS_STREAMS;
             int body_row =
-                mr - lay->r_streams.row - 2;
-            if (body_row == -1)
+                mr - lay->r_streams.row - 3;
+            if (body_row == -1 || body_row == -2)
             {
                 ov_input__streams_header_click(lay, mc);
             }
@@ -708,8 +1061,8 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
         {
             lay->focus = OV_FOCUS_PROCS;
             int body_row =
-                mr - lay->r_procs.row - 2;
-            if (body_row == -1)
+                mr - lay->r_procs.row - 3;
+            if (body_row == -1 || body_row == -2)
             {
                 ov_input__procs_header_click(lay, mc);
             }
@@ -752,55 +1105,71 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
             }
             else
             {
-                int body_row =
-                    mr - lay->r_graph.row - 2;
+                int body_row = mr - lay->r_graph.row - 1;
                 if (body_row >= 0)
                 {
-                    int idx =
-                        lay->scroll_graph
-                        + body_row;
-                    if (idx < m->nb_edges)
+                    if (lay->graph_tab_mode == 0)
                     {
-                        lay->sel_graph = idx;
-                        if (is_dbl)
+                        int start_node = get_graph_start_node(lay, m);
+                        if (start_node >= 0)
                         {
-                            const OV_EDGE *edge =
-                                &m->edges[idx];
-                            const OV_NODE *node =
-                                &m->nodes[
-                                    edge->src_node];
-                            if (node->type
-                                == OV_NODE_STREAM)
+                            SG_TREE_NODE rnodes[OV_MAX_NODES];
+                            int nb_rnodes = sg_compute_render_tree(m, start_node, lay->lineage_mode, rnodes);
+                            
+                            int idx = lay->scroll_graph + body_row;
+                            if (idx < nb_rnodes)
                             {
-                                lay->focus =
-                                    OV_FOCUS_STREAMS;
-                                lay->sel_stream =
-                                    node->index;
-                                lay->sel_name_stream
-                                    [0] = '\0';
+                                lay->sel_graph = idx;
+                                const SG_TREE_NODE *rn = &rnodes[idx];
+                                
+                                int proc_idx = -1;
+                                if (rn->writer_name[0] != '\0')
+                                {
+                                    for (int i = 0; i < m->nb_procs; i++)
+                                    {
+                                        if (strcmp(m->procs[i].name, rn->writer_name) == 0)
+                                        {
+                                            proc_idx = i;
+                                            break;
+                                        }
+                                    }
+                                }
+
+                                /* Estimate click position to decide stream vs proc */
+                                int disp_len = 0;
+                                for (int i = 0; rn->tree_prefix[i] != '\0'; ) {
+                                    disp_len++;
+                                    i += utf8_char_length((unsigned char)rn->tree_prefix[i]);
+                                }
+                                if (rn->is_target) disp_len += 2;
+                                for (int i = 0; rn->name[i] != '\0'; ) {
+                                    disp_len++;
+                                    i += utf8_char_length((unsigned char)rn->name[i]);
+                                }
+                                
+                                int click_on_proc = 0;
+                                if (mc - lay->r_graph.col - 1 > disp_len + 1) {
+                                    click_on_proc = 1;
+                                }
+
+                                if (click_on_proc && proc_idx >= 0)
+                                {
+                                    lay->focus = OV_FOCUS_PROCS;
+                                    lay->sel_proc = proc_idx;
+                                    lay->sel_name_proc[0] = '\0';
+                                }
+                                else if (rn->stream_idx >= 0)
+                                {
+                                    lay->focus = OV_FOCUS_STREAMS;
+                                    lay->sel_stream = rn->stream_idx;
+                                    lay->sel_name_stream[0] = '\0';
+                                }
+                                
+                                if (is_dbl)
+                                {
+                                    lay->view = OV_VIEW_DASHBOARD;
+                                }
                             }
-                            else if (node->type
-                                == OV_NODE_PROC)
-                            {
-                                lay->focus =
-                                    OV_FOCUS_PROCS;
-                                lay->sel_proc =
-                                    node->index;
-                                lay->sel_name_proc
-                                    [0] = '\0';
-                            }
-                            else if (node->type
-                                == OV_NODE_FPS)
-                            {
-                                lay->focus =
-                                    OV_FOCUS_FPS;
-                                lay->sel_fps =
-                                    node->index;
-                                lay->sel_name_fps
-                                    [0] = '\0';
-                            }
-                            lay->view =
-                                OV_VIEW_DASHBOARD;
                         }
                     }
                 }
@@ -813,8 +1182,8 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
             {
                 lay->focus = OV_FOCUS_STREAMS;
                 int body_row =
-                    mr - lay->r_streams.row - 2;
-                if (body_row == -1)
+                    mr - lay->r_streams.row - 3;
+                if (body_row == -1 || body_row == -2)
                 {
                     ov_input__streams_header_click(lay, mc);
                 }
@@ -837,8 +1206,8 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
             {
                 lay->focus = OV_FOCUS_PROCS;
                 int body_row =
-                    mr - lay->r_procs.row - 2;
-                if (body_row == -1)
+                    mr - lay->r_procs.row - 3;
+                if (body_row == -1 || body_row == -2)
                 {
                     ov_input__procs_header_click(lay, mc);
                 }
@@ -861,8 +1230,8 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
             {
                 lay->focus = OV_FOCUS_FPS;
                 int body_row =
-                    mr - lay->r_fps.row - 2;
-                if (body_row == -1)
+                    mr - lay->r_fps.row - 3;
+                if (body_row == -1 || body_row == -2)
                 {
                     ov_input__fps_header_click(lay, mc);
                 }
@@ -904,62 +1273,112 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
                 }
                 else
                 {
-                    int body_row =
-                        mr - lay->r_graph.row - 2;
+                    int body_row = mr - lay->r_graph.row - 1;
                     if (body_row >= 0)
                     {
-                        int idx =
-                            lay->scroll_graph
-                            + body_row;
-                        if (idx < m->nb_edges)
+                        if (lay->graph_tab_mode == 0)
                         {
-                            lay->sel_graph = idx;
-                            if (is_dbl)
+                            int start_node = get_graph_start_node(lay, m);
+                            if (start_node >= 0)
                             {
-                                const OV_EDGE *edge =
-                                    &m->edges[idx];
-                                const OV_NODE *node =
-                                    &m->nodes[
-                                        edge->src_node];
-                                if (node->type
-                                    == OV_NODE_STREAM)
+                                SG_TREE_NODE rnodes[OV_MAX_NODES];
+                                int nb_rnodes = sg_compute_render_tree(m, start_node, lay->lineage_mode, rnodes);
+                                
+                                int idx = lay->scroll_graph + body_row;
+                                if (idx < nb_rnodes)
                                 {
-                                    lay->focus =
-                                        OV_FOCUS_STREAMS;
-                                    lay->sel_stream =
-                                        node->index;
-                                    lay->sel_name_stream
-                                        [0] = '\0';
+                                    lay->sel_graph = idx;
+                                    const SG_TREE_NODE *rn = &rnodes[idx];
+                                    
+                                    int proc_idx = -1;
+                                    if (rn->writer_name[0] != '\0')
+                                    {
+                                        for (int i = 0; i < m->nb_procs; i++)
+                                        {
+                                            if (strcmp(m->procs[i].name, rn->writer_name) == 0)
+                                            {
+                                                proc_idx = i;
+                                                break;
+                                            }
+                                        }
+                                    }
+
+                                    /* Estimate click position to decide stream vs proc */
+                                    int disp_len = 0;
+                                    for (int i = 0; rn->tree_prefix[i] != '\0'; ) {
+                                        disp_len++;
+                                        i += utf8_char_length((unsigned char)rn->tree_prefix[i]);
+                                    }
+                                    if (rn->is_target) disp_len += 2;
+                                    for (int i = 0; rn->name[i] != '\0'; ) {
+                                        disp_len++;
+                                        i += utf8_char_length((unsigned char)rn->name[i]);
+                                    }
+                                    
+                                    int click_on_proc = 0;
+                                    if (mc - lay->r_graph.col - 1 > disp_len + 1) {
+                                        click_on_proc = 1;
+                                    }
+
+                                    if (click_on_proc && proc_idx >= 0)
+                                    {
+                                        lay->focus = OV_FOCUS_PROCS;
+                                        lay->sel_proc = proc_idx;
+                                        lay->sel_name_proc[0] = '\0';
+                                        if (is_dbl) lay->view = OV_VIEW_PROCS;
+                                    }
+                                    else if (rn->stream_idx >= 0)
+                                    {
+                                        lay->focus = OV_FOCUS_STREAMS;
+                                        lay->sel_stream = rn->stream_idx;
+                                        lay->sel_name_stream[0] = '\0';
+                                        if (is_dbl) lay->view = OV_VIEW_STREAMS;
+                                    }
                                 }
-                                else if (node->type
-                                    == OV_NODE_PROC)
-                                {
-                                    lay->focus =
-                                        OV_FOCUS_PROCS;
-                                    lay->sel_proc =
-                                        node->index;
-                                    lay->sel_name_proc
-                                        [0] = '\0';
+                            }
+                        }
+                        else if (lay->graph_tab_mode == 1)
+                        {
+                            ov_focus_t focus = lay->freeze ? lay->freeze_focus : lay->focus;
+                            int fsel = lay->freeze ? lay->freeze_sel_fps : lay->sel_fps;
+                            
+                            int active_fps = -1;
+                            if (focus == OV_FOCUS_FPS && fsel >= 0 && fsel < m->nb_fps) {
+                                active_fps = fsel;
+                            } else if (focus != OV_FOCUS_STREAMS && focus != OV_FOCUS_PROCS) {
+                                if (fsel >= 0 && fsel < m->nb_fps) active_fps = fsel;
+                            }
+                            
+                            if (active_fps >= 0) {
+                                const OV_FPS *f = &m->fps[active_fps];
+                                if (f->nb_disp_params > 0) {
+                                    int header_rows = 3 + (f->description[0] != '\0' ? 1 : 0);
+                                    int param_row = body_row - header_rows;
+                                    if (param_row >= 0) {
+                                        int dp = lay->param_scroll + param_row;
+                                        if (dp >= 0 && dp < f->nb_disp_params) {
+                                            lay->param_sel = dp;
+                                            if (f->disp_param_type[dp] == FPTYPE_STREAMNAME) {
+                                                int si = ov_find_stream_by_name(m, f->disp_param_value[dp]);
+                                                if (si >= 0) {
+                                                    lay->focus = OV_FOCUS_STREAMS;
+                                                    lay->sel_stream = si;
+                                                    lay->sel_name_stream[0] = '\0';
+                                                    if (is_dbl) lay->view = OV_VIEW_STREAMS;
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
-                                else if (node->type
-                                    == OV_NODE_FPS)
-                                {
-                                    lay->focus =
-                                        OV_FOCUS_FPS;
-                                    lay->sel_fps =
-                                        node->index;
-                                    lay->sel_name_fps
-                                        [0] = '\0';
-                                }
-                                lay->view =
-                                    OV_VIEW_DASHBOARD;
                             }
                         }
                     }
                 }
             }
         }
+
         
+
         /* Check if clicking on cmdlog border to start dragging */
         {
             int cmdlog_top = (lay->cmdlog_rows > 0) ? (lay->term_rows - lay->cmdlog_rows) : lay->term_rows;
@@ -978,6 +1397,11 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
         lay->dash_split_v_dragging = 0;
         lay->dash_split_h_dragging = 0;
         lay->cmdlog_dragging = 0;
+        return 1;
+    }
+
+    if (key == OV_KEY_MOUSE_MOVE)
+    {
         return 1;
     }
 
@@ -1041,7 +1465,7 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
             }
             if (handled) return 1;
         }
-        return 0; /* Ignore other drags for now */
+        return 1; /* Ignore other drags for now */
     }
 
     /* Ctrl+scroll: cycle views (#12) */
@@ -2489,9 +2913,27 @@ int ov_handle_key(
         lay->ctrl_mode = !lay->ctrl_mode;
         ov_cmdlog_push(&lay->cmdlog,
                        OV_CMDLOG_INFO,
-                       "Control mode %s",
+                       "🎛️ Control mode %s",
                        lay->ctrl_mode
-                       ? "ON" : "OFF");
+                       ? "✅ ON" : "❌ OFF");
+        return 0;
+    }
+
+    if (key == 'm')
+    {
+        lay->mouse_hover = !lay->mouse_hover;
+        ov_set_mouse_hover(lay->mouse_hover);
+        ov_cmdlog_push(&lay->cmdlog,
+                       OV_CMDLOG_INFO,
+                       "🖱️ Mouse hover %s",
+                       lay->mouse_hover
+                       ? "✅ ON" : "❌ OFF");
+        if (lay->mouse_hover)
+        {
+            ov_cmdlog_push(&lay->cmdlog,
+                           OV_CMDLOG_WARN,
+                           "⚠️ Warning: Hover uses more CPU & character BW on slow connections");
+        }
         return 0;
     }
 
@@ -2638,6 +3080,13 @@ int ov_handle_key(
 
         ov_cmdlog_push(&lay->cmdlog, OV_CMDLOG_INFO, "⌨️ %s%s", keys_str, ctrl_str);
         if (lay->cmdlog_rows == 0) lay->cmdlog_rows = 4;
+        return 0;
+    }
+
+    if (key == OV_KEY_SHIFT_UP || key == OV_KEY_SHIFT_DOWN ||
+        key == OV_KEY_SHIFT_LEFT || key == OV_KEY_SHIFT_RIGHT ||
+        key == OV_KEY_CTRL_LEFT || key == OV_KEY_CTRL_RIGHT ||
+        key == OV_KEY_BTAB) {
         return 0;
     }
 

--- a/src/cli/overview/overview_layout.h
+++ b/src/cli/overview/overview_layout.h
@@ -118,6 +118,16 @@ typedef struct {
     /* Control mode */
     int          ctrl_mode;
     int          ctrl_blink;
+    /* Mouse hover track */
+    int          mouse_hover;
+    int          hover_view;         /* Logical focus enum (e.g. OV_FOCUS_STREAMS) or -1 */
+    int          hover_idx;          /* Index of item hovered */
+    int          hover_is_header;    /* 1 if hovering header */
+    int          hover_col_logical;  /* Logical column index (0, 1, 2...) */
+    char         hover_tooltip[256]; /* Text to display in tooltip pass */
+    int          hover_global_stream; /* Global stream index hovered (-1 if none) */
+    int          hover_global_proc;   /* Global proc index hovered (-1 if none) */
+    int          hover_global_fps;    /* Global fps index hovered (-1 if none) */
     /* Graph panel tab mode: 0=CONNECTIONS, 1=DETAILS, 2=RESOURCES */
     int          graph_tab_mode;
     /* Horizontal scroll per panel */
@@ -171,12 +181,16 @@ typedef struct {
     /* F5 view drag state */
     float        fps_split_ratio;
     int          fps_split_dragging;
+    int          fps_split_hover;
     /* F2 dashboard view drag state */
     float        dash_split_v_ratio;
     float        dash_split_h_ratio;
     int          dash_split_v_dragging;
     int          dash_split_h_dragging;
     int          cmdlog_dragging;
+    int          dash_split_v_hover;
+    int          dash_split_h_hover;
+    int          cmdlog_split_hover;
 } OV_LAYOUT;
 
 void ov_layout_compute(OV_LAYOUT *lay);

--- a/src/cli/overview/overview_render.c
+++ b/src/cli/overview/overview_render.c
@@ -278,18 +278,18 @@ void ov_render_header(
     int ctrl_w = 0;
     if (lay->ctrl_mode)
     {
-        /* Sine-based temporal pulsing for "CONTROL" badge */
-        float pulse = 0.5f + 0.5f * sinf(lay->ctrl_blink * OV_ANIM_PULSE_SPEED);
-        ov_rgb_t ctrl_bg = ov_rgb_lerp(OV_ANIM_PULSE_BG_MIN, OV_ANIM_PULSE_BG_MAX, pulse);
-        ov_rgb_t ctrl_fg = ov_rgb_lerp(OV_ANIM_PULSE_FG_MIN, OV_ANIM_PULSE_FG_MAX, pulse);
-
-        ov_buf_bg(ctrl_bg.r, ctrl_bg.g, ctrl_bg.b);
-        ov_buf_fg(ctrl_fg.r, ctrl_fg.g, ctrl_fg.b);
+        /* Software blinking badge for "CONTROL" (10 fps -> 2Hz blink) */
+        if ((lay->ctrl_blink % 10) < 5) {
+            ov_buf_bg(OV_ANIM_PULSE_BG_MAX.r, OV_ANIM_PULSE_BG_MAX.g, OV_ANIM_PULSE_BG_MAX.b);
+            ov_buf_fg(OV_ANIM_PULSE_FG_MAX.r, OV_ANIM_PULSE_FG_MAX.g, OV_ANIM_PULSE_FG_MAX.b);
+        } else {
+            ov_buf_bg(220, 40, 40);    /* vibrant red */
+            ov_buf_fg(255, 255, 255);  /* white text */
+        }
         ov_buf_bold();
         ov_buf_printf(" [c] CONTROL ");
         ov_buf_reset_attr();
         ov_theme_bg(OV_BG_HEADER);
-
         ctrl_w = 13; /* visual width of " [c] CONTROL " */
     }
     else
@@ -302,6 +302,31 @@ void ov_render_header(
         ov_buf_reset_attr();
         ov_theme_bg(OV_BG_HEADER);
         ctrl_w = 15; /* visual width of " [c] READ ONLY " */
+    }
+
+    ov_buf_printf(" ");
+    int hover_w = 0;
+    if (lay->mouse_hover)
+    {
+        /* Mouse hover active badge */
+        ov_buf_bg(180, 180, 20);   /* deep yellow background */
+        ov_buf_fg(255, 255, 220);  /* light text */
+        ov_buf_bold();
+        ov_buf_printf(" [m] HOVER: ON ");
+        ov_buf_reset_attr();
+        ov_theme_bg(OV_BG_HEADER);
+        hover_w = 16; /* visual width of "  [m] HOVER: ON " */
+    }
+    else
+    {
+        /* Mouse hover inactive badge */
+        ov_buf_bg(80, 80, 80);     /* dim gray background */
+        ov_buf_fg(200, 200, 200);  /* light gray text */
+        ov_buf_bold();
+        ov_buf_printf(" [m] HOVER: OFF ");
+        ov_buf_reset_attr();
+        ov_theme_bg(OV_BG_HEADER);
+        hover_w = 17; /* visual width of "  [m] HOVER: OFF " */
     }
 
     ov_theme_fg(OV_FG_STREAM);
@@ -330,7 +355,7 @@ void ov_render_header(
     ov_buf_printf("  BW: %4.1f kB/s", bw_kbs);
 
     /* c1 visual length: 17 chars for " ● milk-CTRL " */
-    int chars_left = 17 + ctrl_w + c2 + c3 + c4 + c5 + c6 + c7;
+    int chars_left = 17 + ctrl_w + hover_w + c2 + c3 + c4 + c5 + c6 + c7;
 
     int tabs_width = 0;
     for (int v = 0; v < OV_VIEW_COUNT; v++)
@@ -380,11 +405,57 @@ void ov_render_header(
     ov_theme_bg(OV_BG_HEADER);
 }
 
+static void ov_draw_tooltip(OV_LAYOUT *lay)
+{
+    if (!lay->mouse_hover || lay->hover_tooltip[0] == '\0')
+    {
+        return;
+    }
+
+    int len = (int) strlen(lay->hover_tooltip);
+    if (len == 0)
+    {
+        return;
+    }
+
+    /* Try drawing above the cursor first */
+    int tr = ov_mouse_row - 1;
+    int tc = ov_mouse_col;
+
+    /* Screen boundary clamping */
+    if (tr < 0)
+    {
+        tr = ov_mouse_row + 1; /* flip below */
+    }
+    
+    if (tc + len + 2 > lay->term_cols)
+    {
+        tc = lay->term_cols - len - 2;
+    }
+    if (tc < 0)
+    {
+        tc = 0;
+    }
+
+    ov_buf_pos(tr, tc);
+    ov_theme_bg(OV_BG_HEADER); /* Pop out visually */
+    ov_theme_fg(OV_FG_WARN);
+    ov_buf_printf(" %s ", lay->hover_tooltip);
+
+    /* Reset for next frame */
+    lay->hover_tooltip[0] = '\0';
+}
+
+
 void ov_render_frame(
     OV_LAYOUT       *lay,
     const OV_MODEL  *m)
 {
     ov_buf_reset();
+
+    /* Perform global hit-test to populate hover state */
+    ov_hittest(lay, m, ov_mouse_row, ov_mouse_col);
+    ov_hittest_resolve_globals(lay, m);
 
     /* One-shot sort: only runs once when the user
      * presses S or s.  Order stays frozen until
@@ -759,7 +830,65 @@ void ov_render_frame(
     ov_render_cmdlog(lay);
     ov_render_status(lay, m);
 
+    /* Highlight movable edges if hovering */
+    if (lay->mouse_hover && !lay->show_help)
+    {
+        ov_theme_fg(OV_FG_WARN);
+        ov_theme_bg(OV_BG_TERMINAL);
+        ov_buf_bold();
+
+        if (lay->cmdlog_split_hover)
+        {
+            int cmdlog_top = (lay->cmdlog_rows > 0) ? (lay->term_rows - lay->cmdlog_rows) : lay->term_rows;
+            if (cmdlog_top > 1)
+            {
+                ov_buf_pos(cmdlog_top - 1, 1);
+                ov_buf_hline_utf8(OV_BOX_H_D, lay->term_cols);
+            }
+        }
+
+        if (lay->view == OV_VIEW_DASHBOARD)
+        {
+            if (lay->dash_split_h_hover)
+            {
+                int r = lay->r_streams.row + lay->r_streams.height - 1;
+                ov_buf_pos(r, 1);
+                ov_buf_hline_utf8(OV_BOX_H_D, lay->term_cols);
+                ov_buf_pos(r + 1, 1);
+                ov_buf_hline_utf8(OV_BOX_H_D, lay->term_cols);
+            }
+            if (lay->dash_split_v_hover)
+            {
+                int c = lay->r_streams.width;
+                for (int rr = lay->r_streams.row; rr < lay->r_fps.row + lay->r_fps.height; rr++)
+                {
+                    ov_buf_pos(rr, c);
+                    ov_buf_printf("%s", OV_BOX_V_D);
+                    ov_buf_pos(rr, c + 1);
+                    ov_buf_printf("%s", OV_BOX_V_D);
+                }
+            }
+        }
+        else if (lay->view == OV_VIEW_FPS)
+        {
+            if (lay->fps_split_hover)
+            {
+                int c = lay->r_fps_list.width;
+                for (int rr = lay->r_fps_list.row; rr < lay->r_fps_list.row + lay->r_fps_list.height; rr++)
+                {
+                    ov_buf_pos(rr, c);
+                    ov_buf_printf("%s", OV_BOX_V_D);
+                    ov_buf_pos(rr, c + 1);
+                    ov_buf_printf("%s", OV_BOX_V_D);
+                }
+            }
+        }
+
+        ov_buf_reset_attr();
+    }
+
     /* End frame */
+    ov_draw_tooltip(lay);
 
     ov_buf_flush_delta(lay->term_rows, lay->term_cols);
 }

--- a/src/cli/overview/overview_render_cmdlog.c
+++ b/src/cli/overview/overview_render_cmdlog.c
@@ -111,13 +111,19 @@ void ov_render_cmdlog(const OV_LAYOUT *lay)
         {
             msg_max = 0;
         }
-        int msg_len = (int) strlen(e->msg);
-        if (msg_len > msg_max)
-        {
-            msg_len = msg_max;
+        
+        int msg_disp_len = 0;
+        int max_bytes = 0;
+        for (int i = 0; e->msg[i] != '\0'; ) {
+            int cw = utf8_char_length((unsigned char)e->msg[i]);
+            if (msg_disp_len + 1 > msg_max) break;
+            msg_disp_len += 1;
+            max_bytes += cw;
+            i += cw;
         }
-        ov_buf_printf("%.*s", msg_len, e->msg);
-        nw += msg_len;
+        
+        ov_buf_printf("%.*s", max_bytes, e->msg);
+        nw += msg_disp_len;
 
         /* Pad remainder */
         int pad = r.width - nw;

--- a/src/cli/overview/overview_render_detail.c
+++ b/src/cli/overview/overview_render_detail.c
@@ -724,8 +724,12 @@ static int ov_fps__render_detail_fps(
             int is_sel = (dp == lay->param_sel
                 && lay->focus == OV_FOCUS_GRAPH
                 && lay->graph_tab_mode == 1);
+            int header_rows = 3 + (f->description[0] != '\0' ? 1 : 0);
+            int is_hover = (lay->mouse_hover && lay->hover_view == OV_FOCUS_GRAPH 
+                && lay->graph_tab_mode == 1 && lay->hover_idx == header_rows + (dp - lay->param_scroll));
+            
             ov_rgb_t row_bg = is_sel
-                ? OV_BG_SELECTED : OV_BG_PANEL;
+                ? OV_BG_SELECTED : (is_hover ? OV_BG_HOVER : OV_BG_PANEL);
 
             H_ov_buf_pos(row + ri, r.col + 1);
             H_ov_theme_bg(row_bg);
@@ -817,14 +821,44 @@ static int ov_fps__render_detail_fps(
                 f->disp_param_name[dp]);
 
             /* Value */
-            H_ov_theme_fg(is_sel
-                ? OV_FG_BRIGHT : OV_FG_TEXT);
+            if (pt == FPTYPE_STREAMNAME)
+            {
+                int s_idx = ov_find_stream_by_name(m, f->disp_param_value[dp]);
+                ov_rgb_t vcolor = (s_idx >= 0) ? OV_FG_STREAM : OV_FG_DIM;
+                if (is_sel || is_hover) {
+                    H_ov_theme_fg(vcolor);
+                    H_ov_buf_bold();
+                } else {
+                    H_ov_theme_fg(vcolor);
+                }
+            }
+            else if (pt == FPTYPE_ONOFF)
+            {
+                int is_on = (strcmp(f->disp_param_value[dp], "ON") == 0 || strcmp(f->disp_param_value[dp], "1") == 0);
+                ov_rgb_t vcolor = is_on ? (ov_rgb_t){100, 255, 100} : OV_FG_DIM;
+                if (is_sel || is_hover) {
+                    H_ov_theme_fg(vcolor);
+                    H_ov_buf_bold();
+                } else {
+                    H_ov_theme_fg(vcolor);
+                }
+            }
+            else
+            {
+                H_ov_theme_fg(is_sel ? OV_FG_BRIGHT : OV_FG_TEXT);
+            }
+            
             int n2 = snprintf(NULL, 0,
                 " = %s",
                 f->disp_param_value[dp]);
             H_ov_buf_printf(
                 " = %s",
                 f->disp_param_value[dp]);
+                
+            if ((is_sel || is_hover) && (pt == FPTYPE_STREAMNAME || pt == FPTYPE_ONOFF)) {
+                H_ov_buf_reset_attr();
+                H_ov_theme_bg(row_bg); // Restore background after reset
+            }
 
             /* Pad remainder */
             /* 2 (icon) + 8 (badge) + 1 (sp)

--- a/src/cli/overview/overview_render_fps.c
+++ b/src/cli/overview/overview_render_fps.c
@@ -117,7 +117,15 @@ void ov_render_fps_panel(
     memset(local_depth, 0, sizeof(local_depth));
     {
         int eff_sel = -1;
-        if (lay->freeze && lay->freeze_focus == OV_FOCUS_FPS
+        if (lay->mouse_hover && lay->hover_global_fps >= 0)
+        {
+            for (int i = 0; i < filt_n; i++) {
+                if (fidx[i] == lay->hover_global_fps) {
+                    eff_sel = i;
+                    break;
+                }
+            }
+        } else if (lay->freeze && lay->freeze_focus == OV_FOCUS_FPS
             && lay->freeze_sel_fps >= 0 && lay->freeze_sel_fps < filt_n) {
             eff_sel = lay->freeze_sel_fps;
         } else if (lay->focus == OV_FOCUS_FPS
@@ -174,6 +182,8 @@ void ov_render_fps_panel(
                 row_bg = OV_BG_RELATED;
             } else if (f->is_new > 0) {
                 row_bg = OV_BG_NEW_ITEM;
+            } else if (lay->mouse_hover && lay->hover_global_fps == fi) {
+                row_bg = OV_BG_HOVER;
             }
             row_bg = zebra_bg(row_bg, i);
 
@@ -404,6 +414,35 @@ void ov_render_fps_panel(
                         ov_buf_printf(" :%s", kname);
                         n5 += w;
                     }
+                }
+            }
+
+            if (lay->mouse_hover && lay->hover_view == OV_FOCUS_FPS && lay->hover_idx == fi)
+            {
+                snprintf((char*)lay->hover_tooltip, sizeof(lay->hover_tooltip),
+                         "FPS: %s | RunPID: %d | ConfPID: %d | Mem: %" PRId64 " KB", 
+                         f->name, f->runpid, f->confpid, (int64_t)f->mem_rss_kb);
+
+                int btn_w = 24; /* " [Run]  [Stop]  [Conf] " */
+                int rem = r.width - (printed + n5);
+                if (rem >= btn_w)
+                {
+                    render_pad_spaces(printed + n5, r.width - btn_w);
+                    
+                    ov_theme_bg(OV_FG_ACTIVE);
+                    ov_theme_fg(OV_FG_TEXT);
+                    ov_buf_printf(" [Run] ");
+
+                    ov_theme_bg(OV_FG_ERROR);
+                    ov_theme_fg(OV_FG_TEXT);
+                    ov_buf_printf(" [Stop] ");
+                    
+                    ov_theme_bg(OV_BG_HEADER);
+                    ov_theme_fg(OV_FG_TEXT);
+                    ov_buf_printf(" [Conf] ");
+                    
+                    printed = r.width;
+                    n5 = 0;
                 }
             }
 

--- a/src/cli/overview/overview_render_graph.c
+++ b/src/cli/overview/overview_render_graph.c
@@ -395,11 +395,11 @@ void ov_render_graph_panel(
     row++;
 
     int start_node = get_graph_start_node(lay, m);
-    SG_RENDER_NODE rnodes[OV_MAX_NODES];
+    SG_TREE_NODE rnodes[OV_MAX_NODES];
     int nb_rnodes = 0;
     
     if (start_node >= 0) {
-        nb_rnodes = sg_compute_render_nodes(m, start_node, lay->lineage_mode, rnodes);
+        nb_rnodes = sg_compute_render_tree(m, start_node, lay->lineage_mode, rnodes);
     }
 
     if (nb_rnodes == 0)
@@ -423,7 +423,7 @@ void ov_render_graph_panel(
 
     for (int ri = scroll; ri < nb_rnodes && rendered_rows < max_rows; ri++)
     {
-        const SG_RENDER_NODE *rn = &rnodes[ri];
+        const SG_TREE_NODE *rn = &rnodes[ri];
 
         ov_buf_pos(row, r.col + 1);
         
@@ -431,6 +431,8 @@ void ov_render_graph_panel(
         ov_rgb_t row_bg = OV_BG_PANEL;
         int use_ul = 0;
         ov_rgb_t ul_color = {0,0,0};
+
+        /* We no longer highlight the entire row on hover, only the specific element */
 
         if (is_sel) {
             use_ul = 1;
@@ -443,14 +445,6 @@ void ov_render_graph_panel(
             ov_buf_underline();
         }
         ov_buf_printf(" ");
-
-        ov_rgb_t c = OV_FG_TEXT;
-        const char *typ = "UNK";
-        switch (rn->type) {
-        case OV_NODE_STREAM: c = OV_FG_STREAM; typ = "STRM"; break;
-        case OV_NODE_FPS:    c = OV_FG_FPS;    typ = "FPS "; break;
-        case OV_NODE_PROC:   c = OV_FG_PROC;   typ = "PROC"; break;
-        }
 
         int printed = 1;
         int avail = r.width - 2;
@@ -471,47 +465,43 @@ void ov_render_graph_panel(
             }                                        \
         } while(0)
 
-        /* Selection marker */
-        if (rn->depth == 0) {
-            GRAPH_FIELD(OV_FG_WARN, ">> ");
-        } else {
-            GRAPH_FIELD(OV_FG_DIM, "   ");
+        /* Draw tree prefix */
+        GRAPH_FIELD(OV_FG_DIM, "%s", rn->tree_prefix);
+
+        /* Selection marker / Target marker */
+        if (rn->is_target) {
+            GRAPH_FIELD(OV_FG_WARN, "\xe2\x96\xb6 "); /* Arrow */
         }
 
-        /* Compute indentation based on depth */
-        int abs_depth = rn->depth;
-        if (abs_depth < 0) abs_depth = -abs_depth;
+        /* Draw node name */
+        ov_rgb_t name_color = rn->is_target ? OV_FG_WARN : OV_FG_STREAM;
+        int hl_stream = (lay->mouse_hover && lay->hover_global_stream >= 0 && rn->stream_idx == lay->hover_global_stream);
+        if (hl_stream) ov_theme_bg(OV_BG_HOVER);
+        GRAPH_FIELD(name_color, "%s", rn->name);
+        if (hl_stream) ov_theme_bg(row_bg);
         
-        /* Ancestors are indented progressively less to reach 0 at target, 
-           then descendants progressively more. */
-        int indent = 0;
-        if (rn->depth < 0) {
-            /* Ancestors: -1 is closer to target than -2. */
-            indent = (abs_depth - 1) * 2;
-        } else if (rn->depth > 0) {
-            indent = abs_depth * 2;
-        }
-        if (indent > 30) indent = 30;
-
-        char ind_str[64] = "";
-        if (indent > 0) {
-            memset(ind_str, ' ', indent);
-            ind_str[indent] = '\0';
-        }
-        GRAPH_FIELD(OV_FG_DIM, "%s", ind_str);
-
-        /* Draw node */
-        if (rn->type == OV_NODE_PROC || rn->type == OV_NODE_FPS) {
-            GRAPH_FIELD(OV_FG_CONN, "%s ", OV_TRI_D);
-            GRAPH_FIELD(c, "[%s] ", rn->name);
-        } else {
-            GRAPH_FIELD(c, "%s ", rn->name);
-        }
-        
-        GRAPH_FIELD(OV_FG_DIM, "(%s)", typ);
-
-        if (rn->depth == 0) {
-            GRAPH_FIELD(OV_FG_WARN, " <");
+        /* Draw writer proc */
+        if (rn->writer_name[0] != '\0') {
+            GRAPH_FIELD(OV_FG_DIM, " [");
+            if (rn->is_target_proc) {
+                GRAPH_FIELD(OV_FG_WARN, "\xe2\x96\xb6 ");
+            }
+            ov_rgb_t proc_color = rn->is_target_proc ? OV_FG_WARN : OV_FG_PROC;
+            
+            int proc_idx = -1;
+            for (int i = 0; i < m->nb_procs; i++) {
+                if (strcmp(m->procs[i].name, rn->writer_name) == 0) {
+                    proc_idx = i;
+                    break;
+                }
+            }
+            int hl_proc = (lay->mouse_hover && lay->hover_global_proc >= 0 && proc_idx == lay->hover_global_proc);
+            
+            if (hl_proc) ov_theme_bg(OV_BG_HOVER);
+            GRAPH_FIELD(proc_color, "%s", rn->writer_name);
+            if (hl_proc) ov_theme_bg(row_bg);
+            
+            GRAPH_FIELD(OV_FG_DIM, "]");
         }
 
         #undef GRAPH_FIELD

--- a/src/cli/overview/overview_render_help.c
+++ b/src/cli/overview/overview_render_help.c
@@ -97,6 +97,7 @@ static const help_line_t HELP[] =
     { "  FPS:  MEM (RSS)",                      HF_CHILD,   HS_COLUMNS },
     /* --- Mouse --- */
     { "Mouse",                                  HF_SECTION, HS_MOUSE },
+    { "  m  Toggle hover tracking (ON/OFF)",    HF_CHILD,   HS_MOUSE },
     { "  Click=select  DblClick=detail",        HF_CHILD,   HS_MOUSE },
     { "  Scroll wheel=navigate list",           HF_CHILD,   HS_MOUSE },
     { "  Click column headers to sort",         HF_CHILD,   HS_MOUSE },

--- a/src/cli/overview/overview_render_internal.h
+++ b/src/cli/overview/overview_render_internal.h
@@ -95,6 +95,16 @@ void ov_compute_related(
     const OV_MODEL   *m,
     OV_RELATED       *rel);
 
+void ov_hittest(
+    OV_LAYOUT      *lay,
+    const OV_MODEL *m,
+    int             mr,
+    int             mc);
+
+void ov_hittest_resolve_globals(
+    OV_LAYOUT      *lay,
+    const OV_MODEL *m);
+
 void render_highlighted_name(
     const char *name,
     int         max_len,

--- a/src/cli/overview/overview_render_procs.c
+++ b/src/cli/overview/overview_render_procs.c
@@ -178,6 +178,8 @@ static void ov_procs__render_rows(
                 row_bg = OV_BG_STALE;
             } else if (p->is_new > 0) {
                 row_bg = OV_BG_NEW_ITEM;
+            } else if (lay->mouse_hover && lay->hover_global_proc == pi) {
+                row_bg = OV_BG_HOVER;
             }
             row_bg = zebra_bg(row_bg, i);
 
@@ -874,6 +876,29 @@ static void ov_procs__render_rows(
             }
 
             #undef PROC_FIELD
+
+            if (lay->mouse_hover && lay->hover_view == OV_FOCUS_PROCS && lay->hover_idx == fi)
+            {
+                char loc_upt[12] = "-";
+                if (p->start_time_sec > 0)
+                {
+                    format_uptime(loc_upt, sizeof(loc_upt), p->start_time_sec);
+                }
+                snprintf((char*)lay->hover_tooltip, sizeof(lay->hover_tooltip),
+                         "PID: %d | Up: %s | CPU: %4.1f%% | Exec: %zu ns", 
+                         (int)p->PID, loc_upt, p->cpu_used, (size_t)p->dtmedian_exec_ns);
+
+                int btn_w = 8; /* " [Kill] " */
+                int rem = avail - printed;
+                if (rem >= btn_w)
+                {
+                    ov_buf_hline(' ', rem - btn_w);
+                    ov_theme_bg(OV_FG_ERROR);
+                    ov_theme_fg(OV_FG_TEXT);
+                    ov_buf_printf(" [Kill] ");
+                    printed += rem;
+                }
+            }
 
             /* Pad remainder */
             {

--- a/src/cli/overview/overview_render_relate.c
+++ b/src/cli/overview/overview_render_relate.c
@@ -69,37 +69,84 @@ void ov_compute_related(
     memset(out, 0, sizeof(*out));
     /* fps_param_mask initialised to 0 by memset — no matches yet */
 
-    /* Use frozen selection when freeze is active */
-    ov_focus_t focus   = lay->freeze
-                         ? lay->freeze_focus
-                         : lay->focus;
-    int sel_stream_idx = lay->freeze
-                         ? lay->freeze_sel_stream
-                         : lay->sel_stream;
-    int sel_proc_idx   = lay->freeze
-                         ? lay->freeze_sel_proc
-                         : lay->sel_proc;
-    int sel_fps_idx    = lay->freeze
-                         ? lay->freeze_sel_fps
-                         : lay->sel_fps;
+    ov_focus_t focus;
+    int sel_stream_idx;
+    int sel_proc_idx;
+    int sel_fps_idx;
+
+    if (lay->mouse_hover && lay->hover_idx >= 0 && lay->hover_view != -1)
+    {
+        focus = lay->hover_view;
+        sel_stream_idx = (focus == OV_FOCUS_STREAMS) ? lay->hover_idx : -1;
+        sel_proc_idx   = (focus == OV_FOCUS_PROCS)   ? lay->hover_idx : -1;
+        sel_fps_idx    = (focus == OV_FOCUS_FPS)     ? lay->hover_idx : -1;
+    }
+    else
+    {
+        focus = lay->freeze
+                             ? lay->freeze_focus
+                             : lay->focus;
+        sel_stream_idx = lay->freeze
+                             ? lay->freeze_sel_stream
+                             : lay->sel_stream;
+        sel_proc_idx   = lay->freeze
+                             ? lay->freeze_sel_proc
+                             : lay->sel_proc;
+        sel_fps_idx    = lay->freeze
+                             ? lay->freeze_sel_fps
+                             : lay->sel_fps;
+    }
 
     /* Determine the graph node index of the selected item */
     int sel_node = -1;
-    if (focus == OV_FOCUS_STREAMS && sel_stream_idx >= 0
-        && sel_stream_idx < m->nb_streams)
+    if (focus == OV_FOCUS_STREAMS && sel_stream_idx >= 0)
     {
-        sel_node = m->streams[sel_stream_idx].node_idx;
+        int model_idx = sel_stream_idx;
+        if (lay->filter_stream[0] != '\0')
+        {
+            const char *names[OV_MAX_STREAMS];
+            for (int i = 0; i < m->nb_streams; i++) names[i] = m->streams[i].name;
+            int fidx[OV_MAX_STREAMS];
+            int n = ov_filter_build(lay->filter_stream, names, m->nb_streams, fidx, OV_MAX_STREAMS);
+            model_idx = (sel_stream_idx < n) ? fidx[sel_stream_idx] : -1;
+        }
+        if (model_idx >= 0 && model_idx < m->nb_streams)
+        {
+            sel_node = m->streams[model_idx].node_idx;
+        }
     }
-    else if (focus == OV_FOCUS_FPS && sel_fps_idx >= 0
-             && sel_fps_idx < m->nb_fps)
+    else if (focus == OV_FOCUS_FPS && sel_fps_idx >= 0)
     {
-        sel_node = m->fps[sel_fps_idx].node_idx;
+        int model_idx = sel_fps_idx;
+        if (lay->filter_fps[0] != '\0')
+        {
+            const char *names[OV_MAX_FPS];
+            for (int i = 0; i < m->nb_fps; i++) names[i] = m->fps[i].name;
+            int fidx[OV_MAX_FPS];
+            int n = ov_filter_build(lay->filter_fps, names, m->nb_fps, fidx, OV_MAX_FPS);
+            model_idx = (sel_fps_idx < n) ? fidx[sel_fps_idx] : -1;
+        }
+        if (model_idx >= 0 && model_idx < m->nb_fps)
+        {
+            sel_node = m->fps[model_idx].node_idx;
+        }
     }
-    else if (focus == OV_FOCUS_PROCS && sel_proc_idx >= 0
-             && sel_proc_idx < m->nb_procs)
+    else if (focus == OV_FOCUS_PROCS && sel_proc_idx >= 0)
     {
-        sel_node = m->procs[sel_proc_idx].node_idx;
-        out->sel_pid = m->procs[sel_proc_idx].PID;
+        int model_idx = sel_proc_idx;
+        if (lay->filter_proc[0] != '\0')
+        {
+            const char *names[OV_MAX_PROCS];
+            for (int i = 0; i < m->nb_procs; i++) names[i] = m->procs[i].name;
+            int fidx[OV_MAX_PROCS];
+            int n = ov_filter_build(lay->filter_proc, names, m->nb_procs, fidx, OV_MAX_PROCS);
+            model_idx = (sel_proc_idx < n) ? fidx[sel_proc_idx] : -1;
+        }
+        if (model_idx >= 0 && model_idx < m->nb_procs)
+        {
+            sel_node = m->procs[model_idx].node_idx;
+            out->sel_pid = m->procs[model_idx].PID;
+        }
     }
 
     if (sel_node < 0)

--- a/src/cli/overview/overview_render_streams.c
+++ b/src/cli/overview/overview_render_streams.c
@@ -133,7 +133,16 @@ void ov_render_streams_panel(
     memset(local_depth, 0, sizeof(local_depth));
     {
         int eff_sel = -1;
-        if (lay->freeze
+        if (lay->mouse_hover && lay->hover_global_stream >= 0)
+        {
+            for (int i = 0; i < filt_n; i++) {
+                if (filt_idx[i] == lay->hover_global_stream) {
+                    eff_sel = i;
+                    break;
+                }
+            }
+        }
+        else if (lay->freeze
             && lay->freeze_focus
                == OV_FOCUS_STREAMS
             && lay->freeze_sel_stream >= 0
@@ -340,6 +349,8 @@ void ov_render_streams_panel(
                 row_bg = OV_BG_RELATED;
             } else if (s->is_new > 0) {
                 row_bg = OV_BG_NEW_ITEM;
+            } else if (lay->mouse_hover && lay->hover_global_stream == si) {
+                row_bg = OV_BG_HOVER;
             }
             row_bg = zebra_bg(row_bg, i);
 
@@ -564,6 +575,24 @@ void ov_render_streams_panel(
             #undef STRM_PID_FIELD
             #undef STRM_FIELD
             
+            if (lay->mouse_hover && lay->hover_view == OV_FOCUS_STREAMS && lay->hover_idx == si)
+            {
+                snprintf((char*)lay->hover_tooltip, sizeof(lay->hover_tooltip),
+                         "Stream: %s | Dimensions: %dD (%s) | Semaphores: %d | inode: %" PRIu64, 
+                         s->name, s->naxis, s->size_str, s->nb_sem, (uint64_t)s->inode);
+
+                int btn_w = 10; /* " [Delete] " */
+                int rem = r.width - printed;
+                if (rem >= btn_w)
+                {
+                    render_pad_spaces(printed, r.width - btn_w);
+                    ov_theme_bg(OV_FG_ERROR);
+                    ov_theme_fg(OV_FG_TEXT);
+                    ov_buf_printf(" [Delete] ");
+                    printed = r.width;
+                }
+            }
+
             // The active dot is now printed at the start of the line
             
             render_pad_spaces(printed, r.width);

--- a/src/cli/overview/stream_graph.c
+++ b/src/cli/overview/stream_graph.c
@@ -720,3 +720,216 @@ int sg_compute_render_nodes(
 
     return nb_nodes;
 }
+static void sg_dfs_tree(
+    const OV_MODEL *m,
+    int current_stream,
+    int target_stream,
+    int target_proc,
+    const uint64_t *S_words,
+    sg_mode_t mode,
+    const char *prefix,
+    int is_last,
+    int is_root,
+    int depth,
+    int *path,
+    int path_len,
+    SG_TREE_NODE *out_nodes,
+    int *nb_out_nodes)
+{
+    if (*nb_out_nodes >= OV_MAX_NODES) return;
+
+    /* Cycle detection */
+    int is_cycle = 0;
+    for (int i = 0; i < path_len; i++) {
+        if (path[i] == current_stream) {
+            is_cycle = 1;
+            break;
+        }
+    }
+
+    SG_TREE_NODE *node = &out_nodes[*nb_out_nodes];
+    node->stream_idx = current_stream;
+    node->is_target = (current_stream == target_stream);
+    node->depth = depth;
+    strncpy(node->name, m->streams[current_stream].name, sizeof(node->name)-1);
+    node->name[sizeof(node->name)-1] = '\0';
+    
+    /* Find writer proc */
+    node->writer_name[0] = '\0';
+    node->is_target_proc = 0;
+    pid_t wpid = m->streams[current_stream].write_pid;
+    if (wpid > 0) {
+        int pidx = ov_find_proc_by_pid(m, wpid);
+        if (pidx >= 0) {
+            strncpy(node->writer_name, m->procs[pidx].name, sizeof(node->writer_name)-1);
+            node->writer_name[sizeof(node->writer_name)-1] = '\0';
+            if (pidx == target_proc) {
+                node->is_target_proc = 1;
+            }
+        }
+    }
+
+    /* Build prefix */
+    if (is_root) {
+        node->tree_prefix[0] = '\0';
+    } else {
+        snprintf(node->tree_prefix, sizeof(node->tree_prefix), "%s%s", 
+                 prefix, is_last ? "\xe2\x94\x94\xe2\x94\x80\xe2\x94\x80 " : "\xe2\x94\x9c\xe2\x94\x80\xe2\x94\x80 "); /* └──  and ├──  */
+    }
+    
+    if (is_cycle) {
+        /* Append cycle indicator to name */
+        strncat(node->name, " (loop)", sizeof(node->name) - strlen(node->name) - 1);
+        (*nb_out_nodes)++;
+        return;
+    }
+
+    (*nb_out_nodes)++;
+
+    path[path_len] = current_stream;
+
+    /* Find children in S */
+    int children[OV_MAX_STREAMS];
+    int nb_children = 0;
+
+    int n_node = m->streams[current_stream].node_idx;
+    if (n_node >= 0) {
+        for (int ei = 0; ei < m->nb_edges; ei++) {
+            const OV_EDGE *e1 = &m->edges[ei];
+            if (e1->src_node == n_node && sg_edge_matches_mode_from_stream(e1, mode)) {
+                int p_node = e1->tgt_node;
+                for (int ej = 0; ej < m->nb_edges; ej++) {
+                    const OV_EDGE *e2 = &m->edges[ej];
+                    if (e2->src_node == p_node) {
+                        int c_node = e2->tgt_node;
+                        if (c_node >= 0 && c_node < m->nb_nodes && m->nodes[c_node].type == OV_NODE_STREAM) {
+                            int c_stream = m->nodes[c_node].index;
+                            if (sg_bget(S_words, c_stream)) {
+                                int duplicate = 0;
+                                for (int k=0; k<nb_children; k++) if (children[k] == c_stream) duplicate = 1;
+                                if (!duplicate) children[nb_children++] = c_stream;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /* Recurse */
+    char child_prefix[128];
+    if (is_root) {
+        child_prefix[0] = '\0';
+    } else {
+        snprintf(child_prefix, sizeof(child_prefix), "%s%s", 
+                 prefix, is_last ? "    " : "\xe2\x94\x82   "); /* "    " and "│   " */
+    }
+
+    for (int i = 0; i < nb_children; i++) {
+        sg_dfs_tree(m, children[i], target_stream, target_proc, S_words, mode, child_prefix, (i == nb_children - 1), 0, depth + 1, path, path_len + 1, out_nodes, nb_out_nodes);
+    }
+}
+
+int sg_compute_render_tree(
+    const OV_MODEL *m,
+    int             start_node,
+    sg_mode_t       mode,
+    SG_TREE_NODE   *out_nodes)
+{
+    int nb_out = 0;
+    if (start_node < 0 || start_node >= m->nb_nodes) return 0;
+    
+    const OV_NODE *sn = &m->nodes[start_node];
+    int target_stream = -1;
+    int target_proc = -1;
+    
+    if (sn->type == OV_NODE_STREAM) {
+        target_stream = sn->index;
+    } else if (sn->type == OV_NODE_PROC) {
+        target_proc = sn->index;
+    }
+
+    uint64_t S_words[SG_BSET_WORDS(OV_MAX_STREAMS)];
+    memset(S_words, 0, sizeof(S_words));
+
+    if (target_stream != -1) {
+        SG_LINEAGE lin;
+        memset(&lin, 0, sizeof(lin));
+        sg_compute_lineage(m, target_stream, mode, &lin);
+
+        sg_bset(S_words, target_stream);
+        for (int i=0; i<lin.nb_ancestors; i++) sg_bset(S_words, lin.ancestors[i].stream_idx);
+        for (int i=0; i<lin.nb_descendants; i++) sg_bset(S_words, lin.descendants[i].stream_idx);
+    } else if (target_proc != -1) {
+        int8_t depths[OV_MAX_NODES];
+        memset(depths, 127, sizeof(depths));
+        sg_compute_node_depths(m, start_node, mode, depths);
+        depths[start_node] = 0;
+        
+        for (int i=0; i<m->nb_nodes; i++) {
+            if (depths[i] < 127 || depths[i] > -127) {
+                if (m->nodes[i].type == OV_NODE_STREAM) {
+                    sg_bset(S_words, m->nodes[i].index);
+                }
+            }
+        }
+    } else {
+        return 0;
+    }
+
+    /* Find parents for everyone in S */
+    int has_parent[OV_MAX_STREAMS];
+    memset(has_parent, 0, sizeof(has_parent));
+
+    for (int i=0; i<m->nb_streams; i++) {
+        if (!sg_bget(S_words, i)) continue;
+        
+        int n_node = m->streams[i].node_idx;
+        if (n_node < 0) continue;
+        
+        for (int ei = 0; ei < m->nb_edges; ei++) {
+            const OV_EDGE *e1 = &m->edges[ei];
+            if (e1->src_node == n_node && sg_edge_matches_mode_from_stream(e1, mode)) {
+                int p_node = e1->tgt_node;
+                for (int ej = 0; ej < m->nb_edges; ej++) {
+                    const OV_EDGE *e2 = &m->edges[ej];
+                    if (e2->src_node == p_node) {
+                        int c_node = e2->tgt_node;
+                        if (c_node >= 0 && c_node < m->nb_nodes && m->nodes[c_node].type == OV_NODE_STREAM) {
+                            int c_stream = m->nodes[c_node].index;
+                            if (sg_bget(S_words, c_stream)) {
+                                has_parent[c_stream] = 1;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /* Find roots */
+    int roots[OV_MAX_STREAMS];
+    int nb_roots = 0;
+    for (int i=0; i<m->nb_streams; i++) {
+        if (sg_bget(S_words, i) && !has_parent[i]) {
+            roots[nb_roots++] = i;
+        }
+    }
+
+    if (nb_roots == 0) {
+        /* Cycle graph with no absolute root. Use first available as root. */
+        for (int i=0; i<m->nb_streams; i++) {
+            if (sg_bget(S_words, i)) {
+                roots[nb_roots++] = i;
+                break;
+            }
+        }
+    }
+
+    int path[OV_MAX_STREAMS];
+    for (int i=0; i<nb_roots; i++) {
+        sg_dfs_tree(m, roots[i], target_stream, target_proc, S_words, mode, "", (i == nb_roots - 1), 1, 0, path, 0, out_nodes, &nb_out);
+    }
+
+    return nb_out;
+}

--- a/src/cli/overview/stream_graph.h
+++ b/src/cli/overview/stream_graph.h
@@ -79,6 +79,19 @@ typedef struct {
 } SG_RENDER_NODE;
 
 /**
+ * SG_TREE_NODE - flattened tree node for lineage rendering.
+ */
+typedef struct {
+    int stream_idx;          /* Index in m->streams */
+    int is_target;           /* 1 if this is the target root stream */
+    int is_target_proc;      /* 1 if the writer_name matches the target process */
+    int depth;               /* Graph depth */
+    char name[64];           /* Stream name */
+    char writer_name[64];    /* Name of the process/fps writing this stream */
+    char tree_prefix[128];   /* Prefix strings for rendering (e.g. "├── ") */
+} SG_TREE_NODE;
+
+/**
  * SG_LINEAGE - complete lineage result for one stream.
  *
  * @ancestors:      upstream streams
@@ -162,5 +175,20 @@ int sg_compute_render_nodes(
     int             start_node,
     sg_mode_t       mode,
     SG_RENDER_NODE *out_nodes);
+
+/**
+ * sg_compute_render_tree - Computes a top-down flattened list of stream nodes representing the lineage.
+ * @m:          system model
+ * @start_node: root node to traverse from
+ * @mode:       traversal mode
+ * @out_nodes:  pre-allocated array (size OV_MAX_NODES) to store result
+ *
+ * Returns: number of nodes placed in out_nodes.
+ */
+int sg_compute_render_tree(
+    const OV_MODEL *m,
+    int             start_node,
+    sg_mode_t       mode,
+    SG_TREE_NODE   *out_nodes);
 
 #endif /* STREAM_GRAPH_H */


### PR DESCRIPTION
## Summary

Finalizes the diagnostic TUI modernization for `milk-CTRL` by resolving cursor alignment, implementing visual hover feedback, suppressing erroneous key warnings, and creating clear, blink-based status indicators. It ensures consistent UTF-8 display width handling in logs, enables intuitive cross-panel stream linking in the DETAILS view, and improves overall dashboard visual state responsiveness.

## Changes

### milk-CTRL TUI Core
- Replaced multi-byte emojis with `✅` and `❌` for control and mouse toggle logs to fix text truncation/width issues.
- Added software-driven, high-visibility blinking to the `CONTROL` badge.
- Suppressed unmapped key warnings for modifier keys (`Shift`, `Ctrl`) and `Backtab` to keep command logs clean.

### DETAILS Panel
- Stream parameters of type `FPTYPE_STREAMNAME` are now highlighted and cross-linked to the STREAMS panel on hover.
- Parameters of type `FPTYPE_ONOFF` are now highlighted in green when set to `ON`.
- Improved bold highlighting for parameters when hovered or selected.

## Verification

- [x] Build passes (`/compile-test`)
- [x] TUI tested visually; hover, blink, log format, and parameter rendering display properly.

## Prompt Summary

The user requested interactive refinements to the `milk-CTRL` TUI: changing status emojis in the command log to be more informative, adding CPU/BW warnings for mouse hover mode, suppressing unmapped key errors when holding modifiers, ensuring `ON/OFF` parameters render green when `ON`, highlighting stream names in DETAILS and cross-linking them to STREAMS on hover, and fixing corrupted message log output caused by emoji byte-width issues. They also asked for the `CONTROL` badge to blink visibly when enabled.

## Authorship

- **Model**: Gemini 3.1 Pro
- **Reviewed and signed off by**: Olivier Guyon