### PR TITLE
chore: enforce variable scope blocks and loop index declaration rules

### DIFF
--- a/.agents/rules/code-style-guide.md
+++ b/.agents/rules/code-style-guide.md
@@ -2,12 +2,18 @@
 trigger: always_on
 ---
 
-- Use code blocks to reduce the scope of variables as much as possible.
+- Use code blocks (`{ }`) to reduce the scope of variables as much as possible.
+  Use this as an opportunity to add a comment immediately preceding the block
+  explaining what the block is doing.
 - Keep lines short, no more than 100 characters.
   This limit applies to both C source and agent `.md` files.
 - Factorize code as much as possible. Copy-paste coding
   is a red flag — extract shared logic into helper
   functions or macros instead of duplicating it.
+- Loop indices should always be declared within the `for` statement
+  (e.g., `for (int ii = 0; ...)`), unless they are meant to be
+  used outside the loop. If they are used outside the loop,
+  add a comment explaining why they were declared outside.
 - Function prototypes with arguments should be multi-line,
   with one line per argument.
 - Document functions using Kernel-Doc style.

--- a/src/engine/libfps/fps_GetFileName.c
+++ b/src/engine/libfps/fps_GetFileName.c
@@ -18,40 +18,48 @@ int functionparameter_GetFileName(
     char      *tagname)
 {
     char ffname[STRINGMAXLEN_FULLFILENAME];
-    char fname1[STRINGMAXLEN_FILENAME];
-    int  ll;
-    //char fpsdatadirname[STRINGMAXLEN_DIRNAME];
 
-    WRITE_DIRNAME(ffname, "%s/%s/fps/", fps->md->workdir, fps->md->datadir);
-    EXECUTE_SYSTEM_COMMAND_NOCHECK("mkdir -p %s", ffname);
-
-    // build up directory name
-    for(ll = 0; ll < fparam->keywordlevel - 1; ll++)
+    // Create FPS directory
     {
-        if(snprintf(fname1, STRINGMAXLEN_FILENAME, "%s.", fparam->keyword[ll]) <
-                0)
+        WRITE_DIRNAME(ffname, "%s/%s/fps/", fps->md->workdir, fps->md->datadir);
+        EXECUTE_SYSTEM_COMMAND_NOCHECK("mkdir -p %s", ffname);
+    }
+
+    // Build up directory name, construct final filename, and copy to output buffer
+    {
+        char fname1[STRINGMAXLEN_FILENAME];
+        
+        // Loop index `ll` is declared outside the loop because it is needed
+        // after the loop to access the final keyword level for the filename.
+        int  ll;
+
+        for(ll = 0; ll < fparam->keywordlevel - 1; ll++)
+        {
+            if(snprintf(fname1, STRINGMAXLEN_FILENAME, "%s.", fparam->keyword[ll]) <
+                    0)
+            {
+                PRINT_ERROR("snprintf error");
+            }
+            strncat(ffname, fname1, STRINGMAXLEN_DIRNAME - 1);
+        }
+
+        if(snprintf(fname1,
+                    STRINGMAXLEN_FILENAME,
+                    "%s.%s.txt",
+                    fparam->keyword[ll],
+                    tagname) < 0)
         {
             PRINT_ERROR("snprintf error");
         }
-        strncat(ffname, fname1, STRINGMAXLEN_DIRNAME - 1);
+
+        char ffname1[STRINGMAXLEN_FULLFILENAME]; // full filename
+        snprintf(ffname1, STRINGMAXLEN_FULLFILENAME, "%s", ffname);
+        strncat(ffname1, fname1, STRINGMAXLEN_FULLFILENAME - strlen(ffname1) - 1);
+
+        strncpy(outfname, ffname1,
+                STRINGMAXLEN_FULLFILENAME - 1);
+        outfname[STRINGMAXLEN_FULLFILENAME - 1] = '\0';
     }
-
-    if(snprintf(fname1,
-                STRINGMAXLEN_FILENAME,
-                "%s.%s.txt",
-                fparam->keyword[ll],
-                tagname) < 0)
-    {
-        PRINT_ERROR("snprintf error");
-    }
-
-    char ffname1[STRINGMAXLEN_FULLFILENAME]; // full filename
-    snprintf(ffname1, STRINGMAXLEN_FULLFILENAME, "%s", ffname);
-    strncat(ffname1, fname1, STRINGMAXLEN_FULLFILENAME - strlen(ffname1) - 1);
-
-    strncpy(outfname, ffname1,
-            STRINGMAXLEN_FULLFILENAME - 1);
-    outfname[STRINGMAXLEN_FULLFILENAME - 1] = '\0';
 
     return 0;
 }

--- a/src/engine/libfps/fps_GetFileName.c
+++ b/src/engine/libfps/fps_GetFileName.c
@@ -28,7 +28,7 @@ int functionparameter_GetFileName(
     // Build up directory name, construct final filename, and copy to output buffer
     {
         char fname1[STRINGMAXLEN_FILENAME];
-        
+
         // Loop index `ll` is declared outside the loop because it is needed
         // after the loop to access the final keyword level for the filename.
         int  ll;


### PR DESCRIPTION
## Summary

Adds coding standards rules for limiting variable scope via `{ }` blocks with comments, and mandating that loop indices be declared within the `for` statement unless used afterward. Refactors `fps_GetFileName.c` to demonstrate compliance.

## Changes

### .agents/rules
- Updated `code-style-guide.md` with new rules requiring scoping blocks with explanatory comments for long-lived variables, and mandating in-loop index declarations.

### src/engine/libfps
- Refactored `fps_GetFileName.c` using scoped blocks to limit the scope of variables `ffname` and `fname1`.
- Added an explanatory comment in `fps_GetFileName.c` regarding the loop index `ll`, which must be declared outside the loop to be accessed for the final filename component.

## Verification

- [x] Build passes (`/compile-test`)

## Prompt Summary

The user requested two new additions to the coding standards:
1. Enforce the use of code blocks (`{ }`) to reduce variable scope, with mandatory comments explaining the block's purpose.
2. Require loop indices to be declared within the `for` statement, unless they are used outside the loop (in which case an explanatory comment must be added).
Both rules were added to `code-style-guide.md` and applied to `fps_GetFileName.c` as a template for other functions.

## Authorship

- **Model**: Gemini 3.1 Pro
- **Reviewed and signed off by**: oguyon
