### PR TITLE
docs: adopt coding conventions from PR #197 (vdeo)

### DIFF
--- a/.agents/rules/cmake-conventions.md
+++ b/.agents/rules/cmake-conventions.md
@@ -7,3 +7,36 @@ trigger: always_on
 - **Standardize CMake Include Paths**: Use CMake `INTERFACE` or `PUBLIC` properties more strictly. When a library like `milkTUI` or `milkdata` is created, explicitly set its `target_include_directories` and `target_link_libraries` as `PUBLIC`. This ensures any target linking against it automatically inherits the include paths.
 - **Header Installation Responsibility**: Each module (e.g., `libmilkdata`, `libprocessinfo`) is strictly responsible for installing its own header files. Other modules must not install headers they do not own.
 - **Include Syntax**: Enforce `#include "module_name/header.h"` syntax or equivalent standard public API organization across the codebase to avoid naming collisions and make dependencies clearer.
+
+## Header File Taxonomy
+
+Each module should organize its headers into these
+categories:
+
+| Category | Naming | Installed? | Purpose |
+|----------|--------|------------|---------|
+| **Public API** | `<module>.h` | Yes | External function declarations |
+| **Internal** | `<module>_internal.h` | No | Private functions, shared state across `.c` files |
+| **Types/structs** | `<module>_types.h` | Yes | Struct definitions, typedefs |
+| **Macros** | `<module>_macros.h` | Optional | Exported macro APIs |
+
+**Rules:**
+
+- Only public API and type headers should be installed.
+  Internal headers must not be exported at install time.
+- Per-function `.h` files (e.g., `image_crop.h`,
+  `fps_connect.h`) are acceptable for fine-grained
+  include control, but the module must still have a
+  top-level public API header that includes them.
+- Function declarations intended only for use within
+  the module should go in `_internal.h`, not in the
+  per-function headers.
+
+**Good examples in the codebase:**
+
+- `libfps`: `fps.h` (public), `fps_internal.h`
+  (internal), `fps_types.h` (types)
+- `ImageStreamIO`: `ImageStreamIO.h` (public),
+  `ImageStruct.h` (types)
+- `libprocessinfo`: `processinfo.h` (public),
+  `processinfo_internal.h` (internal)

--- a/.agents/rules/code-style-guide.md
+++ b/.agents/rules/code-style-guide.md
@@ -90,3 +90,8 @@ trigger: always_on
   data in compute-heavy functions where pointers are
   guaranteed non-aliasing. See `performance-practices.md`
   for full performance guidelines.
+- **Non-ASCII characters** are only permitted in **TUI
+  display code** (e.g., `streamCTRL`, `overview`,
+  `fpsCTRL`) for box-drawing symbols, status indicators,
+  and progress bars. All other source files, headers,
+  comments, and string literals must use ASCII only.

--- a/.agents/rules/naming-conventions.md
+++ b/.agents/rules/naming-conventions.md
@@ -434,5 +434,3 @@ Macros:       UPPER_CASE_WITH_UNDERSCORES
 FPS keywords: .snake_case
 Scripts:      milk-subsys-verb
 ```
-
-

--- a/.agents/rules/naming-conventions.md
+++ b/.agents/rules/naming-conventions.md
@@ -155,6 +155,15 @@ for vectorization (see §3.8).
   float *restrict pix_in  = imgin.im->array.F;
   float *restrict pix_out = imgout.im->array.F;
   ```
+- **GPU device pointers**: prefix with `d_` to distinguish
+  device memory from host memory:
+  ```c
+  float *d_modes  = NULL;  /* GPU device memory */
+  float *d_in     = NULL;  /* GPU input buffer  */
+  float *d_wfsVec = NULL;  /* GPU WFS vector    */
+  ```
+  This convention is already established in `linalgebra`,
+  `ImageStreamIO`, and `cudacomp` modules.
 - Raw pointers (`void *`): `raw`, `buf`, `ptr`
 - IMGID variables (`IMGID`): `img`, `imgptr`, `img_input`
 - Stream metadata (`IMAGE_METADATA *`): `md`

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,102 @@
+name: pre-commit
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+on:
+  push:
+    branches: [framework-dev, main]
+  pull_request:
+    branches: [framework-dev, main]
+  workflow_call:
+    inputs:
+      working-directory:
+        type: string
+        required: false
+        default: '.'
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: >
+            ${{ format('pre-commit-{0}-{1}',
+            steps.setup-python.outputs.python-version,
+            hashFiles('.pre-commit-config.yaml')
+            ) }}
+
+      - name: Install pre-commit
+        run: |
+          pip install --upgrade pip
+          pip install pre-commit
+          pre-commit install
+
+      - name: Run pre-commit hooks
+        continue-on-error: true
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          git fetch --no-tags --depth=1 \
+            origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            pre-commit run \
+              --from-ref "origin/${{ github.base_ref }}" \
+              --to-ref "HEAD" \
+              --show-diff-on-failure \
+              --color=always
+          else
+            pre-commit run \
+              --from-ref "HEAD~1" \
+              --to-ref "HEAD" \
+              --show-diff-on-failure \
+              --color=always
+          fi
+
+      - name: Commit if changes
+        if: >
+          github.event_name == 'pull_request' &&
+          github.actor != 'github-actions[bot]'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email \
+            "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: auto-format code [skip ci]"
+            git push
+          fi
+
+      - name: Re-run pre-commit hooks
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          git fetch --no-tags --depth=1 \
+            origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            pre-commit run \
+              --from-ref "origin/${{ github.base_ref }}" \
+              --to-ref "HEAD" \
+              --show-diff-on-failure \
+              --color=always
+          else
+            pre-commit run \
+              --from-ref "HEAD~1" \
+              --to-ref "HEAD" \
+              --show-diff-on-failure \
+              --color=always
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     -   id: astyle
         name: astyle custom script lints C/C++
         entry: /usr/bin/astyle
-        args: ['-A1', '-s4', '-U', '-p', '-j', '-xC80', '-xG', '-k3', '-q', '-n']
+        args: ['-A1', '-s4', '-U', '-p', '-j', '-xC100', '-xG', '-k3', '-q', '-n']
         language: script
         files: '\.(cpp|c|h|hpp)$'
         stages: [commit, push]


### PR DESCRIPTION
## Summary

This PR implements and adapts selected proposals from @DasVinch's [PR #197 (Vd/project doc draft)](https://github.com/milk-org/milk/pull/197) into the `framework-dev` branch's agent rules and CI configuration.

PR #197 proposed formal project-level coding, git, and AI-usage guidelines. This PR adopts the conventions that align with and strengthen the established milk coding standards, while adapting them to the current `framework-dev` workflow.

## Adopted from PR #197

| Proposal | Status | Adaptation |
|----------|--------|------------|
| GPU `d_` pointer naming convention | ✅ Adopted | Added to `naming-conventions.md` §3.5 |
| Non-ASCII character restriction | ✅ Adopted | Restricted to TUI display code only (`streamCTRL`, `overview`, `fpsCTRL`) |
| Header file taxonomy (public/internal/types/macros) | ✅ Adopted | Added to `cmake-conventions.md` with codebase examples |
| `pre-commit` CI workflow | ✅ Adopted | Adapted to target `framework-dev`/`main` (not `dev`) |
| Fix astyle line length | ✅ Fixed | Changed `-xC80` → `-xC100` to match established 100-char rule |

## Not adopted (kept as-is)

| Proposal | Reason |
|----------|--------|
| Git branching model (`dev` as integration) | Keeping `framework-dev` as integration branch |
| Commit message format (`[tag]` style) | Keeping conventional commits (`feat:`, `fix:`, etc.) |
| AI agent push restriction | Current agentic workflow continues |

## Changed Files

- `.agents/rules/naming-conventions.md` — GPU `d_` pointer prefix
- `.agents/rules/code-style-guide.md` — non-ASCII TUI-only rule
- `.agents/rules/cmake-conventions.md` — header file taxonomy
- `.pre-commit-config.yaml` — astyle line length fix
- `.github/workflows/pre-commit.yaml` — **new** CI workflow

## Prompt Summary

User asked to locate and review vdeo's PR #197, compare its proposed coding conventions against established milk rules, and adopt the compatible ones. After analysis and user review of the comparison, the user approved adopting the `d_` naming convention, non-ASCII restriction, header taxonomy, and pre-commit automation while keeping the existing branching model and commit format.

## Authorship

- **Model used**: Claude Opus 4.6 (Thinking)
- **Reviewed and signed off by**: @oguyon