### PR TITLE
chore: enforce loop index scoping and parameter alignment

### DIFF
--- a/src/cli/CLIcore/CLIcore.c
+++ b/src/cli/CLIcore/CLIcore.c
@@ -681,7 +681,10 @@ static int handle_fifo_input(const char *prompt)
  * @return              errno_t Status code (0 on normal exit)
  */
 
-errno_t runCLI(int argc, char *argv[], char *promptstring)
+errno_t runCLI(
+    int argc,
+    char *argv[],
+    char *promptstring)
 {
     DEBUG_TRACE_FSTART();
 
@@ -1152,7 +1155,9 @@ void fnExit1(void)
 }
 
 
-static int command_line_process_options(int argc, char **argv)
+static int command_line_process_options(
+    int argc,
+    char **argv)
 {
     int                option_index = 0;
     struct sched_param schedpar;

--- a/src/cli/CLIcore/CLIcore/CLIcore_UI_completion.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI_completion.c
@@ -223,7 +223,7 @@ void rl_cb_linehandler(char *linein)
 
     /* Expand history (!! and !$) now that the full line is assembled */
     cli_history_expand();
-    
+
     if(data.CLIcmdline[0] == '\0')
     {
         /* Expansion error. Exit loop and prevent execution. */
@@ -248,7 +248,8 @@ void rl_cb_linehandler(char *linein)
         }
     }
 
-    if (data.echo_input) {
+    if(data.echo_input)
+    {
         printf("\033[32m[echo]\033[0m \u2190 \"%s\"\n", data.CLIcmdline);
     }
     CLI_execute_line();
@@ -340,8 +341,8 @@ int levenshtein_distance(
     unsigned int len1 = strlen(s1);
     unsigned int len2 = strlen(s2);
     unsigned int *d = (unsigned int *)
-        xmalloc((len1 + 1) * (len2 + 1)
-                * sizeof(unsigned int));
+                      xmalloc((len1 + 1) * (len2 + 1)
+                              * sizeof(unsigned int));
 
     for(unsigned int i = 0; i <= len1; i++)
     {
@@ -365,7 +366,7 @@ int levenshtein_distance(
                 d[i * (len2 + 1) + j - 1] + 1;
             unsigned int min3 =
                 d[(i - 1) * (len2 + 1)
-                  + j - 1] + cost;
+                          + j - 1] + cost;
             unsigned int m =
                 (min1 < min2) ? min1 : min2;
             d[i * (len2 + 1) + j] =
@@ -378,4 +379,3 @@ int levenshtein_distance(
 }
 
 #endif
-

--- a/src/cli/CLIcore/CLIcore/CLIcore_UI_completion.c
+++ b/src/cli/CLIcore/CLIcore/CLIcore_UI_completion.c
@@ -264,7 +264,9 @@ void rl_cb_linehandler(char *linein)
  * environment. Falls back to the default colored
  * prompt with the process name.
  */
-errno_t runCLI_prompt(char *promptstring, char *prompt)
+errno_t runCLI_prompt(
+    char *promptstring,
+    char *prompt)
 {
     /* Use PS1 only from CLI vars (set inside
      * milk-cli).  Do NOT fall back to

--- a/src/cli/CLIcore/milk-cli-help-synchro.c
+++ b/src/cli/CLIcore/milk-cli-help-synchro.c
@@ -92,7 +92,9 @@ void print_milk_synchro_help(void)
     printf("\n");
 }
 
-int main(int argc, char *argv[])
+int main(
+    int argc,
+    char *argv[])
 {
     /* One-line help - before CLI_startup() */
     for(int i = 1; i < argc; i++)

--- a/src/cli/CLIcore/milk-cli-help.c
+++ b/src/cli/CLIcore/milk-cli-help.c
@@ -15,7 +15,9 @@
 #include <stdio.h>
 #include "CLIcore.h"
 
-int main(int argc, char *argv[])
+int main(
+    int argc,
+    char *argv[])
 {
     /* One-line help — before CLI_startup() to avoid initialization */
     for (int i = 1; i < argc; i++) {

--- a/src/cli/CLIcore/milk-cli-help.c
+++ b/src/cli/CLIcore/milk-cli-help.c
@@ -20,9 +20,10 @@ int main(
     char *argv[])
 {
     /* One-line help — before CLI_startup() to avoid initialization */
-    for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "-h1") == 0 ||
-            strcmp(argv[i], "--help-oneline") == 0)
+    for(int i = 1; i < argc; i++)
+    {
+        if(strcmp(argv[i], "-h1") == 0 ||
+                strcmp(argv[i], "--help-oneline") == 0)
         {
             printf("milk-cli interactive shell help\n");
             return 0;
@@ -35,13 +36,13 @@ int main(
 
     const char *topic = NULL;
 
-    for (int i = 1; i < argc; i++)
+    for(int i = 1; i < argc; i++)
     {
-        if (strcmp(argv[i], "--json") == 0)
+        if(strcmp(argv[i], "--json") == 0)
         {
             help_format_mode = 1;
         }
-        else if (strcmp(argv[i], "--porcelain") == 0)
+        else if(strcmp(argv[i], "--porcelain") == 0)
         {
             help_format_mode = 2;
         }
@@ -51,12 +52,13 @@ int main(
         }
     }
 
-    if (topic != NULL)
+    if(topic != NULL)
     {
         int ret = help_topic_dispatch(topic);
-        if (ret != 0)
+        if(ret != 0)
         {
-            if (help_format_mode == 0) {
+            if(help_format_mode == 0)
+            {
                 fprintf(stderr,
                         "\033[1;31mmilk-cli-help: unknown topic"
                         " \"%s\"\033[0m\n\n",
@@ -73,4 +75,3 @@ int main(
 
     return 0;
 }
-

--- a/src/cli/CLIcore/milk-fuzzy-match.c
+++ b/src/cli/CLIcore/milk-fuzzy-match.c
@@ -176,7 +176,9 @@ static int cmp_score_desc(
 /**
  * @brief Print help message for milk-fuzzy-match.
  */
-static void print_help(const char *prog, int mh_color)
+static void print_help(
+    const char *prog,
+    int mh_color)
 {
     milk_help_banner(prog, FM_ONELINE, mh_color);
     milk_help_section("Usage", mh_color);
@@ -214,7 +216,9 @@ static void print_help(const char *prog, int mh_color)
            mh_color ? MH_ARG : "", mh_color ? MH_RST : "");
 }
 
-int main(int argc, char **argv)
+int main(
+    int argc,
+    char **argv)
 {
     int action = milk_help_init(argc, argv,
                                 FM_ONELINE, FM_DESC_LONG);

--- a/src/cli/CLIcore/milk-help.c
+++ b/src/cli/CLIcore/milk-help.c
@@ -11,9 +11,10 @@ int main(
     char *argv[])
 {
     /* One-line help — before CLI_startup() */
-    for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "-h1") == 0 ||
-            strcmp(argv[i], "--help-oneline") == 0)
+    for(int i = 1; i < argc; i++)
+    {
+        if(strcmp(argv[i], "-h1") == 0 ||
+                strcmp(argv[i], "--help-oneline") == 0)
         {
             printf("milk framework overview\n");
             return 0;

--- a/src/cli/CLIcore/milk-help.c
+++ b/src/cli/CLIcore/milk-help.c
@@ -6,7 +6,9 @@
 #include <string.h>
 #include "CLIcore.h"
 
-int main(int argc, char *argv[])
+int main(
+    int argc,
+    char *argv[])
 {
     /* One-line help — before CLI_startup() */
     for (int i = 1; i < argc; i++) {

--- a/src/cli/CLIcore/termview/milk-termview.c
+++ b/src/cli/CLIcore/termview/milk-termview.c
@@ -18,7 +18,9 @@
 /**
  * @brief Print help message for milk-termview.
  */
-static void print_help(const char *progname, int mh_color)
+static void print_help(
+    const char *progname,
+    int mh_color)
 {
     milk_help_banner(progname, "TrueColor terminal image viewer", mh_color);
     milk_help_section("Usage", mh_color);
@@ -66,7 +68,9 @@ static void print_help(const char *progname, int mh_color)
     printf("  %s%-12s%s %s\n\n", mh_color ? MH_CMD : "", "q", mh_color ? MH_RST : "", "Quit");
 }
 
-int main(int argc, char **argv)
+int main(
+    int argc,
+    char **argv)
 {
     const char *progname = basename(argv[0]);
 

--- a/src/cli/CLIcore/termview/termview.c
+++ b/src/cli/CLIcore/termview/termview.c
@@ -220,7 +220,9 @@ static void tv_exit_alt_screen(void)
     if(write(STDOUT_FILENO, "\033[?1006l\033[?1002l\033[?1049l\033[?25h", 30) < 0) {} // exit alt screen + show cursor + no mouse track
 }
 
-static void tv_get_size(unsigned short *rows, unsigned short *cols)
+static void tv_get_size(
+    unsigned short *rows,
+    unsigned short *cols)
 {
     struct winsize ws;
     if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == -1 || ws.ws_col == 0) {
@@ -962,7 +964,9 @@ static void termview_flush_ansi(tv_context_t *ctx) {
     }
 }
 
-errno_t termview_screen(const char *imagename, termview_options_t options)
+errno_t termview_screen(
+    const char *imagename,
+    termview_options_t options)
 {
     IMAGE img;
     ImageStreamIO_read_sharedmem_image_toIMAGE(imagename, &img);

--- a/src/cli/CLIcore/termview/termview.c
+++ b/src/cli/CLIcore/termview/termview.c
@@ -22,7 +22,8 @@
 /* -----------------------------------------------------------------------
  * Typedefs & Constants
  * ----------------------------------------------------------------------- */
-typedef struct {
+typedef struct
+{
     uint8_t r, g, b;
 } rgb_t;
 
@@ -32,7 +33,8 @@ typedef struct {
 #define TV_KEY_RIGHT 0x1004
 #define TV_KEY_MOUSE 0x1005
 
-typedef struct {
+typedef struct
+{
     int button; // 0: Left, 1: Middle, 2: Right, 64: ScrollUp, 65: ScrollDown
     int x; // 1-indexed
     int y; // 1-indexed
@@ -61,7 +63,8 @@ static double current_max_val = 1.0;
 /* -----------------------------------------------------------------------
  * Grid-based Rendering State
  * ----------------------------------------------------------------------- */
-typedef struct {
+typedef struct
+{
     uint8_t bg_r, bg_g, bg_b;
     uint8_t fg_r, fg_g, fg_b;
     char ch[4]; // utf-8 char (half-block is 3 bytes, full-block 3 bytes)
@@ -73,101 +76,355 @@ static int lut_scale = -1;
 static double lut_min = -1.0;
 static double lut_max = -1.0;
 
-static rgb_t get_colormap_color(termview_colormap_t cmap, double v) {
-    if (v < 0.0) v = 0.0;
-    if (v > 1.0) v = 1.0;
-    
+static rgb_t get_colormap_color(termview_colormap_t cmap, double v)
+{
+    if(v < 0.0)
+    {
+        v = 0.0;
+    }
+    if(v > 1.0)
+    {
+        v = 1.0;
+    }
+
     rgb_t c = {0, 0, 0};
-    if (cmap == COLORMAP_GREYSCALE) {
+    if(cmap == COLORMAP_GREYSCALE)
+    {
         c.r = c.g = c.b = (uint8_t)(v * 255.0f);
-    } else {
+    }
+    else
+    {
         float r = 0.0f, g = 0.0f, b = 0.0f;
-        if (cmap == COLORMAP_HEAT) {
-            if (v < 0.25f) { b = v * 4.0f; }
-            else if (v < 0.5f) { b = 1.0f; g = (v - 0.25f) * 4.0f; }
-            else if (v < 0.75f) { b = 1.0f - (v - 0.5f) * 4.0f; g = 1.0f; r = (v - 0.5f) * 4.0f; }
-            else { g = 1.0f - (v - 0.75f) * 4.0f; r = 1.0f; }
-        } else if (cmap == COLORMAP_COLD) {
-            if (v < 0.33f) { b = v * 3.0f; }
-            else if (v < 0.66f) { b = 1.0f; g = (v - 0.33f) * 3.0f; }
-            else { b = 1.0f; g = 1.0f; r = (v - 0.66f) * 3.0f; }
-        } else if (cmap == COLORMAP_JET) {
-            if (v < 0.25f) { b = 1.0f; g = v * 4.0f; }
-            else if (v < 0.5f) { b = 1.0f - (v - 0.25f) * 4.0f; g = 1.0f; }
-            else if (v < 0.75f) { g = 1.0f; r = (v - 0.5f) * 4.0f; }
-            else { g = 1.0f - (v - 0.75f) * 4.0f; r = 1.0f; }
-        } else if (cmap == COLORMAP_INFERNO) {
-            if (v < 0.33f) { r = v * 1.5f; b = v * 2.0f; }
-            else if (v < 0.66f) { r = 0.5f + (v-0.33f)*1.5f; g = (v-0.33f)*1.5f; b = 0.66f - (v-0.33f)*2.0f; }
-            else { r = 1.0f; g = 0.5f + (v-0.66f)*1.5f; }
-        } else if (cmap == COLORMAP_VIRIDIS) {
-            if (v < 0.33f) { r = 0.2f; g = v * 1.5f; b = 0.4f + v * 1.2f; }
-            else if (v < 0.66f) { r = 0.2f; g = 0.5f + (v-0.33f)*1.0f; b = 0.8f - (v-0.33f)*1.5f; }
-            else { r = 0.2f + (v-0.66f)*2.4f; g = 0.83f + (v-0.66f)*0.5f; b = 0.3f - (v-0.66f)*0.9f; }
-        } else if (cmap == COLORMAP_MAGMA) {
-            if (v < 0.25f) { r = v*2.0f; g = 0.0f; b = v*2.0f; }
-            else if (v < 0.5f) { r = 0.5f + (v-0.25f)*2.0f; g = 0.0f; b = 0.5f - (v-0.25f)*2.0f; }
-            else if (v < 0.75f) { r = 1.0f; g = (v-0.5f)*2.0f; b = 0.0f; }
-            else { r = 1.0f; g = 0.5f + (v-0.75f)*2.0f; b = (v-0.75f)*4.0f; }
-        } else if (cmap == COLORMAP_PLASMA) {
-            if (v < 0.33f) { r = v*1.5f; g = 0.0f; b = 0.5f + v*1.5f; }
-            else if (v < 0.66f) { r = 0.5f + (v-0.33f)*1.5f; g = (v-0.33f)*1.5f; b = 1.0f - (v-0.33f)*1.5f; }
-            else { r = 1.0f; g = 0.5f + (v-0.66f)*1.5f; b = 0.5f - (v-0.66f)*1.5f; }
-        } else if (cmap == COLORMAP_BONE) {
-            if (v < 0.33f) { r = v*1.5f; g = v*1.5f; b = v*2.0f; }
-            else if (v < 0.66f) { r = 0.5f + (v-0.33f)*1.0f; g = 0.5f + (v-0.33f)*1.5f; b = 0.66f + (v-0.33f)*1.0f; }
-            else { r = 0.83f + (v-0.66f)*0.5f; g = 1.0f; b = 1.0f; }
-        } else if (cmap == COLORMAP_RAINBOW) {
-            float h = (1.0f - v) * 5.0f; 
+        if(cmap == COLORMAP_HEAT)
+        {
+            if(v < 0.25f)
+            {
+                b = v * 4.0f;
+            }
+            else if(v < 0.5f)
+            {
+                b = 1.0f;
+                g = (v - 0.25f) * 4.0f;
+            }
+            else if(v < 0.75f)
+            {
+                b = 1.0f - (v - 0.5f) * 4.0f;
+                g = 1.0f;
+                r = (v - 0.5f) * 4.0f;
+            }
+            else
+            {
+                g = 1.0f - (v - 0.75f) * 4.0f;
+                r = 1.0f;
+            }
+        }
+        else if(cmap == COLORMAP_COLD)
+        {
+            if(v < 0.33f)
+            {
+                b = v * 3.0f;
+            }
+            else if(v < 0.66f)
+            {
+                b = 1.0f;
+                g = (v - 0.33f) * 3.0f;
+            }
+            else
+            {
+                b = 1.0f;
+                g = 1.0f;
+                r = (v - 0.66f) * 3.0f;
+            }
+        }
+        else if(cmap == COLORMAP_JET)
+        {
+            if(v < 0.25f)
+            {
+                b = 1.0f;
+                g = v * 4.0f;
+            }
+            else if(v < 0.5f)
+            {
+                b = 1.0f - (v - 0.25f) * 4.0f;
+                g = 1.0f;
+            }
+            else if(v < 0.75f)
+            {
+                g = 1.0f;
+                r = (v - 0.5f) * 4.0f;
+            }
+            else
+            {
+                g = 1.0f - (v - 0.75f) * 4.0f;
+                r = 1.0f;
+            }
+        }
+        else if(cmap == COLORMAP_INFERNO)
+        {
+            if(v < 0.33f)
+            {
+                r = v * 1.5f;
+                b = v * 2.0f;
+            }
+            else if(v < 0.66f)
+            {
+                r = 0.5f + (v - 0.33f) * 1.5f;
+                g = (v - 0.33f) * 1.5f;
+                b = 0.66f - (v - 0.33f) * 2.0f;
+            }
+            else
+            {
+                r = 1.0f;
+                g = 0.5f + (v - 0.66f) * 1.5f;
+            }
+        }
+        else if(cmap == COLORMAP_VIRIDIS)
+        {
+            if(v < 0.33f)
+            {
+                r = 0.2f;
+                g = v * 1.5f;
+                b = 0.4f + v * 1.2f;
+            }
+            else if(v < 0.66f)
+            {
+                r = 0.2f;
+                g = 0.5f + (v - 0.33f) * 1.0f;
+                b = 0.8f - (v - 0.33f) * 1.5f;
+            }
+            else
+            {
+                r = 0.2f + (v - 0.66f) * 2.4f;
+                g = 0.83f + (v - 0.66f) * 0.5f;
+                b = 0.3f - (v - 0.66f) * 0.9f;
+            }
+        }
+        else if(cmap == COLORMAP_MAGMA)
+        {
+            if(v < 0.25f)
+            {
+                r = v * 2.0f;
+                g = 0.0f;
+                b = v * 2.0f;
+            }
+            else if(v < 0.5f)
+            {
+                r = 0.5f + (v - 0.25f) * 2.0f;
+                g = 0.0f;
+                b = 0.5f - (v - 0.25f) * 2.0f;
+            }
+            else if(v < 0.75f)
+            {
+                r = 1.0f;
+                g = (v - 0.5f) * 2.0f;
+                b = 0.0f;
+            }
+            else
+            {
+                r = 1.0f;
+                g = 0.5f + (v - 0.75f) * 2.0f;
+                b = (v - 0.75f) * 4.0f;
+            }
+        }
+        else if(cmap == COLORMAP_PLASMA)
+        {
+            if(v < 0.33f)
+            {
+                r = v * 1.5f;
+                g = 0.0f;
+                b = 0.5f + v * 1.5f;
+            }
+            else if(v < 0.66f)
+            {
+                r = 0.5f + (v - 0.33f) * 1.5f;
+                g = (v - 0.33f) * 1.5f;
+                b = 1.0f - (v - 0.33f) * 1.5f;
+            }
+            else
+            {
+                r = 1.0f;
+                g = 0.5f + (v - 0.66f) * 1.5f;
+                b = 0.5f - (v - 0.66f) * 1.5f;
+            }
+        }
+        else if(cmap == COLORMAP_BONE)
+        {
+            if(v < 0.33f)
+            {
+                r = v * 1.5f;
+                g = v * 1.5f;
+                b = v * 2.0f;
+            }
+            else if(v < 0.66f)
+            {
+                r = 0.5f + (v - 0.33f) * 1.0f;
+                g = 0.5f + (v - 0.33f) * 1.5f;
+                b = 0.66f + (v - 0.33f) * 1.0f;
+            }
+            else
+            {
+                r = 0.83f + (v - 0.66f) * 0.5f;
+                g = 1.0f;
+                b = 1.0f;
+            }
+        }
+        else if(cmap == COLORMAP_RAINBOW)
+        {
+            float h = (1.0f - v) * 5.0f;
             int i = (int)h;
             float f = h - i;
             float q = 1.0f - f;
-            switch (i) {
-                case 0: r = 1.0f; g = f; b = 0.0f; break;
-                case 1: r = q; g = 1.0f; b = 0.0f; break;
-                case 2: r = 0.0f; g = 1.0f; b = f; break;
-                case 3: r = 0.0f; g = q; b = 1.0f; break;
-                case 4: r = f; g = 0.0f; b = 1.0f; break;
-                case 5: r = 1.0f; g = 0.0f; b = 1.0f; break;
-                default: r = 1.0f; g = 0.0f; b = 1.0f; break;
+            switch(i)
+            {
+            case 0:
+                r = 1.0f;
+                g = f;
+                b = 0.0f;
+                break;
+            case 1:
+                r = q;
+                g = 1.0f;
+                b = 0.0f;
+                break;
+            case 2:
+                r = 0.0f;
+                g = 1.0f;
+                b = f;
+                break;
+            case 3:
+                r = 0.0f;
+                g = q;
+                b = 1.0f;
+                break;
+            case 4:
+                r = f;
+                g = 0.0f;
+                b = 1.0f;
+                break;
+            case 5:
+                r = 1.0f;
+                g = 0.0f;
+                b = 1.0f;
+                break;
+            default:
+                r = 1.0f;
+                g = 0.0f;
+                b = 1.0f;
+                break;
             }
-        } else if (cmap == COLORMAP_TURBO) {
-            float k1 = 0.1357f + v * (4.5974f - v * (42.3277f - v * (130.5887f - v * (150.5666f - v * 58.1375f))));
-            float k2 = 0.0914f + v * (2.1941f + v * (4.8429f - v * (14.1850f - v * (4.2773f + v * 2.8251f))));
-            float k3 = 0.1066f + v * (12.6419f - v * (60.5820f - v * (110.3627f - v * (89.9031f - v * 27.3482f))));
-            r = k1; g = k2; b = k3;
-        } else if (cmap == COLORMAP_OCEAN) {
-            r = v * 0.5f; g = v * 0.8f; b = 0.2f + v * 0.8f;
-        } else if (cmap == COLORMAP_COPPER) {
-            r = v * 1.25f; g = v * 0.7812f; b = v * 0.4975f;
-        } else if (cmap == COLORMAP_SPRING) {
-            r = 1.0f; g = v; b = 1.0f - v;
-        } else if (cmap == COLORMAP_SUMMER) {
-            r = v; g = 0.5f + v * 0.5f; b = 0.4f;
-        } else if (cmap == COLORMAP_AUTUMN) {
-            r = 1.0f; g = v; b = 0.0f;
-        } else if (cmap == COLORMAP_WINTER) {
-            r = 0.0f; g = v; b = 1.0f - v * 0.5f;
         }
-        if(r>1.0f) r=1.0f; if(r<0.0f) r=0.0f;
-        if(g>1.0f) g=1.0f; if(g<0.0f) g=0.0f;
-        if(b>1.0f) b=1.0f; if(b<0.0f) b=0.0f;
-        c.r = (uint8_t)(r * 255.0f); c.g = (uint8_t)(g * 255.0f); c.b = (uint8_t)(b * 255.0f);
+        else if(cmap == COLORMAP_TURBO)
+        {
+            float k1 = 0.1357f + v * (4.5974f - v * (42.3277f - v * (130.5887f - v *
+                                      (150.5666f - v * 58.1375f))));
+            float k2 = 0.0914f + v * (2.1941f + v * (4.8429f - v * (14.1850f - v * (4.2773f + v * 2.8251f))));
+            float k3 = 0.1066f + v * (12.6419f - v * (60.5820f - v * (110.3627f - v *
+                                      (89.9031f - v * 27.3482f))));
+            r = k1;
+            g = k2;
+            b = k3;
+        }
+        else if(cmap == COLORMAP_OCEAN)
+        {
+            r = v * 0.5f;
+            g = v * 0.8f;
+            b = 0.2f + v * 0.8f;
+        }
+        else if(cmap == COLORMAP_COPPER)
+        {
+            r = v * 1.25f;
+            g = v * 0.7812f;
+            b = v * 0.4975f;
+        }
+        else if(cmap == COLORMAP_SPRING)
+        {
+            r = 1.0f;
+            g = v;
+            b = 1.0f - v;
+        }
+        else if(cmap == COLORMAP_SUMMER)
+        {
+            r = v;
+            g = 0.5f + v * 0.5f;
+            b = 0.4f;
+        }
+        else if(cmap == COLORMAP_AUTUMN)
+        {
+            r = 1.0f;
+            g = v;
+            b = 0.0f;
+        }
+        else if(cmap == COLORMAP_WINTER)
+        {
+            r = 0.0f;
+            g = v;
+            b = 1.0f - v * 0.5f;
+        }
+        if(r > 1.0f)
+        {
+            r = 1.0f;
+        }
+        if(r < 0.0f)
+        {
+            r = 0.0f;
+        }
+        if(g > 1.0f)
+        {
+            g = 1.0f;
+        }
+        if(g < 0.0f)
+        {
+            g = 0.0f;
+        }
+        if(b > 1.0f)
+        {
+            b = 1.0f;
+        }
+        if(b < 0.0f)
+        {
+            b = 0.0f;
+        }
+        c.r = (uint8_t)(r * 255.0f);
+        c.g = (uint8_t)(g * 255.0f);
+        c.b = (uint8_t)(b * 255.0f);
     }
     return c;
 }
 
-static void build_colormap_lut(termview_colormap_t cmap, termview_scale_t scale) {
-    for (int i = 0; i < 1024; i++) {
+static void build_colormap_lut(termview_colormap_t cmap, termview_scale_t scale)
+{
+    for(int i = 0; i < 1024; i++)
+    {
         double v = i / 1023.0;
-        if (scale == SCALE_SQRT) v = sqrt(v);
-        else if (scale == SCALE_LOG) v = log(v * 9.0 + 1.0) / log(10.0);
-        else if (scale == SCALE_LOG_STRONG) v = log(v * 99.0 + 1.0) / log(100.0);
-        else if (scale == SCALE_LOG_EXTREME) v = log(v * 999.0 + 1.0) / log(1000.0);
-        else if (scale == SCALE_ASINH) v = asinh(v * 10.0) / asinh(10.0);
-        else if (scale == SCALE_SQUARED) v = v * v;
-        else if (scale == SCALE_CUBED) v = v * v * v;
-        
+        if(scale == SCALE_SQRT)
+        {
+            v = sqrt(v);
+        }
+        else if(scale == SCALE_LOG)
+        {
+            v = log(v * 9.0 + 1.0) / log(10.0);
+        }
+        else if(scale == SCALE_LOG_STRONG)
+        {
+            v = log(v * 99.0 + 1.0) / log(100.0);
+        }
+        else if(scale == SCALE_LOG_EXTREME)
+        {
+            v = log(v * 999.0 + 1.0) / log(1000.0);
+        }
+        else if(scale == SCALE_ASINH)
+        {
+            v = asinh(v * 10.0) / asinh(10.0);
+        }
+        else if(scale == SCALE_SQUARED)
+        {
+            v = v * v;
+        }
+        else if(scale == SCALE_CUBED)
+        {
+            v = v * v * v;
+        }
+
         colormap_lut[i] = get_colormap_color(cmap, v);
     }
     lut_colormap = cmap;
@@ -212,12 +469,14 @@ static void tv_enter_raw(void)
 
 static void tv_enter_alt_screen(void)
 {
-    if(write(STDOUT_FILENO, "\033[?1049h\033[?25l\033[?1002h\033[?1006h", 30) < 0) {} // alt screen + hide cursor + mouse track
+    if(write(STDOUT_FILENO, "\033[?1049h\033[?25l\033[?1002h\033[?1006h",
+             30) < 0) {} // alt screen + hide cursor + mouse track
 }
 
 static void tv_exit_alt_screen(void)
 {
-    if(write(STDOUT_FILENO, "\033[?1006l\033[?1002l\033[?1049l\033[?25h", 30) < 0) {} // exit alt screen + show cursor + no mouse track
+    if(write(STDOUT_FILENO, "\033[?1006l\033[?1002l\033[?1049l\033[?25h",
+             30) < 0) {} // exit alt screen + show cursor + no mouse track
 }
 
 static void tv_get_size(
@@ -225,10 +484,13 @@ static void tv_get_size(
     unsigned short *cols)
 {
     struct winsize ws;
-    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == -1 || ws.ws_col == 0) {
+    if(ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == -1 || ws.ws_col == 0)
+    {
         *rows = 24;
         *cols = 80;
-    } else {
+    }
+    else
+    {
         *rows = ws.ws_row;
         *cols = ws.ws_col;
     }
@@ -245,59 +507,106 @@ static int tv_read_key(long timeout_us)
     tv.tv_usec = timeout_us % 1000000;
 
     int ready = select(STDIN_FILENO + 1, &readfds, NULL, NULL, &tv);
-    if (ready == -1 || ready == 0) {
+    if(ready == -1 || ready == 0)
+    {
         return -1;
     }
 
     char seq[32];
     int nread = read(STDIN_FILENO, &seq[0], 1);
-    if (nread != 1) return -1;
+    if(nread != 1)
+    {
+        return -1;
+    }
 
-    if (seq[0] == 27) {
-        if (read(STDIN_FILENO, &seq[1], 1) != 1) return 27;
-        if (read(STDIN_FILENO, &seq[2], 1) != 1) return 27;
+    if(seq[0] == 27)
+    {
+        if(read(STDIN_FILENO, &seq[1], 1) != 1)
+        {
+            return 27;
+        }
+        if(read(STDIN_FILENO, &seq[2], 1) != 1)
+        {
+            return 27;
+        }
 
-        if (seq[1] == '[') {
-            if (seq[2] == '<') {
+        if(seq[1] == '[')
+        {
+            if(seq[2] == '<')
+            {
                 // Parse SGR mouse: \033[<B;X;Y[M|m]
                 int b = 0, x = 0, y = 0;
                 int type = 0; // 'M' or 'm'
                 int state = 0; // 0: b, 1: x, 2: y, 3: type
-                for (int i = 3; i < 31; i++) {
-                    if (read(STDIN_FILENO, &seq[i], 1) != 1) return 27;
-                    if (seq[i] == ';') {
+                for(int i = 3; i < 31; i++)
+                {
+                    if(read(STDIN_FILENO, &seq[i], 1) != 1)
+                    {
+                        return 27;
+                    }
+                    if(seq[i] == ';')
+                    {
                         state++;
-                    } else if (seq[i] == 'M' || seq[i] == 'm') {
+                    }
+                    else if(seq[i] == 'M' || seq[i] == 'm')
+                    {
                         type = seq[i];
                         break;
-                    } else {
-                        if (state == 0) b = b * 10 + (seq[i] - '0');
-                        else if (state == 1) x = x * 10 + (seq[i] - '0');
-                        else if (state == 2) y = y * 10 + (seq[i] - '0');
+                    }
+                    else
+                    {
+                        if(state == 0)
+                        {
+                            b = b * 10 + (seq[i] - '0');
+                        }
+                        else if(state == 1)
+                        {
+                            x = x * 10 + (seq[i] - '0');
+                        }
+                        else if(state == 2)
+                        {
+                            y = y * 10 + (seq[i] - '0');
+                        }
                     }
                 }
                 last_mouse_event.is_drag = ((b & 32) != 0);
-                if (b & 64) {
+                if(b & 64)
+                {
                     last_mouse_event.button = b; // 64 or 65
                     last_mouse_event.is_drag = 0;
-                } else {
+                }
+                else
+                {
                     last_mouse_event.button = b & 3; // 0: Left, 1: Middle, 2: Right
                 }
                 last_mouse_event.x = x;
                 last_mouse_event.y = y;
                 last_mouse_event.is_press = (type == 'M');
                 return TV_KEY_MOUSE;
-            } else {
-                switch (seq[2]) {
-                    case 'A': force_redraw = 1; return TV_KEY_UP;
-                    case 'B': force_redraw = 1; return TV_KEY_DOWN;
-                    case 'C': force_redraw = 1; return TV_KEY_RIGHT;
-                    case 'D': force_redraw = 1; return TV_KEY_LEFT;
+            }
+            else
+            {
+                switch(seq[2])
+                {
+                case 'A':
+                    force_redraw = 1;
+                    return TV_KEY_UP;
+                case 'B':
+                    force_redraw = 1;
+                    return TV_KEY_DOWN;
+                case 'C':
+                    force_redraw = 1;
+                    return TV_KEY_RIGHT;
+                case 'D':
+                    force_redraw = 1;
+                    return TV_KEY_LEFT;
                 }
             }
         }
         return 27;
-    } else {
+    }
+    else
+    {
         return seq[0];
     }
 }
@@ -305,33 +614,54 @@ static int tv_read_key(long timeout_us)
 /* -----------------------------------------------------------------------
  * Data Retrieval & Colormaps
  * ----------------------------------------------------------------------- */
-static inline double get_pixel_value(IMAGE *img, int x, int y) {
+static inline double get_pixel_value(IMAGE *img, int x, int y)
+{
     long idx = y * img->md[0].size[0] + x;
-    if (x < 0 || x >= img->md[0].size[0] || y < 0 || y >= img->md[0].size[1]) {
+    if(x < 0 || x >= img->md[0].size[0] || y < 0 || y >= img->md[0].size[1])
+    {
         return 0.0;
     }
-    switch(img->md[0].datatype) {
-        case _DATATYPE_UINT8:  return (double) img->array.UI8[idx];
-        case _DATATYPE_INT8:   return (double) img->array.SI8[idx];
-        case _DATATYPE_UINT16: return (double) img->array.UI16[idx];
-        case _DATATYPE_INT16:  return (double) img->array.SI16[idx];
-        case _DATATYPE_UINT32: return (double) img->array.UI32[idx];
-        case _DATATYPE_INT32:  return (double) img->array.SI32[idx];
-        case _DATATYPE_UINT64: return (double) img->array.UI64[idx];
-        case _DATATYPE_INT64:  return (double) img->array.SI64[idx];
-        case _DATATYPE_FLOAT:  return (double) img->array.F[idx];
-        case _DATATYPE_DOUBLE: return (double) img->array.D[idx];
-        default: return 0.0;
+    switch(img->md[0].datatype)
+    {
+    case _DATATYPE_UINT8:
+        return (double) img->array.UI8[idx];
+    case _DATATYPE_INT8:
+        return (double) img->array.SI8[idx];
+    case _DATATYPE_UINT16:
+        return (double) img->array.UI16[idx];
+    case _DATATYPE_INT16:
+        return (double) img->array.SI16[idx];
+    case _DATATYPE_UINT32:
+        return (double) img->array.UI32[idx];
+    case _DATATYPE_INT32:
+        return (double) img->array.SI32[idx];
+    case _DATATYPE_UINT64:
+        return (double) img->array.UI64[idx];
+    case _DATATYPE_INT64:
+        return (double) img->array.SI64[idx];
+    case _DATATYPE_FLOAT:
+        return (double) img->array.F[idx];
+    case _DATATYPE_DOUBLE:
+        return (double) img->array.D[idx];
+    default:
+        return 0.0;
     }
 }
 
 
 
-static inline int compare_doubles(const void *a, const void *b) {
+static inline int compare_doubles(const void *a, const void *b)
+{
     double arg1 = *(const double *)a;
     double arg2 = *(const double *)b;
-    if (arg1 < arg2) return -1;
-    if (arg1 > arg2) return 1;
+    if(arg1 < arg2)
+    {
+        return -1;
+    }
+    if(arg1 > arg2)
+    {
+        return 1;
+    }
     return 0;
 }
 
@@ -342,7 +672,8 @@ static inline int compare_doubles(const void *a, const void *b) {
 /* -----------------------------------------------------------------------
  * Termview Refactored Context
  * ----------------------------------------------------------------------- */
-typedef struct {
+typedef struct
+{
     IMAGE *img;
     int target_fps;
     double current_cpu_usage;
@@ -352,7 +683,7 @@ typedef struct {
     struct timespec last_time_real;
     struct timespec last_time_cpu;
     struct timespec last_render_real;
-    
+
     int popup_type;
     struct timespec popup_expiry_time;
 
@@ -375,36 +706,39 @@ typedef struct {
     int screen_size;
     char *frame_buffer;
     size_t frame_buffer_size;
-    
+
     long timeout_us;
 } tv_context_t;
 
 
-static void termview_update_fps_stats(tv_context_t *ctx) {
+static void termview_update_fps_stats(tv_context_t *ctx)
+{
     clock_gettime(CLOCK_MONOTONIC, &ctx->last_render_real);
-    double real_diff = (ctx->last_render_real.tv_sec - ctx->last_time_real.tv_sec) + 
+    double real_diff = (ctx->last_render_real.tv_sec - ctx->last_time_real.tv_sec) +
                        (ctx->last_render_real.tv_nsec - ctx->last_time_real.tv_nsec) / 1e9;
-    if (real_diff >= 1.0) {
+    if(real_diff >= 1.0)
+    {
         struct timespec now_cpu;
         clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &now_cpu);
-        double cpu_diff = (now_cpu.tv_sec - ctx->last_time_cpu.tv_sec) + 
+        double cpu_diff = (now_cpu.tv_sec - ctx->last_time_cpu.tv_sec) +
                           (now_cpu.tv_nsec - ctx->last_time_cpu.tv_nsec) / 1e9;
         ctx->current_cpu_usage = (cpu_diff / real_diff) * 100.0;
-        
+
         uint64_t current_cnt0 = ctx->img->md[0].cnt0;
         ctx->current_stream_fps = (current_cnt0 - ctx->last_cnt0_for_fps) / real_diff;
         ctx->last_cnt0_for_fps = current_cnt0;
-        
+
         ctx->last_time_real = ctx->last_render_real;
         ctx->last_time_cpu = now_cpu;
     }
 }
 
-static void termview_handle_mouse_event(tv_context_t *ctx) {
+static void termview_handle_mouse_event(tv_context_t *ctx)
+{
     force_redraw = 1;
     int mx = last_mouse_event.x;
     int my = last_mouse_event.y;
-    
+
     uint32_t xsize = ctx->img->md[0].size[0];
     uint32_t ysize = ctx->img->md[0].size[1];
     int bar_width = 12;
@@ -421,198 +755,323 @@ static void termview_handle_mouse_event(tv_context_t *ctx) {
     double center_disp_x = disp_cols / 2.0;
     double center_disp_y = disp_img_rows / 2.0;
 
-    if (last_mouse_event.button == 64) {
+    if(last_mouse_event.button == 64)
+    {
         // Scroll Up -> Zoom in
         view_zoom *= 1.2;
-    } else if (last_mouse_event.button == 65) {
+    }
+    else if(last_mouse_event.button == 65)
+    {
         // Scroll Down -> Zoom out
         view_zoom /= 1.2;
-        if (view_zoom < 0.1) view_zoom = 0.1;
-    } else if (last_mouse_event.button == 0) { // Left Button
-        if (last_mouse_event.is_press && !last_mouse_event.is_drag) {
+        if(view_zoom < 0.1)
+        {
+            view_zoom = 0.1;
+        }
+    }
+    else if(last_mouse_event.button == 0)      // Left Button
+    {
+        if(last_mouse_event.is_press && !last_mouse_event.is_drag)
+        {
             ctx->mouse_is_dragging = 1;
             ctx->last_mouse_x = mx;
             ctx->last_mouse_y = my;
-        } else if (last_mouse_event.is_press && last_mouse_event.is_drag && ctx->mouse_is_dragging) {
+        }
+        else if(last_mouse_event.is_press && last_mouse_event.is_drag && ctx->mouse_is_dragging)
+        {
             int dx = mx - ctx->last_mouse_x;
             int dy = my - ctx->last_mouse_y;
-            
+
             double dx_pixels = -dx * step;
             double dy_pixels = -dy * 2 * step;
-            
+
             view_center_x += dx_pixels / xsize;
             view_center_y += dy_pixels / ysize;
-            
-            if (view_center_x < 0.0) view_center_x = 0.0;
-            if (view_center_x > 1.0) view_center_x = 1.0;
-            if (view_center_y < 0.0) view_center_y = 0.0;
-            if (view_center_y > 1.0) view_center_y = 1.0;
-            
+
+            if(view_center_x < 0.0)
+            {
+                view_center_x = 0.0;
+            }
+            if(view_center_x > 1.0)
+            {
+                view_center_x = 1.0;
+            }
+            if(view_center_y < 0.0)
+            {
+                view_center_y = 0.0;
+            }
+            if(view_center_y > 1.0)
+            {
+                view_center_y = 1.0;
+            }
+
             ctx->last_mouse_x = mx;
             ctx->last_mouse_y = my;
-        } else if (!last_mouse_event.is_press) {
+        }
+        else if(!last_mouse_event.is_press)
+        {
             ctx->mouse_is_dragging = 0;
         }
-    } else if (last_mouse_event.button == 2) { // Right Button
-        if (last_mouse_event.is_press && !last_mouse_event.is_drag) {
+    }
+    else if(last_mouse_event.button == 2)      // Right Button
+    {
+        if(last_mouse_event.is_press && !last_mouse_event.is_drag)
+        {
             ctx->roi_is_dragging = 1;
             ctx->roi_start_x = mx;
             ctx->roi_start_y = my;
             ctx->roi_end_x = mx;
             ctx->roi_end_y = my;
-        } else if (last_mouse_event.is_press && last_mouse_event.is_drag && ctx->roi_is_dragging) {
+        }
+        else if(last_mouse_event.is_press && last_mouse_event.is_drag && ctx->roi_is_dragging)
+        {
             ctx->roi_end_x = mx;
             ctx->roi_end_y = my;
-        } else if (!last_mouse_event.is_press && ctx->roi_is_dragging) {
+        }
+        else if(!last_mouse_event.is_press && ctx->roi_is_dragging)
+        {
             ctx->roi_end_x = mx;
             ctx->roi_end_y = my;
             ctx->roi_is_dragging = 0;
-            
+
             int min_x = (ctx->roi_start_x < ctx->roi_end_x) ? ctx->roi_start_x : ctx->roi_end_x;
             int max_x = (ctx->roi_start_x > ctx->roi_end_x) ? ctx->roi_start_x : ctx->roi_end_x;
             int min_y = (ctx->roi_start_y < ctx->roi_end_y) ? ctx->roi_start_y : ctx->roi_end_y;
             int max_y = (ctx->roi_start_y > ctx->roi_end_y) ? ctx->roi_start_y : ctx->roi_end_y;
-            
-            if (max_x - min_x >= 2 && max_y - min_y >= 2) {
+
+            if(max_x - min_x >= 2 && max_y - min_y >= 2)
+            {
                 double roi_center_mx = (min_x + max_x) / 2.0;
                 double roi_center_my = (min_y + max_y) / 2.0;
-                
+
                 double new_cx_pixel = center_img_x + (roi_center_mx - 1.0 - center_disp_x) * step;
                 double roi_center_img_row = (roi_center_my - 1.0) * 2.0 + 0.5;
                 double new_cy_pixel = center_img_y + (roi_center_img_row - center_disp_y) * step;
-                
+
                 double roi_w_char = max_x - min_x + 1;
                 double roi_h_char = max_y - min_y + 1;
                 double new_step_x = (roi_w_char * step) / disp_cols;
                 double new_step_y = (roi_h_char * 2 * step) / disp_img_rows;
                 double new_step = fmax(new_step_x, new_step_y);
-                
+
                 view_center_x = new_cx_pixel / xsize;
                 view_center_y = new_cy_pixel / ysize;
                 view_zoom *= (step / new_step);
-                
-                if (view_center_x < 0.0) view_center_x = 0.0;
-                if (view_center_x > 1.0) view_center_x = 1.0;
-                if (view_center_y < 0.0) view_center_y = 0.0;
-                if (view_center_y > 1.0) view_center_y = 1.0;
+
+                if(view_center_x < 0.0)
+                {
+                    view_center_x = 0.0;
+                }
+                if(view_center_x > 1.0)
+                {
+                    view_center_x = 1.0;
+                }
+                if(view_center_y < 0.0)
+                {
+                    view_center_y = 0.0;
+                }
+                if(view_center_y > 1.0)
+                {
+                    view_center_y = 1.0;
+                }
             }
         }
     }
 }
 
-static void termview_handle_keyboard_event(tv_context_t *ctx, int ch) {
-    switch(ch) {
-        case 10: // ENTER key (LF)
-        case 13: // ENTER key (CR)
-        case 27: // ESC key
-            if (ctx->popup_type > 0) {
-                ctx->popup_type = 0;
-                force_redraw = 1;
+static void termview_handle_keyboard_event(tv_context_t *ctx, int ch)
+{
+    switch(ch)
+    {
+    case 10: // ENTER key (LF)
+    case 13: // ENTER key (CR)
+    case 27: // ESC key
+        if(ctx->popup_type > 0)
+        {
+            ctx->popup_type = 0;
+            force_redraw = 1;
+        }
+        break;
+    case 'q':
+        force_redraw = 1;
+        loop = 0;
+        break;
+    case 'c':
+        force_redraw = 1;
+        current_options.colormap = (current_options.colormap + 1) % COLORMAP_NB;
+        ctx->popup_type = 1;
+        clock_gettime(CLOCK_MONOTONIC, &ctx->popup_expiry_time);
+        ctx->popup_expiry_time.tv_sec += 2;
+        break;
+    case 's':
+        force_redraw = 1;
+        current_options.scale = (current_options.scale + 1) % SCALE_NB;
+        ctx->popup_type = 2;
+        clock_gettime(CLOCK_MONOTONIC, &ctx->popup_expiry_time);
+        ctx->popup_expiry_time.tv_sec += 2;
+        break;
+    case 'r':
+        force_redraw = 1;
+        current_options.range = (current_options.range + 1) % RANGE_NB;
+        ctx->popup_type = 3;
+        clock_gettime(CLOCK_MONOTONIC, &ctx->popup_expiry_time);
+        ctx->popup_expiry_time.tv_sec += 2;
+        break;
+    case 'l':
+        force_redraw = 1;
+        current_options.range_locked = !current_options.range_locked;
+        if(current_options.range_locked)
+        {
+            current_options.manual_min = current_min_val;
+            current_options.manual_max = current_max_val;
+        }
+        break;
+    case 'm':
+        force_redraw = 1;
+        ctx->input_mode = 1;
+        ctx->input_len = 0;
+        ctx->input_buf[0] = '\0';
+        break;
+    case 'M':
+        force_redraw = 1;
+        ctx->input_mode = 2;
+        ctx->input_len = 0;
+        ctx->input_buf[0] = '\0';
+        break;
+    case 'h':
+        force_redraw = 1;
+        current_options.flip_h = !current_options.flip_h;
+        break;
+    case 'v':
+        force_redraw = 1;
+        current_options.flip_v = !current_options.flip_v;
+        break;
+    case '+':
+        force_redraw = 1;
+    case '=':
+        force_redraw = 1;
+        view_zoom *= 1.2;
+        break;
+    case '-':
+        force_redraw = 1;
+    case '_':
+        force_redraw = 1;
+        view_zoom /= 1.2;
+        if(view_zoom < 0.1)
+        {
+            view_zoom = 0.1;
+        }
+        break;
+    case '0':
+        force_redraw = 1;
+        view_zoom = 1.0;
+        view_center_x = 0.5;
+        view_center_y = 0.5;
+        break;
+    case TV_KEY_LEFT:
+        force_redraw = 1;
+        view_center_x -= 0.1 / view_zoom;
+        if(view_center_x < 0.0)
+        {
+            view_center_x = 0.0;
+        }
+        break;
+    case TV_KEY_RIGHT:
+        force_redraw = 1;
+        view_center_x += 0.1 / view_zoom;
+        if(view_center_x > 1.0)
+        {
+            view_center_x = 1.0;
+        }
+        break;
+    case TV_KEY_UP:
+        force_redraw = 1;
+        if(ctx->popup_type == 1)
+        {
+            current_options.colormap = (current_options.colormap + COLORMAP_NB - 1) % COLORMAP_NB;
+            clock_gettime(CLOCK_MONOTONIC, &ctx->popup_expiry_time);
+            ctx->popup_expiry_time.tv_sec += 2;
+        }
+        else if(ctx->popup_type == 2)
+        {
+            current_options.scale = (current_options.scale + SCALE_NB - 1) % SCALE_NB;
+            clock_gettime(CLOCK_MONOTONIC, &ctx->popup_expiry_time);
+            ctx->popup_expiry_time.tv_sec += 2;
+        }
+        else if(ctx->popup_type == 3)
+        {
+            current_options.range = (current_options.range + RANGE_NB - 1) % RANGE_NB;
+            clock_gettime(CLOCK_MONOTONIC, &ctx->popup_expiry_time);
+            ctx->popup_expiry_time.tv_sec += 2;
+        }
+        else
+        {
+            view_center_y -= 0.1 / view_zoom;
+            if(view_center_y < 0.0)
+            {
+                view_center_y = 0.0;
             }
-            break;
-        case 'q': force_redraw = 1; loop = 0; break;
-        case 'c': force_redraw = 1; 
-            current_options.colormap = (current_options.colormap + 1) % COLORMAP_NB; 
-            ctx->popup_type = 1;
+        }
+        break;
+    case TV_KEY_DOWN:
+        force_redraw = 1;
+        if(ctx->popup_type == 1)
+        {
+            current_options.colormap = (current_options.colormap + 1) % COLORMAP_NB;
             clock_gettime(CLOCK_MONOTONIC, &ctx->popup_expiry_time);
             ctx->popup_expiry_time.tv_sec += 2;
-            break;
-        case 's': force_redraw = 1; 
-            current_options.scale = (current_options.scale + 1) % SCALE_NB; 
-            ctx->popup_type = 2;
+        }
+        else if(ctx->popup_type == 2)
+        {
+            current_options.scale = (current_options.scale + 1) % SCALE_NB;
             clock_gettime(CLOCK_MONOTONIC, &ctx->popup_expiry_time);
             ctx->popup_expiry_time.tv_sec += 2;
-            break;
-        case 'r': force_redraw = 1;
+        }
+        else if(ctx->popup_type == 3)
+        {
             current_options.range = (current_options.range + 1) % RANGE_NB;
-            ctx->popup_type = 3;
             clock_gettime(CLOCK_MONOTONIC, &ctx->popup_expiry_time);
             ctx->popup_expiry_time.tv_sec += 2;
-            break;
-        case 'l': force_redraw = 1;
-            current_options.range_locked = !current_options.range_locked;
-            if (current_options.range_locked) {
-                current_options.manual_min = current_min_val;
-                current_options.manual_max = current_max_val;
+        }
+        else
+        {
+            view_center_y += 0.1 / view_zoom;
+            if(view_center_y > 1.0)
+            {
+                view_center_y = 1.0;
             }
-            break;
-        case 'm': force_redraw = 1; ctx->input_mode = 1; ctx->input_len = 0; ctx->input_buf[0] = '\0'; break;
-        case 'M': force_redraw = 1; ctx->input_mode = 2; ctx->input_len = 0; ctx->input_buf[0] = '\0'; break;
-        case 'h': force_redraw = 1; current_options.flip_h = !current_options.flip_h; break;
-        case 'v': force_redraw = 1; current_options.flip_v = !current_options.flip_v; break;
-        case '+': force_redraw = 1;
-        case '=': force_redraw = 1; view_zoom *= 1.2; break;
-        case '-': force_redraw = 1;
-        case '_': force_redraw = 1;
-            view_zoom /= 1.2;
-            if (view_zoom < 0.1) view_zoom = 0.1;
-            break;
-        case '0': force_redraw = 1;
-            view_zoom = 1.0;
-            view_center_x = 0.5;
-            view_center_y = 0.5;
-            break;
-        case TV_KEY_LEFT: force_redraw = 1;
-            view_center_x -= 0.1 / view_zoom;
-            if (view_center_x < 0.0) view_center_x = 0.0;
-            break;
-        case TV_KEY_RIGHT: force_redraw = 1;
-            view_center_x += 0.1 / view_zoom;
-            if (view_center_x > 1.0) view_center_x = 1.0;
-            break;
-        case TV_KEY_UP: force_redraw = 1;
-            if (ctx->popup_type == 1) {
-                current_options.colormap = (current_options.colormap + COLORMAP_NB - 1) % COLORMAP_NB;
-                clock_gettime(CLOCK_MONOTONIC, &ctx->popup_expiry_time);
-                ctx->popup_expiry_time.tv_sec += 2;
-            } else if (ctx->popup_type == 2) {
-                current_options.scale = (current_options.scale + SCALE_NB - 1) % SCALE_NB;
-                clock_gettime(CLOCK_MONOTONIC, &ctx->popup_expiry_time);
-                ctx->popup_expiry_time.tv_sec += 2;
-            } else if (ctx->popup_type == 3) {
-                current_options.range = (current_options.range + RANGE_NB - 1) % RANGE_NB;
-                clock_gettime(CLOCK_MONOTONIC, &ctx->popup_expiry_time);
-                ctx->popup_expiry_time.tv_sec += 2;
-            } else {
-                view_center_y -= 0.1 / view_zoom;
-                if (view_center_y < 0.0) view_center_y = 0.0;
-            }
-            break;
-        case TV_KEY_DOWN: force_redraw = 1;
-            if (ctx->popup_type == 1) {
-                current_options.colormap = (current_options.colormap + 1) % COLORMAP_NB;
-                clock_gettime(CLOCK_MONOTONIC, &ctx->popup_expiry_time);
-                ctx->popup_expiry_time.tv_sec += 2;
-            } else if (ctx->popup_type == 2) {
-                current_options.scale = (current_options.scale + 1) % SCALE_NB;
-                clock_gettime(CLOCK_MONOTONIC, &ctx->popup_expiry_time);
-                ctx->popup_expiry_time.tv_sec += 2;
-            } else if (ctx->popup_type == 3) {
-                current_options.range = (current_options.range + 1) % RANGE_NB;
-                clock_gettime(CLOCK_MONOTONIC, &ctx->popup_expiry_time);
-                ctx->popup_expiry_time.tv_sec += 2;
-            } else {
-                view_center_y += 0.1 / view_zoom;
-                if (view_center_y > 1.0) view_center_y = 1.0;
-            }
-            break;
-        case '<': force_redraw = 1;
-        case ',': force_redraw = 1;
-            ctx->target_fps -= 1;
-            if (ctx->target_fps < 1) ctx->target_fps = 1;
-            break;
-        case '>': force_redraw = 1;
-        case '.': force_redraw = 1;
-            ctx->target_fps += 1;
-            if (ctx->target_fps > 120) ctx->target_fps = 120;
-            break;
-        case TV_KEY_MOUSE: 
-            termview_handle_mouse_event(ctx);
-            break;
+        }
+        break;
+    case '<':
+        force_redraw = 1;
+    case ',':
+        force_redraw = 1;
+        ctx->target_fps -= 1;
+        if(ctx->target_fps < 1)
+        {
+            ctx->target_fps = 1;
+        }
+        break;
+    case '>':
+        force_redraw = 1;
+    case '.':
+        force_redraw = 1;
+        ctx->target_fps += 1;
+        if(ctx->target_fps > 120)
+        {
+            ctx->target_fps = 120;
+        }
+        break;
+    case TV_KEY_MOUSE:
+        termview_handle_mouse_event(ctx);
+        break;
     }
 }
 
-static void termview_render_image(tv_context_t *ctx, int disp_char_rows, int disp_cols, double center_img_x, double center_img_y, double sign_x, double sign_y, double step, uint32_t xsize, uint32_t ysize, double min_val, double max_val) {
+static void termview_render_image(tv_context_t *ctx, int disp_char_rows, int disp_cols,
+                                  double center_img_x, double center_img_y, double sign_x, double sign_y, double step, uint32_t xsize,
+                                  uint32_t ysize, double min_val, double max_val)
+{
 #define IS_IN_BOUNDS(jj, yy) \
     ( ((int)(center_img_x + sign_x * ((jj) - center_disp_x) * step) >= 0) && \
       ((int)(center_img_x + sign_x * ((jj) - center_disp_x) * step) < (int)xsize) && \
@@ -622,334 +1081,624 @@ static void termview_render_image(tv_context_t *ctx, int disp_char_rows, int dis
     double center_disp_x = disp_cols / 2.0;
     double center_disp_y = (disp_char_rows * 2) / 2.0;
 
-    for (int i = 0; i < disp_char_rows; i++) {
-        for (int j = 0; j < disp_cols; j++) {
-            int img_y_top = (int)(center_img_y + sign_y * ((i*2) - center_disp_y) * step);
+    for(int i = 0; i < disp_char_rows; i++)
+    {
+        for(int j = 0; j < disp_cols; j++)
+        {
+            int img_y_top = (int)(center_img_y + sign_y * ((i * 2) - center_disp_y) * step);
             int img_x_top = (int)(center_img_x + sign_x * (j - center_disp_x) * step);
-            bool in_bounds_top = (img_x_top >= 0 && img_x_top < (int)xsize && img_y_top >= 0 && img_y_top < (int)ysize);
+            bool in_bounds_top = (img_x_top >= 0 && img_x_top < (int)xsize && img_y_top >= 0
+                                  && img_y_top < (int)ysize);
 
-            int img_y_bot = (int)(center_img_y + sign_y * ((i*2+1) - center_disp_y) * step);
+            int img_y_bot = (int)(center_img_y + sign_y * ((i * 2 + 1) - center_disp_y) * step);
             int img_x_bot = (int)(center_img_x + sign_x * (j - center_disp_x) * step);
-            bool in_bounds_bot = (img_x_bot >= 0 && img_x_bot < (int)xsize && img_y_bot >= 0 && img_y_bot < (int)ysize);
+            bool in_bounds_bot = (img_x_bot >= 0 && img_x_bot < (int)xsize && img_y_bot >= 0
+                                  && img_y_bot < (int)ysize);
 
             tv_cell_t *cell = &ctx->screen[i * wcol + j];
 
-            if (!in_bounds_top && !in_bounds_bot) {
-                bool near_top = IS_IN_BOUNDS(j-1, i*2) || IS_IN_BOUNDS(j+1, i*2) || IS_IN_BOUNDS(j, i*2-1) || IS_IN_BOUNDS(j, i*2+1);
-                bool near_bot = IS_IN_BOUNDS(j-1, i*2+1) || IS_IN_BOUNDS(j+1, i*2+1) || IS_IN_BOUNDS(j, i*2) || IS_IN_BOUNDS(j, i*2+2);
-                if (!near_top && !near_bot) continue; // left as space
+            if(!in_bounds_top && !in_bounds_bot)
+            {
+                bool near_top = IS_IN_BOUNDS(j - 1, i * 2) || IS_IN_BOUNDS(j + 1, i * 2)
+                                || IS_IN_BOUNDS(j, i * 2 - 1) || IS_IN_BOUNDS(j, i * 2 + 1);
+                bool near_bot = IS_IN_BOUNDS(j - 1, i * 2 + 1) || IS_IN_BOUNDS(j + 1, i * 2 + 1)
+                                || IS_IN_BOUNDS(j, i * 2) || IS_IN_BOUNDS(j, i * 2 + 2);
+                if(!near_top && !near_bot)
+                {
+                    continue;    // left as space
+                }
             }
 
-            double val_top = in_bounds_top ? ctx->display_buffer[(i*2)*disp_cols + j] : 0.0;
-            double val_bot = in_bounds_bot ? ctx->display_buffer[(i*2+1)*disp_cols + j] : 0.0;
+            double val_top = in_bounds_top ? ctx->display_buffer[(i * 2) * disp_cols + j] : 0.0;
+            double val_bot = in_bounds_bot ? ctx->display_buffer[(i * 2 + 1) * disp_cols + j] : 0.0;
 
             double norm_top = (val_top - min_val) / (max_val - min_val);
-            if (norm_top < 0) norm_top = 0; if (norm_top > 1) norm_top = 1;
-            
+            if(norm_top < 0)
+            {
+                norm_top = 0;
+            }
+            if(norm_top > 1)
+            {
+                norm_top = 1;
+            }
+
             double norm_bot = (val_bot - min_val) / (max_val - min_val);
-            if (norm_bot < 0) norm_bot = 0; if (norm_bot > 1) norm_bot = 1;
+            if(norm_bot < 0)
+            {
+                norm_bot = 0;
+            }
+            if(norm_bot > 1)
+            {
+                norm_bot = 1;
+            }
 
             rgb_t rgb_top = colormap_lut[(int)(norm_top * 1023)];
             rgb_t rgb_bot = colormap_lut[(int)(norm_bot * 1023)];
 
-            if (!in_bounds_top) {
-                if (IS_IN_BOUNDS(j-1, i*2) || IS_IN_BOUNDS(j+1, i*2) || IS_IN_BOUNDS(j, i*2-1) || IS_IN_BOUNDS(j, i*2+1)) {
-                    rgb_top = (rgb_t){64, 64, 64}; // Dark gray border
-                } else {
-                    rgb_top = (rgb_t){0,0,0};
+            if(!in_bounds_top)
+            {
+                if(IS_IN_BOUNDS(j - 1, i * 2) || IS_IN_BOUNDS(j + 1, i * 2) || IS_IN_BOUNDS(j, i * 2 - 1)
+                        || IS_IN_BOUNDS(j, i * 2 + 1))
+                {
+                    rgb_top = (rgb_t)
+                    {
+                        64, 64, 64
+                    }; // Dark gray border
+                }
+                else
+                {
+                    rgb_top = (rgb_t)
+                    {
+                        0, 0, 0
+                    };
                 }
             }
 
-            if (!in_bounds_bot) {
-                if (IS_IN_BOUNDS(j-1, i*2+1) || IS_IN_BOUNDS(j+1, i*2+1) || IS_IN_BOUNDS(j, i*2) || IS_IN_BOUNDS(j, i*2+2)) {
-                    rgb_bot = (rgb_t){64, 64, 64}; // Dark gray border
-                } else {
-                    rgb_bot = (rgb_t){0,0,0};
+            if(!in_bounds_bot)
+            {
+                if(IS_IN_BOUNDS(j - 1, i * 2 + 1) || IS_IN_BOUNDS(j + 1, i * 2 + 1) || IS_IN_BOUNDS(j, i * 2)
+                        || IS_IN_BOUNDS(j, i * 2 + 2))
+                {
+                    rgb_bot = (rgb_t)
+                    {
+                        64, 64, 64
+                    }; // Dark gray border
+                }
+                else
+                {
+                    rgb_bot = (rgb_t)
+                    {
+                        0, 0, 0
+                    };
                 }
             }
 
-            if (ctx->roi_is_dragging) {
+            if(ctx->roi_is_dragging)
+            {
                 int rx_min = (ctx->roi_start_x < ctx->roi_end_x) ? ctx->roi_start_x : ctx->roi_end_x;
                 int rx_max = (ctx->roi_start_x > ctx->roi_end_x) ? ctx->roi_start_x : ctx->roi_end_x;
                 int ry_min = (ctx->roi_start_y < ctx->roi_end_y) ? ctx->roi_start_y : ctx->roi_end_y;
                 int ry_max = (ctx->roi_start_y > ctx->roi_end_y) ? ctx->roi_start_y : ctx->roi_end_y;
-                
+
                 int term_x = j + 1;
                 int term_y = i + 1;
-                
-                if (term_x >= rx_min && term_x <= rx_max && term_y >= ry_min && term_y <= ry_max) {
-                    if (term_x == rx_min || term_x == rx_max || term_y == ry_min || term_y == ry_max) {
-                        rgb_top = (rgb_t){255, 255, 0}; // Yellow border
-                        rgb_bot = (rgb_t){255, 255, 0};
-                    } else {
+
+                if(term_x >= rx_min && term_x <= rx_max && term_y >= ry_min && term_y <= ry_max)
+                {
+                    if(term_x == rx_min || term_x == rx_max || term_y == ry_min || term_y == ry_max)
+                    {
+                        rgb_top = (rgb_t)
+                        {
+                            255, 255, 0
+                        }; // Yellow border
+                        rgb_bot = (rgb_t)
+                        {
+                            255, 255, 0
+                        };
+                    }
+                    else
+                    {
                         // Dim the inside of the ROI
-                        rgb_top.r /= 2; rgb_top.g /= 2; rgb_top.b /= 2;
-                        rgb_bot.r /= 2; rgb_bot.g /= 2; rgb_bot.b /= 2;
+                        rgb_top.r /= 2;
+                        rgb_top.g /= 2;
+                        rgb_top.b /= 2;
+                        rgb_bot.r /= 2;
+                        rgb_bot.g /= 2;
+                        rgb_bot.b /= 2;
                     }
                 }
             }
 
-            cell->bg_r = rgb_top.r; cell->bg_g = rgb_top.g; cell->bg_b = rgb_top.b;
-            cell->fg_r = rgb_bot.r; cell->fg_g = rgb_bot.g; cell->fg_b = rgb_bot.b;
-            cell->ch[0] = (char)0xE2; cell->ch[1] = (char)0x96; cell->ch[2] = (char)0x84; cell->ch[3] = '\0';
+            cell->bg_r = rgb_top.r;
+            cell->bg_g = rgb_top.g;
+            cell->bg_b = rgb_top.b;
+            cell->fg_r = rgb_bot.r;
+            cell->fg_g = rgb_bot.g;
+            cell->fg_b = rgb_bot.b;
+            cell->ch[0] = (char)0xE2;
+            cell->ch[1] = (char)0x96;
+            cell->ch[2] = (char)0x84;
+            cell->ch[3] = '\0';
         }
     }
 #undef IS_IN_BOUNDS
 }
 
-static void termview_render_colorbar(tv_context_t *ctx, int disp_char_rows, int bar_col_start, double min_val, double max_val) {
-    for (int i = 0; i < disp_char_rows; i++) {
+static void termview_render_colorbar(tv_context_t *ctx, int disp_char_rows, int bar_col_start,
+                                     double min_val, double max_val)
+{
+    for(int i = 0; i < disp_char_rows; i++)
+    {
         double norm_val = 1.0 - (double)i / (disp_char_rows - 1);
         rgb_t rgb = colormap_lut[(int)(norm_val * 1023)];
-        
+
         tv_cell_t *c1 = &ctx->screen[i * wcol + bar_col_start - 1];
         tv_cell_t *c2 = &ctx->screen[i * wcol + bar_col_start];
-        c1->fg_r = rgb.r; c1->fg_g = rgb.g; c1->fg_b = rgb.b;
-        c1->bg_r = 0; c1->bg_g = 0; c1->bg_b = 0;
-        c1->ch[0] = (char)0xE2; c1->ch[1] = (char)0x96; c1->ch[2] = (char)0x88; c1->ch[3] = '\0';
-        
-        c2->fg_r = rgb.r; c2->fg_g = rgb.g; c2->fg_b = rgb.b;
-        c2->bg_r = 0; c2->bg_g = 0; c2->bg_b = 0;
-        c2->ch[0] = (char)0xE2; c2->ch[1] = (char)0x96; c2->ch[2] = (char)0x88; c2->ch[3] = '\0';
+        c1->fg_r = rgb.r;
+        c1->fg_g = rgb.g;
+        c1->fg_b = rgb.b;
+        c1->bg_r = 0;
+        c1->bg_g = 0;
+        c1->bg_b = 0;
+        c1->ch[0] = (char)0xE2;
+        c1->ch[1] = (char)0x96;
+        c1->ch[2] = (char)0x88;
+        c1->ch[3] = '\0';
+
+        c2->fg_r = rgb.r;
+        c2->fg_g = rgb.g;
+        c2->fg_b = rgb.b;
+        c2->bg_r = 0;
+        c2->bg_g = 0;
+        c2->bg_b = 0;
+        c2->ch[0] = (char)0xE2;
+        c2->ch[1] = (char)0x96;
+        c2->ch[2] = (char)0x88;
+        c2->ch[3] = '\0';
 
         char label[32];
         int label_len = 0;
-        if (i == 0) label_len = snprintf(label, sizeof(label), "%.2g", max_val);
-        else if (i == disp_char_rows/2) label_len = snprintf(label, sizeof(label), "%.2g", (min_val+max_val)/2);
-        else if (i == disp_char_rows-1) label_len = snprintf(label, sizeof(label), "%.2g", min_val);
+        if(i == 0)
+        {
+            label_len = snprintf(label, sizeof(label), "%.2g", max_val);
+        }
+        else if(i == disp_char_rows / 2)
+        {
+            label_len = snprintf(label, sizeof(label), "%.2g", (min_val + max_val) / 2);
+        }
+        else if(i == disp_char_rows - 1)
+        {
+            label_len = snprintf(label, sizeof(label), "%.2g", min_val);
+        }
 
-        for(int k = 0; k < label_len; k++) {
-            if (bar_col_start + 2 + k < wcol) {
+        for(int k = 0; k < label_len; k++)
+        {
+            if(bar_col_start + 2 + k < wcol)
+            {
                 tv_cell_t *lc = &ctx->screen[i * wcol + bar_col_start + 2 + k];
-                lc->ch[0] = label[k]; lc->ch[1] = '\0';
+                lc->ch[0] = label[k];
+                lc->ch[1] = '\0';
             }
         }
     }
 }
 
-static void termview_render_infobar(tv_context_t *ctx, uint32_t xsize, uint32_t ysize, double step, double min_val, double max_val) {
+static void termview_render_infobar(tv_context_t *ctx, uint32_t xsize, uint32_t ysize, double step,
+                                    double min_val, double max_val)
+{
     int info_row = wrow - 3;
-    
-    const char* cmap_str = "GREYSCALE";
-    switch(current_options.colormap) {
-        case COLORMAP_HEAT: cmap_str = "HEAT"; break;
-        case COLORMAP_COLD: cmap_str = "COLD"; break;
-        case COLORMAP_JET: cmap_str = "JET"; break;
-        case COLORMAP_INFERNO: cmap_str = "INFERNO"; break;
-        case COLORMAP_VIRIDIS: cmap_str = "VIRIDIS"; break;
-        case COLORMAP_MAGMA: cmap_str = "MAGMA"; break;
-        case COLORMAP_PLASMA: cmap_str = "PLASMA"; break;
-        case COLORMAP_BONE: cmap_str = "BONE"; break;
-        case COLORMAP_RAINBOW: cmap_str = "RAINBOW"; break;
-        case COLORMAP_TURBO: cmap_str = "TURBO"; break;
-        case COLORMAP_OCEAN: cmap_str = "OCEAN"; break;
-        case COLORMAP_COPPER: cmap_str = "COPPER"; break;
-        case COLORMAP_SPRING: cmap_str = "SPRING"; break;
-        case COLORMAP_SUMMER: cmap_str = "SUMMER"; break;
-        case COLORMAP_AUTUMN: cmap_str = "AUTUMN"; break;
-        case COLORMAP_WINTER: cmap_str = "WINTER"; break;
-        default: break;
+
+    const char *cmap_str = "GREYSCALE";
+    switch(current_options.colormap)
+    {
+    case COLORMAP_HEAT:
+        cmap_str = "HEAT";
+        break;
+    case COLORMAP_COLD:
+        cmap_str = "COLD";
+        break;
+    case COLORMAP_JET:
+        cmap_str = "JET";
+        break;
+    case COLORMAP_INFERNO:
+        cmap_str = "INFERNO";
+        break;
+    case COLORMAP_VIRIDIS:
+        cmap_str = "VIRIDIS";
+        break;
+    case COLORMAP_MAGMA:
+        cmap_str = "MAGMA";
+        break;
+    case COLORMAP_PLASMA:
+        cmap_str = "PLASMA";
+        break;
+    case COLORMAP_BONE:
+        cmap_str = "BONE";
+        break;
+    case COLORMAP_RAINBOW:
+        cmap_str = "RAINBOW";
+        break;
+    case COLORMAP_TURBO:
+        cmap_str = "TURBO";
+        break;
+    case COLORMAP_OCEAN:
+        cmap_str = "OCEAN";
+        break;
+    case COLORMAP_COPPER:
+        cmap_str = "COPPER";
+        break;
+    case COLORMAP_SPRING:
+        cmap_str = "SPRING";
+        break;
+    case COLORMAP_SUMMER:
+        cmap_str = "SUMMER";
+        break;
+    case COLORMAP_AUTUMN:
+        cmap_str = "AUTUMN";
+        break;
+    case COLORMAP_WINTER:
+        cmap_str = "WINTER";
+        break;
+    default:
+        break;
     }
-    const char* scale_str = "LIN";
-    switch(current_options.scale) {
-        case SCALE_SQRT: scale_str = "SQRT"; break;
-        case SCALE_LOG: scale_str = "LOG"; break;
-        case SCALE_LOG_STRONG: scale_str = "LOG_STR"; break;
-        case SCALE_LOG_EXTREME: scale_str = "LOG_EXT"; break;
-        case SCALE_ASINH: scale_str = "ASINH"; break;
-        case SCALE_SQUARED: scale_str = "SQUARED"; break;
-        case SCALE_CUBED: scale_str = "CUBED"; break;
-        default: break;
+    const char *scale_str = "LIN";
+    switch(current_options.scale)
+    {
+    case SCALE_SQRT:
+        scale_str = "SQRT";
+        break;
+    case SCALE_LOG:
+        scale_str = "LOG";
+        break;
+    case SCALE_LOG_STRONG:
+        scale_str = "LOG_STR";
+        break;
+    case SCALE_LOG_EXTREME:
+        scale_str = "LOG_EXT";
+        break;
+    case SCALE_ASINH:
+        scale_str = "ASINH";
+        break;
+    case SCALE_SQUARED:
+        scale_str = "SQUARED";
+        break;
+    case SCALE_CUBED:
+        scale_str = "CUBED";
+        break;
+    default:
+        break;
     }
-    const char* range_str = "MINMAX";
-    switch(current_options.range) {
-        case RANGE_001_999: range_str = "0.1-99.9%"; break;
-        case RANGE_005_995: range_str = "0.5-99.5%"; break;
-        case RANGE_01_99: range_str = "1-99%"; break;
-        case RANGE_05_95: range_str = "5-95%"; break;
-        case RANGE_10_90: range_str = "10-90%"; break;
-        case RANGE_15_85: range_str = "15-85%"; break;
-        case RANGE_20_80: range_str = "20-80%"; break;
-        default: break;
+    const char *range_str = "MINMAX";
+    switch(current_options.range)
+    {
+    case RANGE_001_999:
+        range_str = "0.1-99.9%";
+        break;
+    case RANGE_005_995:
+        range_str = "0.5-99.5%";
+        break;
+    case RANGE_01_99:
+        range_str = "1-99%";
+        break;
+    case RANGE_05_95:
+        range_str = "5-95%";
+        break;
+    case RANGE_10_90:
+        range_str = "10-90%";
+        break;
+    case RANGE_15_85:
+        range_str = "15-85%";
+        break;
+    case RANGE_20_80:
+        range_str = "20-80%";
+        break;
+    default:
+        break;
     }
 
     char info[256];
     int len;
-    
-    len = snprintf(info, sizeof(info), "Image: %s [%d x %d] Type: %d  |  CPU: %5.1f%%  UI: %3d FPS  Stream: %5.1f Hz", 
-                       ctx->img->md[0].name, xsize, ysize, ctx->img->md[0].datatype, ctx->current_cpu_usage, ctx->target_fps, ctx->current_stream_fps);
-    for(int k=0; k<len && k<wcol; k++) { 
+
+    len = snprintf(info, sizeof(info),
+                   "Image: %s [%d x %d] Type: %d  |  CPU: %5.1f%%  UI: %3d FPS  Stream: %5.1f Hz",
+                   ctx->img->md[0].name, xsize, ysize, ctx->img->md[0].datatype, ctx->current_cpu_usage,
+                   ctx->target_fps, ctx->current_stream_fps);
+    for(int k = 0; k < len && k < wcol; k++)
+    {
         tv_cell_t *c = &ctx->screen[info_row * wcol + k];
-        c->ch[0] = info[k]; 
+        c->ch[0] = info[k];
         c->ch[1] = '\0';
         int name_len = strlen(ctx->img->md[0].name);
-        if (k >= 7 && k < 7 + name_len) {
-            c->fg_r = 0; c->fg_g = 255; c->fg_b = 255; // Cyan
+        if(k >= 7 && k < 7 + name_len)
+        {
+            c->fg_r = 0;
+            c->fg_g = 255;
+            c->fg_b = 255; // Cyan
         }
     }
-    len = snprintf(info, sizeof(info), "Val: [%.4g : %.4g] Zoom: %.2fx (%.2f px/char H, %.2f px/char V)", min_val, max_val, view_zoom, step, step * 2.0);
-    for(int k=0; k<len && k<wcol; k++) { ctx->screen[(info_row+1) * wcol + k].ch[0] = info[k]; ctx->screen[(info_row+1) * wcol + k].ch[1] = '\0'; }
+    len = snprintf(info, sizeof(info),
+                   "Val: [%.4g : %.4g] Zoom: %.2fx (%.2f px/char H, %.2f px/char V)", min_val, max_val, view_zoom,
+                   step, step * 2.0);
+    for(int k = 0; k < len && k < wcol; k++)
+    {
+        ctx->screen[(info_row + 1) * wcol + k].ch[0] = info[k];
+        ctx->screen[(info_row + 1) * wcol + k].ch[1] = '\0';
+    }
 
-    if (ctx->input_mode > 0) {
-        len = snprintf(info, sizeof(info), "Enter Manual %s: %s_", ctx->input_mode == 1 ? "Min" : "Max", ctx->input_buf);
-        for(int k=0; k<len && k<wcol; k++) { 
-            tv_cell_t *c = &ctx->screen[(info_row+2) * wcol + k];
-            c->ch[0] = info[k]; c->ch[1] = '\0';
-            c->fg_r = 255; c->fg_g = 255; c->fg_b = 0; // Yellow text
+    if(ctx->input_mode > 0)
+    {
+        len = snprintf(info, sizeof(info), "Enter Manual %s: %s_", ctx->input_mode == 1 ? "Min" : "Max",
+                       ctx->input_buf);
+        for(int k = 0; k < len && k < wcol; k++)
+        {
+            tv_cell_t *c = &ctx->screen[(info_row + 2) * wcol + k];
+            c->ch[0] = info[k];
+            c->ch[1] = '\0';
+            c->fg_r = 255;
+            c->fg_g = 255;
+            c->fg_b = 0; // Yellow text
         }
-        for(int k=len; k<wcol; k++) {
-            ctx->screen[(info_row+2) * wcol + k].ch[0] = ' '; ctx->screen[(info_row+2) * wcol + k].ch[1] = '\0';
+        for(int k = len; k < wcol; k++)
+        {
+            ctx->screen[(info_row + 2) * wcol + k].ch[0] = ' ';
+            ctx->screen[(info_row + 2) * wcol + k].ch[1] = '\0';
         }
-    } else {
+    }
+    else
+    {
         char info1[128];
-        int len1 = snprintf(info1, sizeof(info1), "[C]map: %s  [S]cale: %s  [R]ange: %s [", cmap_str, scale_str, range_str);
-        const char* lock_str = current_options.range_locked ? "LOCKED" : "AUTO";
+        int len1 = snprintf(info1, sizeof(info1), "[C]map: %s  [S]cale: %s  [R]ange: %s [", cmap_str,
+                            scale_str, range_str);
+        const char *lock_str = current_options.range_locked ? "LOCKED" : "AUTO";
         int lock_len = strlen(lock_str);
         char info2[256];
         int len2 = snprintf(info2, sizeof(info2), "%s%s]  (< >:FPS l:Lock m/M:MinMax ", info1, lock_str);
-        
-        const char* h_str = current_options.flip_h ? "h:FLIPH" : "h:fliph";
-        const char* v_str = current_options.flip_v ? "v:FLIPV" : "v:flipv";
-        
+
+        const char *h_str = current_options.flip_h ? "h:FLIPH" : "h:fliph";
+        const char *v_str = current_options.flip_v ? "v:FLIPV" : "v:flipv";
+
         len = snprintf(info, sizeof(info), "%s%s %s q:Quit)", info2, h_str, v_str);
 
-        for(int k=0; k<len && k<wcol; k++) { 
-            tv_cell_t *c = &ctx->screen[(info_row+2) * wcol + k];
-            c->ch[0] = info[k]; c->ch[1] = '\0';
-            if (k >= len1 && k < len1 + lock_len) {
-                if (current_options.range_locked) {
-                    c->fg_r = 255; c->fg_g = 50; c->fg_b = 50; // Red for Locked
-                } else {
-                    c->fg_r = 50; c->fg_g = 255; c->fg_b = 50; // Green for Auto
+        for(int k = 0; k < len && k < wcol; k++)
+        {
+            tv_cell_t *c = &ctx->screen[(info_row + 2) * wcol + k];
+            c->ch[0] = info[k];
+            c->ch[1] = '\0';
+            if(k >= len1 && k < len1 + lock_len)
+            {
+                if(current_options.range_locked)
+                {
+                    c->fg_r = 255;
+                    c->fg_g = 50;
+                    c->fg_b = 50; // Red for Locked
+                }
+                else
+                {
+                    c->fg_r = 50;
+                    c->fg_g = 255;
+                    c->fg_b = 50; // Green for Auto
                 }
             }
-            if (current_options.flip_h && k >= len2 && k < len2 + (int)strlen(h_str)) {
-                c->fg_r = 255; c->fg_g = 255; c->fg_b = 0; // Yellow
+            if(current_options.flip_h && k >= len2 && k < len2 + (int)strlen(h_str))
+            {
+                c->fg_r = 255;
+                c->fg_g = 255;
+                c->fg_b = 0; // Yellow
             }
-            if (current_options.flip_v && k >= len2 + (int)strlen(h_str) + 1 && k < len2 + (int)strlen(h_str) + 1 + (int)strlen(v_str)) {
-                c->fg_r = 255; c->fg_g = 255; c->fg_b = 0; // Yellow
+            if(current_options.flip_v && k >= len2 + (int)strlen(h_str) + 1
+                    && k < len2 + (int)strlen(h_str) + 1 + (int)strlen(v_str))
+            {
+                c->fg_r = 255;
+                c->fg_g = 255;
+                c->fg_b = 0; // Yellow
             }
         }
-        for(int k=len; k<wcol; k++) {
-            ctx->screen[(info_row+2) * wcol + k].ch[0] = ' '; ctx->screen[(info_row+2) * wcol + k].ch[1] = '\0';
+        for(int k = len; k < wcol; k++)
+        {
+            ctx->screen[(info_row + 2) * wcol + k].ch[0] = ' ';
+            ctx->screen[(info_row + 2) * wcol + k].ch[1] = '\0';
         }
     }
 }
 
-static void termview_render_popup(tv_context_t *ctx, int disp_char_rows, int disp_cols) {
-    if (ctx->popup_type <= 0) return;
+static void termview_render_popup(tv_context_t *ctx, int disp_char_rows, int disp_cols)
+{
+    if(ctx->popup_type <= 0)
+    {
+        return;
+    }
     int num_opts = 0;
-    const char* title = "";
-    const char* opts[32];
+    const char *title = "";
+    const char *opts[32];
     int selected_idx = 0;
     int box_w = 16;
-    if (ctx->popup_type == 1) {
+    if(ctx->popup_type == 1)
+    {
         title = "COLORMAP";
-        opts[0] = "GREYSCALE"; opts[1] = "HEAT"; opts[2] = "COLD"; opts[3] = "JET"; opts[4] = "INFERNO"; opts[5] = "VIRIDIS";
-        opts[6] = "MAGMA"; opts[7] = "PLASMA"; opts[8] = "BONE";
-        opts[9] = "RAINBOW"; opts[10] = "TURBO"; opts[11] = "OCEAN"; opts[12] = "COPPER"; opts[13] = "SPRING";
-        opts[14] = "SUMMER"; opts[15] = "AUTUMN"; opts[16] = "WINTER";
+        opts[0] = "GREYSCALE";
+        opts[1] = "HEAT";
+        opts[2] = "COLD";
+        opts[3] = "JET";
+        opts[4] = "INFERNO";
+        opts[5] = "VIRIDIS";
+        opts[6] = "MAGMA";
+        opts[7] = "PLASMA";
+        opts[8] = "BONE";
+        opts[9] = "RAINBOW";
+        opts[10] = "TURBO";
+        opts[11] = "OCEAN";
+        opts[12] = "COPPER";
+        opts[13] = "SPRING";
+        opts[14] = "SUMMER";
+        opts[15] = "AUTUMN";
+        opts[16] = "WINTER";
         num_opts = COLORMAP_NB;
         selected_idx = current_options.colormap;
         box_w = 40; // Wider box to fit colormap preview
-    } else if (ctx->popup_type == 2) {
+    }
+    else if(ctx->popup_type == 2)
+    {
         title = "SCALE";
-        opts[0] = "LINEAR"; opts[1] = "SQRT"; opts[2] = "LOG"; opts[3] = "LOG_STRONG"; opts[4] = "LOG_EXTREME"; opts[5] = "ASINH"; opts[6] = "SQUARED"; opts[7] = "CUBED";
+        opts[0] = "LINEAR";
+        opts[1] = "SQRT";
+        opts[2] = "LOG";
+        opts[3] = "LOG_STRONG";
+        opts[4] = "LOG_EXTREME";
+        opts[5] = "ASINH";
+        opts[6] = "SQUARED";
+        opts[7] = "CUBED";
         num_opts = SCALE_NB;
         selected_idx = current_options.scale;
-    } else if (ctx->popup_type == 3) {
+    }
+    else if(ctx->popup_type == 3)
+    {
         title = "RANGE";
-        opts[0] = "MINMAX"; opts[1] = "0.1-99.9%"; opts[2] = "0.5-99.5%"; opts[3] = "1-99%"; opts[4] = "5-95%"; opts[5] = "10-90%"; opts[6] = "15-85%"; opts[7] = "20-80%";
+        opts[0] = "MINMAX";
+        opts[1] = "0.1-99.9%";
+        opts[2] = "0.5-99.5%";
+        opts[3] = "1-99%";
+        opts[4] = "5-95%";
+        opts[5] = "10-90%";
+        opts[6] = "15-85%";
+        opts[7] = "20-80%";
         num_opts = RANGE_NB;
         selected_idx = current_options.range;
     }
-    
+
     int box_h = num_opts + 2;
     int start_r = (disp_char_rows - box_h) / 2;
     int start_c = (disp_cols - box_w) / 2;
-    if (start_r < 0) start_r = 0;
-    if (start_c < 0) start_c = 0;
-    
-    for (int i = 0; i < box_h; i++) {
+    if(start_r < 0)
+    {
+        start_r = 0;
+    }
+    if(start_c < 0)
+    {
+        start_c = 0;
+    }
+
+    for(int i = 0; i < box_h; i++)
+    {
         int r = start_r + i;
-        if (r >= disp_char_rows) break;
-        for (int j = 0; j < box_w; j++) {
+        if(r >= disp_char_rows)
+        {
+            break;
+        }
+        for(int j = 0; j < box_w; j++)
+        {
             int c = start_c + j;
-            if (c >= disp_cols) break;
-            
+            if(c >= disp_cols)
+            {
+                break;
+            }
+
             tv_cell_t *cell = &ctx->screen[r * wcol + c];
-            cell->bg_r = 50; cell->bg_g = 50; cell->bg_b = 50; // dark gray bg
-            cell->fg_r = 255; cell->fg_g = 255; cell->fg_b = 255; // white fg
-            cell->ch[0] = ' '; cell->ch[1] = '\0';
-            
-            if (i == 0) {
+            cell->bg_r = 50;
+            cell->bg_g = 50;
+            cell->bg_b = 50; // dark gray bg
+            cell->fg_r = 255;
+            cell->fg_g = 255;
+            cell->fg_b = 255; // white fg
+            cell->ch[0] = ' ';
+            cell->ch[1] = '\0';
+
+            if(i == 0)
+            {
                 int tlen = strlen(title);
                 int tstart = (box_w - tlen) / 2;
-                if (j >= tstart && j < tstart + tlen) {
+                if(j >= tstart && j < tstart + tlen)
+                {
                     cell->ch[0] = title[j - tstart];
-                    cell->fg_r = 255; cell->fg_g = 255; cell->fg_b = 0; // Yellow title
+                    cell->fg_r = 255;
+                    cell->fg_g = 255;
+                    cell->fg_b = 0; // Yellow title
                 }
-            } else if (i <= num_opts) {
+            }
+            else if(i <= num_opts)
+            {
                 int opt_idx = i - 1;
                 int is_sel = (opt_idx == selected_idx);
-                if (is_sel) {
-                    cell->bg_r = 200; cell->bg_g = 200; cell->bg_b = 200; // light gray selected
-                    cell->fg_r = 0; cell->fg_g = 0; cell->fg_b = 0; // black fg
+                if(is_sel)
+                {
+                    cell->bg_r = 200;
+                    cell->bg_g = 200;
+                    cell->bg_b = 200; // light gray selected
+                    cell->fg_r = 0;
+                    cell->fg_g = 0;
+                    cell->fg_b = 0; // black fg
                 }
-                
+
                 // Text portion
-                if (j >= 2 && j - 2 < (int)strlen(opts[opt_idx])) {
+                if(j >= 2 && j - 2 < (int)strlen(opts[opt_idx]))
+                {
                     cell->ch[0] = opts[opt_idx][j - 2];
                 }
-                
+
                 // Compressed colormap rendering
-                if (ctx->popup_type == 1 && j >= 16 && j < box_w - 2) {
+                if(ctx->popup_type == 1 && j >= 16 && j < box_w - 2)
+                {
                     int bar_len = box_w - 2 - 16;
                     double v = (double)(j - 16) / (double)(bar_len - 1);
                     rgb_t color = get_colormap_color((termview_colormap_t)opt_idx, v);
-                    cell->bg_r = color.r; cell->bg_g = color.g; cell->bg_b = color.b;
-                    cell->ch[0] = ' '; cell->ch[1] = '\0';
+                    cell->bg_r = color.r;
+                    cell->bg_g = color.g;
+                    cell->bg_b = color.b;
+                    cell->ch[0] = ' ';
+                    cell->ch[1] = '\0';
                 }
             }
         }
     }
 }
 
-static void termview_flush_ansi(tv_context_t *ctx) {
+static void termview_flush_ansi(tv_context_t *ctx)
+{
     size_t fb_pos = 0;
     int cur_r = -1, cur_c = -1;
     int last_bg_r = -1, last_bg_g = -1, last_bg_b = -1;
     int last_fg_r = -1, last_fg_g = -1, last_fg_b = -1;
 
-    for (int r = 0; r < wrow; r++) {
-        for (int c = 0; c < wcol; c++) {
+    for(int r = 0; r < wrow; r++)
+    {
+        for(int c = 0; c < wcol; c++)
+        {
             tv_cell_t *cell = &ctx->screen[r * wcol + c];
             tv_cell_t *prev = &ctx->prev_screen[r * wcol + c];
-            
-            if (memcmp(cell, prev, sizeof(tv_cell_t)) != 0) {
+
+            if(memcmp(cell, prev, sizeof(tv_cell_t)) != 0)
+            {
                 // Update cursor if not sequential
-                if (cur_r != r || cur_c != c) {
+                if(cur_r != r || cur_c != c)
+                {
                     tv_move(ctx->frame_buffer, &fb_pos, r + 1, c + 1);
                 }
-                
+
                 // Update BG
-                if (cell->bg_r != last_bg_r || cell->bg_g != last_bg_g || cell->bg_b != last_bg_b) {
+                if(cell->bg_r != last_bg_r || cell->bg_g != last_bg_g || cell->bg_b != last_bg_b)
+                {
                     tv_bg(ctx->frame_buffer, &fb_pos, cell->bg_r, cell->bg_g, cell->bg_b);
-                    last_bg_r = cell->bg_r; last_bg_g = cell->bg_g; last_bg_b = cell->bg_b;
+                    last_bg_r = cell->bg_r;
+                    last_bg_g = cell->bg_g;
+                    last_bg_b = cell->bg_b;
                 }
-                
+
                 // Update FG
-                if (cell->fg_r != last_fg_r || cell->fg_g != last_fg_g || cell->fg_b != last_fg_b) {
+                if(cell->fg_r != last_fg_r || cell->fg_g != last_fg_g || cell->fg_b != last_fg_b)
+                {
                     tv_fg(ctx->frame_buffer, &fb_pos, cell->fg_r, cell->fg_g, cell->fg_b);
-                    last_fg_r = cell->fg_r; last_fg_g = cell->fg_g; last_fg_b = cell->fg_b;
+                    last_fg_r = cell->fg_r;
+                    last_fg_g = cell->fg_g;
+                    last_fg_b = cell->fg_b;
                 }
 
                 // Write Char
                 int k = 0;
-                while(cell->ch[k] != '\0' && k < 4) {
+                while(cell->ch[k] != '\0' && k < 4)
+                {
                     ctx->frame_buffer[fb_pos++] = cell->ch[k++];
                 }
-                
+
                 cur_r = r;
                 cur_c = c + 1;
                 *prev = *cell;
@@ -959,7 +1708,8 @@ static void termview_flush_ansi(tv_context_t *ctx) {
 
     tv_reset(ctx->frame_buffer, &fb_pos);
 
-    if (fb_pos > 0) {
+    if(fb_pos > 0)
+    {
         if(write(STDOUT_FILENO, ctx->frame_buffer, fb_pos) < 0) {}
     }
 }
@@ -971,7 +1721,8 @@ errno_t termview_screen(
     IMAGE img;
     ImageStreamIO_read_sharedmem_image_toIMAGE(imagename, &img);
 
-    if (img.md == NULL) {
+    if(img.md == NULL)
+    {
         printf("Error: Could not connect to image %s\n", imagename);
         return 1;
     }
@@ -986,19 +1737,22 @@ errno_t termview_screen(
     tv_context_t *ctx = &context_instance;
     ctx->img = &img;
     ctx->target_fps = 20;
-    ctx->last_cnt0 = (uint64_t)-1;
+    ctx->last_cnt0 = (uint64_t) -1;
     ctx->last_cnt0_for_fps = img.md[0].cnt0;
 
     clock_gettime(CLOCK_MONOTONIC, &ctx->last_time_real);
     clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ctx->last_time_cpu);
     ctx->last_render_real = ctx->last_time_real;
 
-    while(loop) {
-        if (tv_resize_flag) {
+    while(loop)
+    {
+        if(tv_resize_flag)
+        {
             tv_get_size(&wrow, &wcol);
             tv_resize_flag = 0;
             force_redraw = 1;
-            if (ctx->prev_screen) {
+            if(ctx->prev_screen)
+            {
                 memset(ctx->prev_screen, 0, ctx->screen_size * sizeof(tv_cell_t));
             }
             if(write(STDOUT_FILENO, "\033[2J\033[H", 7) < 0) {}
@@ -1007,40 +1761,57 @@ errno_t termview_screen(
         long target_us = 1000000L / ctx->target_fps;
         struct timespec now_real;
         clock_gettime(CLOCK_MONOTONIC, &now_real);
-        long elapsed_since_last = (now_real.tv_sec - ctx->last_render_real.tv_sec) * 1000000L + 
+        long elapsed_since_last = (now_real.tv_sec - ctx->last_render_real.tv_sec) * 1000000L +
                                   (now_real.tv_nsec - ctx->last_render_real.tv_nsec) / 1000L;
         ctx->timeout_us = target_us - elapsed_since_last;
-        if (ctx->timeout_us < 0) ctx->timeout_us = 0;
+        if(ctx->timeout_us < 0)
+        {
+            ctx->timeout_us = 0;
+        }
 
-        if (ctx->popup_type > 0) {
+        if(ctx->popup_type > 0)
+        {
             struct timespec now;
             clock_gettime(CLOCK_MONOTONIC, &now);
-            long popup_remain_us = (ctx->popup_expiry_time.tv_sec - now.tv_sec) * 1000000L + 
+            long popup_remain_us = (ctx->popup_expiry_time.tv_sec - now.tv_sec) * 1000000L +
                                    (ctx->popup_expiry_time.tv_nsec - now.tv_nsec) / 1000L;
-            if (popup_remain_us <= 0) {
+            if(popup_remain_us <= 0)
+            {
                 ctx->popup_type = 0;
                 force_redraw = 1;
-            } else if (popup_remain_us < ctx->timeout_us) {
+            }
+            else if(popup_remain_us < ctx->timeout_us)
+            {
                 ctx->timeout_us = popup_remain_us;
             }
         }
 
         int ch;
         int first_wait = 1;
-        while (1) {
+        while(1)
+        {
             long wait_us = first_wait ? ctx->timeout_us : 0;
             ch = tv_read_key(wait_us);
             first_wait = 0;
-            if (ch == -1) break;
+            if(ch == -1)
+            {
+                break;
+            }
 
-            if (ctx->input_mode > 0) {
-                if (ch == 10 || ch == 13 || ch == 27) {
-                    if (ch != 27 && ctx->input_len > 0) {
+            if(ctx->input_mode > 0)
+            {
+                if(ch == 10 || ch == 13 || ch == 27)
+                {
+                    if(ch != 27 && ctx->input_len > 0)
+                    {
                         ctx->input_buf[ctx->input_len] = '\0';
-                        if (ctx->input_mode == 1) {
+                        if(ctx->input_mode == 1)
+                        {
                             current_options.manual_min = atof(ctx->input_buf);
                             current_options.range_locked = 1;
-                        } else if (ctx->input_mode == 2) {
+                        }
+                        else if(ctx->input_mode == 2)
+                        {
                             current_options.manual_max = atof(ctx->input_buf);
                             current_options.range_locked = 1;
                         }
@@ -1049,13 +1820,18 @@ errno_t termview_screen(
                     ctx->input_len = 0;
                     ctx->input_buf[0] = '\0';
                     force_redraw = 1;
-                } else if (ch == 127 || ch == 8) {
-                    if (ctx->input_len > 0) {
+                }
+                else if(ch == 127 || ch == 8)
+                {
+                    if(ctx->input_len > 0)
+                    {
                         ctx->input_len--;
                         ctx->input_buf[ctx->input_len] = '\0';
                         force_redraw = 1;
                     }
-                } else if (ch >= 32 && ch <= 126 && ctx->input_len < 63) {
+                }
+                else if(ch >= 32 && ch <= 126 && ctx->input_len < 63)
+                {
                     ctx->input_buf[ctx->input_len++] = ch;
                     ctx->input_buf[ctx->input_len] = '\0';
                     force_redraw = 1;
@@ -1065,22 +1841,28 @@ errno_t termview_screen(
 
             termview_handle_keyboard_event(ctx, ch);
         }
-        if (loop == 0) break;
+        if(loop == 0)
+        {
+            break;
+        }
 
-        if (ctx->popup_type > 0) {
+        if(ctx->popup_type > 0)
+        {
             struct timespec now;
             clock_gettime(CLOCK_MONOTONIC, &now);
-            long popup_remain_us = (ctx->popup_expiry_time.tv_sec - now.tv_sec) * 1000000L + 
+            long popup_remain_us = (ctx->popup_expiry_time.tv_sec - now.tv_sec) * 1000000L +
                                    (ctx->popup_expiry_time.tv_nsec - now.tv_nsec) / 1000L;
-            if (popup_remain_us <= 0) {
+            if(popup_remain_us <= 0)
+            {
                 ctx->popup_type = 0;
                 force_redraw = 1;
             }
         }
-        
+
         termview_update_fps_stats(ctx);
-        
-        if (!force_redraw && img.md[0].cnt0 == ctx->last_cnt0) {
+
+        if(!force_redraw && img.md[0].cnt0 == ctx->last_cnt0)
+        {
             continue;
         }
         ctx->last_cnt0 = img.md[0].cnt0;
@@ -1094,41 +1876,51 @@ errno_t termview_screen(
         int disp_cols = wcol - bar_width - 1;
         int bar_col_start = wcol - bar_width;
 
-        if (wrow * wcol > ctx->screen_size) {
+        if(wrow * wcol > ctx->screen_size)
+        {
             ctx->screen_size = wrow * wcol;
-            ctx->screen = (tv_cell_t*)realloc(ctx->screen, ctx->screen_size * sizeof(tv_cell_t));
-            ctx->prev_screen = (tv_cell_t*)realloc(ctx->prev_screen, ctx->screen_size * sizeof(tv_cell_t));
+            ctx->screen = (tv_cell_t *)realloc(ctx->screen, ctx->screen_size * sizeof(tv_cell_t));
+            ctx->prev_screen = (tv_cell_t *)realloc(ctx->prev_screen, ctx->screen_size * sizeof(tv_cell_t));
             memset(ctx->prev_screen, 0, ctx->screen_size * sizeof(tv_cell_t));
         }
-        
-        for (int i = 0; i < wrow * wcol; i++) {
-            ctx->screen[i].bg_r = 0; ctx->screen[i].bg_g = 0; ctx->screen[i].bg_b = 0;
-            ctx->screen[i].fg_r = 255; ctx->screen[i].fg_g = 255; ctx->screen[i].fg_b = 255;
-            ctx->screen[i].ch[0] = ' '; ctx->screen[i].ch[1] = 0;
+
+        for(int i = 0; i < wrow * wcol; i++)
+        {
+            ctx->screen[i].bg_r = 0;
+            ctx->screen[i].bg_g = 0;
+            ctx->screen[i].bg_b = 0;
+            ctx->screen[i].fg_r = 255;
+            ctx->screen[i].fg_g = 255;
+            ctx->screen[i].fg_b = 255;
+            ctx->screen[i].ch[0] = ' ';
+            ctx->screen[i].ch[1] = 0;
         }
 
-        if (disp_char_rows <= 0 || disp_cols <= 0) {
+        if(disp_char_rows <= 0 || disp_cols <= 0)
+        {
             usleep(10000);
             continue;
         }
 
         int disp_img_rows = disp_char_rows * 2;
 
-        if (disp_img_rows * disp_cols > ctx->buffer_size) {
+        if(disp_img_rows * disp_cols > ctx->buffer_size)
+        {
             ctx->buffer_size = disp_img_rows * disp_cols;
-            ctx->display_buffer = (double*)realloc(ctx->display_buffer, ctx->buffer_size * sizeof(double));
+            ctx->display_buffer = (double *)realloc(ctx->display_buffer, ctx->buffer_size * sizeof(double));
         }
 
         size_t needed_fb = tv_framebuf_size(wrow, wcol);
-        if (needed_fb > ctx->frame_buffer_size) {
+        if(needed_fb > ctx->frame_buffer_size)
+        {
             ctx->frame_buffer_size = needed_fb;
-            ctx->frame_buffer = (char*)realloc(ctx->frame_buffer, ctx->frame_buffer_size);
+            ctx->frame_buffer = (char *)realloc(ctx->frame_buffer, ctx->frame_buffer_size);
         }
 
         double view_w_img = (double)xsize / view_zoom;
         double view_h_img = (double)ysize / view_zoom;
         double step = fmax(view_w_img / disp_cols, view_h_img / disp_img_rows);
-        
+
         double center_img_x = view_center_x * xsize;
         double center_img_y = view_center_y * ysize;
         double center_disp_x = disp_cols / 2.0;
@@ -1138,40 +1930,60 @@ errno_t termview_screen(
         double sign_x = current_options.flip_h ? -1.0 : 1.0;
 
         int buf_idx = 0;
-        if (img.md[0].datatype == _DATATYPE_FLOAT) {
-            const float * restrict data = img.array.F;
-            for (int i = 0; i < disp_img_rows; i++) {
-                for (int j = 0; j < disp_cols; j++) {
+        if(img.md[0].datatype == _DATATYPE_FLOAT)
+        {
+            const float *restrict data = img.array.F;
+            for(int i = 0; i < disp_img_rows; i++)
+            {
+                for(int j = 0; j < disp_cols; j++)
+                {
                     int img_y = (int)(center_img_y + sign_y * (i - center_disp_y) * step);
                     int img_x = (int)(center_img_x + sign_x * (j - center_disp_x) * step);
-                    if (img_x >= 0 && img_x < (int)xsize && img_y >= 0 && img_y < (int)ysize) {
+                    if(img_x >= 0 && img_x < (int)xsize && img_y >= 0 && img_y < (int)ysize)
+                    {
                         ctx->display_buffer[buf_idx++] = (double)data[img_y * xsize + img_x];
-                    } else {
+                    }
+                    else
+                    {
                         ctx->display_buffer[buf_idx++] = 0.0;
                     }
                 }
             }
-        } else if (img.md[0].datatype == _DATATYPE_UINT16) {
-            const uint16_t * restrict data = img.array.UI16;
-            for (int i = 0; i < disp_img_rows; i++) {
-                for (int j = 0; j < disp_cols; j++) {
+        }
+        else if(img.md[0].datatype == _DATATYPE_UINT16)
+        {
+            const uint16_t *restrict data = img.array.UI16;
+            for(int i = 0; i < disp_img_rows; i++)
+            {
+                for(int j = 0; j < disp_cols; j++)
+                {
                     int img_y = (int)(center_img_y + sign_y * (i - center_disp_y) * step);
                     int img_x = (int)(center_img_x + sign_x * (j - center_disp_x) * step);
-                    if (img_x >= 0 && img_x < (int)xsize && img_y >= 0 && img_y < (int)ysize) {
+                    if(img_x >= 0 && img_x < (int)xsize && img_y >= 0 && img_y < (int)ysize)
+                    {
                         ctx->display_buffer[buf_idx++] = (double)data[img_y * xsize + img_x];
-                    } else {
+                    }
+                    else
+                    {
                         ctx->display_buffer[buf_idx++] = 0.0;
                     }
                 }
             }
-        } else {
-            for (int i = 0; i < disp_img_rows; i++) {
-                for (int j = 0; j < disp_cols; j++) {
+        }
+        else
+        {
+            for(int i = 0; i < disp_img_rows; i++)
+            {
+                for(int j = 0; j < disp_cols; j++)
+                {
                     int img_y = (int)(center_img_y + sign_y * (i - center_disp_y) * step);
                     int img_x = (int)(center_img_x + sign_x * (j - center_disp_x) * step);
-                    if (img_x >= 0 && img_x < (int)xsize && img_y >= 0 && img_y < (int)ysize) {
+                    if(img_x >= 0 && img_x < (int)xsize && img_y >= 0 && img_y < (int)ysize)
+                    {
                         ctx->display_buffer[buf_idx++] = get_pixel_value(&img, img_x, img_y);
-                    } else {
+                    }
+                    else
+                    {
                         ctx->display_buffer[buf_idx++] = 0.0;
                     }
                 }
@@ -1181,44 +1993,85 @@ errno_t termview_screen(
         int num_pixels = buf_idx;
 
         double min_val = 0.0, max_val = 1.0;
-        if (current_options.range_locked) {
+        if(current_options.range_locked)
+        {
             min_val = current_options.manual_min;
             max_val = current_options.manual_max;
-        } else if (current_options.range == RANGE_MINMAX) {
-            min_val = 1e20; max_val = -1e20;
-            for(int k=0; k<num_pixels; k++) {
-                if(ctx->display_buffer[k] < min_val) min_val = ctx->display_buffer[k];
-                if(ctx->display_buffer[k] > max_val) max_val = ctx->display_buffer[k];
+        }
+        else if(current_options.range == RANGE_MINMAX)
+        {
+            min_val = 1e20;
+            max_val = -1e20;
+            for(int k = 0; k < num_pixels; k++)
+            {
+                if(ctx->display_buffer[k] < min_val)
+                {
+                    min_val = ctx->display_buffer[k];
+                }
+                if(ctx->display_buffer[k] > max_val)
+                {
+                    max_val = ctx->display_buffer[k];
+                }
             }
-        } else {
-            double *sorted_buf = (double*)malloc(num_pixels * sizeof(double));
+        }
+        else
+        {
+            double *sorted_buf = (double *)malloc(num_pixels * sizeof(double));
             memcpy(sorted_buf, ctx->display_buffer, num_pixels * sizeof(double));
             qsort(sorted_buf, num_pixels, sizeof(double), compare_doubles);
             double p_low = 0.0, p_high = 1.0;
-            switch(current_options.range) {
-                case RANGE_001_999: p_low = 0.001; p_high = 0.999; break;
-                case RANGE_005_995: p_low = 0.005; p_high = 0.995; break;
-                case RANGE_01_99: p_low = 0.01; p_high = 0.99; break;
-                case RANGE_05_95: p_low = 0.05; p_high = 0.95; break;
-                case RANGE_10_90: p_low = 0.10; p_high = 0.90; break;
-                case RANGE_15_85: p_low = 0.15; p_high = 0.85; break;
-                case RANGE_20_80: p_low = 0.20; p_high = 0.80; break;
-                default: break;
+            switch(current_options.range)
+            {
+            case RANGE_001_999:
+                p_low = 0.001;
+                p_high = 0.999;
+                break;
+            case RANGE_005_995:
+                p_low = 0.005;
+                p_high = 0.995;
+                break;
+            case RANGE_01_99:
+                p_low = 0.01;
+                p_high = 0.99;
+                break;
+            case RANGE_05_95:
+                p_low = 0.05;
+                p_high = 0.95;
+                break;
+            case RANGE_10_90:
+                p_low = 0.10;
+                p_high = 0.90;
+                break;
+            case RANGE_15_85:
+                p_low = 0.15;
+                p_high = 0.85;
+                break;
+            case RANGE_20_80:
+                p_low = 0.20;
+                p_high = 0.80;
+                break;
+            default:
+                break;
             }
-            min_val = sorted_buf[(int)(p_low * (num_pixels-1))];
-            max_val = sorted_buf[(int)(p_high * (num_pixels-1))];
+            min_val = sorted_buf[(int)(p_low * (num_pixels - 1))];
+            max_val = sorted_buf[(int)(p_high * (num_pixels - 1))];
             free(sorted_buf);
         }
-        if (max_val <= min_val) max_val = min_val + 1.0;
+        if(max_val <= min_val)
+        {
+            max_val = min_val + 1.0;
+        }
 
         current_min_val = min_val;
         current_max_val = max_val;
 
-        if (current_options.colormap != lut_colormap || current_options.scale != lut_scale) {
+        if(current_options.colormap != lut_colormap || current_options.scale != lut_scale)
+        {
             build_colormap_lut(current_options.colormap, current_options.scale);
         }
 
-        termview_render_image(ctx, disp_char_rows, disp_cols, center_img_x, center_img_y, sign_x, sign_y, step, xsize, ysize, min_val, max_val);
+        termview_render_image(ctx, disp_char_rows, disp_cols, center_img_x, center_img_y, sign_x, sign_y,
+                              step, xsize, ysize, min_val, max_val);
         termview_render_colorbar(ctx, disp_char_rows, bar_col_start, min_val, max_val);
         termview_render_infobar(ctx, xsize, ysize, step, min_val, max_val);
         termview_render_popup(ctx, disp_char_rows, disp_cols);
@@ -1228,10 +2081,22 @@ errno_t termview_screen(
     tv_exit_alt_screen();
     tv_exit_raw();
 
-    if (ctx->display_buffer) free(ctx->display_buffer);
-    if (ctx->screen) free(ctx->screen);
-    if (ctx->prev_screen) free(ctx->prev_screen);
-    if (ctx->frame_buffer) free(ctx->frame_buffer);
+    if(ctx->display_buffer)
+    {
+        free(ctx->display_buffer);
+    }
+    if(ctx->screen)
+    {
+        free(ctx->screen);
+    }
+    if(ctx->prev_screen)
+    {
+        free(ctx->prev_screen);
+    }
+    if(ctx->frame_buffer)
+    {
+        free(ctx->frame_buffer);
+    }
 
     ImageStreamIO_closeIm(&img);
     return 0;

--- a/src/cli/CLIcore/termview/termview_ansi.h
+++ b/src/cli/CLIcore/termview/termview_ansi.h
@@ -182,7 +182,9 @@ static inline void tv_fg(
  * and the bottom half in the FOREGROUND color, giving 2 image rows per
  * character row.
  * ----------------------------------------------------------------------- */
-static inline void tv_halfblock(char *buf, size_t *pos)
+static inline void tv_halfblock(
+    char *buf,
+    size_t *pos)
 {
     buf[(*pos)++] = (char)0xE2;
     buf[(*pos)++] = (char)0x96;
@@ -193,7 +195,9 @@ static inline void tv_halfblock(char *buf, size_t *pos)
  * Full block █ (U+2588): UTF-8 = 0xE2 0x96 0x88  (3 bytes)
  * Used for the colorbar and single-row fallback.
  * ----------------------------------------------------------------------- */
-static inline void tv_fullblock(char *buf, size_t *pos)
+static inline void tv_fullblock(
+    char *buf,
+    size_t *pos)
 {
     buf[(*pos)++] = (char)0xE2;
     buf[(*pos)++] = (char)0x96;
@@ -203,7 +207,9 @@ static inline void tv_fullblock(char *buf, size_t *pos)
 /* -----------------------------------------------------------------------
  * Reset all attributes: \e[0m  (4 bytes)
  * ----------------------------------------------------------------------- */
-static inline void tv_reset(char *buf, size_t *pos)
+static inline void tv_reset(
+    char *buf,
+    size_t *pos)
 {
     buf[(*pos)++] = '\033';
     buf[(*pos)++] = '[';
@@ -214,7 +220,9 @@ static inline void tv_reset(char *buf, size_t *pos)
 /* -----------------------------------------------------------------------
  * Emit a plain ASCII space with the current attribute state (1 byte).
  * ----------------------------------------------------------------------- */
-static inline void tv_space(char *buf, size_t *pos)
+static inline void tv_space(
+    char *buf,
+    size_t *pos)
 {
     buf[(*pos)++] = ' ';
 }
@@ -222,7 +230,9 @@ static inline void tv_space(char *buf, size_t *pos)
 /* -----------------------------------------------------------------------
  * Emit a newline (1 byte).
  * ----------------------------------------------------------------------- */
-static inline void tv_newline(char *buf, size_t *pos)
+static inline void tv_newline(
+    char *buf,
+    size_t *pos)
 {
     buf[(*pos)++] = '\n';
 }
@@ -238,7 +248,9 @@ static inline void tv_newline(char *buf, size_t *pos)
  * = 45 bytes per cell.  Multiply by cell count and add headroom for
  * cursor-positioning escapes and the info bar.
  * ----------------------------------------------------------------------- */
-static inline size_t tv_framebuf_size(int rows, int cols)
+static inline size_t tv_framebuf_size(
+    int rows,
+    int cols)
 {
     return (size_t)(rows * cols * 48 + rows * 16 + 4096);
 }

--- a/src/cli/CLIcore/treesitter/cli_treesitter.c
+++ b/src/cli/CLIcore/treesitter/cli_treesitter.c
@@ -143,7 +143,9 @@ typedef struct
     const char *color;
 } HighlightSpan;
 
-static int compare_spans(const void *a, const void *b)
+static int compare_spans(
+    const void *a,
+    const void *b)
 {
     const HighlightSpan *sa = (const HighlightSpan *)a;
     const HighlightSpan *sb = (const HighlightSpan *)b;
@@ -155,7 +157,10 @@ static int compare_spans(const void *a, const void *b)
     return sb->end_byte - sa->end_byte;
 }
 
-void cli_ts_highlight_line(const char *line, int len, FILE *out)
+void cli_ts_highlight_line(
+    const char *line,
+    int len,
+    FILE *out)
 {
     if(!ts_parser || !ts_query || !line || len == 0)
     {
@@ -301,7 +306,10 @@ int cli_ts_detect_color_level(void)
     return 1;
 }
 void cli_ts_cleanup(void) {}
-void cli_ts_highlight_line(const char *line, int len, FILE *out)
+void cli_ts_highlight_line(
+    const char *line,
+    int len,
+    FILE *out)
 {
     (void)len;
     fprintf(out, "%s", line);

--- a/src/cli/libmilkscript/CLIcore_UI_execute_redir.c
+++ b/src/cli/libmilkscript/CLIcore_UI_execute_redir.c
@@ -1063,7 +1063,9 @@ int cli_handle_background(
  *                no-space arithmetic like "a=b+1" is
  *                still evaluated by the calc engine.
  */
-int is_internal_cmd(const char *firstword, int check_assign)
+int is_internal_cmd(
+    const char *firstword,
+    int check_assign)
 {
     static const char *keywords[] =
     {

--- a/src/cli/libmilkscript/CLIcore_checkargs.c
+++ b/src/cli/libmilkscript/CLIcore_checkargs.c
@@ -271,7 +271,9 @@ static int CLI_checkarg0(
  * @param funcargtype
  * @return int
  */
-int CLI_checkarg(int CLIargnum, uint32_t funcargtype)
+int CLI_checkarg(
+    int CLIargnum,
+    uint32_t funcargtype)
 {
     DEBUG_TRACE_FSTART();
 
@@ -302,7 +304,9 @@ int CLI_checkarg(int CLIargnum, uint32_t funcargtype)
  * @param funcargtype
  * @return int
  */
-int CLI_checkarg_noerrmsg(int CLIargnum, uint32_t funcargtype)
+int CLI_checkarg_noerrmsg(
+    int CLIargnum,
+    uint32_t funcargtype)
 {
     DEBUG_TRACE_FSTART();
 

--- a/src/cli/libmilkscript/CLIcore_help_command.c
+++ b/src/cli/libmilkscript/CLIcore_help_command.c
@@ -733,7 +733,7 @@ errno_t help_module()
     }
     else
     {
-        long i;
+
         printf("\n");
         printf("%2s  %10s %32s %10s %7s    %20s %s\n",
                "#",
@@ -747,7 +747,7 @@ errno_t help_module()
             "--------------------------------------------------------------"
             "-----------------------------------------"
             "-------\n");
-        for(i = 0; i < data.NBmodule; i++)
+        for(long i = 0; i < data.NBmodule; i++)
         {
             printf(
                 "%2ld %10s \033[1m%32s\033[0m %10s %2d.%02d.%02d    "

--- a/src/cli/libmilkscript/CLIcore_script_intercept_env_trap.c
+++ b/src/cli/libmilkscript/CLIcore_script_intercept_env_trap.c
@@ -432,7 +432,9 @@ static void cli_trap_process_proc(const char *pp, const char *tcmd, long opt_int
     }
 }
 
-static void cli_trap_process_posix(const char *sname, const char *tcmd)
+static void cli_trap_process_posix(
+    const char *sname,
+    const char *tcmd)
 {
     /* POSIX signal name */
     int sn =

--- a/src/cli/libmilkscript/CLIcore_script_intercept_exec_waitany.c
+++ b/src/cli/libmilkscript/CLIcore_script_intercept_exec_waitany.c
@@ -74,7 +74,10 @@ struct wa_event
  * Extracts stream/FPS names and timeout values
  * from the argument list.
  */
-static int parse_waitany_args(const char *p, struct wa_event *events, double *timeout_v)
+static int parse_waitany_args(
+    const char *p,
+    struct wa_event *events,
+    double *timeout_v)
 {
     char argbuf[STRINGMAXLEN_CLICMDLINE];
     strncpy(argbuf, p, STRINGMAXLEN_CLICMDLINE - 1);
@@ -282,7 +285,9 @@ static int parse_waitany_args(const char *p, struct wa_event *events, double *ti
  * Connects to all specified streams/FPS instances
  * for event monitoring.
  */
-static int open_waitany_handles(struct wa_event *events, int nevents)
+static int open_waitany_handles(
+    struct wa_event *events,
+    int nevents)
 {
     int any_open = 0;
     for(int i = 0; i < nevents; i++)
@@ -330,7 +335,9 @@ static int open_waitany_handles(struct wa_event *events, int nevents)
     return any_open;
 }
 
-static void close_waitany_handles(struct wa_event *events, int nevents)
+static void close_waitany_handles(
+    struct wa_event *events,
+    int nevents)
 {
     for(int i = 0; i < nevents; i++)
     {
@@ -345,7 +352,10 @@ static void close_waitany_handles(struct wa_event *events, int nevents)
     }
 }
 
-static int poll_waitany_events(struct wa_event *events, int nevents, double timeout)
+static int poll_waitany_events(
+    struct wa_event *events,
+    int nevents,
+    double timeout)
 {
     struct timespec ts_start;
     clock_gettime(CLOCK_MONOTONIC, &ts_start);
@@ -440,7 +450,9 @@ static int poll_waitany_events(struct wa_event *events, int nevents, double time
  * Checks if any FPS parameter meets the
  * specified condition.
  */
-static int eval_waitany_fps(struct wa_event *ev, const char *vstr)
+static int eval_waitany_fps(
+    struct wa_event *ev,
+    const char *vstr)
 {
     int fired = 0;
     switch(ev->cmp_op)

--- a/src/cli/libmilkscript/cli_calc_parser.c
+++ b/src/cli/libmilkscript/cli_calc_parser.c
@@ -4,7 +4,7 @@
  *
  * Architecture Overview:
  * The Pratt (precedence-climbing) parser replaces legacy bison-generated parsers
- * for expression evaluation. It parses operator precedence natively supporting 
+ * for expression evaluation. It parses operator precedence natively supporting
  * +, -, *, /, ^, % arithmetic, logical/relational operators, and dynamic variable
  * assignments. Supports `long`, `double`, and `string` (image name) evaluation.
  * Evaluates expressions immediately, supporting math on images as well
@@ -59,7 +59,7 @@ cli_token *cur_parse(void)
 cli_token *advance_parse(void)
 {
     cli_token *t = &parse_tokens[parse_pos];
-    if (parse_pos < parse_ntok)
+    if(parse_pos < parse_ntok)
     {
         parse_pos++;
     }
@@ -75,7 +75,7 @@ cli_token *cur_eval(void)
 cli_token *advance_eval(void)
 {
     cli_token *t = &eval_tokens[eval_pos];
-    if (eval_pos < eval_ntok)
+    if(eval_pos < eval_ntok)
     {
         eval_pos++;
     }
@@ -88,13 +88,14 @@ cli_token *advance_eval(void)
  */
 void parse_errmsg(const char *msg)
 {
-    if ((parse_mode == 1 || data.core.Debug > 0) && dcquiet == 0)
+    if((parse_mode == 1 || data.core.Debug > 0) && dcquiet == 0)
     {
         PRINT_ERROR("   [CALC_PARSER_ERROR] %s", msg);
     }
     data.parseerror = 1;
     parse_error = 1;
-    if (parse_mode == 1) {
+    if(parse_mode == 1)
+    {
         eval_error = 1;
     }
 }
@@ -113,7 +114,7 @@ void parse_errmsg(const char *msg)
  */
 double to_double(val_t v)
 {
-    if (v.type == VAL_LONG)
+    if(v.type == VAL_LONG)
     {
         return (double) v.lval;
     }
@@ -169,10 +170,10 @@ val_t mk_string(const char *s)
  */
 int check_image(const char *name)
 {
-    if (image_ID(
-            name,
-            data.core.image,
-            data.core.NB_MAX_IMAGE) == -1)
+    if(image_ID(
+                name,
+                data.core.image,
+                data.core.NB_MAX_IMAGE) == -1)
     {
         char msg[200];
         snprintf(msg, 200,
@@ -230,12 +231,12 @@ void cli_parse(const char *input)
 
 
     parse_ntok = cli_tokenize(
-        input,
-        parse_tokens,
-        CLI_CALC_MAX_TOKENS
-    );
+                     input,
+                     parse_tokens,
+                     CLI_CALC_MAX_TOKENS
+                 );
 
-    if (parse_ntok <= 0)
+    if(parse_ntok <= 0)
     {
         return;
     }
@@ -243,26 +244,26 @@ void cli_parse(const char *input)
     parse_pos = 0;
 
     /* skip if only a newline */
-    if (parse_tokens[0].type == TOK_NEWLINE
-        || parse_tokens[0].type == TOK_EOF)
+    if(parse_tokens[0].type == TOK_NEWLINE
+            || parse_tokens[0].type == TOK_EOF)
     {
         return;
     }
 
     val_t result = parse_expr(0);
-    if (parse_error)
+    if(parse_error)
     {
         /* Fallback: if it's not a valid expression, treat it as a raw string */
         data.parseerror = 0;
         parse_error = 0;
-        
+
         data.cmdargtoken[data.cmdNBarg].type = CMDARGTOKEN_TYPE_RAWSTRING;
         snprintf(data.cmdargtoken[data.cmdNBarg].val.string,
                  STRINGMAXLEN_CMDARGTOKEN_VAL, "%s", input);
-        
+
         /* Remove trailing newline if `input` had one (which it does via snprintf earlier) */
         size_t len = strlen(data.cmdargtoken[data.cmdNBarg].val.string);
-        if (len > 0 && data.cmdargtoken[data.cmdNBarg].val.string[len - 1] == '\n')
+        if(len > 0 && data.cmdargtoken[data.cmdNBarg].val.string[len - 1] == '\n')
         {
             data.cmdargtoken[data.cmdNBarg].val.string[len - 1] = '\0';
         }
@@ -270,15 +271,15 @@ void cli_parse(const char *input)
     }
 
     /* consume the trailing newline if present */
-    if (cur_parse()->type == TOK_NEWLINE)
+    if(cur_parse()->type == TOK_NEWLINE)
     {
         advance_parse();
     }
 
     /* store result in data.cmdargtoken */
-    if (result.type == VAL_DOUBLE)
+    if(result.type == VAL_DOUBLE)
     {
-        if (data.core.Debug > 0)
+        if(data.core.Debug > 0)
         {
             printf("\t double: %.10g\n",
                    result.dval);
@@ -286,11 +287,11 @@ void cli_parse(const char *input)
         data.cmdargtoken[data.cmdNBarg].type =
             CMDARGTOKEN_TYPE_FLOAT;
         data.cmdargtoken[data.cmdNBarg]
-            .val.numf = result.dval;
+        .val.numf = result.dval;
     }
-    else if (result.type == VAL_LONG)
+    else if(result.type == VAL_LONG)
     {
-        if (data.core.Debug > 0)
+        if(data.core.Debug > 0)
         {
             printf("\t long:   %ld\n",
                    result.lval);
@@ -298,18 +299,18 @@ void cli_parse(const char *input)
         data.cmdargtoken[data.cmdNBarg].type =
             CMDARGTOKEN_TYPE_LONG;
         data.cmdargtoken[data.cmdNBarg].val
-            .numl = result.lval;
+        .numl = result.lval;
     }
-    else if (result.type == VAL_STRING)
+    else if(result.type == VAL_STRING)
     {
-        if (data.core.Debug > 0)
+        if(data.core.Debug > 0)
         {
             printf("\t string: %s\n",
                    result.sval);
         }
         snprintf(
             data.cmdargtoken[data.cmdNBarg]
-                .val.string,
+            .val.string,
             STRINGMAXLEN_CMDARGTOKEN_VAL,
             "%s",
             result.sval
@@ -338,7 +339,7 @@ int cli_calc_eval_line(const char *input)
     eval_error  = 0;
     eval_pos    = 0;
 
-    if (eval_ntok <= 0 || cur_eval()->type == TOK_NEWLINE || cur_eval()->type == TOK_EOF)
+    if(eval_ntok <= 0 || cur_eval()->type == TOK_NEWLINE || cur_eval()->type == TOK_EOF)
     {
         return 0; // empty expression
     }
@@ -346,7 +347,7 @@ int cli_calc_eval_line(const char *input)
     val_t result = parse_expr(0);
 
     /* if there is any parse error or trailing garbage */
-    if (parse_error || eval_error || (cur_eval()->type != TOK_EOF && cur_eval()->type != TOK_NEWLINE))
+    if(parse_error || eval_error || (cur_eval()->type != TOK_EOF && cur_eval()->type != TOK_NEWLINE))
     {
         return 0; /* not a pure math expression */
     }
@@ -354,10 +355,13 @@ int cli_calc_eval_line(const char *input)
     /* Check if this was a top-level assignment for output formatting */
     int is_assignment = 0;
     const char *assign_var_name = NULL;
-    if (eval_ntok >= 3)
+    if(eval_ntok >= 3)
     {
-        if ((eval_tokens[0].type == TOK_VAR || eval_tokens[0].type == TOK_NVAR || eval_tokens[0].type == TOK_IMAGE) &&
-            (eval_tokens[1].type == TOK_EQUAL || eval_tokens[1].type == TOK_OP_PLUS_EQ || eval_tokens[1].type == TOK_OP_MINUS_EQ || eval_tokens[1].type == TOK_OP_STAR_EQ || eval_tokens[1].type == TOK_OP_SLASH_EQ))
+        if((eval_tokens[0].type == TOK_VAR || eval_tokens[0].type == TOK_NVAR
+                || eval_tokens[0].type == TOK_IMAGE) &&
+                (eval_tokens[1].type == TOK_EQUAL || eval_tokens[1].type == TOK_OP_PLUS_EQ
+                 || eval_tokens[1].type == TOK_OP_MINUS_EQ || eval_tokens[1].type == TOK_OP_STAR_EQ
+                 || eval_tokens[1].type == TOK_OP_SLASH_EQ))
         {
             is_assignment = 1;
             assign_var_name = eval_tokens[0].sval;
@@ -365,9 +369,9 @@ int cli_calc_eval_line(const char *input)
     }
 
     /* Success! Print output and return 1 */
-    if (result.type == VAL_LONG)
+    if(result.type == VAL_LONG)
     {
-        if (is_assignment)
+        if(is_assignment)
         {
             printf("    %s long: %ld\n", assign_var_name, result.lval);
         }
@@ -376,9 +380,9 @@ int cli_calc_eval_line(const char *input)
             printf("    long: %ld\n", result.lval);
         }
     }
-    else if (result.type == VAL_DOUBLE)
+    else if(result.type == VAL_DOUBLE)
     {
-        if (is_assignment)
+        if(is_assignment)
         {
             printf("    %s double: %.*g\n",
                    assign_var_name,
@@ -392,13 +396,14 @@ int cli_calc_eval_line(const char *input)
                    result.dval);
         }
     }
-    else if (result.type == VAL_STRING)
+    else if(result.type == VAL_STRING)
     {
         /* Just string returned, maybe "ls" etc */
         /* To prevent capturing generic shell commands that happen to be single string tokens */
-        if (eval_ntok > 2)
-        {   /* it took operators to combine them into string? Rare... */
-            if (is_assignment)
+        if(eval_ntok > 2)
+        {
+            /* it took operators to combine them into string? Rare... */
+            if(is_assignment)
             {
                 printf("    %s string: %s\n", assign_var_name, result.sval);
             }
@@ -412,10 +417,10 @@ int cli_calc_eval_line(const char *input)
             return 0; /* It was probably a generic 1-word shell command like `ls` */
         }
     }
-    else if (result.type == VAL_GENERIC)
+    else if(result.type == VAL_GENERIC)
     {
-         /* generic usually means function evaluated but no specific printable value returned */
-         //printf("    generic\n");
+        /* generic usually means function evaluated but no specific printable value returned */
+        //printf("    generic\n");
     }
 
     /* Clean up temporary images created
@@ -424,17 +429,17 @@ int cli_calc_eval_line(const char *input)
      * slice materialization buffers). */
     {
         char tmpn[200];
-        for (long i = 0;
-             i < data.calctmp_imindex;
-             i++)
+        for(long i = 0;
+                i < data.calctmp_imindex;
+                i++)
         {
             snprintf(tmpn, sizeof(tmpn),
                      "_tmpcalc%ld", i);
             imageID tid = image_ID(
-                tmpn,
-                data.core.image,
-                data.core.NB_MAX_IMAGE);
-            if (tid != -1)
+                              tmpn,
+                              data.core.image,
+                              data.core.NB_MAX_IMAGE);
+            if(tid != -1)
             {
                 delete_image_ID(
                     tmpn,
@@ -449,7 +454,7 @@ int cli_calc_eval_line(const char *input)
 
 /**
  * @brief Evaluate a string as a pure math expression, returning the result value silently.
- * 
+ *
  * @param input     Expression string
  * @param out_type  Pointer to receive the parsed type (1=long, 2=double)
  * @param out_lval  Pointer to receive long value
@@ -471,7 +476,7 @@ int cli_calc_eval_math_to_val(
     eval_error  = 0;
     eval_pos    = 0;
 
-    if (eval_ntok <= 0 || cur_eval()->type == TOK_NEWLINE || cur_eval()->type == TOK_EOF)
+    if(eval_ntok <= 0 || cur_eval()->type == TOK_NEWLINE || cur_eval()->type == TOK_EOF)
     {
         return 0; // empty expression
     }
@@ -479,25 +484,42 @@ int cli_calc_eval_math_to_val(
     val_t result = parse_expr(0);
 
     /* if there is any parse error or trailing garbage */
-    if (parse_error || eval_error || (cur_eval()->type != TOK_EOF && cur_eval()->type != TOK_NEWLINE))
+    if(parse_error || eval_error || (cur_eval()->type != TOK_EOF && cur_eval()->type != TOK_NEWLINE))
     {
         return 0; /* not a pure math expression */
     }
 
     /* Success! If it's a string, it's not pure math unless it was evaluated from an operator */
-    if (result.type == VAL_STRING && eval_ntok <= 2)
+    if(result.type == VAL_STRING && eval_ntok <= 2)
     {
         return 0;
     }
 
     /* Output values */
-    if (result.type == VAL_LONG) {
-        if (out_type) *out_type = 1;
-        if (out_lval) *out_lval = result.lval;
-    } else if (result.type == VAL_DOUBLE) {
-        if (out_type) *out_type = 2;
-        if (out_dval) *out_dval = result.dval;
-    } else {
+    if(result.type == VAL_LONG)
+    {
+        if(out_type)
+        {
+            *out_type = 1;
+        }
+        if(out_lval)
+        {
+            *out_lval = result.lval;
+        }
+    }
+    else if(result.type == VAL_DOUBLE)
+    {
+        if(out_type)
+        {
+            *out_type = 2;
+        }
+        if(out_dval)
+        {
+            *out_dval = result.dval;
+        }
+    }
+    else
+    {
         return 0; // Not a numeric result
     }
 

--- a/src/cli/libmilkscript/cli_calc_parser.c
+++ b/src/cli/libmilkscript/cli_calc_parser.c
@@ -456,7 +456,11 @@ int cli_calc_eval_line(const char *input)
  * @param out_dval  Pointer to receive double value
  * @return 1 on success (pure math), 0 on failure/string
  */
-int cli_calc_eval_math_to_val(const char *input, int *out_type, long *out_lval, double *out_dval)
+int cli_calc_eval_math_to_val(
+    const char *input,
+    int *out_type,
+    long *out_lval,
+    double *out_dval)
 {
     parse_mode = 1;
     char tbuf[8192];

--- a/src/cli/libmilkscript/milkscript_api.c
+++ b/src/cli/libmilkscript/milkscript_api.c
@@ -41,7 +41,9 @@ extern void libinit_COREMOD_iofits(void);
  * Sets up the interpreter state, loads modules,
  * and prepares the command dispatch table.
  */
-errno_t milkscript_init(int argc, char **argv)
+errno_t milkscript_init(
+    int argc,
+    char **argv)
 {
     if(argc > 0 && argv && argv[0])
     {

--- a/src/cli/libmilkscript/milkscript_main.c
+++ b/src/cli/libmilkscript/milkscript_main.c
@@ -164,7 +164,9 @@ static void milkscript_main_usage(const char *prog)
  * Sets $0 (script name), $1..$N (arguments), and $# (count).
  * Unsets any leftover positional variables beyond $N.
  */
-static void set_positional_args(int argc, char **argv)
+static void set_positional_args(
+    int argc,
+    char **argv)
 {
     char nbuf[32];
 
@@ -190,7 +192,9 @@ static void set_positional_args(int argc, char **argv)
     cli_var_set("#", nbuf);
 }
 
-int main(int argc, char **argv)
+int main(
+    int argc,
+    char **argv)
 {
     /* Handle -h1/--help-oneline before getopt so "-h1" is not
      * parsed as "-h" (flag) + "1" (unknown). */

--- a/src/cli/libmilkscript/standalone_dependencies.c
+++ b/src/cli/libmilkscript/standalone_dependencies.c
@@ -35,7 +35,9 @@ int        C_ERRNO = 0;
 /*                                         DUPLICATED CODE */
 /* ===============================================================================================
  */
-struct timespec timespec_diff(struct timespec start, struct timespec end)
+struct timespec timespec_diff(
+    struct timespec start,
+    struct timespec end)
 {
     struct timespec temp;
     if((end.tv_nsec - start.tv_nsec) < 0)
@@ -54,14 +56,16 @@ struct timespec timespec_diff(struct timespec start, struct timespec end)
 /**
  * @brief Print the milk script engine header banner.
  */
-int print_header(const char *str, char c)
+int print_header(
+    const char *str,
+    char c)
 {
     long n;
-    long i;
+
 
     attron(A_BOLD);
     n = strlen(str);
-    for(i = 0; i < (wcol - n) / 2; i++)
+    for(long i = 0; i < (wcol - n) / 2; i++)
     {
         printw("%c", c);
     }
@@ -79,7 +83,11 @@ int print_header(const char *str, char c)
 /**
  * @brief Quicksort partition for long array.
  */
-void qs2l(double *array, long *array1, long left, long right)
+void qs2l(
+    double *array,
+    long *array1,
+    long left,
+    long right)
 {
     register long i, j;
     double        x, y;
@@ -129,12 +137,19 @@ void qs2l(double *array, long *array1, long left, long right)
 /**
  * @brief Quicksort two parallel long arrays.
  */
-void quick_sort2l(double *array, long *array1, long count)
+void quick_sort2l(
+    double *array,
+    long *array1,
+    long count)
 {
     qs2l(array, array1, 0, count - 1);
 }
 
-void qs2l_double(double *array, long *array1, long left, long right)
+void qs2l_double(
+    double *array,
+    long *array1,
+    long left,
+    long right)
 {
     register long i, j;
     double        x, y;
@@ -181,12 +196,18 @@ void qs2l_double(double *array, long *array1, long left, long right)
     }
 }
 
-void quick_sort2l_double(double *array, long *array1, long count)
+void quick_sort2l_double(
+    double *array,
+    long *array1,
+    long count)
 {
     qs2l_double(array, array1, 0, count - 1);
 }
 
-void qs_long(long *array, long left, long right)
+void qs_long(
+    long *array,
+    long left,
+    long right)
 {
     register long i, j;
     long          x, y;
@@ -227,7 +248,9 @@ void qs_long(long *array, long left, long right)
     }
 }
 
-void quick_sort_long(long *array, long count)
+void quick_sort_long(
+    long *array,
+    long count)
 {
     qs_long(array, 0, count - 1);
 }
@@ -256,7 +279,11 @@ void quick_sort_long(long *array, long count)
  * 			error message to be printed
  *
  */
-int printERROR(const char *file, const char *func, int line, char *errmessage)
+int printERROR(
+    const char *file,
+    const char *func,
+    int line,
+    char *errmessage)
 {
     fprintf(stderr,
             "%c[%d;%dm ERROR [ %s:%d: %s ]  %c[%d;m\n",

--- a/src/cli/overview/milk-procinfo-info.c
+++ b/src/cli/overview/milk-procinfo-info.c
@@ -383,7 +383,9 @@ static void print_proc_info(
  * Help
  * ========================================================= */
 
-static void print_help(const char *progname, int mh_color)
+static void print_help(
+    const char *progname,
+    int mh_color)
 {
     milk_help_banner(progname, PI_ONELINE, mh_color);
     milk_help_section("Usage", mh_color);
@@ -450,7 +452,9 @@ static int find_proc_by_name(
  * main
  * ========================================================= */
 
-int main(int argc, char *argv[])
+int main(
+    int argc,
+    char *argv[])
 {
     int action = milk_help_init(argc, argv,
                                 PI_ONELINE, PI_DESC_LONG);

--- a/src/cli/overview/milk-stream-graph.c
+++ b/src/cli/overview/milk-stream-graph.c
@@ -141,7 +141,9 @@ static void sg_raw_exit(void)
  * Usage
  * ========================================================= */
 
-static void print_usage(const char *prog, int mh_color)
+static void print_usage(
+    const char *prog,
+    int mh_color)
 {
     milk_help_banner(prog, SG_ONELINE, mh_color);
     milk_help_section("Usage", mh_color);
@@ -764,7 +766,9 @@ static void sg_interactive(
  * main
  * ========================================================= */
 
-int main(int argc, char *argv[])
+int main(
+    int argc,
+    char *argv[])
 {
     int action = milk_help_init(argc, argv,
                                 SG_ONELINE, SG_DESC_LONG);

--- a/src/cli/overview/milk-stream-info.c
+++ b/src/cli/overview/milk-stream-info.c
@@ -61,7 +61,7 @@ volatile sig_atomic_t ov_sigTERM = 0;
 
 static const char *dtype_name(uint8_t dt)
 {
-    switch (dt)
+    switch(dt)
     {
     case _DATATYPE_UINT8:
         return "UINT8";
@@ -94,7 +94,7 @@ static const char *dtype_name(uint8_t dt)
 
 static unsigned int dtype_bytes(uint8_t dt)
 {
-    switch (dt)
+    switch(dt)
     {
     case _DATATYPE_UINT8:
     case _DATATYPE_INT8:
@@ -124,12 +124,12 @@ static unsigned int dtype_bytes(uint8_t dt)
 
 static const char *pid_status_str(pid_t pid)
 {
-    if (pid <= 0)
+    if(pid <= 0)
     {
         return C_DIM "N/A" C_RST;
     }
     ov_pid_status_t st = pid_get_status(pid);
-    switch (st)
+    switch(st)
     {
     case OV_PID_ALIVE:
         return C_ALIVE "ALIVE" C_RST;
@@ -149,7 +149,7 @@ static const char *proc_name_by_pid(
     pid_t pid)
 {
     int pi = ov_find_proc_by_pid(m, pid);
-    if (pi >= 0)
+    if(pi >= 0)
     {
         return m->procs[pi].name;
     }
@@ -182,13 +182,13 @@ static void print_stream_info(
     /* Dimensions */
     {
         char dimstr[64];
-        if (s->naxis == 1)
+        if(s->naxis == 1)
         {
             snprintf(dimstr, sizeof(dimstr),
                      "1D  %u",
                      (unsigned) s->size[0]);
         }
-        else if (s->naxis == 2)
+        else if(s->naxis == 2)
         {
             snprintf(dimstr, sizeof(dimstr),
                      "2D  %u x %u",
@@ -238,7 +238,7 @@ static void print_stream_info(
         printf("   %-18s: " C_PROC "%d" C_RST,
                "Creator PID",
                (int) s->creatorPID);
-        if (cname)
+        if(cname)
         {
             printf(" (%s)", cname);
         }
@@ -251,7 +251,7 @@ static void print_stream_info(
         printf("   %-18s: " C_PROC "%d" C_RST,
                "Owner PID",
                (int) s->ownerPID);
-        if (oname)
+        if(oname)
         {
             printf(" (%s)", oname);
         }
@@ -264,7 +264,7 @@ static void print_stream_info(
     printf("   %-18s: " C_VAL "%" PRIu64 C_RST "\n",
            "cnt0",
            (uint64_t) s->cnt0);
-    if (s->update_hz > 0.01)
+    if(s->update_hz > 0.01)
     {
         printf("   %-18s: " C_VAL "%.1f Hz"
                C_RST "\n",
@@ -274,10 +274,10 @@ static void print_stream_info(
     /* ---- Semaphores ---- */
     printf("\n" C_HDR " Semaphores" C_RST
            " (%d active)\n", s->nb_sem);
-    if (s->nb_sem > 0)
+    if(s->nb_sem > 0)
     {
         printf("   ");
-        for (int i = 0; i < s->nb_sem; i++)
+        for(int i = 0; i < s->nb_sem; i++)
         {
             printf("[%d]=%d  ", i, s->semval[i]);
         }
@@ -289,7 +289,7 @@ static void print_stream_info(
            C_RST " (from system graph)\n");
 
     int sni = s->node_idx;
-    if (sni < 0)
+    if(sni < 0)
     {
         printf("   " C_DIM
                "(stream not in graph)"
@@ -300,21 +300,21 @@ static void print_stream_info(
         int found_any = 0;
 
         /* Written by (PROC → stream) */
-        for (int e = 0; e < m->nb_edges; e++)
+        for(int e = 0; e < m->nb_edges; e++)
         {
-            if (m->edges[e].tgt_node != sni)
+            if(m->edges[e].tgt_node != sni)
             {
                 continue;
             }
-            if (m->edges[e].type
-                != OV_EDGE_PROC_WRITES_STREAM)
+            if(m->edges[e].type
+                    != OV_EDGE_PROC_WRITES_STREAM)
             {
                 continue;
             }
             int ni = m->edges[e].src_node;
-            if (ni < 0
-                || ni >= m->nb_nodes
-                || m->nodes[ni].type
+            if(ni < 0
+                    || ni >= m->nb_nodes
+                    || m->nodes[ni].type
                     != OV_NODE_PROC)
             {
                 continue;
@@ -329,23 +329,23 @@ static void print_stream_info(
         }
 
         /* Triggers (stream → PROC) */
-        for (int e = 0; e < m->nb_edges; e++)
+        for(int e = 0; e < m->nb_edges; e++)
         {
-            if (m->edges[e].src_node != sni)
+            if(m->edges[e].src_node != sni)
             {
                 continue;
             }
-            if (m->edges[e].type
-                != OV_EDGE_STREAM_TRIGGERS_PROC
-                && m->edges[e].type
-                != OV_EDGE_PROC_TRIGGER_STREAM)
+            if(m->edges[e].type
+                    != OV_EDGE_STREAM_TRIGGERS_PROC
+                    && m->edges[e].type
+                    != OV_EDGE_PROC_TRIGGER_STREAM)
             {
                 continue;
             }
             int ni = m->edges[e].tgt_node;
-            if (ni < 0
-                || ni >= m->nb_nodes
-                || m->nodes[ni].type
+            if(ni < 0
+                    || ni >= m->nb_nodes
+                    || m->nodes[ni].type
                     != OV_NODE_PROC)
             {
                 continue;
@@ -360,21 +360,21 @@ static void print_stream_info(
         }
 
         /* Read by (stream → PROC via sem) */
-        for (int e = 0; e < m->nb_edges; e++)
+        for(int e = 0; e < m->nb_edges; e++)
         {
-            if (m->edges[e].src_node != sni)
+            if(m->edges[e].src_node != sni)
             {
                 continue;
             }
-            if (m->edges[e].type
-                != OV_EDGE_STREAM_READ_BY_PROC)
+            if(m->edges[e].type
+                    != OV_EDGE_STREAM_READ_BY_PROC)
             {
                 continue;
             }
             int ni = m->edges[e].tgt_node;
-            if (ni < 0
-                || ni >= m->nb_nodes
-                || m->nodes[ni].type
+            if(ni < 0
+                    || ni >= m->nb_nodes
+                    || m->nodes[ni].type
                     != OV_NODE_PROC)
             {
                 continue;
@@ -389,21 +389,21 @@ static void print_stream_info(
         }
 
         /* FPS input to (stream → FPS) */
-        for (int e = 0; e < m->nb_edges; e++)
+        for(int e = 0; e < m->nb_edges; e++)
         {
-            if (m->edges[e].src_node != sni)
+            if(m->edges[e].src_node != sni)
             {
                 continue;
             }
-            if (m->edges[e].type
-                != OV_EDGE_FPS_INPUT_STREAM)
+            if(m->edges[e].type
+                    != OV_EDGE_FPS_INPUT_STREAM)
             {
                 continue;
             }
             int ni = m->edges[e].tgt_node;
-            if (ni < 0
-                || ni >= m->nb_nodes
-                || m->nodes[ni].type
+            if(ni < 0
+                    || ni >= m->nb_nodes
+                    || m->nodes[ni].type
                     != OV_NODE_FPS)
             {
                 continue;
@@ -417,21 +417,21 @@ static void print_stream_info(
         }
 
         /* FPS output of (FPS → stream) */
-        for (int e = 0; e < m->nb_edges; e++)
+        for(int e = 0; e < m->nb_edges; e++)
         {
-            if (m->edges[e].tgt_node != sni)
+            if(m->edges[e].tgt_node != sni)
             {
                 continue;
             }
-            if (m->edges[e].type
-                != OV_EDGE_FPS_OUTPUT_STREAM)
+            if(m->edges[e].type
+                    != OV_EDGE_FPS_OUTPUT_STREAM)
             {
                 continue;
             }
             int ni = m->edges[e].src_node;
-            if (ni < 0
-                || ni >= m->nb_nodes
-                || m->nodes[ni].type
+            if(ni < 0
+                    || ni >= m->nb_nodes
+                    || m->nodes[ni].type
                     != OV_NODE_FPS)
             {
                 continue;
@@ -444,7 +444,7 @@ static void print_stream_info(
             found_any = 1;
         }
 
-        if (!found_any)
+        if(!found_any)
         {
             printf("   " C_DIM
                    "(no connections found)"
@@ -453,12 +453,12 @@ static void print_stream_info(
     }
 
     /* ---- Process trace ---- */
-    if (s->nb_proctrace > 0)
+    if(s->nb_proctrace > 0)
     {
         printf("\n" C_HDR " Process Trace"
                C_RST " (STREAM_PROC_TRACE)\n");
-        for (int t = 0;
-             t < s->nb_proctrace; t++)
+        for(int t = 0;
+                t < s->nb_proctrace; t++)
         {
             const char *pn =
                 proc_name_by_pid(
@@ -469,9 +469,9 @@ static void print_stream_info(
                    t,
                    (int) s->proctrace_pid[t],
                    (uint64_t)
-                       s->proctrace_inode[t],
+                   s->proctrace_inode[t],
                    s->proctrace_trigmode[t]);
-            if (pn)
+            if(pn)
             {
                 printf("  (%s)", pn);
             }
@@ -515,7 +515,8 @@ static void print_help(
     printf("  %s$ milk-stream-info%s %sdm00disp%s\n\n",
            mh_color ? MH_CMD : "", mh_color ? MH_RST : "",
            mh_color ? MH_ARG : "", mh_color ? MH_RST : "");
-    const char *see_also[] = {
+    const char *see_also[] =
+    {
         "milk-stream-list:list active shared memory streams",
         "milk-stream-rm:remove shared memory streams",
         "milk-procinfo-info:inspect processinfo memory contents"
@@ -533,28 +534,32 @@ int main(
 {
     int action = milk_help_init(argc, argv,
                                 SI_ONELINE, SI_DESC_LONG);
-    if (action == MH_ACTION_H1 || action == MH_ACTION_H2)
+    if(action == MH_ACTION_H1 || action == MH_ACTION_H2)
+    {
         return 0;
+    }
     int mh_color = (action == MH_ACTION_HELP);
-    if (action == MH_ACTION_HELP || action == MH_ACTION_MONO)
+    if(action == MH_ACTION_HELP || action == MH_ACTION_MONO)
     {
         print_help(argv[0], mh_color);
         return 0;
     }
 
-    static struct option long_opts[] = {
+    static struct option long_opts[] =
+    {
         {"help", no_argument, 0, 'h'},
         {0, 0, 0, 0}
     };
 
     int opt;
-    while ((opt = getopt_long(
-                argc, argv, "h",
-                long_opts, NULL)) != -1)
+    while((opt = getopt_long(
+                     argc, argv, "h",
+                     long_opts, NULL)) != -1)
     {
-        switch (opt)
+        switch(opt)
         {
-        case 'h': break; /* handled above */
+        case 'h':
+            break; /* handled above */
         default:
             printf("\n\033[1;31mERROR\033[0m invalid option\n\n");
             print_help(argv[0], 1);
@@ -562,7 +567,7 @@ int main(
         }
     }
 
-    if (optind >= argc)
+    if(optind >= argc)
     {
         printf("\n\033[1;31mERROR\033[0m stream name required\n\n");
         print_help(argv[0], 1);
@@ -579,7 +584,7 @@ int main(
     /* Find the requested stream */
     int si = ov_find_stream_by_name(
                  &model, stream_name);
-    if (si < 0)
+    if(si < 0)
     {
         PRINT_ERROR(
             "stream '%s' not found in shared memory",

--- a/src/cli/overview/milk-stream-info.c
+++ b/src/cli/overview/milk-stream-info.c
@@ -486,7 +486,9 @@ static void print_stream_info(
  * Help
  * ========================================================= */
 
-static void print_help(const char *progname, int mh_color)
+static void print_help(
+    const char *progname,
+    int mh_color)
 {
     milk_help_banner(progname, SI_ONELINE, mh_color);
     milk_help_section("Usage", mh_color);
@@ -525,7 +527,9 @@ static void print_help(const char *progname, int mh_color)
  * main
  * ========================================================= */
 
-int main(int argc, char *argv[])
+int main(
+    int argc,
+    char *argv[])
 {
     int action = milk_help_init(argc, argv,
                                 SI_ONELINE, SI_DESC_LONG);

--- a/src/cli/overview/milkCTRL.c
+++ b/src/cli/overview/milkCTRL.c
@@ -128,7 +128,9 @@ extern int ov_handle_key(
  * Usage / help
  * ========================================================= */
 
-static void print_help(const char *prog, int mh_color)
+static void print_help(
+    const char *prog,
+    int mh_color)
 {
     milk_help_banner(prog, "unified system dashboard TUI (milk-CTRL) for streams, FPS, and processes",
                      mh_color);
@@ -248,7 +250,9 @@ static void print_help(const char *prog, int mh_color)
  * main
  * ========================================================= */
 
-int main(int argc, char *argv[])
+int main(
+    int argc,
+    char *argv[])
 {
     /* --- Help handling --- */
     int action = milk_help_init(argc, argv,

--- a/src/cli/overview/overview_ansi.h
+++ b/src/cli/overview/overview_ansi.h
@@ -75,12 +75,18 @@ extern int            ov__raw_active;
 static inline void ov_raw_mode_enter(void)
 {
     struct termios raw;
-    if (ov__raw_active) return;
-    if (tcgetattr(STDIN_FILENO, &ov__orig_termios) == -1) return;
+    if(ov__raw_active)
+    {
+        return;
+    }
+    if(tcgetattr(STDIN_FILENO, &ov__orig_termios) == -1)
+    {
+        return;
+    }
     raw = ov__orig_termios;
     raw.c_iflag &= ~(unsigned int)(IXON | ICRNL | BRKINT | INPCK | ISTRIP);
     raw.c_oflag &= ~(unsigned int)(OPOST);
-    raw.c_cflag |=  (unsigned int)(CS8);
+    raw.c_cflag |= (unsigned int)(CS8);
     raw.c_lflag &= ~(unsigned int)(ECHO | ICANON | IEXTEN | ISIG);
     raw.c_cc[VMIN]  = 0;
     raw.c_cc[VTIME] = 0;
@@ -90,27 +96,33 @@ static inline void ov_raw_mode_enter(void)
     fcntl(STDIN_FILENO, F_SETFL, flags | O_NONBLOCK);
 
     const char seq[] = "\033[?1049h\033[?25l\033[?7l\033[?1002h\033[?1006h";
-    if (write(STDOUT_FILENO, seq, sizeof(seq) - 1) < 0) {}
+    if(write(STDOUT_FILENO, seq, sizeof(seq) - 1) < 0) {}
     ov__raw_active = 1;
 }
 
 static inline void ov_raw_mode_exit(void)
 {
-    if (!ov__raw_active) return;
+    if(!ov__raw_active)
+    {
+        return;
+    }
     const char seq[] = "\033[?1003l\033[?1006l\033[?1002l\033[?25h\033[?7h\033[0m\033[?1049l";
-    if (write(STDOUT_FILENO, seq, sizeof(seq) - 1) < 0) {}
+    if(write(STDOUT_FILENO, seq, sizeof(seq) - 1) < 0) {}
     tcsetattr(STDIN_FILENO, TCSAFLUSH, &ov__orig_termios);
     ov__raw_active = 0;
 }
 
 static inline void ov_set_mouse_hover(int enable)
 {
-    if (enable) {
+    if(enable)
+    {
         const char seq[] = "\033[?1002l\033[?1003h";
-        if (write(STDOUT_FILENO, seq, sizeof(seq) - 1) < 0) {}
-    } else {
+        if(write(STDOUT_FILENO, seq, sizeof(seq) - 1) < 0) {}
+    }
+    else
+    {
         const char seq[] = "\033[?1003l\033[?1002h";
-        if (write(STDOUT_FILENO, seq, sizeof(seq) - 1) < 0) {}
+        if(write(STDOUT_FILENO, seq, sizeof(seq) - 1) < 0) {}
     }
 }
 
@@ -121,9 +133,16 @@ static inline void ov_get_terminal_size(
     struct winsize ws;
     *rows = 24;
     *cols = 80;
-    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == 0) {
-        if (ws.ws_row > 0) *rows = (int) ws.ws_row;
-        if (ws.ws_col > 0) *cols = (int) ws.ws_col;
+    if(ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == 0)
+    {
+        if(ws.ws_row > 0)
+        {
+            *rows = (int) ws.ws_row;
+        }
+        if(ws.ws_col > 0)
+        {
+            *cols = (int) ws.ws_col;
+        }
     }
 }
 
@@ -148,7 +167,8 @@ static inline void ov_get_terminal_size(
 #define OV_ATTR_REVERSE   (1 << 4)
 #define OV_ATTR_BLINK     (1 << 5)
 
-typedef struct {
+typedef struct
+{
     char     ch[5];    // UTF-8 char up to 4 bytes + null terminator
     uint32_t fg;       // Color code + flag
     uint32_t bg;       // Color code + flag
@@ -185,8 +205,10 @@ static inline void ov_buf_reset(void)
     ov__current_ul = OV_COLOR_NONE;
     ov__current_attr = 0;
 
-    for (int r = 0; r < OV_MAX_ROWS; r++) {
-        for (int c = 0; c < OV_MAX_COLS; c++) {
+    for(int r = 0; r < OV_MAX_ROWS; r++)
+    {
+        for(int c = 0; c < OV_MAX_COLS; c++)
+        {
             ov__shadow[r][c].ch[0] = ' ';
             ov__shadow[r][c].ch[1] = '\0';
             ov__shadow[r][c].fg = OV_COLOR_NONE;
@@ -201,7 +223,8 @@ static inline void ov_buf_append(
     const char *data,
     int len)
 {
-    if (ov__screenbuf_len + len < OV_SCREENBUF_SIZE) {
+    if(ov__screenbuf_len + len < OV_SCREENBUF_SIZE)
+    {
         memcpy(ov__screenbuf + ov__screenbuf_len, data, (size_t) len);
         ov__screenbuf_len += len;
     }
@@ -209,20 +232,32 @@ static inline void ov_buf_append(
 
 static inline void ov_buf_flush_internal(void)
 {
-    if (ov__screenbuf_len > 0) {
+    if(ov__screenbuf_len > 0)
+    {
         int written = 0;
-        while (written < ov__screenbuf_len) {
-            ssize_t ret = write(STDOUT_FILENO, ov__screenbuf + written, (size_t) (ov__screenbuf_len - written));
-            if (ret < 0) {
-                if (errno == EINTR) continue;
-                if (errno == EAGAIN || errno == EWOULDBLOCK) {
-                    struct pollfd pfd; pfd.fd = STDOUT_FILENO; pfd.events = POLLOUT;
+        while(written < ov__screenbuf_len)
+        {
+            ssize_t ret = write(STDOUT_FILENO, ov__screenbuf + written, (size_t)(ov__screenbuf_len - written));
+            if(ret < 0)
+            {
+                if(errno == EINTR)
+                {
+                    continue;
+                }
+                if(errno == EAGAIN || errno == EWOULDBLOCK)
+                {
+                    struct pollfd pfd;
+                    pfd.fd = STDOUT_FILENO;
+                    pfd.events = POLLOUT;
                     poll(&pfd, 1, 100);
                     continue;
                 }
                 break;
             }
-            if (ret == 0) break;
+            if(ret == 0)
+            {
+                break;
+            }
             written += ret;
             ov__total_bytes_rendered += ret;
         }
@@ -242,24 +277,36 @@ static inline void ov_buf_flush_delta(
     uint8_t emit_attr = 0;
     char tmp[128];
 
-    if (term_rows > OV_MAX_ROWS) term_rows = OV_MAX_ROWS;
-    if (term_cols > OV_MAX_COLS) term_cols = OV_MAX_COLS;
+    if(term_rows > OV_MAX_ROWS)
+    {
+        term_rows = OV_MAX_ROWS;
+    }
+    if(term_cols > OV_MAX_COLS)
+    {
+        term_cols = OV_MAX_COLS;
+    }
 
     // Start synchronized output
     ov_buf_append("\033[?2026h", 8);
 
-    for (int r = 0; r < term_rows; r++) {
-        for (int c = 0; c < term_cols; c++) {
+    for(int r = 0; r < term_rows; r++)
+    {
+        for(int c = 0; c < term_cols; c++)
+        {
             OV_CELL *sc = &ov__shadow[r][c];
             OV_CELL *fc = &ov__front[r][c];
 
-            if (sc->ch[0] == '\0') {
-                sc->ch[0] = ' '; sc->ch[1] = '\0'; // ensure valid char
+            if(sc->ch[0] == '\0')
+            {
+                sc->ch[0] = ' ';
+                sc->ch[1] = '\0'; // ensure valid char
             }
 
-            if (memcmp(sc, fc, sizeof(OV_CELL)) != 0) {
+            if(memcmp(sc, fc, sizeof(OV_CELL)) != 0)
+            {
                 // Pos
-                if (emit_cursor_r != r + 1 || emit_cursor_c != c + 1) {
+                if(emit_cursor_r != r + 1 || emit_cursor_c != c + 1)
+                {
                     int n = snprintf(tmp, sizeof(tmp), "\033[%d;%dH", r + 1, c + 1);
                     ov_buf_append(tmp, n);
                     emit_cursor_r = r + 1;
@@ -267,10 +314,11 @@ static inline void ov_buf_flush_delta(
                 }
 
                 // Attr reset if missing
-                if ((emit_attr & ~sc->attr) != 0 || 
-                    (sc->fg != emit_fg && emit_fg != OV_COLOR_NONE && sc->fg == OV_COLOR_NONE) ||
-                    (sc->bg != emit_bg && emit_bg != OV_COLOR_NONE && sc->bg == OV_COLOR_NONE) ||
-                    (sc->ul != emit_ul && emit_ul != OV_COLOR_NONE && sc->ul == OV_COLOR_NONE)) {
+                if((emit_attr & ~sc->attr) != 0 ||
+                        (sc->fg != emit_fg && emit_fg != OV_COLOR_NONE && sc->fg == OV_COLOR_NONE) ||
+                        (sc->bg != emit_bg && emit_bg != OV_COLOR_NONE && sc->bg == OV_COLOR_NONE) ||
+                        (sc->ul != emit_ul && emit_ul != OV_COLOR_NONE && sc->ul == OV_COLOR_NONE))
+                {
                     ov_buf_append("\033[0m", 4);
                     emit_attr = 0;
                     emit_fg = OV_COLOR_NONE;
@@ -279,47 +327,84 @@ static inline void ov_buf_flush_delta(
                 }
 
                 // Add attrs
-                if (sc->attr != emit_attr) {
-                    if ((sc->attr & OV_ATTR_BOLD)      && !(emit_attr & OV_ATTR_BOLD))      ov_buf_append("\033[1m", 4);
-                    if ((sc->attr & OV_ATTR_DIM)       && !(emit_attr & OV_ATTR_DIM))       ov_buf_append("\033[2m", 4);
-                    if ((sc->attr & OV_ATTR_ITALIC)    && !(emit_attr & OV_ATTR_ITALIC))    ov_buf_append("\033[3m", 4);
-                    if ((sc->attr & OV_ATTR_UNDERLINE) && !(emit_attr & OV_ATTR_UNDERLINE)) ov_buf_append("\033[4m", 4);
-                    if ((sc->attr & OV_ATTR_REVERSE)   && !(emit_attr & OV_ATTR_REVERSE))   ov_buf_append("\033[7m", 4);
-                    if ((sc->attr & OV_ATTR_BLINK)     && !(emit_attr & OV_ATTR_BLINK))     ov_buf_append("\033[5m", 4);
+                if(sc->attr != emit_attr)
+                {
+                    if((sc->attr & OV_ATTR_BOLD)      && !(emit_attr & OV_ATTR_BOLD))
+                    {
+                        ov_buf_append("\033[1m", 4);
+                    }
+                    if((sc->attr & OV_ATTR_DIM)       && !(emit_attr & OV_ATTR_DIM))
+                    {
+                        ov_buf_append("\033[2m", 4);
+                    }
+                    if((sc->attr & OV_ATTR_ITALIC)    && !(emit_attr & OV_ATTR_ITALIC))
+                    {
+                        ov_buf_append("\033[3m", 4);
+                    }
+                    if((sc->attr & OV_ATTR_UNDERLINE) && !(emit_attr & OV_ATTR_UNDERLINE))
+                    {
+                        ov_buf_append("\033[4m", 4);
+                    }
+                    if((sc->attr & OV_ATTR_REVERSE)   && !(emit_attr & OV_ATTR_REVERSE))
+                    {
+                        ov_buf_append("\033[7m", 4);
+                    }
+                    if((sc->attr & OV_ATTR_BLINK)     && !(emit_attr & OV_ATTR_BLINK))
+                    {
+                        ov_buf_append("\033[5m", 4);
+                    }
                     emit_attr = sc->attr;
                 }
 
                 // Colors
-                if (sc->fg != emit_fg) {
-                    if (sc->fg != OV_COLOR_NONE) {
-                        if (sc->fg & OV_COLOR_TRUE) {
-                            int n = snprintf(tmp, sizeof(tmp), "\033[38;2;%u;%u;%um", (sc->fg >> 16) & 0xFF, (sc->fg >> 8) & 0xFF, sc->fg & 0xFF);
+                if(sc->fg != emit_fg)
+                {
+                    if(sc->fg != OV_COLOR_NONE)
+                    {
+                        if(sc->fg & OV_COLOR_TRUE)
+                        {
+                            int n = snprintf(tmp, sizeof(tmp), "\033[38;2;%u;%u;%um", (sc->fg >> 16) & 0xFF,
+                                             (sc->fg >> 8) & 0xFF, sc->fg & 0xFF);
                             ov_buf_append(tmp, n);
-                        } else if (sc->fg & OV_COLOR_256) {
+                        }
+                        else if(sc->fg & OV_COLOR_256)
+                        {
                             int n = snprintf(tmp, sizeof(tmp), "\033[38;5;%um", sc->fg & 0xFF);
                             ov_buf_append(tmp, n);
                         }
                     }
                     emit_fg = sc->fg;
                 }
-                if (sc->bg != emit_bg) {
-                    if (sc->bg != OV_COLOR_NONE) {
-                        if (sc->bg & OV_COLOR_TRUE) {
-                            int n = snprintf(tmp, sizeof(tmp), "\033[48;2;%u;%u;%um", (sc->bg >> 16) & 0xFF, (sc->bg >> 8) & 0xFF, sc->bg & 0xFF);
+                if(sc->bg != emit_bg)
+                {
+                    if(sc->bg != OV_COLOR_NONE)
+                    {
+                        if(sc->bg & OV_COLOR_TRUE)
+                        {
+                            int n = snprintf(tmp, sizeof(tmp), "\033[48;2;%u;%u;%um", (sc->bg >> 16) & 0xFF,
+                                             (sc->bg >> 8) & 0xFF, sc->bg & 0xFF);
                             ov_buf_append(tmp, n);
-                        } else if (sc->bg & OV_COLOR_256) {
+                        }
+                        else if(sc->bg & OV_COLOR_256)
+                        {
                             int n = snprintf(tmp, sizeof(tmp), "\033[48;5;%um", sc->bg & 0xFF);
                             ov_buf_append(tmp, n);
                         }
                     }
                     emit_bg = sc->bg;
                 }
-                if (sc->ul != emit_ul) {
-                    if (sc->ul != OV_COLOR_NONE) {
-                        if (sc->ul & OV_COLOR_TRUE) {
-                            int n = snprintf(tmp, sizeof(tmp), "\033[58;2;%u;%u;%um", (sc->ul >> 16) & 0xFF, (sc->ul >> 8) & 0xFF, sc->ul & 0xFF);
+                if(sc->ul != emit_ul)
+                {
+                    if(sc->ul != OV_COLOR_NONE)
+                    {
+                        if(sc->ul & OV_COLOR_TRUE)
+                        {
+                            int n = snprintf(tmp, sizeof(tmp), "\033[58;2;%u;%u;%um", (sc->ul >> 16) & 0xFF,
+                                             (sc->ul >> 8) & 0xFF, sc->ul & 0xFF);
                             ov_buf_append(tmp, n);
-                        } else if (sc->ul & OV_COLOR_256) {
+                        }
+                        else if(sc->ul & OV_COLOR_256)
+                        {
                             int n = snprintf(tmp, sizeof(tmp), "\033[58;5;%um", sc->ul & 0xFF);
                             ov_buf_append(tmp, n);
                         }
@@ -338,7 +423,9 @@ static inline void ov_buf_flush_delta(
     }
 
     // Reset terminal state if we left it dirty so the next frame starts clean
-    if (emit_attr != 0 || emit_fg != OV_COLOR_NONE || emit_bg != OV_COLOR_NONE || emit_ul != OV_COLOR_NONE) {
+    if(emit_attr != 0 || emit_fg != OV_COLOR_NONE || emit_bg != OV_COLOR_NONE
+            || emit_ul != OV_COLOR_NONE)
+    {
         ov_buf_append("\033[0m", 4);
     }
 
@@ -348,10 +435,12 @@ static inline void ov_buf_flush_delta(
     ov_buf_flush_internal();
 }
 
-static inline void ov_buf_append_char(const char *utf8_seq, int bytes) {
-    if (ov__cursor_row >= 1 && ov__cursor_row <= OV_MAX_ROWS &&
-        ov__cursor_col >= 1 && ov__cursor_col <= OV_MAX_COLS) {
-        
+static inline void ov_buf_append_char(const char *utf8_seq, int bytes)
+{
+    if(ov__cursor_row >= 1 && ov__cursor_row <= OV_MAX_ROWS &&
+            ov__cursor_col >= 1 && ov__cursor_col <= OV_MAX_COLS)
+    {
+
         OV_CELL *cell = &ov__shadow[ov__cursor_row - 1][ov__cursor_col - 1];
         memcpy(cell->ch, utf8_seq, bytes);
         cell->ch[bytes] = '\0';
@@ -363,11 +452,24 @@ static inline void ov_buf_append_char(const char *utf8_seq, int bytes) {
     ov__cursor_col++;
 }
 
-static inline int utf8_char_length(unsigned char c) {
-    if ((c & 0x80) == 0) return 1;
-    if ((c & 0xE0) == 0xC0) return 2;
-    if ((c & 0xF0) == 0xE0) return 3;
-    if ((c & 0xF8) == 0xF0) return 4;
+static inline int utf8_char_length(unsigned char c)
+{
+    if((c & 0x80) == 0)
+    {
+        return 1;
+    }
+    if((c & 0xE0) == 0xC0)
+    {
+        return 2;
+    }
+    if((c & 0xF0) == 0xE0)
+    {
+        return 3;
+    }
+    if((c & 0xF8) == 0xF0)
+    {
+        return 4;
+    }
     return 1;
 }
 
@@ -381,12 +483,20 @@ static inline void ov_buf_printf(
     int n = vsnprintf(tmp, sizeof(tmp), fmt, ap);
     va_end(ap);
 
-    if (n > 0) {
-        if (n >= (int)sizeof(tmp)) n = (int)sizeof(tmp) - 1;
+    if(n > 0)
+    {
+        if(n >= (int)sizeof(tmp))
+        {
+            n = (int)sizeof(tmp) - 1;
+        }
         int i = 0;
-        while (i < n) {
+        while(i < n)
+        {
             int char_len = utf8_char_length((unsigned char)tmp[i]);
-            if (i + char_len > n) char_len = n - i;
+            if(i + char_len > n)
+            {
+                char_len = n - i;
+            }
             ov_buf_append_char(&tmp[i], char_len);
             i += char_len;
         }
@@ -397,62 +507,93 @@ static inline void ov_buf_printf(
  * Buffered color / attribute helpers
  * ========================================================= */
 
-static inline void ov_buf_fg(int r, int g, int b) {
+static inline void ov_buf_fg(int r, int g, int b)
+{
     ov__current_fg = OV_COLOR_TRUE | ((r & 0xFF) << 16) | ((g & 0xFF) << 8) | (b & 0xFF);
 }
 
-static inline void ov_buf_bg(int r, int g, int b) {
+static inline void ov_buf_bg(int r, int g, int b)
+{
     ov__current_bg = OV_COLOR_TRUE | ((r & 0xFF) << 16) | ((g & 0xFF) << 8) | (b & 0xFF);
 }
 
-static inline void ov_buf_fg_256(int code) {
+static inline void ov_buf_fg_256(int code)
+{
     ov__current_fg = OV_COLOR_256 | (code & 0xFF);
 }
 
-static inline void ov_buf_bg_256(int code) {
+static inline void ov_buf_bg_256(int code)
+{
     ov__current_bg = OV_COLOR_256 | (code & 0xFF);
 }
 
-static inline void ov_buf_ul_color(int r, int g, int b) {
+static inline void ov_buf_ul_color(int r, int g, int b)
+{
     ov__current_ul = OV_COLOR_TRUE | ((r & 0xFF) << 16) | ((g & 0xFF) << 8) | (b & 0xFF);
 }
 
-static inline void ov_buf_ul_color_256(int code) {
+static inline void ov_buf_ul_color_256(int code)
+{
     ov__current_ul = OV_COLOR_256 | (code & 0xFF);
 }
 
-static inline void ov_buf_pos(int row, int col) {
+static inline void ov_buf_pos(int row, int col)
+{
     ov__cursor_row = row;
     ov__cursor_col = col;
 }
 
-static inline void ov_buf_reset_attr(void) {
+static inline void ov_buf_reset_attr(void)
+{
     ov__current_fg = OV_COLOR_NONE;
     ov__current_bg = OV_COLOR_NONE;
     ov__current_ul = OV_COLOR_NONE;
     ov__current_attr = 0;
 }
 
-static inline void ov_buf_bold(void)      { ov__current_attr |= OV_ATTR_BOLD; }
-static inline void ov_buf_dim(void)       { ov__current_attr |= OV_ATTR_DIM; }
-static inline void ov_buf_italic(void)    { ov__current_attr |= OV_ATTR_ITALIC; }
-static inline void ov_buf_underline(void) { ov__current_attr |= OV_ATTR_UNDERLINE; }
-static inline void ov_buf_reverse(void)   { ov__current_attr |= OV_ATTR_REVERSE; }
-static inline void ov_buf_blink(void)     { ov__current_attr |= OV_ATTR_BLINK; }
+static inline void ov_buf_bold(void)
+{
+    ov__current_attr |= OV_ATTR_BOLD;
+}
+static inline void ov_buf_dim(void)
+{
+    ov__current_attr |= OV_ATTR_DIM;
+}
+static inline void ov_buf_italic(void)
+{
+    ov__current_attr |= OV_ATTR_ITALIC;
+}
+static inline void ov_buf_underline(void)
+{
+    ov__current_attr |= OV_ATTR_UNDERLINE;
+}
+static inline void ov_buf_reverse(void)
+{
+    ov__current_attr |= OV_ATTR_REVERSE;
+}
+static inline void ov_buf_blink(void)
+{
+    ov__current_attr |= OV_ATTR_BLINK;
+}
 
-static inline void ov_buf_cls(void) {
+static inline void ov_buf_cls(void)
+{
     ov_buf_force_clear();
 }
 
-static inline void ov_buf_hline(char ch, int len) {
-    for (int i = 0; i < len; i++) {
+static inline void ov_buf_hline(char ch, int len)
+{
+    for(int i = 0; i < len; i++)
+    {
         ov_buf_append_char(&ch, 1);
     }
 }
 
-static inline void ov_buf_hline_utf8(const char *s, int len) {
+static inline void ov_buf_hline_utf8(const char *s, int len)
+{
     int slen = (int) strlen(s);
-    for (int i = 0; i < len; i++) {
+    for(int i = 0; i < len; i++)
+    {
         ov_buf_append_char(s, slen);
     }
 }
@@ -465,14 +606,22 @@ extern int ov__color_level;
 
 static inline void ov_detect_color_level(void)
 {
-    if (ov__color_level > 0) return;
+    if(ov__color_level > 0)
+    {
+        return;
+    }
     const char *colorterm = getenv("COLORTERM");
     const char *term      = getenv("TERM");
-    if (colorterm && (strstr(colorterm, "truecolor") || strstr(colorterm, "24bit"))) {
+    if(colorterm && (strstr(colorterm, "truecolor") || strstr(colorterm, "24bit")))
+    {
         ov__color_level = 3; /* TrueColor */
-    } else if (term && strstr(term, "256color")) {
+    }
+    else if(term && strstr(term, "256color"))
+    {
         ov__color_level = 2; /* 256-color */
-    } else {
+    }
+    else
+    {
         ov__color_level = 1; /* 16-color */
     }
 }
@@ -488,11 +637,18 @@ static inline int ov_get_key(void)
     ssize_t              n;
 
     n = read(STDIN_FILENO, buf + buf_len, sizeof(buf) - (size_t) buf_len);
-    if (n > 0) buf_len += (int) n;
-    if (buf_len == 0) return OV_KEY_NONE;
+    if(n > 0)
+    {
+        buf_len += (int) n;
+    }
+    if(buf_len == 0)
+    {
+        return OV_KEY_NONE;
+    }
 
     /* single ASCII byte, not ESC */
-    if (buf[0] != 0x1b) {
+    if(buf[0] != 0x1b)
+    {
         int key = (int) buf[0];
         memmove(buf, buf + 1, (size_t)(buf_len - 1));
         buf_len--;
@@ -500,22 +656,49 @@ static inline int ov_get_key(void)
     }
 
     /* Escape sequence */
-    if (buf_len >= 2) {
-        if (buf[1] == '[') {
-            if (buf_len >= 3) {
+    if(buf_len >= 2)
+    {
+        if(buf[1] == '[')
+        {
+            if(buf_len >= 3)
+            {
                 int consumed = 0;
                 int key      = 0;
-                switch (buf[2]) {
-                case 'A': key = OV_KEY_UP; consumed = 3; break;
-                case 'B': key = OV_KEY_DOWN; consumed = 3; break;
-                case 'C': key = OV_KEY_RIGHT; consumed = 3; break;
-                case 'D': key = OV_KEY_LEFT; consumed = 3; break;
-                case 'H': key = OV_KEY_HOME; consumed = 3; break;
-                case 'F': key = OV_KEY_END; consumed = 3; break;
-                case 'Z': key = OV_KEY_BTAB; consumed = 3; break;
-                default: break;
+                switch(buf[2])
+                {
+                case 'A':
+                    key = OV_KEY_UP;
+                    consumed = 3;
+                    break;
+                case 'B':
+                    key = OV_KEY_DOWN;
+                    consumed = 3;
+                    break;
+                case 'C':
+                    key = OV_KEY_RIGHT;
+                    consumed = 3;
+                    break;
+                case 'D':
+                    key = OV_KEY_LEFT;
+                    consumed = 3;
+                    break;
+                case 'H':
+                    key = OV_KEY_HOME;
+                    consumed = 3;
+                    break;
+                case 'F':
+                    key = OV_KEY_END;
+                    consumed = 3;
+                    break;
+                case 'Z':
+                    key = OV_KEY_BTAB;
+                    consumed = 3;
+                    break;
+                default:
+                    break;
                 }
-                if (key) {
+                if(key)
+                {
                     memmove(buf, buf + consumed, (size_t)(buf_len - consumed));
                     buf_len -= consumed;
                     return key;
@@ -523,27 +706,57 @@ static inline int ov_get_key(void)
 
                 /* ESC [ <digits> ~ */
                 int tilde_idx = -1;
-                for (int i = 2; i < buf_len && i < 10; i++) {
-                    if (buf[i] == '~') { tilde_idx = i; break; }
-                    if (buf[i] >= 0x40 && buf[i] <= 0x7E) break;
+                for(int i = 2; i < buf_len && i < 10; i++)
+                {
+                    if(buf[i] == '~')
+                    {
+                        tilde_idx = i;
+                        break;
+                    }
+                    if(buf[i] >= 0x40 && buf[i] <= 0x7E)
+                    {
+                        break;
+                    }
                 }
 
-                if (tilde_idx != -1) {
+                if(tilde_idx != -1)
+                {
                     int code = atoi((char *) buf + 2);
                     consumed = tilde_idx + 1;
-                    switch (code) {
-                    case 1: key = OV_KEY_HOME; break;
-                    case 3: key = OV_KEY_DEL; break;
-                    case 4: key = OV_KEY_END; break;
-                    case 5: key = OV_KEY_PGUP; break;
-                    case 6: key = OV_KEY_PGDN; break;
-                    case 15: key = OV_KEY_F5; break;
-                    case 17: key = OV_KEY_F6; break;
-                    case 18: key = OV_KEY_F7; break;
-                    case 19: key = OV_KEY_F8; break;
-                    default: break;
+                    switch(code)
+                    {
+                    case 1:
+                        key = OV_KEY_HOME;
+                        break;
+                    case 3:
+                        key = OV_KEY_DEL;
+                        break;
+                    case 4:
+                        key = OV_KEY_END;
+                        break;
+                    case 5:
+                        key = OV_KEY_PGUP;
+                        break;
+                    case 6:
+                        key = OV_KEY_PGDN;
+                        break;
+                    case 15:
+                        key = OV_KEY_F5;
+                        break;
+                    case 17:
+                        key = OV_KEY_F6;
+                        break;
+                    case 18:
+                        key = OV_KEY_F7;
+                        break;
+                    case 19:
+                        key = OV_KEY_F8;
+                        break;
+                    default:
+                        break;
                     }
-                    if (key) {
+                    if(key)
+                    {
                         memmove(buf, buf + consumed, (size_t)(buf_len - consumed));
                         buf_len -= consumed;
                         return key;
@@ -552,18 +765,46 @@ static inline int ov_get_key(void)
 
                 /* CTRL+Arrow: ESC [ 1 ; 5 C/D
                  * SHIFT+Arrow: ESC [ 1 ; 2 A/B/C/D */
-                if (buf_len >= 6 && buf[2] == '1' && buf[3] == ';') {
-                    if (buf[4] == '5') {
-                        if (buf[5] == 'D') { key = OV_KEY_CTRL_LEFT; consumed = 6; }
-                        else if (buf[5] == 'C') { key = OV_KEY_CTRL_RIGHT; consumed = 6; }
+                if(buf_len >= 6 && buf[2] == '1' && buf[3] == ';')
+                {
+                    if(buf[4] == '5')
+                    {
+                        if(buf[5] == 'D')
+                        {
+                            key = OV_KEY_CTRL_LEFT;
+                            consumed = 6;
+                        }
+                        else if(buf[5] == 'C')
+                        {
+                            key = OV_KEY_CTRL_RIGHT;
+                            consumed = 6;
+                        }
                     }
-                    else if (buf[4] == '2') {
-                        if (buf[5] == 'D') { key = OV_KEY_SHIFT_LEFT; consumed = 6; }
-                        else if (buf[5] == 'C') { key = OV_KEY_SHIFT_RIGHT; consumed = 6; }
-                        else if (buf[5] == 'A') { key = OV_KEY_SHIFT_UP; consumed = 6; }
-                        else if (buf[5] == 'B') { key = OV_KEY_SHIFT_DOWN; consumed = 6; }
+                    else if(buf[4] == '2')
+                    {
+                        if(buf[5] == 'D')
+                        {
+                            key = OV_KEY_SHIFT_LEFT;
+                            consumed = 6;
+                        }
+                        else if(buf[5] == 'C')
+                        {
+                            key = OV_KEY_SHIFT_RIGHT;
+                            consumed = 6;
+                        }
+                        else if(buf[5] == 'A')
+                        {
+                            key = OV_KEY_SHIFT_UP;
+                            consumed = 6;
+                        }
+                        else if(buf[5] == 'B')
+                        {
+                            key = OV_KEY_SHIFT_DOWN;
+                            consumed = 6;
+                        }
                     }
-                    if (key) {
+                    if(key)
+                    {
                         memmove(buf, buf + consumed, (size_t)(buf_len - consumed));
                         buf_len -= consumed;
                         return key;
@@ -571,16 +812,24 @@ static inline int ov_get_key(void)
                 }
 
                 /* SGR mouse: ESC [ < btn;col;row M/m */
-                if (buf[2] == '<') {
+                if(buf[2] == '<')
+                {
                     int end_idx = -1;
-                    for (int i = 3; i < buf_len && i < 32; i++) {
-                        if (buf[i] == 'M' || buf[i] == 'm') { end_idx = i; break; }
+                    for(int i = 3; i < buf_len && i < 32; i++)
+                    {
+                        if(buf[i] == 'M' || buf[i] == 'm')
+                        {
+                            end_idx = i;
+                            break;
+                        }
                     }
-                    if (end_idx > 0) {
+                    if(end_idx > 0)
+                    {
                         int mb = 0, mc = 0, mr = 0;
                         char tmp[64];
                         int tlen = end_idx - 3;
-                        if (tlen > 0 && tlen < (int) sizeof(tmp)) {
+                        if(tlen > 0 && tlen < (int) sizeof(tmp))
+                        {
                             memcpy(tmp, buf + 3, (size_t) tlen);
                             tmp[tlen] = '\0';
                             sscanf(tmp, "%d;%d;%d", &mb, &mc, &mr);
@@ -594,29 +843,53 @@ static inline int ov_get_key(void)
                         ov_mouse_col = mc;
                         ov_mouse_row = mr;
 
-                        if (mb == 64) return OV_KEY_MOUSE_UP;
-                        if (mb == 65) return OV_KEY_MOUSE_DOWN;
+                        if(mb == 64)
+                        {
+                            return OV_KEY_MOUSE_UP;
+                        }
+                        if(mb == 65)
+                        {
+                            return OV_KEY_MOUSE_DOWN;
+                        }
                         /* Ctrl+scroll (#12) */
-                        if (mb == 80) return OV_KEY_CTRL_SCROLL_UP;
-                        if (mb == 81) return OV_KEY_CTRL_SCROLL_DOWN;
-                        
+                        if(mb == 80)
+                        {
+                            return OV_KEY_CTRL_SCROLL_UP;
+                        }
+                        if(mb == 81)
+                        {
+                            return OV_KEY_CTRL_SCROLL_DOWN;
+                        }
+
                         /* Mouse move (passive) */
-                        if (mb == 35 && press) {
+                        if(mb == 35 && press)
+                        {
                             ov_hover_col = mc;
                             ov_hover_row = mr;
                             return OV_KEY_MOUSE_MOVE;
                         }
 
-                        if ((mb & 32) && press) return OV_KEY_MOUSE_DRAG;
-                        if (mb == 0 && press) return OV_KEY_MOUSE_CLICK;
-                        if (!press) return OV_KEY_MOUSE_RELEASE;
+                        if((mb & 32) && press)
+                        {
+                            return OV_KEY_MOUSE_DRAG;
+                        }
+                        if(mb == 0 && press)
+                        {
+                            return OV_KEY_MOUSE_CLICK;
+                        }
+                        if(!press)
+                        {
+                            return OV_KEY_MOUSE_RELEASE;
+                        }
                         return OV_KEY_NONE;
                     }
                     return OV_KEY_NONE;
                 }
 
-                for (int i = 2; i < buf_len; i++) {
-                    if (buf[i] >= 0x40 && buf[i] <= 0x7E) {
+                for(int i = 2; i < buf_len; i++)
+                {
+                    if(buf[i] >= 0x40 && buf[i] <= 0x7E)
+                    {
                         memmove(buf, buf + i + 1, (size_t)(buf_len - (i + 1)));
                         buf_len -= (i + 1);
                         return OV_KEY_NONE;
@@ -627,16 +900,28 @@ static inline int ov_get_key(void)
         }
 
         /* SS3: ESC O ... (xterm F1-F4) */
-        if (buf[1] == 'O') {
-            if (buf_len >= 3) {
+        if(buf[1] == 'O')
+        {
+            if(buf_len >= 3)
+            {
                 int key      = 0;
                 int consumed = 3;
-                switch (buf[2]) {
-                case 'P': key = OV_KEY_F1; break;
-                case 'Q': key = OV_KEY_F2; break;
-                case 'R': key = OV_KEY_F3; break;
-                case 'S': key = OV_KEY_F4; break;
-                default: break;
+                switch(buf[2])
+                {
+                case 'P':
+                    key = OV_KEY_F1;
+                    break;
+                case 'Q':
+                    key = OV_KEY_F2;
+                    break;
+                case 'R':
+                    key = OV_KEY_F3;
+                    break;
+                case 'S':
+                    key = OV_KEY_F4;
+                    break;
+                default:
+                    break;
                 }
                 memmove(buf, buf + consumed, (size_t)(buf_len - consumed));
                 buf_len -= consumed;

--- a/src/cli/overview/overview_ansi.h
+++ b/src/cli/overview/overview_ansi.h
@@ -114,7 +114,9 @@ static inline void ov_set_mouse_hover(int enable)
     }
 }
 
-static inline void ov_get_terminal_size(int *rows, int *cols)
+static inline void ov_get_terminal_size(
+    int *rows,
+    int *cols)
 {
     struct winsize ws;
     *rows = 24;
@@ -195,7 +197,9 @@ static inline void ov_buf_reset(void)
     }
 }
 
-static inline void ov_buf_append(const char *data, int len)
+static inline void ov_buf_append(
+    const char *data,
+    int len)
 {
     if (ov__screenbuf_len + len < OV_SCREENBUF_SIZE) {
         memcpy(ov__screenbuf + ov__screenbuf_len, data, (size_t) len);
@@ -226,7 +230,9 @@ static inline void ov_buf_flush_internal(void)
     }
 }
 
-static inline void ov_buf_flush_delta(int term_rows, int term_cols)
+static inline void ov_buf_flush_delta(
+    int term_rows,
+    int term_cols)
 {
     int emit_cursor_r = -1;
     int emit_cursor_c = -1;
@@ -365,9 +371,9 @@ static inline int utf8_char_length(unsigned char c) {
     return 1;
 }
 
-static inline void ov_buf_printf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-
-static inline void ov_buf_printf(const char *fmt, ...)
+static inline void ov_buf_printf(
+    const char *fmt,
+    ...)
 {
     char tmp[4096];
     va_list ap;

--- a/src/cli/overview/overview_data_sys.c
+++ b/src/cli/overview/overview_data_sys.c
@@ -165,7 +165,10 @@ int pid_get_cpu_ticks(
  *
  * Reads the 39th field of /proc/<pid>/task/<tid>/stat for each thread.
  */
-int pid_get_core_utilization(pid_t pid, int *cores, int max_cores)
+int pid_get_core_utilization(
+    pid_t pid,
+    int *cores,
+    int max_cores)
 {
     if(pid <= 0 || cores == NULL || max_cores <= 0)
     {
@@ -275,7 +278,9 @@ int pid_get_core_utilization(pid_t pid, int *cores, int max_cores)
 /**
  * pid_get_advanced_stats - get scheduling, memory faults, and thread counts
  */
-int pid_get_advanced_stats(pid_t pid, ov_advanced_stats_t *out)
+int pid_get_advanced_stats(
+    pid_t pid,
+    ov_advanced_stats_t *out)
 {
     if(pid <= 0 || out == NULL)
     {
@@ -403,7 +408,10 @@ static long _perf_event_open(struct perf_event_attr *attr, pid_t pid, int cpu, i
  * Configures hardware performance counters for
  * the specified event type.
  */
-static int open_perf_fd(pid_t pid, uint32_t type, uint64_t config)
+static int open_perf_fd(
+    pid_t pid,
+    uint32_t type,
+    uint64_t config)
 {
     struct perf_event_attr attr;
     memset(&attr, 0, sizeof(attr));
@@ -427,7 +435,10 @@ static int open_perf_fd(pid_t pid, uint32_t type, uint64_t config)
  * pid_read_perf_counters - get hardware metrics via perf_event_open
  * Requires CAP_PERFMON or root, or perf_event_paranoid <= 2
  */
-int pid_read_perf_counters(pid_t pid, int64_t loopcnt, ov_perf_counters_t *out)
+int pid_read_perf_counters(
+    pid_t pid,
+    int64_t loopcnt,
+    ov_perf_counters_t *out)
 {
     if(pid <= 0 || !out)
     {

--- a/src/cli/overview/overview_input.c
+++ b/src/cli/overview/overview_input.c
@@ -14,7 +14,9 @@
 #include "overview_fps_edit.h"
 #include "stream_graph.h"
 
-static int get_graph_start_node(const OV_LAYOUT *lay, const OV_MODEL *m)
+static int get_graph_start_node(
+    const OV_LAYOUT *lay,
+    const OV_MODEL *m)
 {
     ov_focus_t eff_focus = lay->freeze ? lay->freeze_focus : lay->focus;
     int target_type = -1;
@@ -103,7 +105,9 @@ static int hit_panel_tab(
  */
 
 
-static int ov_input__handle_filter_mode(int key, OV_LAYOUT *lay)
+static int ov_input__handle_filter_mode(
+    int key,
+    OV_LAYOUT *lay)
 {
     char *active_filter = NULL;
     switch(lay->focus)
@@ -260,7 +264,10 @@ static const OV_FPS *ov_input_get_sel_fps(
 /**
  * @brief Count visible items after filtering.
  */
-static int ov_input_get_filtered_count(int focus, const OV_LAYOUT *lay, const OV_MODEL *m)
+static int ov_input_get_filtered_count(
+    int focus,
+    const OV_LAYOUT *lay,
+    const OV_MODEL *m)
 {
     int count = 0;
     if(focus == OV_FOCUS_STREAMS)
@@ -596,7 +603,11 @@ static void ov_input__exec_preview_btn(
     ov_scan_force_update();
 }
 
-void ov_hittest(OV_LAYOUT *lay, const OV_MODEL *m, int mr, int mc)
+void ov_hittest(
+    OV_LAYOUT *lay,
+    const OV_MODEL *m,
+    int mr,
+    int mc)
 {
     lay->hover_view = -1;
     lay->hover_idx = -1;
@@ -795,7 +806,9 @@ void ov_hittest(OV_LAYOUT *lay, const OV_MODEL *m, int mr, int mc)
     }
 }
 
-void ov_hittest_resolve_globals(OV_LAYOUT *lay, const OV_MODEL *m)
+void ov_hittest_resolve_globals(
+    OV_LAYOUT *lay,
+    const OV_MODEL *m)
 {
     lay->hover_global_stream = -1;
     lay->hover_global_proc = -1;
@@ -976,7 +989,10 @@ void ov_hittest_resolve_globals(OV_LAYOUT *lay, const OV_MODEL *m)
     }
 }
 
-static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
+static int ov_input__handle_mouse(
+    int key,
+    OV_LAYOUT *lay,
+    const OV_MODEL *m)
 {
     if(key == OV_KEY_MOUSE_CLICK)
     {
@@ -2006,7 +2022,9 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
 }
 #undef INSIDE
 
-static int ov_input__handle_view_switch(int key, OV_LAYOUT *lay)
+static int ov_input__handle_view_switch(
+    int key,
+    OV_LAYOUT *lay)
 {
     if(key >= OV_KEY_F2 && key <= OV_KEY_F6)
     {
@@ -2096,7 +2114,10 @@ static int ov_input__handle_view_switch(int key, OV_LAYOUT *lay)
     return 0;
 }
 
-static int ov_input__handle_misc_toggles(int key, OV_LAYOUT *lay, const OV_MODEL *m)
+static int ov_input__handle_misc_toggles(
+    int key,
+    OV_LAYOUT *lay,
+    const OV_MODEL *m)
 {
     if(key == '+' || key == '=')
     {
@@ -2384,7 +2405,9 @@ static int ov_input__handle_misc_toggles(int key, OV_LAYOUT *lay, const OV_MODEL
     return 0;
 }
 
-static int ov_input__handle_sorting(int key, OV_LAYOUT *lay)
+static int ov_input__handle_sorting(
+    int key,
+    OV_LAYOUT *lay)
 {
     if(key == 'S')
     {
@@ -2564,7 +2587,10 @@ static const OV_FPS *ov_input_get_sel_fps(const OV_LAYOUT *lay, const OV_MODEL *
     return NULL;
 }
 
-static int ov_input__handle_actions(int key, OV_LAYOUT *lay, const OV_MODEL *m)
+static int ov_input__handle_actions(
+    int key,
+    OV_LAYOUT *lay,
+    const OV_MODEL *m)
 {
     OV_CMDLOG *log = &lay->cmdlog;
 
@@ -2885,7 +2911,10 @@ static int find_relative_node_of_type(const OV_MODEL *m, int start_node, int tar
     return -1;
 }
 
-static int ov_input__handle_ancestry_nav(int key, OV_LAYOUT *lay, const OV_MODEL *m)
+static int ov_input__handle_ancestry_nav(
+    int key,
+    OV_LAYOUT *lay,
+    const OV_MODEL *m)
 {
     if(key != OV_KEY_SHIFT_UP && key != OV_KEY_SHIFT_DOWN)
     {
@@ -2975,7 +3004,10 @@ static int ov_input__handle_ancestry_nav(int key, OV_LAYOUT *lay, const OV_MODEL
     return 1;
 }
 
-static int ov_input__handle_navigation(int key, OV_LAYOUT *lay, const OV_MODEL *m)
+static int ov_input__handle_navigation(
+    int key,
+    OV_LAYOUT *lay,
+    const OV_MODEL *m)
 {
     int *sel    = NULL;
     int *scroll = NULL;

--- a/src/cli/overview/overview_render.c
+++ b/src/cli/overview/overview_render.c
@@ -76,7 +76,9 @@ static int get_fps_rank(const char *name)
     return 999999;
 }
 
-static int sort_stream_by_rank(const void *a, const void *b)
+static int sort_stream_by_rank(
+    const void *a,
+    const void *b)
 {
     int ra = get_stream_rank(((const OV_STREAM *)a)->name);
     int rb = get_stream_rank(((const OV_STREAM *)b)->name);
@@ -87,7 +89,9 @@ static int sort_stream_by_rank(const void *a, const void *b)
     return strcmp(((const OV_STREAM *)a)->name, ((const OV_STREAM *)b)->name);
 }
 
-static int sort_proc_by_rank(const void *a, const void *b)
+static int sort_proc_by_rank(
+    const void *a,
+    const void *b)
 {
     int ra = get_proc_rank(((const OV_PROC *)a)->name);
     int rb = get_proc_rank(((const OV_PROC *)b)->name);
@@ -98,7 +102,9 @@ static int sort_proc_by_rank(const void *a, const void *b)
     return strcmp(((const OV_PROC *)a)->name, ((const OV_PROC *)b)->name);
 }
 
-static int sort_fps_by_rank(const void *a, const void *b)
+static int sort_fps_by_rank(
+    const void *a,
+    const void *b)
 {
     int ra = get_fps_rank(((const OV_FPS *)a)->name);
     int rb = get_fps_rank(((const OV_FPS *)b)->name);

--- a/src/cli/overview/overview_render_graph.c
+++ b/src/cli/overview/overview_render_graph.c
@@ -390,7 +390,9 @@ void ov_render_preview_line(
     ov_buf_reset_attr();
 }
 
-static int get_graph_start_node(const OV_LAYOUT *lay, const OV_MODEL *m)
+static int get_graph_start_node(
+    const OV_LAYOUT *lay,
+    const OV_MODEL *m)
 {
     ov_focus_t eff_focus = lay->freeze ? lay->freeze_focus : lay->focus;
     int target_type = -1;

--- a/src/cli/overview/overview_render_help.c
+++ b/src/cli/overview/overview_render_help.c
@@ -28,7 +28,8 @@ typedef struct
  * Section indices (must match help_expand bitmask
  * positions).
  */
-enum {
+enum
+{
     HS_NAV = 0,
     HS_SORT,
     HS_DISPLAY,
@@ -105,8 +106,10 @@ static const help_line_t HELP[] =
     { "  Drag panel borders to resize",         HF_CHILD,   HS_MOUSE },
     /* --- Colors --- */
     { "Colors",                                 HF_SECTION, HS_COLORS },
-    { "",                                       HF_CHILD | HF_COLORS,
-                                                            HS_COLORS },
+    {
+        "",                                       HF_CHILD | HF_COLORS,
+        HS_COLORS
+    },
 };
 /* clang-format on */
 
@@ -140,11 +143,11 @@ static int help_nb_sections(void)
 static int help_section_header_idx(int n)
 {
     int sec = 0;
-    for (int i = 0; i < HELP_TOTAL; i++)
+    for(int i = 0; i < HELP_TOTAL; i++)
     {
-        if (HELP[i].flags & HF_SECTION)
+        if(HELP[i].flags & HF_SECTION)
         {
-            if (sec == n)
+            if(sec == n)
             {
                 return i;
             }
@@ -169,15 +172,15 @@ static int help_visible_rows(
     const OV_LAYOUT *lay, int *map)
 {
     int vis = 0;
-    for (int i = 0; i < HELP_TOTAL; i++)
+    for(int i = 0; i < HELP_TOTAL; i++)
     {
-        if (HELP[i].flags & HF_SECTION)
+        if(HELP[i].flags & HF_SECTION)
         {
             map[vis++] = i;
         }
-        else if (HELP[i].flags & HF_CHILD)
+        else if(HELP[i].flags & HF_CHILD)
         {
-            if (help_is_expanded(lay, HELP[i].section))
+            if(help_is_expanded(lay, HELP[i].section))
             {
                 map[vis++] = i;
             }
@@ -196,26 +199,26 @@ void ov_render_help(const OV_LAYOUT *lay)
 
     /* Compute content width */
     int content_w = 0;
-    for (int i = 0; i < HELP_TOTAL; i++)
+    for(int i = 0; i < HELP_TOTAL; i++)
     {
         int l = (int) strlen(HELP[i].text);
         /* Section headers get "▸ " or "▾ " prefix */
-        if (HELP[i].flags & HF_SECTION)
+        if(HELP[i].flags & HF_SECTION)
         {
             l += 4; /* chevron + space + padding */
         }
-        if (l > content_w)
+        if(l > content_w)
         {
             content_w = l;
         }
     }
     /* Color legend row adds extra */
     int legend_extra = (int) strlen("  stream proc fps");
-    if (legend_extra + 4 > content_w)
+    if(legend_extra + 4 > content_w)
     {
         content_w = legend_extra + 4;
     }
-    if (content_w < 44)
+    if(content_w < 44)
     {
         content_w = 44;
     }
@@ -228,13 +231,25 @@ void ov_render_help(const OV_LAYOUT *lay)
     int H = lay->term_rows;
 
     /* Cap to terminal */
-    if (ph > H - 2) { ph = H - 2; }
-    if (pw > W - 2) { pw = W - 2; }
+    if(ph > H - 2)
+    {
+        ph = H - 2;
+    }
+    if(pw > W - 2)
+    {
+        pw = W - 2;
+    }
 
     int pr = (H - ph) / 2;
     int pc = (W - pw) / 2;
-    if (pr < 1) { pr = 1; }
-    if (pc < 1) { pc = 1; }
+    if(pr < 1)
+    {
+        pr = 1;
+    }
+    if(pc < 1)
+    {
+        pc = 1;
+    }
 
     /* Border */
     ov_draw_panel_border(
@@ -243,7 +258,7 @@ void ov_render_help(const OV_LAYOUT *lay)
         OV_FG_BRIGHT, 1, 0);
 
     /* Clear interior */
-    for (int r = pr + 1; r < pr + ph - 1; r++)
+    for(int r = pr + 1; r < pr + ph - 1; r++)
     {
         clear_row(r, pc + 1, pw - 2, OV_BG_PANEL);
     }
@@ -251,24 +266,33 @@ void ov_render_help(const OV_LAYOUT *lay)
     /* Visible content area (inside border + title) */
     int body_top = pr + 2;
     int body_h   = ph - 4;
-    if (body_h < 1) { body_h = 1; }
+    if(body_h < 1)
+    {
+        body_h = 1;
+    }
 
     /* Ensure sel is in range */
     int sel = lay->help_sel;
-    if (sel < 0) { sel = 0; }
-    if (sel >= nvis) { sel = nvis - 1; }
+    if(sel < 0)
+    {
+        sel = 0;
+    }
+    if(sel >= nvis)
+    {
+        sel = nvis - 1;
+    }
 
     /* Scroll so cursor is visible */
     int scroll = 0;
-    if (sel >= body_h)
+    if(sel >= body_h)
     {
         scroll = sel - body_h + 1;
     }
 
     /* Render visible rows */
     int inner_w = pw - 4;
-    for (int vr = 0; vr < body_h && vr + scroll < nvis;
-         vr++)
+    for(int vr = 0; vr < body_h && vr + scroll < nvis;
+            vr++)
     {
         int idx = map[vr + scroll];
         const help_line_t *h = &HELP[idx];
@@ -279,12 +303,12 @@ void ov_render_help(const OV_LAYOUT *lay)
         ov_theme_bg(OV_BG_PANEL);
 
         /* Highlight selected row */
-        if (is_sel)
+        if(is_sel)
         {
             ov_buf_bg(40, 45, 70);
         }
 
-        if (h->flags & HF_SECTION)
+        if(h->flags & HF_SECTION)
         {
             /* Section header with chevron */
             int expanded = help_is_expanded(
@@ -292,7 +316,7 @@ void ov_render_help(const OV_LAYOUT *lay)
             const char *chev = expanded
                                ? "▾" : "▸";
 
-            if (is_sel)
+            if(is_sel)
             {
                 ov_buf_fg(255, 220, 100);
             }
@@ -306,12 +330,12 @@ void ov_render_help(const OV_LAYOUT *lay)
             /* Pad remainder */
             int used = 3 + (int)strlen(h->text) + 2;
             int pad  = inner_w - used;
-            if (pad > 0)
+            if(pad > 0)
             {
                 ov_buf_hline(' ', pad);
             }
         }
-        else if (h->flags & HF_COLORS)
+        else if(h->flags & HF_COLORS)
         {
             /* Color legend row */
             ov_theme_fg(OV_FG_DIM);
@@ -324,7 +348,7 @@ void ov_render_help(const OV_LAYOUT *lay)
             ov_buf_printf("fps");
             int used = 22;
             int pad  = inner_w - used;
-            if (pad > 0)
+            if(pad > 0)
             {
                 ov_buf_hline(' ', pad);
             }
@@ -381,13 +405,13 @@ int ov_help_toggle_at(
     int map[128];
     int nvis = help_visible_rows(lay, map);
 
-    if (vis_row < 0 || vis_row >= nvis)
+    if(vis_row < 0 || vis_row >= nvis)
     {
         return -1;
     }
 
     int idx = map[vis_row];
-    if (!(HELP[idx].flags & HF_SECTION))
+    if(!(HELP[idx].flags & HF_SECTION))
     {
         return -1;
     }
@@ -396,4 +420,3 @@ int ov_help_toggle_at(
     lay->help_expand ^= (1U << sec);
     return sec;
 }
-

--- a/src/cli/overview/overview_render_help.c
+++ b/src/cli/overview/overview_render_help.c
@@ -374,7 +374,9 @@ int ov_help_visible_count(const OV_LAYOUT *lay)
  * bit and returns the section index.  Otherwise
  * returns -1.
  */
-int ov_help_toggle_at(OV_LAYOUT *lay, int vis_row)
+int ov_help_toggle_at(
+    OV_LAYOUT *lay,
+    int vis_row)
 {
     int map[128];
     int nvis = help_visible_rows(lay, map);

--- a/src/cli/overview/overview_render_relate.c
+++ b/src/cli/overview/overview_render_relate.c
@@ -58,12 +58,16 @@ int ov_filter_build(
  * overview_render_internal.h
  */
 
-void bset(uint64_t *words, int idx)
+void bset(
+    uint64_t *words,
+    int idx)
 {
     words[idx / BITS_PER_WORD] |= (UINT64_C(1) << (idx % BITS_PER_WORD));
 }
 
-int bget(const uint64_t *words, int idx)
+int bget(
+    const uint64_t *words,
+    int idx)
 {
     return (words[idx / BITS_PER_WORD] >> (idx % BITS_PER_WORD)) & 1;
 }

--- a/src/cli/overview/overview_render_utils.c
+++ b/src/cli/overview/overview_render_utils.c
@@ -141,7 +141,9 @@ void clear_row(
 }
 
 /* Pad the remainder of a panel's interior row */
-void render_pad_spaces(int chars_written, int panel_width)
+void render_pad_spaces(
+    int chars_written,
+    int panel_width)
 {
     int remain = (panel_width - 2) - chars_written;
     if(remain > 0)

--- a/src/cli/overview/stream_graph.c
+++ b/src/cli/overview/stream_graph.c
@@ -30,7 +30,9 @@
 /**
  * @brief Set a bit in the stream graph adjacency matrix.
  */
-static void sg_bset(uint64_t *words, int idx)
+static void sg_bset(
+    uint64_t *words,
+    int idx)
 {
     words[idx / SG_BITS_PER_WORD] |=
         (UINT64_C(1) << (idx % SG_BITS_PER_WORD));
@@ -39,7 +41,9 @@ static void sg_bset(uint64_t *words, int idx)
 /**
  * @brief Get a bit from the stream graph adjacency matrix.
  */
-static int sg_bget(const uint64_t *words, int idx)
+static int sg_bget(
+    const uint64_t *words,
+    int idx)
 {
     return (words[idx / SG_BITS_PER_WORD]
             >> (idx % SG_BITS_PER_WORD)) & 1;

--- a/src/cli/overview/test_lineage.c
+++ b/src/cli/overview/test_lineage.c
@@ -8,7 +8,9 @@
 #include "overview_data.h"
 #include "stream_graph.h"
 
-int main(int argc, char *argv[])
+int main(
+    int argc,
+    char *argv[])
 {
     if (argc < 2)
     {

--- a/src/cli/overview/test_lineage.c
+++ b/src/cli/overview/test_lineage.c
@@ -12,11 +12,11 @@ int main(
     int argc,
     char *argv[])
 {
-    if (argc < 2)
+    if(argc < 2)
     {
         fprintf(stderr,
-            "Usage: %s <stream_name>\n",
-            argv[0]);
+                "Usage: %s <stream_name>\n",
+                argv[0]);
         return 1;
     }
 
@@ -29,12 +29,12 @@ int main(
 
     printf("Model: %d streams, %d procs, "
            "%d fps, %d nodes, %d edges\n",
-        m.nb_streams, m.nb_procs,
-        m.nb_fps, m.nb_nodes, m.nb_edges);
+           m.nb_streams, m.nb_procs,
+           m.nb_fps, m.nb_nodes, m.nb_edges);
 
     /* Dump all edges */
     printf("\n--- Edges ---\n");
-    for (int i = 0; i < m.nb_edges; i++)
+    for(int i = 0; i < m.nb_edges; i++)
     {
         const OV_EDGE *e = &m.edges[i];
         const char *sn =
@@ -47,7 +47,8 @@ int main(
              && e->tgt_node < m.nb_nodes)
             ? m.nodes[e->tgt_node].name
             : "??";
-        const char *tnames[] = {
+        const char *tnames[] =
+        {
             "PROC_WRITES_STREAM",
             "STREAM_TRIGGERS_PROC",
             "FPS_RUNS_PROC",
@@ -57,15 +58,15 @@ int main(
             "STREAM_READ_BY_PROC",
         };
         const char *tn2 = (e->type <= 6)
-            ? tnames[e->type] : "??";
+                          ? tnames[e->type] : "??";
         printf("  [%2d] %-20s -> %-20s "
                "%s\n",
-            i, sn, tn, tn2);
+               i, sn, tn, tn2);
     }
 
     int si = ov_find_stream_by_name(
-        &m, argv[1]);
-    if (si < 0)
+                 &m, argv[1]);
+    if(si < 0)
     {
         PRINT_ERROR("stream '%s' not found",
                     argv[1]);
@@ -73,43 +74,43 @@ int main(
     }
     printf("\nStream '%s' -> model idx %d, "
            "node_idx %d\n",
-        argv[1], si,
-        m.streams[si].node_idx);
+           argv[1], si,
+           m.streams[si].node_idx);
 
     SG_LINEAGE lin;
     sg_compute_lineage(
         &m, si, SG_MODE_FULL, &lin);
 
     printf("\nAncestors (%d):\n",
-        lin.nb_ancestors);
-    for (int a = 0;
-         a < lin.nb_ancestors; a++)
+           lin.nb_ancestors);
+    for(int a = 0;
+            a < lin.nb_ancestors; a++)
     {
         printf("  depth=%d stream[%d]=%s "
                "via=%s loop=%d\n",
-            lin.ancestors[a].depth,
-            lin.ancestors[a].stream_idx,
-            m.streams[
-                lin.ancestors[a].stream_idx
-            ].name,
-            lin.ancestors[a].via_name,
-            lin.ancestors[a].is_loop);
+               lin.ancestors[a].depth,
+               lin.ancestors[a].stream_idx,
+               m.streams[
+                   lin.ancestors[a].stream_idx
+        ].name,
+               lin.ancestors[a].via_name,
+               lin.ancestors[a].is_loop);
     }
 
     printf("\nDescendants (%d):\n",
-        lin.nb_descendants);
-    for (int d = 0;
-         d < lin.nb_descendants; d++)
+           lin.nb_descendants);
+    for(int d = 0;
+            d < lin.nb_descendants; d++)
     {
         printf("  depth=%d stream[%d]=%s "
                "via=%s loop=%d\n",
-            lin.descendants[d].depth,
-            lin.descendants[d].stream_idx,
-            m.streams[
-                lin.descendants[d].stream_idx
-            ].name,
-            lin.descendants[d].via_name,
-            lin.descendants[d].is_loop);
+               lin.descendants[d].depth,
+               lin.descendants[d].stream_idx,
+               m.streams[
+                   lin.descendants[d].stream_idx
+        ].name,
+               lin.descendants[d].via_name,
+               lin.descendants[d].is_loop);
     }
 
     return 0;

--- a/src/cli/streamCTRL/milk-streamCTRL.c
+++ b/src/cli/streamCTRL/milk-streamCTRL.c
@@ -45,7 +45,9 @@ static void handle_sigterm(int sig)
 /**
  * @brief Print help message for milk-streamCTRL.
  */
-static void print_help(const char *progname, int mh_color)
+static void print_help(
+    const char *progname,
+    int mh_color)
 {
     milk_help_banner(progname, "interactive stream monitor TUI", mh_color);
     milk_help_section("Usage", mh_color);
@@ -85,7 +87,9 @@ static void print_help(const char *progname, int mh_color)
 }
 
 
-int main(int argc, char *argv[])
+int main(
+    int argc,
+    char *argv[])
 {
     const char *progname = basename(argv[0]);
 

--- a/src/cli/streamCTRL/mmon_ui.c
+++ b/src/cli/streamCTRL/mmon_ui.c
@@ -145,7 +145,7 @@ errno_t list_image_ID_ncurses()
     char      str1[500];
     int str2maxlen = 512;
     char      str2[512];
-    long      i, j;
+
     long long tmp_long;
     char      type[STYPESIZE];
     uint8_t   datatype;
@@ -166,7 +166,7 @@ errno_t list_image_ID_ncurses()
 
     printw("INDEX    NAME         SIZE                    TYPE        SIZE  [percent]    LAST ACCESS\n\n");
 
-    for(i = 0; i < dcnimg; i++)
+    for(long i = 0; i < dcnimg; i++)
     {
         if(dcimg[i].used == 1)
         {
@@ -206,7 +206,7 @@ errno_t list_image_ID_ncurses()
 
             snprintf(str, strmaxlen, "[ %6ld", (long) dcimg[i].md[0].size[0]);
 
-            for(j = 1; j < dcimg[i].md[0].naxis; j++)
+            for(long j = 1; j < dcimg[i].md[0].naxis; j++)
             {
                 snprintf(str1, str1maxlen, "%s x %6ld", str, (long) dcimg[i].md[0].size[j]);
             }

--- a/src/cli/streamCTRL/streamCTRL_TUI.c
+++ b/src/cli/streamCTRL/streamCTRL_TUI.c
@@ -88,7 +88,9 @@ int g_sort_dir = 0;
  * g_sort_col. Uses g_sort_dir to flip order.
  * Elements a,b are pointers to long (sindex values).
  */
-int cmp_stream_col(const void *a, const void *b)
+int cmp_stream_col(
+    const void *a,
+    const void *b)
 {
     long idxA = *(const long *)a;
     long idxB = *(const long *)b;

--- a/src/cli/streamCTRL/streamCTRL_TUI_render_stream_rows.c
+++ b/src/cli/streamCTRL/streamCTRL_TUI_render_stream_rows.c
@@ -298,7 +298,7 @@ void streamCTRL__render_stream_rows(streamCTRLarg_struct *streamCTRLdata,
             {
                 char str[STRINGMAXLEN_DEFAULT];
                 char str1[STRINGMAXLEN_DEFAULT];
-                int  j;
+
 
                 if(streamCTRLimages[streaminfo[sindex].ID].md == NULL)
                 {
@@ -323,7 +323,7 @@ void streamCTRL__render_stream_rows(streamCTRLarg_struct *streamCTRLdata,
                              " [%3ld",
                              (long) streamCTRLimages[ID].md[0].size[0]);
 
-                    for(j = 1; j < streamCTRLimages[ID].md[0].naxis; j++)
+                    for(int j = 1; j < streamCTRLimages[ID].md[0].naxis; j++)
                     {
                         {
                             int slen = snprintf(
@@ -512,12 +512,12 @@ void streamCTRL__render_stream_rows(streamCTRLarg_struct *streamCTRLdata,
                         (DisplayFlag == 1)) // sem vals
                 {
 
-                    int s;
+
                     int max_s = sTUIparam.DISPLAY_ALL_SEMS
                                 ? streamCTRLimages[ID].md[0].sem
                                 : 3;
                     TUI_printfw(" ");
-                    for(s = 0; s < max_s; s++)
+                    for(int s = 0; s < max_s; s++)
                     {
                         int semval = ImageStreamIO_semvalue(streamCTRLimages + ID, s);
                         if(s > 0)
@@ -655,12 +655,12 @@ void streamCTRL__render_stream_rows(streamCTRLarg_struct *streamCTRLdata,
                 if((sTUIparam.DisplayMode == DISPLAY_MODE_READ) &&
                         (DisplayFlag == 1)) // sem read PIDs
                 {
-                    int s;
+
                     int max_s = sTUIparam.DISPLAY_ALL_SEMS
                                 ? streamCTRLimages[ID].md[0].sem
                                 : 3;
                     TUI_printfw(" ");
-                    for(s = 0; s < max_s; s++)
+                    for(int s = 0; s < max_s; s++)
                     {
                         pid_t pid = streamCTRLimages[ID].semReadPID[s];
                         if(s > 0)
@@ -851,14 +851,14 @@ void streamCTRL__render_stream_rows(streamCTRLarg_struct *streamCTRLdata,
 
                 DEBUG_TRACEPOINT(" ");
 
-                int pidIndex;
+
 
                 switch(streaminfo[sindex].streamOpenPID_status)
                 {
 
                 case 1:
                     streaminfo[sindex].streamOpenPID_cnt1 = 0;
-                    for(pidIndex = 0;
+                    for(int pidIndex = 0;
                             pidIndex < streaminfo[sindex].streamOpenPID_cnt;
                             pidIndex++)
                     {

--- a/src/cli/streamCTRL/streamCTRL_ansi.h
+++ b/src/cli/streamCTRL/streamCTRL_ansi.h
@@ -102,7 +102,7 @@ static inline void ansi_raw_mode_enter(void)
     raw = ansi__orig_termios;
     raw.c_iflag &= ~(unsigned int)(IXON | ICRNL | BRKINT | INPCK | ISTRIP);
     raw.c_oflag &= ~(unsigned int)(OPOST);
-    raw.c_cflag |=  (unsigned int)(CS8);
+    raw.c_cflag |= (unsigned int)(CS8);
     raw.c_lflag &= ~(unsigned int)(ECHO | ICANON | IEXTEN | ISIG);
     raw.c_cc[VMIN]  = 0;
     raw.c_cc[VTIME] = 0;
@@ -213,7 +213,7 @@ static int ansi__color_level = 0; // 0=uninit, 1=16-color, 2=256-color, 3=TrueCo
 
 static inline void ansi_detect_color_level(void)
 {
-    if (ansi__color_level > 0)
+    if(ansi__color_level > 0)
     {
         return;
     }
@@ -221,11 +221,11 @@ static inline void ansi_detect_color_level(void)
     const char *term = getenv("TERM");
     const char *colorterm = getenv("COLORTERM");
 
-    if (colorterm && (strstr(colorterm, "truecolor") || strstr(colorterm, "24bit")))
+    if(colorterm && (strstr(colorterm, "truecolor") || strstr(colorterm, "24bit")))
     {
         ansi__color_level = 3;
     }
-    else if (term && strstr(term, "256color"))
+    else if(term && strstr(term, "256color"))
     {
         ansi__color_level = 2;
     }
@@ -354,34 +354,66 @@ static inline void ansi_setcolor(int idx)
 {
     ansi_detect_color_level();
 
-    if (ansi__color_level >= 3)
+    if(ansi__color_level >= 3)
     {
         /* TrueColor (24-bit) */
         switch(idx)
         {
-        case 2:  ansi_fg(80,  220, 80);  break; /* green        */
-        case 3:  ansi_fg(220, 200, 0);   break; /* yellow       */
-        case 4:  ansi_fg(240, 60,  60);  break; /* red          */
-        case 5:  ansi_fg(200, 80,  220); break; /* magenta      */
-        case 7:  ansi_fg(0,   200, 220); break; /* cyan         */
-        case 9:  ansi_fg(255, 140, 0);   break; /* orange       */
-        case 12: ansi_fg(100, 255, 100); break; /* bright-green */
-        default: ansi_reset(); break;
+        case 2:
+            ansi_fg(80,  220, 80);
+            break; /* green        */
+        case 3:
+            ansi_fg(220, 200, 0);
+            break; /* yellow       */
+        case 4:
+            ansi_fg(240, 60,  60);
+            break; /* red          */
+        case 5:
+            ansi_fg(200, 80,  220);
+            break; /* magenta      */
+        case 7:
+            ansi_fg(0,   200, 220);
+            break; /* cyan         */
+        case 9:
+            ansi_fg(255, 140, 0);
+            break; /* orange       */
+        case 12:
+            ansi_fg(100, 255, 100);
+            break; /* bright-green */
+        default:
+            ansi_reset();
+            break;
         }
     }
-    else if (ansi__color_level == 2)
+    else if(ansi__color_level == 2)
     {
         /* 256-color fallback */
         switch(idx)
         {
-        case 2:  ansi_fg_256(114); break; /* green        */
-        case 3:  ansi_fg_256(220); break; /* yellow       */
-        case 4:  ansi_fg_256(203); break; /* red          */
-        case 5:  ansi_fg_256(176); break; /* magenta      */
-        case 7:  ansi_fg_256(44);  break; /* cyan         */
-        case 9:  ansi_fg_256(208); break; /* orange       */
-        case 12: ansi_fg_256(119); break; /* bright-green */
-        default: ansi_reset();     break;
+        case 2:
+            ansi_fg_256(114);
+            break; /* green        */
+        case 3:
+            ansi_fg_256(220);
+            break; /* yellow       */
+        case 4:
+            ansi_fg_256(203);
+            break; /* red          */
+        case 5:
+            ansi_fg_256(176);
+            break; /* magenta      */
+        case 7:
+            ansi_fg_256(44);
+            break; /* cyan         */
+        case 9:
+            ansi_fg_256(208);
+            break; /* orange       */
+        case 12:
+            ansi_fg_256(119);
+            break; /* bright-green */
+        default:
+            ansi_reset();
+            break;
         }
     }
     else
@@ -389,14 +421,30 @@ static inline void ansi_setcolor(int idx)
         /* 16-color (standard ANSI) fallback */
         switch(idx)
         {
-        case 2:  ansi_fg_16(32); break; /* green        */
-        case 3:  ansi_fg_16(33); break; /* yellow       */
-        case 4:  ansi_fg_16(31); break; /* red          */
-        case 5:  ansi_fg_16(35); break; /* magenta      */
-        case 7:  ansi_fg_16(36); break; /* cyan         */
-        case 9:  ansi_fg_16(33); break; /* orange -> yellow */
-        case 12: ansi_fg_16(92); break; /* bright-green */
-        default: ansi_reset();   break;
+        case 2:
+            ansi_fg_16(32);
+            break; /* green        */
+        case 3:
+            ansi_fg_16(33);
+            break; /* yellow       */
+        case 4:
+            ansi_fg_16(31);
+            break; /* red          */
+        case 5:
+            ansi_fg_16(35);
+            break; /* magenta      */
+        case 7:
+            ansi_fg_16(36);
+            break; /* cyan         */
+        case 9:
+            ansi_fg_16(33);
+            break; /* orange -> yellow */
+        case 12:
+            ansi_fg_16(92);
+            break; /* bright-green */
+        default:
+            ansi_reset();
+            break;
         }
     }
 }
@@ -528,13 +576,32 @@ static inline int ansi_get_key(void)
 
                 switch(buf[2])
                 {
-                case 'A': key = ANSI_KEY_UP; consumed = 3; break;
-                case 'B': key = ANSI_KEY_DOWN; consumed = 3; break;
-                case 'C': key = ANSI_KEY_RIGHT; consumed = 3; break;
-                case 'D': key = ANSI_KEY_LEFT; consumed = 3; break;
-                case 'H': key = ANSI_KEY_HOME; consumed = 3; break;
-                case 'F': key = ANSI_KEY_END; consumed = 3; break;
-                default:  break;
+                case 'A':
+                    key = ANSI_KEY_UP;
+                    consumed = 3;
+                    break;
+                case 'B':
+                    key = ANSI_KEY_DOWN;
+                    consumed = 3;
+                    break;
+                case 'C':
+                    key = ANSI_KEY_RIGHT;
+                    consumed = 3;
+                    break;
+                case 'D':
+                    key = ANSI_KEY_LEFT;
+                    consumed = 3;
+                    break;
+                case 'H':
+                    key = ANSI_KEY_HOME;
+                    consumed = 3;
+                    break;
+                case 'F':
+                    key = ANSI_KEY_END;
+                    consumed = 3;
+                    break;
+                default:
+                    break;
                 }
 
                 if(key)
@@ -565,24 +632,59 @@ static inline int ansi_get_key(void)
                     consumed = tilde_idx + 1;
                     switch(code)
                     {
-                    case 1:  key = ANSI_KEY_HOME; break;
-                    case 3:  key = ANSI_KEY_DEL; break;
-                    case 4:  key = ANSI_KEY_END; break;
-                    case 5:  key = ANSI_KEY_PGUP; break;
-                    case 6:  key = ANSI_KEY_PGDN; break;
-                    case 11: key = ANSI_KEY_F1; break;
-                    case 12: key = ANSI_KEY_F2; break;
-                    case 13: key = ANSI_KEY_F3; break;
-                    case 14: key = ANSI_KEY_F4; break;
-                    case 15: key = ANSI_KEY_F5; break;
-                    case 17: key = ANSI_KEY_F6; break;
-                    case 18: key = ANSI_KEY_F7; break;
-                    case 19: key = ANSI_KEY_F8; break;
-                    case 20: key = ANSI_KEY_F9; break;
-                    case 21: key = ANSI_KEY_F10; break;
-                    case 23: key = ANSI_KEY_F11; break;
-                    case 24: key = ANSI_KEY_F12; break;
-                    default: break;
+                    case 1:
+                        key = ANSI_KEY_HOME;
+                        break;
+                    case 3:
+                        key = ANSI_KEY_DEL;
+                        break;
+                    case 4:
+                        key = ANSI_KEY_END;
+                        break;
+                    case 5:
+                        key = ANSI_KEY_PGUP;
+                        break;
+                    case 6:
+                        key = ANSI_KEY_PGDN;
+                        break;
+                    case 11:
+                        key = ANSI_KEY_F1;
+                        break;
+                    case 12:
+                        key = ANSI_KEY_F2;
+                        break;
+                    case 13:
+                        key = ANSI_KEY_F3;
+                        break;
+                    case 14:
+                        key = ANSI_KEY_F4;
+                        break;
+                    case 15:
+                        key = ANSI_KEY_F5;
+                        break;
+                    case 17:
+                        key = ANSI_KEY_F6;
+                        break;
+                    case 18:
+                        key = ANSI_KEY_F7;
+                        break;
+                    case 19:
+                        key = ANSI_KEY_F8;
+                        break;
+                    case 20:
+                        key = ANSI_KEY_F9;
+                        break;
+                    case 21:
+                        key = ANSI_KEY_F10;
+                        break;
+                    case 23:
+                        key = ANSI_KEY_F11;
+                        break;
+                    case 24:
+                        key = ANSI_KEY_F12;
+                        break;
+                    default:
+                        break;
                     }
                     if(key)
                     {
@@ -639,11 +741,20 @@ static inline int ansi_get_key(void)
                 int consumed = 3;
                 switch(buf[2])
                 {
-                case 'P': key = ANSI_KEY_F1; break;
-                case 'Q': key = ANSI_KEY_F2; break;
-                case 'R': key = ANSI_KEY_F3; break;
-                case 'S': key = ANSI_KEY_F4; break;
-                default:  break;
+                case 'P':
+                    key = ANSI_KEY_F1;
+                    break;
+                case 'Q':
+                    key = ANSI_KEY_F2;
+                    break;
+                case 'R':
+                    key = ANSI_KEY_F3;
+                    break;
+                case 'S':
+                    key = ANSI_KEY_F4;
+                    break;
+                default:
+                    break;
                 }
                 memmove(buf, buf + consumed, buf_len - consumed);
                 buf_len -= consumed;

--- a/src/cli/streamCTRL/streamCTRL_ansi.h
+++ b/src/cli/streamCTRL/streamCTRL_ansi.h
@@ -157,7 +157,9 @@ static inline void ansi_raw_mode_exit(void)
  * @rows: pointer to store row count
  * @cols: pointer to store column count
  */
-static inline void ansi_get_terminal_size(int *rows, int *cols)
+static inline void ansi_get_terminal_size(
+    int *rows,
+    int *cols)
 {
     struct winsize ws;
 
@@ -191,7 +193,9 @@ static inline void ansi_cls(void)
  * @row: target row (1 = top)
  * @col: target column (1 = left)
  */
-static inline void ansi_pos(int row, int col)
+static inline void ansi_pos(
+    int row,
+    int col)
 {
     char buf[32];
     int  n = snprintf(buf, sizeof(buf), "\033[%d;%dH", row, col);
@@ -241,7 +245,10 @@ static inline void ansi_detect_color_level(void)
  * @g: green component
  * @b: blue component
  */
-static inline void ansi_fg(int r, int g, int b)
+static inline void ansi_fg(
+    int r,
+    int g,
+    int b)
 {
     char buf[32];
     int  n = snprintf(buf, sizeof(buf), "\033[38;2;%d;%d;%dm", r, g, b);
@@ -257,7 +264,10 @@ static inline void ansi_fg(int r, int g, int b)
  * @g: green component
  * @b: blue component
  */
-static inline void ansi_bg(int r, int g, int b)
+static inline void ansi_bg(
+    int r,
+    int g,
+    int b)
 {
     char buf[32];
     int  n = snprintf(buf, sizeof(buf), "\033[48;2;%d;%d;%dm", r, g, b);

--- a/src/coremods/COREMOD_arith/execute_arith.c
+++ b/src/coremods/COREMOD_arith/execute_arith.c
@@ -41,7 +41,8 @@
  * ------------------------------------------------------- */
 
 /** Known single-character binary operators */
-static const char * const operand_names[] = {
+static const char *const operand_names[] =
+{
     "+", "-", "*", "/", "^", NULL
 };
 
@@ -52,7 +53,8 @@ static const char * const operand_names[] = {
  * they are handled with a separate image_reducer sub-table
  * in the dispatch step.
  */
-static const char * const unary_func_names[] = {
+static const char *const unary_func_names[] =
+{
     "acos", "asin", "atan", "ceil",
     "cos",  "cosh", "exp",  "fabs",
     "floor",
@@ -67,12 +69,14 @@ static const char * const unary_func_names[] = {
  * Multi-arg functions: returns the number of input arguments
  * (2 or 3), or 0 if the name is not a multi-arg function.
  */
-struct multfunc_entry {
+struct multfunc_entry
+{
     const char *name;
     int         nargs; /* number of scalar/image arguments */
 };
 
-static const struct multfunc_entry multfunc_table[] = {
+static const struct multfunc_entry multfunc_table[] =
+{
     { "fmod",   2 },
     { "trunc",  3 },
     { "perc",   2 },
@@ -308,16 +312,16 @@ int execute_arith(const char *cmd1)
         /* Inside brackets: everything is part of
          * the current word. Used for slice syntax
          * like im[0:19,10:29]. */
-        if (cmd[i] == '[')
+        if(cmd[i] == '[')
         {
             bracket_depth++;
             word[w][l] = cmd[i];
             l++;
             continue;
         }
-        if (cmd[i] == ']')
+        if(cmd[i] == ']')
         {
-            if (bracket_depth > 0)
+            if(bracket_depth > 0)
             {
                 bracket_depth--;
             }
@@ -325,7 +329,7 @@ int execute_arith(const char *cmd1)
             l++;
             continue;
         }
-        if (bracket_depth > 0)
+        if(bracket_depth > 0)
         {
             word[w][l] = cmd[i];
             l++;
@@ -337,7 +341,7 @@ int execute_arith(const char *cmd1)
 
         case '+':
         case '-':
-            if((i>1) &&((cmd[i - 1] == 'e') || (cmd[i - 1] == 'E')) &&
+            if((i > 1) && ((cmd[i - 1] == 'e') || (cmd[i - 1] == 'E')) &&
                     (isdigit(cmd[i - 2])) && (isdigit(cmd[i + 1])))
             {
                 // + or - is part of exponent
@@ -599,13 +603,13 @@ int execute_arith(const char *cmd1)
         /* Sliced images are materialized into
          * temporary images so the rest of the
          * evaluator can work with plain names. */
-        for (int i = 0; i < nbword; i++)
+        for(int i = 0; i < nbword; i++)
         {
-            if (word_type[i] != ARITHTOKENTYPE_IMAGE)
+            if(word_type[i] != ARITHTOKENTYPE_IMAGE)
             {
                 continue;
             }
-            if (strchr(word[i], '[') == NULL)
+            if(strchr(word[i], '[') == NULL)
             {
                 continue;
             }
@@ -613,15 +617,15 @@ int execute_arith(const char *cmd1)
             IMGID simg =
                 imgid_make_from_name(word[i]);
             resolveIMGID(&simg, ERRMODE_NULL, dcimg, dcnimg);
-            if (simg.ID < 0)
+            if(simg.ID < 0)
             {
                 imgid_free(&simg);
                 continue;
             }
 
             /* Materialize the slice */
-            if (imgid_slice_materialize(
-                    &simg) != 0)
+            if(imgid_slice_materialize(
+                        &simg) != 0)
             {
                 PRINT_WARNING(
                     "slice materialize failed"
@@ -634,7 +638,7 @@ int execute_arith(const char *cmd1)
             int snaxis =
                 (int) slc->md[0].naxis;
             uint32_t ssz[3] = {1, 1, 1};
-            for (int a = 0; a < snaxis; a++)
+            for(int a = 0; a < snaxis; a++)
             {
                 ssz[a] = slc->md[0].size[a];
             }
@@ -658,13 +662,13 @@ int execute_arith(const char *cmd1)
                 0, /* CBsize */
                 &tid);
 
-            if (tid >= 0)
+            if(tid >= 0)
             {
                 uint64_t nbytes =
                     slc->md[0].nelement
                     * (uint64_t)
-                      ImageStreamIO_typesize(
-                          slc->md[0].datatype);
+                    ImageStreamIO_typesize(
+                        slc->md[0].datatype);
                 __builtin_memcpy(
                     dcimg[tid].array.raw,
                     slc->array.raw,
@@ -820,10 +824,10 @@ int execute_arith(const char *cmd1)
                                  tmp_name_index,
                                  (int) getpid());
 
-                if (exec_arith_binary(word[hpi], 
-                                      word_type[hpi - 1], word[hpi - 1], 
-                                      word_type[hpi + 1], word[hpi + 1], 
-                                      name, &type, &tmp_name_index) != 0)
+                if(exec_arith_binary(word[hpi],
+                                     word_type[hpi - 1], word[hpi - 1],
+                                     word_type[hpi + 1], word[hpi + 1],
+                                     name, &type, &tmp_name_index) != 0)
                 {
                     return RETURN_FAILURE;
                 }
@@ -849,8 +853,8 @@ int execute_arith(const char *cmd1)
                                  (int) getpid());
 
                 int hpi = highest_priority_index;
-                if (exec_arith_unary(word[hpi], word_type[hpi + 1], word[hpi + 1], 
-                                     name, &type, &tmp_name_index) != 0)
+                if(exec_arith_unary(word[hpi], word_type[hpi + 1], word[hpi + 1],
+                                    name, &type, &tmp_name_index) != 0)
                 {
                     return RETURN_FAILURE;
                 }
@@ -858,8 +862,8 @@ int execute_arith(const char *cmd1)
                 snprintf(word[highest_priority_index], sizeof(word[highest_priority_index]), "%s", name);
                 word_type[highest_priority_index] = type;
                 for(j = highest_priority_index + 1;
-                    j < nbword - 1;
-                    j++)
+                        j < nbword - 1;
+                        j++)
                 {
                     snprintf(word[j], sizeof(word[j]), "%s", word[j + 1]);
                     word_type[j] = word_type[j + 1];
@@ -873,7 +877,7 @@ int execute_arith(const char *cmd1)
             if(word_type[highest_priority_index] == ARITHTOKENTYPE_MULTFUNC)
             {
                 nbvarinput = isfunction_sev_var(
-                    word[highest_priority_index]);
+                                 word[highest_priority_index]);
                 CREATE_IMAGENAME(name,
                                  "_tmp%d_%d",
                                  tmp_name_index,
@@ -883,15 +887,27 @@ int execute_arith(const char *cmd1)
                 int a1t = 0, a2t = 0, a3t = 0;
                 const char *a1w = NULL, *a2w = NULL, *a3w = NULL;
 
-                if (nbvarinput >= 1) { a1t = word_type[hpi + 2]; a1w = word[hpi + 2]; }
-                if (nbvarinput >= 2) { a2t = word_type[hpi + 4]; a2w = word[hpi + 4]; }
-                if (nbvarinput >= 3) { a3t = word_type[hpi + 6]; a3w = word[hpi + 6]; }
+                if(nbvarinput >= 1)
+                {
+                    a1t = word_type[hpi + 2];
+                    a1w = word[hpi + 2];
+                }
+                if(nbvarinput >= 2)
+                {
+                    a2t = word_type[hpi + 4];
+                    a2w = word[hpi + 4];
+                }
+                if(nbvarinput >= 3)
+                {
+                    a3t = word_type[hpi + 6];
+                    a3w = word[hpi + 6];
+                }
 
-                if (exec_arith_multfunc(word[hpi], nbvarinput, 
-                                        a1t, a1w, 
-                                        a2t, a2w, 
-                                        a3t, a3w, 
-                                        name, &type, &tmp_name_index) != 0)
+                if(exec_arith_multfunc(word[hpi], nbvarinput,
+                                       a1t, a1w,
+                                       a2t, a2w,
+                                       a3t, a3w,
+                                       name, &type, &tmp_name_index) != 0)
                 {
                     return RETURN_FAILURE;
                 }
@@ -899,13 +915,13 @@ int execute_arith(const char *cmd1)
                 snprintf(word[highest_priority_index], sizeof(word[highest_priority_index]), "%s", name);
                 word_type[highest_priority_index] = type;
                 for(j = highest_priority_index + 1;
-                    j < nbword - (nbvarinput * 2 + 1);
-                    j++)
+                        j < nbword - (nbvarinput * 2 + 1);
+                        j++)
                 {
                     snprintf(word[j],
-                           sizeof(word[j]),
-                           "%s",
-                           word[j + (nbvarinput * 2 + 1)]);
+                             sizeof(word[j]),
+                             "%s",
+                             word[j + (nbvarinput * 2 + 1)]);
                     word_type[j] =
                         word_type[j + (nbvarinput * 2 + 1)];
                 }

--- a/src/coremods/COREMOD_arith/execute_arith.c
+++ b/src/coremods/COREMOD_arith/execute_arith.c
@@ -227,7 +227,7 @@ arith_image_dy_wrap(
 int execute_arith(const char *cmd1)
 {
     char word[100][100];
-    int  w, l, j;
+    int w, l;
     int  nbword;
     int  word_type[100];
     int  par_level[100];
@@ -269,7 +269,7 @@ int execute_arith(const char *cmd1)
        - remove any spaces in cmd1
        - replace "=-" by "=0-" and "=+" by "="
        copy result into cmd */
-    j = 0;
+    int j = 0;
 
     for(int i = 0; i < (int)(strlen(cmd1)); i++)
     {
@@ -702,7 +702,7 @@ int execute_arith(const char *cmd1)
                 {
                     snprintf(word[i], sizeof(word[i]), "%s", word[i + 1]);
                     word_type[i] = word_type[i + 1];
-                    for(j = i + 1; j < nbword - 2; j++)
+                    for(int j = i + 1; j < nbword - 2; j++)
                     {
                         snprintf(word[j], sizeof(word[j]), "%s", word[j + 2]);
                         word_type[j] = word_type[j + 2];
@@ -719,7 +719,7 @@ int execute_arith(const char *cmd1)
                         -dcvar[variable_ID(word[i + 2])].value.f;
                     snprintf(word[i], sizeof(word[i]), "%s", word[i + 2]);
                     word_type[i] = word_type[i + 2];
-                    for(j = i + 2; j < nbword - 3; j++)
+                    for(int j = i + 2; j < nbword - 3; j++)
                     {
                         snprintf(word[j], sizeof(word[j]), "%s", word[j + 3]);
                         word_type[j] = word_type[j + 3];

--- a/src/coremods/COREMOD_arith/im_math_basic.c
+++ b/src/coremods/COREMOD_arith/im_math_basic.c
@@ -101,50 +101,101 @@ errno_t arith_image_cstpow_optimized_IMGID(
     IMGID *imgout)
 {
     DEBUG_TRACE_FSTART();
-    if (imgin->im == NULL) { return RETURN_FAILURE; }
+    if(imgin->im == NULL)
+    {
+        return RETURN_FAILURE;
+    }
     imgid_ensure_output(imgin, imgout);
     uint64_t nelement = imgout->md->nelement;
     if(imgin->md->datatype == _DATATYPE_FLOAT && imgout->mdt->datatype == _DATATYPE_FLOAT)
     {
-        float * MILK_RESTRICT p1 = MILK_ASSUME_ALIGNED(imgin->im->array.F);
-        float * MILK_RESTRICT po = MILK_ASSUME_ALIGNED(imgout->im->array.F);
+        float *MILK_RESTRICT p1 = MILK_ASSUME_ALIGNED(imgin->im->array.F);
+        float *MILK_RESTRICT po = MILK_ASSUME_ALIGNED(imgout->im->array.F);
         float cf1 = (float)f1;
-        if (f1 == 0.0) {
+        if(f1 == 0.0)
+        {
             _Pragma("omp parallel for simd if (nelement > OMP_NELEMENT_LIMIT)")
-            for(uint64_t i=0; i<nelement; i++) po[i] = 1.0f;
-        } else if (f1 == 1.0) {
+            for(uint64_t i = 0; i < nelement; i++)
+            {
+                po[i] = 1.0f;
+            }
+        }
+        else if(f1 == 1.0)
+        {
             _Pragma("omp parallel for simd if (nelement > OMP_NELEMENT_LIMIT)")
-            for(uint64_t i=0; i<nelement; i++) po[i] = p1[i];
-        } else if (f1 == 0.5) {
+            for(uint64_t i = 0; i < nelement; i++)
+            {
+                po[i] = p1[i];
+            }
+        }
+        else if(f1 == 0.5)
+        {
             _Pragma("omp parallel for simd if (nelement > OMP_NELEMENT_LIMIT)")
-            for(uint64_t i=0; i<nelement; i++) po[i] = sqrtf(p1[i]);
-        } else if (f1 == 2.0) {
+            for(uint64_t i = 0; i < nelement; i++)
+            {
+                po[i] = sqrtf(p1[i]);
+            }
+        }
+        else if(f1 == 2.0)
+        {
             _Pragma("omp parallel for simd if (nelement > OMP_NELEMENT_LIMIT)")
-            for(uint64_t i=0; i<nelement; i++) po[i] = p1[i] * p1[i];
-        } else {
+            for(uint64_t i = 0; i < nelement; i++)
+            {
+                po[i] = p1[i] * p1[i];
+            }
+        }
+        else
+        {
             _Pragma("omp parallel for simd if (nelement > OMP_NELEMENT_LIMIT)")
-            for(uint64_t i=0; i<nelement; i++) po[i] = powf(p1[i], cf1);
+            for(uint64_t i = 0; i < nelement; i++)
+            {
+                po[i] = powf(p1[i], cf1);
+            }
         }
     }
     else if(imgin->md->datatype == _DATATYPE_DOUBLE && imgout->mdt->datatype == _DATATYPE_DOUBLE)
     {
-        double * MILK_RESTRICT p1 = MILK_ASSUME_ALIGNED(imgin->im->array.D);
-        double * MILK_RESTRICT po = MILK_ASSUME_ALIGNED(imgout->im->array.D);
-        if (f1 == 0.0) {
+        double *MILK_RESTRICT p1 = MILK_ASSUME_ALIGNED(imgin->im->array.D);
+        double *MILK_RESTRICT po = MILK_ASSUME_ALIGNED(imgout->im->array.D);
+        if(f1 == 0.0)
+        {
             _Pragma("omp parallel for simd if (nelement > OMP_NELEMENT_LIMIT)")
-            for(uint64_t i=0; i<nelement; i++) po[i] = 1.0;
-        } else if (f1 == 1.0) {
+            for(uint64_t i = 0; i < nelement; i++)
+            {
+                po[i] = 1.0;
+            }
+        }
+        else if(f1 == 1.0)
+        {
             _Pragma("omp parallel for simd if (nelement > OMP_NELEMENT_LIMIT)")
-            for(uint64_t i=0; i<nelement; i++) po[i] = p1[i];
-        } else if (f1 == 0.5) {
+            for(uint64_t i = 0; i < nelement; i++)
+            {
+                po[i] = p1[i];
+            }
+        }
+        else if(f1 == 0.5)
+        {
             _Pragma("omp parallel for simd if (nelement > OMP_NELEMENT_LIMIT)")
-            for(uint64_t i=0; i<nelement; i++) po[i] = sqrt(p1[i]);
-        } else if (f1 == 2.0) {
+            for(uint64_t i = 0; i < nelement; i++)
+            {
+                po[i] = sqrt(p1[i]);
+            }
+        }
+        else if(f1 == 2.0)
+        {
             _Pragma("omp parallel for simd if (nelement > OMP_NELEMENT_LIMIT)")
-            for(uint64_t i=0; i<nelement; i++) po[i] = p1[i] * p1[i];
-        } else {
+            for(uint64_t i = 0; i < nelement; i++)
+            {
+                po[i] = p1[i] * p1[i];
+            }
+        }
+        else
+        {
             _Pragma("omp parallel for simd if (nelement > OMP_NELEMENT_LIMIT)")
-            for(uint64_t i=0; i<nelement; i++) po[i] = pow(p1[i], f1);
+            for(uint64_t i = 0; i < nelement; i++)
+            {
+                po[i] = pow(p1[i], f1);
+            }
         }
     }
     else

--- a/src/coremods/COREMOD_arith/im_math_basic.c
+++ b/src/coremods/COREMOD_arith/im_math_basic.c
@@ -95,7 +95,10 @@ ARITH_CST_OPTIMIZED_FUNCTION(sub, -)
 ARITH_CST_OPTIMIZED_FUNCTION(mult, *)
 ARITH_CST_OPTIMIZED_FUNCTION(div, /)
 
-errno_t arith_image_cstpow_optimized_IMGID(IMGID *imgin, double f1, IMGID *imgout)
+errno_t arith_image_cstpow_optimized_IMGID(
+    IMGID *imgin,
+    double f1,
+    IMGID *imgout)
 {
     DEBUG_TRACE_FSTART();
     if (imgin->im == NULL) { return RETURN_FAILURE; }

--- a/src/coremods/COREMOD_arith/image_arith__im_f_f__im.c
+++ b/src/coremods/COREMOD_arith/image_arith__im_f_f__im.c
@@ -96,7 +96,10 @@ int arith_image_trunc(const char *ID_name,
     return (0);
 }
 
-int arith_image_trunc_inplace(const char *ID_name, double f1, double f2)
+int arith_image_trunc_inplace(
+    const char *ID_name,
+    double f1,
+    double f2)
 {
     arith_image_function_1ff_1_inplace(ID_name, f1, f2, &Ptrunc);
     return (0);

--- a/src/coremods/COREMOD_arith/image_arith__im_f_f__im.c
+++ b/src/coremods/COREMOD_arith/image_arith__im_f_f__im.c
@@ -27,13 +27,14 @@
  * 1.  FPS COMPONENT IDENTITY
  * ============================================================= */
 
-static FPS_APP_INFO FPS_app_info = {
+static FPS_APP_INFO FPS_app_info =
+{
     .fps_name    = "imtrunc",
     .cmdkey      = "imtrunc",
     .description =
-        "truncate pixel values between min and max",
+    "truncate pixel values between min and max",
     .description_long =
-        "Truncate pixel values in an image stream by clamping them to a specified range [min, max]. Pixels below min are set to min, pixels above max are set to max. Useful for filtering outliers or enforcing dynamic range limits in real-time streams."
+    "Truncate pixel values in an image stream by clamping them to a specified range [min, max]. Pixels below min are set to min, pixels above max are set to max. Useful for filtering outliers or enforcing dynamic range limits in real-time streams."
 };
 
 
@@ -124,7 +125,8 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
     IMGID imgin  = imgid_make_from_name(inimname);
     resolveIMGID(&imgin, ERRMODE_NULL, dcimg, dcnimg);
 
-    if (imgin.im == NULL) {
+    if(imgin.im == NULL)
+    {
         return RETURN_FAILURE;
     }
 
@@ -132,7 +134,8 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
     imgid_copy(&imgin, &imgout);
     imcreateIMGID(&imgout);
 
-    if (imgout.im == NULL) {
+    if(imgout.im == NULL)
+    {
         imgid_free(&imgin);
         return RETURN_FAILURE;
     }
@@ -143,33 +146,47 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
 
     INSERT_STD_PROCINFO_COMPUTEFUNC_LOOPSTART
     {
-        if (imgin.md->datatype == _DATATYPE_FLOAT && imgout.mdt->datatype == _DATATYPE_FLOAT)
+        if(imgin.md->datatype == _DATATYPE_FLOAT && imgout.mdt->datatype == _DATATYPE_FLOAT)
         {
-            float * MILK_RESTRICT pin = MILK_ASSUME_ALIGNED(imgin.im->array.F);
-            float * MILK_RESTRICT pout = MILK_ASSUME_ALIGNED(imgout.im->array.F);
+            float *MILK_RESTRICT pin = MILK_ASSUME_ALIGNED(imgin.im->array.F);
+            float *MILK_RESTRICT pout = MILK_ASSUME_ALIGNED(imgout.im->array.F);
             float f_min = (float)valmin;
             float f_max = (float)valmax;
 
             #pragma omp simd
-            for (uint64_t ii = 0; ii < nelement; ii++) {
+            for(uint64_t ii = 0; ii < nelement; ii++)
+            {
                 float v = pin[ii];
-                if (v < f_min) v = f_min;
-                else if (v > f_max) v = f_max;
+                if(v < f_min)
+                {
+                    v = f_min;
+                }
+                else if(v > f_max)
+                {
+                    v = f_max;
+                }
                 pout[ii] = v;
             }
         }
-        else if (imgin.md->datatype == _DATATYPE_DOUBLE && imgout.mdt->datatype == _DATATYPE_DOUBLE)
+        else if(imgin.md->datatype == _DATATYPE_DOUBLE && imgout.mdt->datatype == _DATATYPE_DOUBLE)
         {
-            double * MILK_RESTRICT pin = MILK_ASSUME_ALIGNED(imgin.im->array.D);
-            double * MILK_RESTRICT pout = MILK_ASSUME_ALIGNED(imgout.im->array.D);
+            double *MILK_RESTRICT pin = MILK_ASSUME_ALIGNED(imgin.im->array.D);
+            double *MILK_RESTRICT pout = MILK_ASSUME_ALIGNED(imgout.im->array.D);
             double d_min = valmin;
             double d_max = valmax;
 
             #pragma omp simd
-            for (uint64_t ii = 0; ii < nelement; ii++) {
+            for(uint64_t ii = 0; ii < nelement; ii++)
+            {
                 double v = pin[ii];
-                if (v < d_min) v = d_min;
-                else if (v > d_max) v = d_max;
+                if(v < d_min)
+                {
+                    v = d_min;
+                }
+                else if(v > d_max)
+                {
+                    v = d_max;
+                }
                 pout[ii] = v;
             }
         }
@@ -197,9 +214,9 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
 static errno_t CLIfunction(void)
 {
     return safe_fps_generic_CLIfunction(
-        &FPS_app_info, farg, &CLIcmddata,
-        my_bindings, nb_bindings,
-        compute_function);
+               &FPS_app_info, farg, &CLIcmddata,
+               my_bindings, nb_bindings,
+               compute_function);
 }
 
 errno_t image_arith__im_f_f__im_addCLIcmd()

--- a/src/coremods/COREMOD_arith/image_crop.c
+++ b/src/coremods/COREMOD_arith/image_crop.c
@@ -268,7 +268,7 @@ imageID arith_image_crop(const char *ID_name,
                          int64_t        cropdim)
 {
     int64_t      naxis;
-    int64_t      i;
+
     uint32_t *naxes    = NULL;
     uint32_t *naxesout = NULL;
     uint8_t   datatype;
@@ -276,7 +276,7 @@ imageID arith_image_crop(const char *ID_name,
     int64_t start_c[3];
     int64_t end_c[3];
 
-    for(i = 0; i < 3; i++)
+    for( int i = 0; i < 3; i++)
     {
         start_c[i] = 0;
         end_c[i]   = 0;
@@ -317,7 +317,7 @@ imageID arith_image_crop(const char *ID_name,
 
     naxes[0]    = 0;
     naxesout[0] = 0;
-    for(i = 0; i < naxis; i++)
+    for(int i = 0; i < naxis; i++)
     {
         naxes[i] =
             imgin.md->size[i];
@@ -328,7 +328,7 @@ imageID arith_image_crop(const char *ID_name,
     IMGID imgout =
         imgid_make_from_name(ID_out);
     imgout.mdt->naxis = naxis;
-    for(i = 0; i < naxis; i++)
+    for(int i = 0; i < naxis; i++)
     {
         imgout.mdt->size[i] =
             naxesout[i];
@@ -379,7 +379,7 @@ imageID arith_image_crop(const char *ID_name,
     }
 
     printf("CROP: \n");
-    for(i = 0; i < 3; i++)
+    for(int i = 0; i < 3; i++)
     {
         printf("axis %ld: %ld -> %ld\n", i, start_c[i], end_c[i]);
     }
@@ -526,7 +526,7 @@ imageID arith_image_extract2D(
     int64_t        *start = NULL;
     int64_t        *end   = NULL;
     imageID      IDout;
-    uint_fast8_t k;
+
 
     IMGID img =
         imgid_make_from_name(in_name);
@@ -552,7 +552,7 @@ imageID arith_image_extract2D(
         return -1;
     }
 
-    for(k = 0; k < naxis; k++)
+    for(uint_fast8_t k = 0; k < naxis; k++)
     {
         start[k] = 0;
         end[k]   = img.md->size[k];

--- a/src/coremods/COREMOD_arith/image_crop.c
+++ b/src/coremods/COREMOD_arith/image_crop.c
@@ -276,7 +276,7 @@ imageID arith_image_crop(const char *ID_name,
     int64_t start_c[3];
     int64_t end_c[3];
 
-    for( int i = 0; i < 3; i++)
+    for(int i = 0; i < 3; i++)
     {
         start_c[i] = 0;
         end_c[i]   = 0;

--- a/src/coremods/COREMOD_arith/image_crop3D.c
+++ b/src/coremods/COREMOD_arith/image_crop3D.c
@@ -264,7 +264,7 @@ imageID arith_image_crop(const char *ID_name,
     int64_t start_c[3];
     int64_t end_c[3];
 
-    for( i = 0; i < 3; i++)
+    for(i = 0; i < 3; i++)
     {
         start_c[i] = 0;
         end_c[i]   = 0;

--- a/src/coremods/COREMOD_arith/image_crop3D.c
+++ b/src/coremods/COREMOD_arith/image_crop3D.c
@@ -256,7 +256,7 @@ imageID arith_image_crop(const char *ID_name,
                          int64_t        cropdim)
 {
     int64_t      naxis;
-    int64_t      i;
+
     uint32_t *naxes    = NULL;
     uint32_t *naxesout = NULL;
     uint8_t   datatype;
@@ -264,7 +264,7 @@ imageID arith_image_crop(const char *ID_name,
     int64_t start_c[3];
     int64_t end_c[3];
 
-    for(i = 0; i < 3; i++)
+    for( i = 0; i < 3; i++)
     {
         start_c[i] = 0;
         end_c[i]   = 0;
@@ -506,7 +506,7 @@ imageID arith_image_extract2D(
     int64_t        *start = NULL;
     int64_t        *end   = NULL;
     imageID      IDout;
-    uint_fast8_t k;
+
 
     IMGID img =
         imgid_make_from_name(in_name);
@@ -532,7 +532,7 @@ imageID arith_image_extract2D(
         return -1;
     }
 
-    for(k = 0; k < naxis; k++)
+    for(uint_fast8_t k = 0; k < naxis; k++)
     {
         start[k] = 0;
         end[k]   = img.md->size[k];

--- a/src/coremods/COREMOD_arith/image_dxdy.c
+++ b/src/coremods/COREMOD_arith/image_dxdy.c
@@ -15,7 +15,9 @@
 
 #include "COREMOD_memory/COREMOD_memory.h"
 
-imageID arith_image_dx_IMGID(IMGID *imgin, IMGID *imgout)
+imageID arith_image_dx_IMGID(
+    IMGID *imgin,
+    IMGID *imgout)
 {
     DEBUG_TRACE_FSTART();
 
@@ -69,7 +71,9 @@ imageID arith_image_dx_IMGID(IMGID *imgin, IMGID *imgout)
  * Uses central differences for interior pixels
  * and forward/backward differences at boundaries.
  */
-imageID arith_image_dx(const char *ID_name, const char *IDout_name)
+imageID arith_image_dx(
+    const char *ID_name,
+    const char *IDout_name)
 {
     IMGID imgin = imgid_make_from_name(ID_name);
     IMGID imgout = imgid_make_from_name(IDout_name);
@@ -80,7 +84,9 @@ imageID arith_image_dx(const char *ID_name, const char *IDout_name)
     return ID;
 }
 
-imageID arith_image_dy_IMGID(IMGID *imgin, IMGID *imgout)
+imageID arith_image_dy_IMGID(
+    IMGID *imgin,
+    IMGID *imgout)
 {
     DEBUG_TRACE_FSTART();
 
@@ -135,7 +141,9 @@ imageID arith_image_dy_IMGID(IMGID *imgin, IMGID *imgout)
 /**
  * @brief Compute y-gradient (finite difference) of an image.
  */
-imageID arith_image_dy(const char *ID_name, const char *IDout_name)
+imageID arith_image_dy(
+    const char *ID_name,
+    const char *IDout_name)
 {
     IMGID imgin = imgid_make_from_name(ID_name);
     IMGID imgout = imgid_make_from_name(IDout_name);

--- a/src/coremods/COREMOD_arith/image_stats.c
+++ b/src/coremods/COREMOD_arith/image_stats.c
@@ -223,7 +223,7 @@ double arith_image_percentile_IMGID(
             PRINT_ERROR("malloc() error");
             exit(EXIT_FAILURE);
         }
-        for (uint64_t ii = 0; ii < nelement; ii++)
+        for(uint64_t ii = 0; ii < nelement; ii++)
         {
             arrayU[ii] = imgin->im->array.UI16[ii];
         }
@@ -239,7 +239,7 @@ double arith_image_percentile_IMGID(
             PRINT_ERROR("malloc() error");
             exit(EXIT_FAILURE);
         }
-        for (uint64_t ii = 0; ii < nelement; ii++)
+        for(uint64_t ii = 0; ii < nelement; ii++)
         {
             arrayL[ii] = imgin->im->array.UI32[ii];
         }
@@ -255,7 +255,7 @@ double arith_image_percentile_IMGID(
             PRINT_ERROR("malloc() error");
             exit(EXIT_FAILURE);
         }
-        for (uint64_t ii = 0; ii < nelement; ii++)
+        for(uint64_t ii = 0; ii < nelement; ii++)
         {
             arrayL[ii] = imgin->im->array.UI64[ii];
         }
@@ -271,7 +271,7 @@ double arith_image_percentile_IMGID(
             PRINT_ERROR("malloc() error");
             exit(EXIT_FAILURE);
         }
-        for (uint64_t ii = 0; ii < nelement; ii++)
+        for(uint64_t ii = 0; ii < nelement; ii++)
         {
             arrayL[ii] = (long) imgin->im->array.SI8[ii];
         }
@@ -287,7 +287,7 @@ double arith_image_percentile_IMGID(
             PRINT_ERROR("malloc() error");
             exit(EXIT_FAILURE);
         }
-        for (uint64_t ii = 0; ii < nelement; ii++)
+        for(uint64_t ii = 0; ii < nelement; ii++)
         {
             arrayL[ii] = (long) imgin->im->array.SI16[ii];
         }
@@ -303,7 +303,7 @@ double arith_image_percentile_IMGID(
             PRINT_ERROR("malloc() error");
             exit(EXIT_FAILURE);
         }
-        for (uint64_t ii = 0; ii < nelement; ii++)
+        for(uint64_t ii = 0; ii < nelement; ii++)
         {
             arrayL[ii] = (long) imgin->im->array.SI32[ii];
         }
@@ -319,7 +319,7 @@ double arith_image_percentile_IMGID(
             PRINT_ERROR("malloc() error");
             exit(EXIT_FAILURE);
         }
-        for (uint64_t ii = 0; ii < nelement; ii++)
+        for(uint64_t ii = 0; ii < nelement; ii++)
         {
             arrayL[ii] = (long) imgin->im->array.SI64[ii];
         }

--- a/src/coremods/COREMOD_arith/image_stats.c
+++ b/src/coremods/COREMOD_arith/image_stats.c
@@ -152,9 +152,11 @@ double arith_image_max(const char *ID_name)
     return arith_image_max_IMGID(&imgin);
 }
 
-double arith_image_percentile_IMGID(IMGID *imgin, double fraction)
+double arith_image_percentile_IMGID(
+    IMGID *imgin,
+    double fraction)
 {
-    uint64_t        ii;
+
     double          value  = 0;
     long           *arrayL = NULL;
     float          *arrayF = NULL;
@@ -205,7 +207,7 @@ double arith_image_percentile_IMGID(IMGID *imgin, double fraction)
             PRINT_ERROR("malloc() error");
             exit(EXIT_FAILURE);
         }
-        for(ii = 0; ii < nelement; ii++)
+        for(uint64_t ii = 0; ii < nelement; ii++)
         {
             arrayU[ii] = imgin->im->array.UI8[ii];
         }
@@ -221,7 +223,7 @@ double arith_image_percentile_IMGID(IMGID *imgin, double fraction)
             PRINT_ERROR("malloc() error");
             exit(EXIT_FAILURE);
         }
-        for(ii = 0; ii < nelement; ii++)
+        for (uint64_t ii = 0; ii < nelement; ii++)
         {
             arrayU[ii] = imgin->im->array.UI16[ii];
         }
@@ -237,7 +239,7 @@ double arith_image_percentile_IMGID(IMGID *imgin, double fraction)
             PRINT_ERROR("malloc() error");
             exit(EXIT_FAILURE);
         }
-        for(ii = 0; ii < nelement; ii++)
+        for (uint64_t ii = 0; ii < nelement; ii++)
         {
             arrayL[ii] = imgin->im->array.UI32[ii];
         }
@@ -253,7 +255,7 @@ double arith_image_percentile_IMGID(IMGID *imgin, double fraction)
             PRINT_ERROR("malloc() error");
             exit(EXIT_FAILURE);
         }
-        for(ii = 0; ii < nelement; ii++)
+        for (uint64_t ii = 0; ii < nelement; ii++)
         {
             arrayL[ii] = imgin->im->array.UI64[ii];
         }
@@ -269,7 +271,7 @@ double arith_image_percentile_IMGID(IMGID *imgin, double fraction)
             PRINT_ERROR("malloc() error");
             exit(EXIT_FAILURE);
         }
-        for(ii = 0; ii < nelement; ii++)
+        for (uint64_t ii = 0; ii < nelement; ii++)
         {
             arrayL[ii] = (long) imgin->im->array.SI8[ii];
         }
@@ -285,7 +287,7 @@ double arith_image_percentile_IMGID(IMGID *imgin, double fraction)
             PRINT_ERROR("malloc() error");
             exit(EXIT_FAILURE);
         }
-        for(ii = 0; ii < nelement; ii++)
+        for (uint64_t ii = 0; ii < nelement; ii++)
         {
             arrayL[ii] = (long) imgin->im->array.SI16[ii];
         }
@@ -301,7 +303,7 @@ double arith_image_percentile_IMGID(IMGID *imgin, double fraction)
             PRINT_ERROR("malloc() error");
             exit(EXIT_FAILURE);
         }
-        for(ii = 0; ii < nelement; ii++)
+        for (uint64_t ii = 0; ii < nelement; ii++)
         {
             arrayL[ii] = (long) imgin->im->array.SI32[ii];
         }
@@ -317,7 +319,7 @@ double arith_image_percentile_IMGID(IMGID *imgin, double fraction)
             PRINT_ERROR("malloc() error");
             exit(EXIT_FAILURE);
         }
-        for(ii = 0; ii < nelement; ii++)
+        for (uint64_t ii = 0; ii < nelement; ii++)
         {
             arrayL[ii] = (long) imgin->im->array.SI64[ii];
         }
@@ -348,7 +350,9 @@ double arith_image_percentile_IMGID(IMGID *imgin, double fraction)
  * Sorts pixel values and returns the value at
  * the specified fractional position.
  */
-double arith_image_percentile(const char *ID_name, double fraction)
+double arith_image_percentile(
+    const char *ID_name,
+    double fraction)
 {
     IMGID imgin = imgid_make_from_name(ID_name);
     return arith_image_percentile_IMGID(&imgin, fraction);
@@ -372,7 +376,9 @@ double arith_image_median(const char *ID_name)
     return arith_image_median_IMGID(&imgin);
 }
 
-double MILK_HOT arith_image_dot_IMGID(IMGID *imgin1, IMGID *imgin2)
+double MILK_HOT arith_image_dot_IMGID(
+    IMGID *imgin1,
+    IMGID *imgin2)
 {
     uint64_t nelement;
     uint8_t  datatype1, datatype2;
@@ -484,7 +490,9 @@ double MILK_HOT arith_image_dot_IMGID(IMGID *imgin1, IMGID *imgin2)
     return value;
 }
 
-double arith_image_dot(const char *ID1_name, const char *ID2_name)
+double arith_image_dot(
+    const char *ID1_name,
+    const char *ID2_name)
 {
     IMGID imgin1 = imgid_make_from_name(ID1_name);
     IMGID imgin2 = imgid_make_from_name(ID2_name);

--- a/src/coremods/COREMOD_arith/imfunctions.c
+++ b/src/coremods/COREMOD_arith/imfunctions.c
@@ -434,9 +434,9 @@ errno_t arith_image_function_imd_im__dd_d_IMGID(
  * @return RETURN_SUCCESS or RETURN_FAILURE
  */
 errno_t arith_image_function_imd_im__dd_d(
-    const char *__restrict ID_name,
-    double                 v0,
-    const char *__restrict ID_out,
+    const char *__restrict        ID_name,
+    double                        v0,
+    const char *__restrict        ID_out,
     double (*pt2function)(double, double))
 {
     RESOLVE_CALL_CLEANUP(ID_name, ID_out,

--- a/src/coremods/COREMOD_arith/mathfuncs.c
+++ b/src/coremods/COREMOD_arith/mathfuncs.c
@@ -431,7 +431,7 @@ complex_double CPdiv_CD_CD(
     double         den;
 
     den = b.re * b.re + b.im * b.im;
-    
+
     v.re = (a.re * b.re + a.im * b.im) / den;
     v.im = (a.im * b.re - a.re * b.im) / den;
 

--- a/src/coremods/COREMOD_arith/mathfuncs.c
+++ b/src/coremods/COREMOD_arith/mathfuncs.c
@@ -128,42 +128,58 @@ double Ppositive(double a)
  * Pdiv1(a,b) returns b/a (reverse divide).
  * ========================================================== */
 
-double Pfmod(double a, double b)
+double Pfmod(
+    double a,
+    double b)
 {
     return ((double) fmod(a, b));
 }
 
-double Ppow(double a, double b)
+double Ppow(
+    double a,
+    double b)
 {
     return ((double) pow(a, b));
 }
 
-double Padd(double a, double b)
+double Padd(
+    double a,
+    double b)
 {
     return ((double) a + b);
 }
 
-double Psubm(double a, double b)
+double Psubm(
+    double a,
+    double b)
 {
     return ((double) b - a);
 }
 
-double Psub(double a, double b)
+double Psub(
+    double a,
+    double b)
 {
     return ((double) a - b);
 }
 
-double Pmult(double a, double b)
+double Pmult(
+    double a,
+    double b)
 {
     return ((double) a * b);
 }
 
-double Pdiv(double a, double b)
+double Pdiv(
+    double a,
+    double b)
 {
     return ((double) a / b);
 }
 
-double Pdiv1(double a, double b)
+double Pdiv1(
+    double a,
+    double b)
 {
     return ((double) b / a);
 }
@@ -175,7 +191,9 @@ double Pdiv1(double a, double b)
 /**
  * @brief Element-wise minimum of two values
  */
-double Pminv(double a, double b)
+double Pminv(
+    double a,
+    double b)
 {
     if(a < b)
     {
@@ -190,7 +208,9 @@ double Pminv(double a, double b)
 /**
  * @brief Element-wise maximum of two values
  */
-double Pmaxv(double a, double b)
+double Pmaxv(
+    double a,
+    double b)
 {
     if(a > b)
     {
@@ -211,7 +231,9 @@ double Pmaxv(double a, double b)
  * ========================================================== */
 
 /** @brief a < b → 1.0 */
-double Ptestlt(double a, double b)
+double Ptestlt(
+    double a,
+    double b)
 {
     if(a < b)
     {
@@ -224,7 +246,9 @@ double Ptestlt(double a, double b)
 }
 
 /** @brief a >= b → 1.0 ("mt" = more than) */
-double Ptestmt(double a, double b)
+double Ptestmt(
+    double a,
+    double b)
 {
     if(a < b)
     {
@@ -237,7 +261,9 @@ double Ptestmt(double a, double b)
 }
 
 /** @brief a == b → 1.0 */
-double Pteste(double a, double b)
+double Pteste(
+    double a,
+    double b)
 {
     if(a == b)
     {
@@ -250,7 +276,9 @@ double Pteste(double a, double b)
 }
 
 /** @brief a != b → 1.0 */
-double Ptestne(double a, double b)
+double Ptestne(
+    double a,
+    double b)
 {
     if(a != b)
     {
@@ -263,7 +291,9 @@ double Ptestne(double a, double b)
 }
 
 /** @brief a <= b → 1.0 */
-double Ptestle(double a, double b)
+double Ptestle(
+    double a,
+    double b)
 {
     if(a <= b)
     {
@@ -276,7 +306,9 @@ double Ptestle(double a, double b)
 }
 
 /** @brief a >= b → 1.0 */
-double Ptestge(double a, double b)
+double Ptestge(
+    double a,
+    double b)
 {
     if(a >= b)
     {
@@ -293,7 +325,9 @@ double Ptestge(double a, double b)
  * ========================================================== */
 
 /** @brief Logical AND: (a!=0 && b!=0) → 1.0 */
-double Pand(double a, double b)
+double Pand(
+    double a,
+    double b)
 {
     if((a != 0.0) && (b != 0.0))
     {
@@ -306,7 +340,9 @@ double Pand(double a, double b)
 }
 
 /** @brief Logical OR: (a!=0 || b!=0) → 1.0 */
-double Por(double a, double b)
+double Por(
+    double a,
+    double b)
 {
     if((a != 0.0) || (b != 0.0))
     {
@@ -326,7 +362,10 @@ double Por(double a, double b)
  * @param c  Upper bound
  * @return Clamped value
  */
-double Ptrunc(double a, double b, double c)
+double Ptrunc(
+    double a,
+    double b,
+    double c)
 {
     double value;
     value = a;

--- a/src/coremods/COREMOD_memory/create_variable.c
+++ b/src/coremods/COREMOD_memory/create_variable.c
@@ -16,7 +16,9 @@
 #include "variable_ID.h"
 
 /* creates floating point variable */
-variableID create_variable_ID(const char *name, double value)
+variableID create_variable_ID(
+    const char *name,
+    double value)
 {
     variableID ID;
     long       i2;
@@ -55,7 +57,9 @@ variableID create_variable_ID(const char *name, double value)
 }
 
 /* creates long variable */
-variableID create_variable_long_ID(const char *name, long value)
+variableID create_variable_long_ID(
+    const char *name,
+    long value)
 {
     variableID ID;
     long       i2;
@@ -94,7 +98,9 @@ variableID create_variable_long_ID(const char *name, long value)
 }
 
 /* creates long variable */
-variableID create_variable_string_ID(const char *name, const char *value)
+variableID create_variable_string_ID(
+    const char *name,
+    const char *value)
 {
     variableID ID;
     long       i2;

--- a/src/coremods/COREMOD_memory/fps_ID.c
+++ b/src/coremods/COREMOD_memory/fps_ID.c
@@ -73,8 +73,8 @@ long next_avail_fps_ID()
     if(ID == -1)
     {
         PRINT_ERROR("ran out of FPS IDs"
-            " (NB_MAX_FPS=%ld)",
-            dcnfps);
+                    " (NB_MAX_FPS=%ld)",
+                    dcnfps);
     }
 
     return ID;

--- a/src/coremods/COREMOD_memory/fps_ID.c
+++ b/src/coremods/COREMOD_memory/fps_ID.c
@@ -50,14 +50,14 @@ long fps_ID(const char *name)
 /* next available ID number */
 long next_avail_fps_ID()
 {
-    long i;
+
     long ID = -1;
 
 #ifdef _OPENMP
     #pragma omp critical
     {
 #endif
-        for(i = 0; i < dcnfps; i++)
+        for(long i = 0; i < dcnfps; i++)
         {
             if(dcfpsarr[i].SMfd < 0)
             {

--- a/src/coremods/COREMOD_memory/fps_list.c
+++ b/src/coremods/COREMOD_memory/fps_list.c
@@ -20,13 +20,14 @@
  * 1.  FPS COMPONENT IDENTITY
  * ============================================================= */
 
-static FPS_APP_INFO FPS_app_info = {
+static FPS_APP_INFO FPS_app_info =
+{
     .fps_name    = "fpslist",
     .cmdkey      = "fpslist",
     .description =
-        "list function parameter structures",
+    "list function parameter structures",
     .description_long =
-        "List all FPS (Function Parameter Structure) instances currently active in shared memory. Shows FPS name, status, and associated process."
+    "List all FPS (Function Parameter Structure) instances currently active in shared memory. Shows FPS name, status, and associated process."
 };
 
 
@@ -101,7 +102,7 @@ errno_t fps_list()
     while((de = readdir(dr)) != NULL)
     {
         if(strstr(de->d_name, ".fps.shm")
-            != NULL)
+                != NULL)
         {
             char fpsname[100];
             int  slen1 =
@@ -128,9 +129,11 @@ errno_t fps_list()
  * ============================================================= */
 
 #ifdef FPS_STANDALONE
-CLICMDDATA CLIcmddata = {
+CLICMDDATA CLIcmddata =
+{
 #else
-static CLICMDDATA CLIcmddata = {
+static CLICMDDATA CLIcmddata =
+{
 #endif
     "",
     "",
@@ -163,16 +166,16 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
 static errno_t CLIfunction(void)
 {
     return safe_fps_generic_CLIfunction(
-        &FPS_app_info, NULL, &CLIcmddata,
-        NULL, 0,
-        compute_function);
+               &FPS_app_info, NULL, &CLIcmddata,
+               NULL, 0,
+               compute_function);
 }
 
 errno_t
 CLIADDCMD_COREMOD_memory__fps_list()
 {
     int cmdi = RegisterCLIcmd(
-        CLIcmddata, CLIfunction);
+                   CLIcmddata, CLIfunction);
     CLIcmddata.cmdsettings =
         &data.cmd[cmdi].cmdsettings;
 

--- a/src/coremods/COREMOD_memory/fps_list.c
+++ b/src/coremods/COREMOD_memory/fps_list.c
@@ -50,14 +50,14 @@ static FPS_APP_INFO FPS_app_info = {
 
 errno_t fps_list()
 {
-    long fpsID;
+
     long fpscnt = 0;
 
     int NBchar_fpsID   = 5;
     int NBchar_fpsname = 12;
     int NBchar_NBparam = 4;
 
-    for(fpsID = 0; fpsID < dcnfps; fpsID++)
+    for(long fpsID = 0; fpsID < dcnfps; fpsID++)
     {
         if(dcfpsarr[fpsID].SMfd > -1)
         {

--- a/src/coremods/COREMOD_memory/imageID.h
+++ b/src/coremods/COREMOD_memory/imageID.h
@@ -260,7 +260,9 @@ static inline int imgid_exists(const char *name)
  * @param ID    Index into the global dcimg[] array
  * @return Fully populated IMGID
  */
-static inline IMGID makesetIMGID(CONST_WORD name, imageID ID)
+static inline IMGID makesetIMGID(
+    CONST_WORD name,
+    imageID ID)
 {
     IMGID img;
 

--- a/src/coremods/COREMOD_memory/image_ID.c
+++ b/src/coremods/COREMOD_memory/image_ID.c
@@ -117,8 +117,8 @@ imageID next_avail_image_ID(
     {
 #endif
         if((preferredID > -1)
-            && (preferredID < dcnimg)
-            && (dcimg[preferredID].used == 0))
+                && (preferredID < dcnimg)
+                && (dcimg[preferredID].used == 0))
         {
             ID = preferredID;
             dcimg[ID].used = 1;
@@ -141,8 +141,8 @@ imageID next_avail_image_ID(
     if(ID == -1)
     {
         PRINT_ERROR("ran out of image IDs"
-            " (NB_MAX_IMAGE=%ld)",
-            dcnimg);
+                    " (NB_MAX_IMAGE=%ld)",
+                    dcnimg);
     }
 
     DEBUG_TRACEPOINT("FOUT ID : %ld", ID);

--- a/src/coremods/COREMOD_memory/image_ID.c
+++ b/src/coremods/COREMOD_memory/image_ID.c
@@ -14,7 +14,10 @@
 #endif
 
 /* ID number corresponding to a name */
-imageID image_ID(const char *name, IMAGE *imagearray, long NB_images)
+imageID image_ID(
+    const char *name,
+    IMAGE *imagearray,
+    long NB_images)
 {
     DEBUG_TRACE_FSTART();
 

--- a/src/coremods/COREMOD_memory/image_checksize.c
+++ b/src/coremods/COREMOD_memory/image_checksize.c
@@ -16,7 +16,10 @@
 /**
  * @brief Verify that an image has the expected 2D size.
  */
-int check_2Dsize(const char *ID_name, uint32_t xsize, uint32_t ysize)
+int check_2Dsize(
+    const char *ID_name,
+    uint32_t xsize,
+    uint32_t ysize)
 {
     int     retval;
     IMGID img = imgid_make_from_name(ID_name);

--- a/src/coremods/COREMOD_memory/image_keyword.c
+++ b/src/coremods/COREMOD_memory/image_keyword.c
@@ -338,19 +338,31 @@ long image_write_keyword_S(
 /**
  * @brief Legacy wrappers taking IMGID
  */
-errno_t image_keyword_addL(IMGID img, const char *kwname, long kwval, const char *comment)
+errno_t image_keyword_addL(
+    IMGID img,
+    const char *kwname,
+    long kwval,
+    const char *comment)
 {
     _image_write_keyword(img, kwname, 'L', kwval, 0.0, NULL, comment);
     return RETURN_SUCCESS;
 }
 
-errno_t image_keyword_addD(IMGID img, const char *kwname, double kwval, const char *comment)
+errno_t image_keyword_addD(
+    IMGID img,
+    const char *kwname,
+    double kwval,
+    const char *comment)
 {
     _image_write_keyword(img, kwname, 'D', 0, kwval, NULL, comment);
     return RETURN_SUCCESS;
 }
 
-errno_t image_keyword_addS(IMGID img, const char *kwname, const char *kwval, const char *comment)
+errno_t image_keyword_addS(
+    IMGID img,
+    const char *kwname,
+    const char *kwval,
+    const char *comment)
 {
     _image_write_keyword(img, kwname, 'S', 0, 0.0, kwval, comment);
     return RETURN_SUCCESS;
@@ -375,10 +387,10 @@ imageID image_list_keywords(
     {
         return RETURN_FAILURE;
     }
-    long    kw;
+
 
     int kwcnt = 0;
-    for(kw = 0;
+    for(long kw = 0;
             kw < dcimg[ID].md->NBkw;
             kw++)
     {
@@ -442,11 +454,11 @@ long image_read_keyword_D(
         return -1;
     }
     long ID = img.ID;
-    long       kw;
+
     long       kw0;
 
     kw0 = -1;
-    for(kw = 0;
+    for(long kw = 0;
             kw < dcimg[ID].md[0].NBkw;
             kw++)
     {
@@ -485,11 +497,11 @@ long image_read_keyword_L(
         return -1;
     }
     long ID = img.ID;
-    long       kw;
+
     long       kw0;
 
     kw0 = -1;
-    for(kw = 0;
+    for(long kw = 0;
             kw < dcimg[ID].md[0].NBkw;
             kw++)
     {

--- a/src/coremods/COREMOD_memory/list_image.c
+++ b/src/coremods/COREMOD_memory/list_image.c
@@ -77,8 +77,8 @@ static errno_t __attribute__((unused)) compute_listim()
     int porcelain_mode = 0;
 
 #if !defined(FPS_STANDALONE) && !defined(MILK_NO_CLI)
-    long arg;
-    for(arg = 1; arg < data.cmdNBarg; arg++)
+
+    for(long arg = 1; arg < data.cmdNBarg; arg++)
     {
         if(data.cmdargtoken[arg].type == CMDARGTOKEN_TYPE_STRING
                 || data.cmdargtoken[arg].type == CMDARGTOKEN_TYPE_RAWSTRING)
@@ -144,7 +144,7 @@ CLIADDCMD_COREMOD_memory__list_image()
 
 errno_t list_image_ID_ofp(FILE *fo)
 {
-    long               i;
+
     long               j;
     long long          tmp_long;
     char               type[STYPESIZE];
@@ -171,7 +171,7 @@ errno_t list_image_ID_ofp(FILE *fo)
             "[percent]    LAST ACCESS\n");
     fprintf(fo, "\n");
 
-    for(i = 0; i < dcnimg; i++)
+    for(long i = 0; i < dcnimg; i++)
         if(dcimg[i].used == 1)
         {
             datatype = dcimg[i].md[0].datatype;
@@ -295,7 +295,7 @@ errno_t list_image_ID_ofp(FILE *fo)
 
 errno_t list_image_ID_ofp_simple(FILE *fo)
 {
-    long i, j;
+    long i;
     //long long   tmp_long;
     uint8_t datatype;
 
@@ -313,7 +313,7 @@ errno_t list_image_ID_ofp_simple(FILE *fo)
                     dcimg[i].md[0].shared,
                     (long) dcimg[i].md[0].size[0]);
 
-            for(j = 1; j < dcimg[i].md[0].naxis; j++)
+            for(long j = 1; j < dcimg[i].md[0].naxis; j++)
             {
                 fprintf(fo, " %4ld", (long) dcimg[i].md[0].size[j]);
             }
@@ -340,7 +340,7 @@ errno_t list_image_ID()
 
 errno_t list_image_ID_ofp_json(FILE *fo)
 {
-    long i, j;
+
     long long   tmp_long;
     uint8_t datatype;
     unsigned long long sizeb = compute_image_memory();
@@ -349,7 +349,7 @@ errno_t list_image_ID_ofp_json(FILE *fo)
 
     fprintf(fo, "{\n  \"images\": [\n");
     int first = 1;
-    for(i = 0; i < dcnimg; i++)
+    for(long i = 0; i < dcnimg; i++)
         if(dcimg[i].used == 1)
         {
             if(!first)
@@ -365,7 +365,7 @@ errno_t list_image_ID_ofp_json(FILE *fo)
             fprintf(fo, "      \"name\": \"%s\",\n", dcimg[i].name);
             fprintf(fo, "      \"naxis\": %ld,\n", (long) dcimg[i].md[0].naxis);
             fprintf(fo, "      \"size\": [");
-            for(j = 0; j < dcimg[i].md[0].naxis; j++)
+            for(long j = 0; j < dcimg[i].md[0].naxis; j++)
             {
                 fprintf(fo, "%ld%s", (long) dcimg[i].md[0].size[j], (j < dcimg[i].md[0].naxis - 1) ? ", " : "");
             }
@@ -391,7 +391,7 @@ errno_t list_image_ID_ofp_json(FILE *fo)
 
 errno_t list_image_ID_ofp_porcelain(FILE *fo)
 {
-    long i, j;
+
     long long   tmp_long;
     uint8_t datatype;
     struct timespec timenow;
@@ -399,14 +399,14 @@ errno_t list_image_ID_ofp_porcelain(FILE *fo)
 
     fprintf(fo, "INDEX\tNAME\tNAXIS\tSIZE\tTYPE\tSHARED\tSIZE_KB\tLAST_ACCESS_DT\n");
 
-    for(i = 0; i < dcnimg; i++)
+    for(long i = 0; i < dcnimg; i++)
         if(dcimg[i].used == 1)
         {
             datatype = dcimg[i].md[0].datatype;
             tmp_long = ((long long)(dcimg[i].md[0].nelement)) * ImageStreamIO_typesize(datatype);
 
             fprintf(fo, "%ld\t%s\t%ld\t", i, dcimg[i].name, (long) dcimg[i].md[0].naxis);
-            for(j = 0; j < dcimg[i].md[0].naxis; j++)
+            for(long j = 0; j < dcimg[i].md[0].naxis; j++)
             {
                 fprintf(fo, "%ld%s", (long) dcimg[i].md[0].size[j], (j < dcimg[i].md[0].naxis - 1) ? "x" : "");
             }
@@ -435,7 +435,7 @@ errno_t list_image_ID_ofp_porcelain(FILE *fo)
 errno_t list_image_ID_file(const char *fname)
 {
     FILE   *fp;
-    long    i, j;
+
     uint8_t datatype;
     char    type[STYPESIZE];
     int     n;
@@ -447,13 +447,13 @@ errno_t list_image_ID_file(const char *fname)
         abort();
     }
 
-    for(i = 0; i < dcnimg; i++)
+    for(long i = 0; i < dcnimg; i++)
         if(dcimg[i].used == 1)
         {
             datatype = dcimg[i].md[0].datatype;
             fprintf(fp, "%ld %s", i, dcimg[i].name);
             fprintf(fp, " %ld", (long) dcimg[i].md[0].naxis);
-            for(j = 0; j < dcimg[i].md[0].naxis; j++)
+            for(long j = 0; j < dcimg[i].md[0].naxis; j++)
             {
                 fprintf(fp, " %ld", (long) dcimg[i].md[0].size[j]);
             }

--- a/src/coremods/COREMOD_memory/milk-logshim-ctrl.c
+++ b/src/coremods/COREMOD_memory/milk-logshim-ctrl.c
@@ -64,7 +64,9 @@
  * @progname: argv[0]
  * @mh_color: non-zero for ANSI color output
  */
-static void print_help(const char *progname, int mh_color)
+static void print_help(
+    const char *progname,
+    int mh_color)
 {
     milk_help_banner(progname, LSC_DESC, mh_color);
     milk_help_section("Usage", mh_color);
@@ -180,7 +182,9 @@ static const char *get_shmdir(void)
  * The FIFO is at $MILK_SHM_DIR/milkFITSlogger.fifo,
  * matching the path used by milk-streamFITSlog.
  */
-static void fifo_path(char *buf, size_t bufsz)
+static void fifo_path(
+    char *buf,
+    size_t bufsz)
 {
     snprintf(buf, bufsz,
              "%s/milkFITSlogger.fifo", get_shmdir());
@@ -194,7 +198,9 @@ static void fifo_path(char *buf, size_t bufsz)
  * Opens the FIFO in non-blocking write-only mode, writes the
  * command, then closes. Returns 0 on success, 1 on error.
  */
-static int fifo_write(const char *fifo, const char *cmd)
+static int fifo_write(
+    const char *fifo,
+    const char *cmd)
 {
     /* Check FIFO exists */
     struct stat st;
@@ -522,7 +528,9 @@ static int action_start(
     return system(cmd) == 0 ? 0 : 1;
 }
 
-int main(int argc, char *argv[])
+int main(
+    int argc,
+    char *argv[])
 {
     int action = milk_help_init(
         argc, argv, LSC_DESC, LSC_DESC_LONG);

--- a/src/coremods/COREMOD_memory/milk-logshim-ctrl.c
+++ b/src/coremods/COREMOD_memory/milk-logshim-ctrl.c
@@ -145,7 +145,8 @@ static void print_help(
     printf("  %s$ milk-logshim-ctrl%s %sstat ircam0%s\n\n",
            mh_color ? MH_CMD : "", mh_color ? MH_RST : "",
            mh_color ? MH_ARG : "", mh_color ? MH_RST : "");
-    const char *see_also[] = {
+    const char *see_also[] =
+    {
         "milk-streamFITSlog:log stream frames to FITS files",
         "milk-logshim:launch the logging shim daemon",
         "milk-fpsCTRL:launch the FPS dashboard TUI"
@@ -161,14 +162,16 @@ static void print_help(
 static const char *get_shmdir(void)
 {
     const char *env = getenv("MILK_SHM_DIR");
-    if (env != NULL) {
+    if(env != NULL)
+    {
         return env;
     }
 
     static const char fallback[] = "/milk/shm";
     struct stat st;
 
-    if (stat(fallback, &st) == 0 && S_ISDIR(st.st_mode)) {
+    if(stat(fallback, &st) == 0 && S_ISDIR(st.st_mode))
+    {
         return fallback;
     }
     return "/dev/shm";
@@ -204,7 +207,8 @@ static int fifo_write(
 {
     /* Check FIFO exists */
     struct stat st;
-    if (stat(fifo, &st) != 0 || !S_ISFIFO(st.st_mode)) {
+    if(stat(fifo, &st) != 0 || !S_ISFIFO(st.st_mode))
+    {
         fprintf(stderr,
                 "\033[1;31mERROR\033[0m: FIFO '%s' not found.\n"
                 "  Is the logging process running?\n"
@@ -221,13 +225,17 @@ static int fifo_write(
      * with O_NONBLOCK first to detect a missing reader immediately.
      */
     int fd = open(fifo, O_WRONLY | O_NONBLOCK);
-    if (fd < 0) {
-        if (errno == ENXIO) {
+    if(fd < 0)
+    {
+        if(errno == ENXIO)
+        {
             fprintf(stderr,
                     "\033[1;31mERROR\033[0m: No reader on"
                     " FIFO '%s' — is milk-fpsCTRL running?\n",
                     fifo);
-        } else {
+        }
+        else
+        {
             fprintf(stderr,
                     "\033[1;31mERROR\033[0m: open('%s'): %s\n",
                     fifo, strerror(errno));
@@ -242,7 +250,8 @@ static int fifo_write(
     ssize_t written = write(fd, line, (size_t)n);
     close(fd);
 
-    if (written < 0) {
+    if(written < 0)
+    {
         fprintf(stderr,
                 "\033[1;31mERROR\033[0m: write to FIFO: %s\n",
                 strerror(errno));
@@ -360,10 +369,12 @@ static int action_kill(const char *stream)
     snprintf(buf1, sizeof(buf1),
              "%s/%s_logbuff1%s", shmdir, stream, SHM_SUFFIX);
 
-    if (unlink(buf0) == 0) {
+    if(unlink(buf0) == 0)
+    {
         printf("  removed: %s_logbuff0\n", stream);
     }
-    if (unlink(buf1) == 0) {
+    if(unlink(buf1) == 0)
+    {
         printf("  removed: %s_logbuff1\n", stream);
     }
 
@@ -413,7 +424,8 @@ static int action_stat(const char *stream)
            fifo);
 
     /* If FPS SHM exists, parse saveON by scanning for key */
-    if (fps_alive) {
+    if(fps_alive)
+    {
         /* We can't include milkfpsStandalone here (standalone binary
          * must not link CLIcore).  Read raw bytes from the SHM file
          * and search for the saveON parameter name.
@@ -428,7 +440,8 @@ static int action_stat(const char *stream)
          * the CLIcore dependency for a standalone binary.
          */
         FILE *fp = fopen(shm_path, "rb");
-        if (fp != NULL) {
+        if(fp != NULL)
+        {
             /* Scan up to 4 MB */
             static unsigned char buf[4 * 1024 * 1024];
             size_t nr = fread(buf, 1, sizeof(buf), fp);
@@ -438,17 +451,20 @@ static int action_stat(const char *stream)
             size_t nlen = strlen(needle);
             int found = 0;
 
-            for (size_t i = 0; i + nlen + 10 < nr; i++) {
-                if (memcmp(&buf[i], needle, nlen) == 0) {
+            for(size_t i = 0; i + nlen + 10 < nr; i++)
+            {
+                if(memcmp(&buf[i], needle, nlen) == 0)
+                {
                     /* The ON/OFF flag is stored as a uint8
                      * in the val.u8 union member.  Walk
                      * forward past the null-terminator of
                      * the name to find the first non-zero
                      * byte that is 0 or 1. */
-                    for (size_t j = i + nlen;
-                         j < i + nlen + 64 && j < nr; j++)
+                    for(size_t j = i + nlen;
+                            j < i + nlen + 64 && j < nr; j++)
                     {
-                        if (buf[j] == 0 || buf[j] == 1) {
+                        if(buf[j] == 0 || buf[j] == 1)
+                        {
                             printf("  saveON   : %s%s\033[0m\n\n",
                                    buf[j]
                                    ? "\033[1;32mON "
@@ -458,17 +474,21 @@ static int action_stat(const char *stream)
                             break;
                         }
                     }
-                    if (found) {
+                    if(found)
+                    {
                         break;
                     }
                 }
             } // for i
 
-            if (!found) {
+            if(!found)
+            {
                 printf("  saveON   : \033[33m(cannot parse)\033[0m\n\n");
             }
         } // if (fp)
-    } else {
+    }
+    else
+    {
         printf("\n  Start logging first with:\n"
                "    milk-logshim-ctrl start %s <blocksize> <dir>\n\n",
                stream);
@@ -500,7 +520,8 @@ static int action_start(
              "%s/%s%s", shmdir, stream, SHM_SUFFIX);
 
     struct stat st;
-    if (stat(shmfile, &st) != 0) {
+    if(stat(shmfile, &st) != 0)
+    {
         fprintf(stderr,
                 "\n\033[1;31mERROR\033[0m:"
                 " stream SHM '%s' not found.\n\n",
@@ -510,13 +531,16 @@ static int action_start(
 
     /* Build milk-streamFITSlog command */
     char cmd[1024];
-    if (cpuset != NULL) {
+    if(cpuset != NULL)
+    {
         snprintf(cmd, sizeof(cmd),
                  "milk-streamFITSlog -cset \"%s\" -D \"%s\""
                  " -z %s %s pstart && "
                  "milk-streamFITSlog %s on",
                  cpuset, dir, blocksize, stream, stream);
-    } else {
+    }
+    else
+    {
         snprintf(cmd, sizeof(cmd),
                  "milk-streamFITSlog -D \"%s\" -z %s %s pstart &&"
                  " milk-streamFITSlog %s on",
@@ -533,19 +557,22 @@ int main(
     char *argv[])
 {
     int action = milk_help_init(
-        argc, argv, LSC_DESC, LSC_DESC_LONG);
+                     argc, argv, LSC_DESC, LSC_DESC_LONG);
 
-    if (action == MH_ACTION_H1 || action == MH_ACTION_H2) {
+    if(action == MH_ACTION_H1 || action == MH_ACTION_H2)
+    {
         return 0;
     }
 
     int mh_color = (action == MH_ACTION_HELP);
-    if (action == MH_ACTION_HELP || action == MH_ACTION_MONO) {
+    if(action == MH_ACTION_HELP || action == MH_ACTION_MONO)
+    {
         print_help(argv[0], mh_color);
         return 0;
     }
 
-    if (argc < 3) {
+    if(argc < 3)
+    {
         fprintf(stderr,
                 "\n\033[1;31mERROR\033[0m:"
                 " expected <action> <stream> [options].\n\n");
@@ -558,51 +585,65 @@ int main(
 
     /* Optional -c <cpuset> (only used by 'start') */
     const char *cpuset = NULL;
-    for (int i = 3; i < argc - 1; i++) {
-        if (strcmp(argv[i], "-c") == 0) {
+    for(int i = 3; i < argc - 1; i++)
+    {
+        if(strcmp(argv[i], "-c") == 0)
+        {
             cpuset = argv[i + 1];
             i++;
         }
     }
 
     /* Dispatch */
-    if (strcmp(act, "on") == 0) {
-        if (argc < 3) {
+    if(strcmp(act, "on") == 0)
+    {
+        if(argc < 3)
+        {
             goto missing_stream;
         }
         return action_on(stream);
     }
 
-    if (strcmp(act, "off") == 0) {
-        if (argc < 3) {
+    if(strcmp(act, "off") == 0)
+    {
+        if(argc < 3)
+        {
             goto missing_stream;
         }
         return action_off(stream);
     }
 
-    if (strcmp(act, "offc") == 0) {
-        if (argc < 3) {
+    if(strcmp(act, "offc") == 0)
+    {
+        if(argc < 3)
+        {
             goto missing_stream;
         }
         return action_offc(stream);
     }
 
-    if (strcmp(act, "kill") == 0) {
-        if (argc < 3) {
+    if(strcmp(act, "kill") == 0)
+    {
+        if(argc < 3)
+        {
             goto missing_stream;
         }
         return action_kill(stream);
     }
 
-    if (strcmp(act, "stat") == 0) {
-        if (argc < 3) {
+    if(strcmp(act, "stat") == 0)
+    {
+        if(argc < 3)
+        {
             goto missing_stream;
         }
         return action_stat(stream);
     }
 
-    if (strcmp(act, "start") == 0) {
-        if (argc < 5) {
+    if(strcmp(act, "start") == 0)
+    {
+        if(argc < 5)
+        {
             fprintf(stderr,
                     "\n\033[1;31mERROR\033[0m:"
                     " 'start' requires <stream> <blocksize> <dir>.\n\n");

--- a/src/coremods/COREMOD_memory/milk-makecsetandrt.c
+++ b/src/coremods/COREMOD_memory/milk-makecsetandrt.c
@@ -212,7 +212,9 @@ static void print_help(
  * Prints a ✓ / ✗ line for each step. Returns CGCHECK_OK only when all
  * four pass; returns the first failing CGCHECK_* constant otherwise.
  */
-static int check_cgroup_setup(const char *cgname, int color)
+static int check_cgroup_setup(
+    const char *cgname,
+    int color)
 {
     const char *ok  = color ? ANSI_GRN "✓" ANSI_RST : "[OK]";
     const char *err = color ? ANSI_RED "✗" ANSI_RST : "[!!]";
@@ -350,7 +352,9 @@ static int move_thread_to_cgroup(
  *
  * Returns 0 on success, 1 on error.
  */
-static int move_to_cgroup(pid_t pid, const char *cgname)
+static int move_to_cgroup(
+    pid_t pid,
+    const char *cgname)
 {
     if(strcmp(cgname, "NULL") == 0)
     {
@@ -436,7 +440,9 @@ static int move_to_cgroup(pid_t pid, const char *cgname)
  *
  * Returns 0 on success, 1 if any thread failed.
  */
-static int set_rt_priority(pid_t pid, int rtprio)
+static int set_rt_priority(
+    pid_t pid,
+    int rtprio)
 {
     if(rtprio <= 0)
     {
@@ -533,7 +539,9 @@ static int set_rt_priority(pid_t pid, int rtprio)
 /* main()                                                              */
 /* ------------------------------------------------------------------ */
 
-int main(int argc, char *argv[])
+int main(
+    int argc,
+    char *argv[])
 {
     int action = milk_help_init(
                      argc, argv, MCSR_DESC, MCSR_DESC_LONG);

--- a/src/coremods/COREMOD_memory/milk-shmimpurge.c
+++ b/src/coremods/COREMOD_memory/milk-shmimpurge.c
@@ -98,7 +98,8 @@ static void print_help(
     printf("  %s$ milk-shmimpurge%s %s-n%s\n\n",
            mh_color ? MH_CMD : "", mh_color ? MH_RST : "",
            mh_color ? MH_OPT : "", mh_color ? MH_RST : "");
-    const char *see_also[] = {
+    const char *see_also[] =
+    {
         "milk-stream-rm:remove shared memory streams",
         "milk-stream-list:list active shared memory streams"
     };
@@ -113,14 +114,16 @@ static void print_help(
 static const char *get_shmdir(void)
 {
     const char *env = getenv("MILK_SHM_DIR");
-    if (env != NULL) {
+    if(env != NULL)
+    {
         return env;
     }
 
     static const char fallback1[] = "/milk/shm";
     struct stat st;
 
-    if (stat(fallback1, &st) == 0 && S_ISDIR(st.st_mode)) {
+    if(stat(fallback1, &st) == 0 && S_ISDIR(st.st_mode))
+    {
         return fallback1;
     }
     return "/dev/shm";
@@ -142,15 +145,18 @@ static int pid_has_inode_open(
     snprintf(fddir, sizeof(fddir), "/proc/%d/fd", (int)pid);
 
     DIR *d = opendir(fddir);
-    if (d == NULL) {
+    if(d == NULL)
+    {
         return 0;
     }
 
     struct dirent *de;
     int found = 0;
 
-    while (!found && (de = readdir(d)) != NULL) {
-        if (de->d_name[0] == '.') {
+    while(!found && (de = readdir(d)) != NULL)
+    {
+        if(de->d_name[0] == '.')
+        {
             continue;
         }
 
@@ -159,7 +165,8 @@ static int pid_has_inode_open(
                  "/proc/%d/fd/%s", (int)pid, de->d_name);
 
         struct stat st;
-        if (stat(fdpath, &st) == 0 && st.st_ino == inode) {
+        if(stat(fdpath, &st) == 0 && st.st_ino == inode)
+        {
             found = 1;
         }
     } // while !found
@@ -180,14 +187,16 @@ static int is_stream_orphan(
     int verbose)
 {
     struct stat st;
-    if (stat(fullpath, &st) != 0) {
+    if(stat(fullpath, &st) != 0)
+    {
         return 1; /* cannot stat — treat as orphan */
     }
 
     ino_t inode = st.st_ino;
 
     DIR *proc = opendir("/proc");
-    if (proc == NULL) {
+    if(proc == NULL)
+    {
         PRINT_ERROR("opendir(/proc): %s", strerror(errno));
         return 0; /* fail-safe: assume live */
     }
@@ -195,19 +204,25 @@ static int is_stream_orphan(
     int any_live = 0;
     struct dirent *de;
 
-    while ((de = readdir(proc)) != NULL) {
+    while((de = readdir(proc)) != NULL)
+    {
         char *ep;
         long pid_l = strtol(de->d_name, &ep, 10);
-        if (*ep != '\0' || pid_l <= 0) {
+        if(*ep != '\0' || pid_l <= 0)
+        {
             continue;
         }
         pid_t pid = (pid_t)pid_l;
 
-        if (pid_has_inode_open(pid, inode)) {
+        if(pid_has_inode_open(pid, inode))
+        {
             any_live = 1;
-            if (verbose) {
+            if(verbose)
+            {
                 printf("    held by PID %d\n", (int)pid);
-            } else {
+            }
+            else
+            {
                 break; /* early exit when not verbose */
             }
         }
@@ -228,7 +243,8 @@ static int read_confirm(void)
     struct termios old_t;
     int is_tty = isatty(STDIN_FILENO);
 
-    if (is_tty) {
+    if(is_tty)
+    {
         tcgetattr(STDIN_FILENO, &old_t);
         struct termios t = old_t;
         t.c_lflag |= (ICANON | ECHO);
@@ -239,7 +255,8 @@ static int read_confirm(void)
     char buf[32];
     int ok = (fgets(buf, sizeof(buf), stdin) != NULL);
 
-    if (is_tty) {
+    if(is_tty)
+    {
         tcsetattr(STDIN_FILENO, TCSANOW, &old_t);
     }
 
@@ -265,14 +282,17 @@ static int remove_orphan(
     errno_t ret =
         ImageStreamIO_read_sharedmem_image_toIMAGE(sname, &image);
 
-    if (ret == IMAGESTREAMIO_SUCCESS) {
-        for (int i = 0; i < image.md->sem; i++) {
+    if(ret == IMAGESTREAMIO_SUCCESS)
+    {
+        for(int i = 0; i < image.md->sem; i++)
+        {
             sem_destroy(image.semptr[i]);
         }
         ImageStreamIO_closeIm(&image);
     }
 
-    if (unlink(fullpath) != 0) {
+    if(unlink(fullpath) != 0)
+    {
         PRINT_ERROR("  \033[1;31mFAILED\033[0m: unlink '%s': %s", fullpath, strerror(errno));
         return 1;
     }
@@ -287,13 +307,15 @@ int main(
 {
     int action = milk_help_init(argc, argv, SP_DESC, SP_DESC_LONG);
 
-    if (action == MH_ACTION_H1 || action == MH_ACTION_H2) {
+    if(action == MH_ACTION_H1 || action == MH_ACTION_H2)
+    {
         return 0;
     }
 
     int mh_color = (action == MH_ACTION_HELP);
 
-    if (action == MH_ACTION_HELP || action == MH_ACTION_MONO) {
+    if(action == MH_ACTION_HELP || action == MH_ACTION_MONO)
+    {
         print_help(argv[0], mh_color);
         return 0;
     }
@@ -304,22 +326,31 @@ int main(
     int         dry_run = 0;
     int         verbose = 0;
 
-    for (int i = 1; i < argc; i++) {
-        if ((strcmp(argv[i], "-f") == 0 ||
-             strcmp(argv[i], "--filter") == 0) &&
-            i + 1 < argc)
+    for(int i = 1; i < argc; i++)
+    {
+        if((strcmp(argv[i], "-f") == 0 ||
+                strcmp(argv[i], "--filter") == 0) &&
+                i + 1 < argc)
         {
             filter = argv[++i];
-        } else if (strcmp(argv[i], "-y") == 0 ||
-                   strcmp(argv[i], "--force") == 0) {
+        }
+        else if(strcmp(argv[i], "-y") == 0 ||
+                strcmp(argv[i], "--force") == 0)
+        {
             force = 1;
-        } else if (strcmp(argv[i], "-n") == 0 ||
-                   strcmp(argv[i], "--dry-run") == 0) {
+        }
+        else if(strcmp(argv[i], "-n") == 0 ||
+                strcmp(argv[i], "--dry-run") == 0)
+        {
             dry_run = 1;
-        } else if (strcmp(argv[i], "-v") == 0 ||
-                   strcmp(argv[i], "--verbose") == 0) {
+        }
+        else if(strcmp(argv[i], "-v") == 0 ||
+                strcmp(argv[i], "--verbose") == 0)
+        {
             verbose = 1;
-        } else {
+        }
+        else
+        {
             fprintf(stderr,
                     "\n\033[1;31mERROR\033[0m:"
                     " unknown option '%s'.\n\n", argv[i]);
@@ -332,9 +363,10 @@ int main(
 
     /* Scan SHM directory */
     DIR *d = opendir(shmdir);
-    if (d == NULL) {
+    if(d == NULL)
+    {
         PRINT_ERROR("\033[1;31mERROR\033[0m:"
-                " cannot open '%s': %s", shmdir, strerror(errno));
+                    " cannot open '%s': %s", shmdir, strerror(errno));
         return 1;
     }
 
@@ -342,22 +374,26 @@ int main(
     int total = 0;
     struct dirent *de;
 
-    while ((de = readdir(d)) != NULL &&
-           total < SP_MAX_STREAMS)
+    while((de = readdir(d)) != NULL &&
+            total < SP_MAX_STREAMS)
     {
         char *suf = strstr(de->d_name, ".im.shm");
-        if (suf == NULL) {
+        if(suf == NULL)
+        {
             continue;
         }
         size_t nl = (size_t)(suf - de->d_name);
-        if (nl == 0 || nl >= sizeof(names[0])) {
+        if(nl == 0 || nl >= sizeof(names[0]))
+        {
             continue;
         }
-        if (suf != de->d_name + strlen(de->d_name) - 7) {
+        if(suf != de->d_name + strlen(de->d_name) - 7)
+        {
             continue;
         }
-        if (filter != NULL &&
-            strstr(de->d_name, filter) == NULL) {
+        if(filter != NULL &&
+                strstr(de->d_name, filter) == NULL)
+        {
             continue;
         }
 
@@ -368,9 +404,11 @@ int main(
 
     closedir(d);
 
-    if (total == 0) {
+    if(total == 0)
+    {
         printf("No streams found");
-        if (filter != NULL) {
+        if(filter != NULL)
+        {
             printf(" matching '%s'", filter);
         }
         printf(".\n");
@@ -383,52 +421,63 @@ int main(
 
     printf("Scanning %d stream(s)...\n\n", total);
 
-    for (int i = 0; i < total; i++) {
+    for(int i = 0; i < total; i++)
+    {
         char fullpath[512];
         snprintf(fullpath, sizeof(fullpath),
                  "%s/%s.im.shm", shmdir, names[i]);
 
-        if (verbose) {
+        if(verbose)
+        {
             printf("  %s\n", names[i]);
         }
 
         is_orphan[i] = is_stream_orphan(fullpath, verbose);
-        if (is_orphan[i]) {
+        if(is_orphan[i])
+        {
             n_orphan++;
         }
     } // for i
 
-    if (n_orphan == 0) {
+    if(n_orphan == 0)
+    {
         printf("No orphan streams found.\n");
         return 0;
     }
 
     printf("\n  Orphan streams (%d):\n\n", n_orphan);
-    for (int i = 0; i < total; i++) {
-        if (is_orphan[i]) {
+    for(int i = 0; i < total; i++)
+    {
+        if(is_orphan[i])
+        {
             printf("    %s\n", names[i]);
         }
     }
     printf("\n");
 
-    if (dry_run) {
+    if(dry_run)
+    {
         printf("  [dry-run] No streams removed.\n");
         return 0;
     }
 
-    if (!force && !read_confirm()) {
+    if(!force && !read_confirm())
+    {
         printf("  Cancelled.\n");
         return 0;
     }
 
     int errors = 0;
-    for (int i = 0; i < total; i++) {
-        if (is_orphan[i]) {
+    for(int i = 0; i < total; i++)
+    {
+        if(is_orphan[i])
+        {
             errors += remove_orphan(shmdir, names[i]);
         }
     }
 
-    if (errors > 0) {
+    if(errors > 0)
+    {
         PRINT_ERROR("%d stream(s) failed to remove.", errors);
         return 1;
     }

--- a/src/coremods/COREMOD_memory/milk-shmimpurge.c
+++ b/src/coremods/COREMOD_memory/milk-shmimpurge.c
@@ -48,7 +48,9 @@
  * @progname: argv[0]
  * @mh_color: non-zero for ANSI color output
  */
-static void print_help(const char *progname, int mh_color)
+static void print_help(
+    const char *progname,
+    int mh_color)
 {
     milk_help_banner(progname, SP_DESC, mh_color);
     milk_help_section("Usage", mh_color);
@@ -132,7 +134,9 @@ static const char *get_shmdir(void)
  * Scans /proc/<pid>/fd/ symlinks for a stat inode match.
  * Returns 1 if the process has the inode open, 0 otherwise.
  */
-static int pid_has_inode_open(pid_t pid, ino_t inode)
+static int pid_has_inode_open(
+    pid_t pid,
+    ino_t inode)
 {
     char fddir[64];
     snprintf(fddir, sizeof(fddir), "/proc/%d/fd", (int)pid);
@@ -171,7 +175,9 @@ static int pid_has_inode_open(pid_t pid, ino_t inode)
  *
  * Returns 1 if orphan (no live holder), 0 if live.
  */
-static int is_stream_orphan(const char *fullpath, int verbose)
+static int is_stream_orphan(
+    const char *fullpath,
+    int verbose)
 {
     struct stat st;
     if (stat(fullpath, &st) != 0) {
@@ -247,7 +253,9 @@ static int read_confirm(void)
  *
  * Returns 0 on success, 1 on error.
  */
-static int remove_orphan(const char *shmdir, const char *sname)
+static int remove_orphan(
+    const char *shmdir,
+    const char *sname)
 {
     char fullpath[512];
     snprintf(fullpath, sizeof(fullpath),
@@ -273,7 +281,9 @@ static int remove_orphan(const char *shmdir, const char *sname)
     return 0;
 }
 
-int main(int argc, char *argv[])
+int main(
+    int argc,
+    char *argv[])
 {
     int action = milk_help_init(argc, argv, SP_DESC, SP_DESC_LONG);
 

--- a/src/coremods/COREMOD_memory/milk-stream-create.c
+++ b/src/coremods/COREMOD_memory/milk-stream-create.c
@@ -129,7 +129,9 @@ void print_help(const char *progname)
            progname);
 }
 
-int main(int argc, char *argv[])
+int main(
+    int argc,
+    char *argv[])
 {
     /* One-line help — before getopt so it works without any positional args */
     for (int i = 1; i < argc; i++) {

--- a/src/coremods/COREMOD_memory/milk-stream-create.c
+++ b/src/coremods/COREMOD_memory/milk-stream-create.c
@@ -13,12 +13,14 @@
 
 #include "ImageStreamIO/ImageStreamIO.h"
 
-typedef struct {
+typedef struct
+{
     const char *name;
     uint8_t     code;
 } DTYPE_ENTRY;
 
-static const DTYPE_ENTRY dtype_table[] = {
+static const DTYPE_ENTRY dtype_table[] =
+{
     {"uint8",   _DATATYPE_UINT8},
     {"u8",      _DATATYPE_UINT8},
     {"int8",    _DATATYPE_INT8},
@@ -45,15 +47,18 @@ static const DTYPE_ENTRY dtype_table[] = {
 static uint8_t parse_dtype(const char *s)
 {
     /* Try by name */
-    for (int i = 0; dtype_table[i].name; i++) {
-        if (strcasecmp(s, dtype_table[i].name) == 0) {
+    for(int i = 0; dtype_table[i].name; i++)
+    {
+        if(strcasecmp(s, dtype_table[i].name) == 0)
+        {
             return dtype_table[i].code;
         }
     }
     /* Try numeric code */
     char *end;
     long v = strtol(s, &end, 10);
-    if (*end == '\0' && v >= 1 && v <= 12) {
+    if(*end == '\0' && v >= 1 && v <= 12)
+    {
         return (uint8_t) v;
     }
     return 0;
@@ -134,9 +139,10 @@ int main(
     char *argv[])
 {
     /* One-line help — before getopt so it works without any positional args */
-    for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "-h1") == 0 ||
-            strcmp(argv[i], "--help-oneline") == 0)
+    for(int i = 1; i < argc; i++)
+    {
+        if(strcmp(argv[i], "-h1") == 0 ||
+                strcmp(argv[i], "--help-oneline") == 0)
         {
             printf("create a shared-memory image stream\n");
             return 0;
@@ -147,42 +153,46 @@ int main(
     int nbkw = 10;
     int opt;
 
-    static struct option long_options[] = {
+    static struct option long_options[] =
+    {
         {"type", required_argument, 0, 't'},
         {"kw",   required_argument, 0, 'k'},
         {"help", no_argument,       0, 'h'},
         {0, 0, 0, 0}
     };
 
-    while ((opt = getopt_long(argc, argv,
-                              "t:k:h",
-                              long_options,
-                              NULL)) != -1)
+    while((opt = getopt_long(argc, argv,
+                             "t:k:h",
+                             long_options,
+                             NULL)) != -1)
     {
-        switch (opt) {
-            case 't':
-                dtype = parse_dtype(optarg);
-                if (dtype == 0) {
-                    printf("\n\033[1;31mERROR\033[0m unknown type: %s\n\n", optarg);
-                    print_help(argv[0]);
-                    return 1;
-                }
-                break;
-            case 'k':
-                nbkw = atoi(optarg);
-                break;
-            case 'h':
-                print_help(argv[0]);
-                return 0;
-            default:
-                printf("\n\033[1;31mERROR\033[0m invalid option\n\n");
+        switch(opt)
+        {
+        case 't':
+            dtype = parse_dtype(optarg);
+            if(dtype == 0)
+            {
+                printf("\n\033[1;31mERROR\033[0m unknown type: %s\n\n", optarg);
                 print_help(argv[0]);
                 return 1;
+            }
+            break;
+        case 'k':
+            nbkw = atoi(optarg);
+            break;
+        case 'h':
+            print_help(argv[0]);
+            return 0;
+        default:
+            printf("\n\033[1;31mERROR\033[0m invalid option\n\n");
+            print_help(argv[0]);
+            return 1;
         }
     }
 
     int npos = argc - optind;
-    if (npos < 2) {
+    if(npos < 2)
+    {
         printf("\n\033[1;31mERROR\033[0m need at least name and xsize\n\n");
         print_help(argv[0]);
         return 1;
@@ -191,13 +201,16 @@ int main(
     const char *name = argv[optind];
     uint32_t sz[3];
     long naxis = npos - 1;
-    if (naxis > 3) {
+    if(naxis > 3)
+    {
         naxis = 3;
     }
 
-    for (int i = 0; i < naxis; i++) {
+    for(int i = 0; i < naxis; i++)
+    {
         sz[i] = (uint32_t) atol(argv[optind + 1 + i]);
-        if (sz[i] == 0) {
+        if(sz[i] == 0)
+        {
             fprintf(stderr,
                     "Error: invalid size %s\n",
                     argv[optind + 1 + i]);
@@ -209,15 +222,17 @@ int main(
     memset(&image, 0, sizeof(IMAGE));
 
     int cbsize = 0;
-    if (naxis == 3) {
+    if(naxis == 3)
+    {
         cbsize = sz[2];
     }
 
     errno_t ret = ImageStreamIO_createIm(
-        &image, name, naxis, sz,
-        dtype, 1, nbkw, cbsize);
+                      &image, name, naxis, sz,
+                      dtype, 1, nbkw, cbsize);
 
-    if (ret != IMAGESTREAMIO_SUCCESS) {
+    if(ret != IMAGESTREAMIO_SUCCESS)
+    {
         fprintf(stderr,
                 "Failed to create stream '%s'\n",
                 name);
@@ -231,8 +246,12 @@ int main(
     printf("Created stream '%s'  ", name);
     printf("type=%s  size=",
            tname ? tname : "?");
-    for (int i = 0; i < naxis; i++) {
-        if (i > 0) printf("x");
+    for(int i = 0; i < naxis; i++)
+    {
+        if(i > 0)
+        {
+            printf("x");
+        }
         printf("%u", sz[i]);
     }
     printf("\n");

--- a/src/coremods/COREMOD_memory/milk-stream-link.c
+++ b/src/coremods/COREMOD_memory/milk-stream-link.c
@@ -38,14 +38,16 @@
 static const char *get_shmdir(void)
 {
     const char *env = getenv("MILK_SHM_DIR");
-    if (env != NULL) {
+    if(env != NULL)
+    {
         return env;
     }
 
     static const char fallback[] = "/milk/shm";
     struct stat st;
 
-    if (stat(fallback, &st) == 0 && S_ISDIR(st.st_mode)) {
+    if(stat(fallback, &st) == 0 && S_ISDIR(st.st_mode))
+    {
         return fallback;
     }
     return "/dev/shm";
@@ -88,7 +90,8 @@ static void print_help(
     printf("  %s$ milk-stream-link%s %s-p myprefix- ircam0%s\n\n",
            color ? MH_CMD : "", color ? MH_RST : "",
            color ? MH_ARG : "", color ? MH_RST : "");
-    const char *see_also[] = {
+    const char *see_also[] =
+    {
         "milk-stream-list:list active shared memory streams",
         "milk-stream-create:create a new shared memory stream"
     };
@@ -114,7 +117,8 @@ static void write_imsize(
     IMAGE img;
     int   ret = ImageStreamIO_openIm(&img, srcname);
 
-    if (ret != 0) {
+    if(ret != 0)
+    {
         fprintf(stderr,
                 "  [warn] could not open stream '%s'"
                 " — skipping imsize write\n", srcname);
@@ -122,7 +126,8 @@ static void write_imsize(
     }
 
     /* Ensure conf/ directory exists */
-    if (mkdir("conf", 0755) != 0 && errno != EEXIST) {
+    if(mkdir("conf", 0755) != 0 && errno != EEXIST)
+    {
         fprintf(stderr,
                 "  [warn] cannot create conf/ directory: %s\n",
                 strerror(errno));
@@ -135,7 +140,8 @@ static void write_imsize(
              "conf/streamlink.%s.imsize.txt", linkname);
 
     FILE *fp = fopen(outfile, "w");
-    if (fp == NULL) {
+    if(fp == NULL)
+    {
         fprintf(stderr,
                 "  [warn] cannot write '%s': %s\n",
                 outfile, strerror(errno));
@@ -145,7 +151,8 @@ static void write_imsize(
 
     uint8_t naxis = img.md->naxis;
 
-    for (uint8_t i = 0; i < naxis; i++) {
+    for(uint8_t i = 0; i < naxis; i++)
+    {
         fprintf(fp, "%u ", (unsigned)img.md->size[i]);
     }
     fprintf(fp, "\n");
@@ -161,14 +168,16 @@ int main(
     char *argv[])
 {
     int action = milk_help_init(
-        argc, argv, LSL_DESC, LSL_DESC_LONG);
+                     argc, argv, LSL_DESC, LSL_DESC_LONG);
 
-    if (action == MH_ACTION_H1 || action == MH_ACTION_H2) {
+    if(action == MH_ACTION_H1 || action == MH_ACTION_H2)
+    {
         return 0;
     }
 
     int color = (action == MH_ACTION_HELP);
-    if (action == MH_ACTION_HELP || action == MH_ACTION_MONO) {
+    if(action == MH_ACTION_HELP || action == MH_ACTION_MONO)
+    {
         print_help(argv[0], color);
         return 0;
     }
@@ -177,15 +186,20 @@ int main(
     const char *prefix    = "";
     const char *linkname  = NULL;
 
-    for (int i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "-p") == 0 && i + 1 < argc) {
+    for(int i = 1; i < argc; i++)
+    {
+        if(strcmp(argv[i], "-p") == 0 && i + 1 < argc)
+        {
             prefix = argv[++i];
-        } else if (argv[i][0] != '-') {
+        }
+        else if(argv[i][0] != '-')
+        {
             linkname = argv[i];
         }
     }
 
-    if (linkname == NULL) {
+    if(linkname == NULL)
+    {
         fprintf(stderr,
                 "\n\033[1;31mERROR\033[0m:"
                 " <streamname> argument required.\n\n");
@@ -199,7 +213,8 @@ int main(
              "conf/streamlink.%s.name.txt", linkname);
 
     FILE *fp = fopen(conffile, "r");
-    if (fp == NULL) {
+    if(fp == NULL)
+    {
         fprintf(stderr,
                 "\n\033[1;31mERROR\033[0m:"
                 " cannot open '%s': %s\n"
@@ -209,7 +224,8 @@ int main(
     }
 
     char srcname[256];
-    if (fgets(srcname, sizeof(srcname), fp) == NULL) {
+    if(fgets(srcname, sizeof(srcname), fp) == NULL)
+    {
         fprintf(stderr,
                 "\033[1;31mERROR\033[0m: '%s' is empty.\n", conffile);
         fclose(fp);
@@ -233,8 +249,10 @@ int main(
 
     /* Remove stale link/file */
     struct stat st;
-    if (lstat(linkpath, &st) == 0) {
-        if (unlink(linkpath) != 0) {
+    if(lstat(linkpath, &st) == 0)
+    {
+        if(unlink(linkpath) != 0)
+        {
             fprintf(stderr,
                     "\033[1;31mERROR\033[0m:"
                     " cannot remove '%s': %s\n",
@@ -244,7 +262,8 @@ int main(
     }
 
     /* Create symlink */
-    if (symlink(srcpath, linkpath) != 0) {
+    if(symlink(srcpath, linkpath) != 0)
+    {
         fprintf(stderr,
                 "\033[1;31mERROR\033[0m:"
                 " symlink('%s' → '%s'): %s\n",
@@ -258,9 +277,12 @@ int main(
            prefix, linkname, srcpath, linkpath);
 
     /* If source stream exists, write imsize */
-    if (stat(srcpath, &st) == 0) {
+    if(stat(srcpath, &st) == 0)
+    {
         write_imsize(shmdir, srcname, linkname);
-    } else {
+    }
+    else
+    {
         printf("  [warn] source '%s' not found"
                " — skipping imsize write\n", srcpath);
     }

--- a/src/coremods/COREMOD_memory/milk-stream-link.c
+++ b/src/coremods/COREMOD_memory/milk-stream-link.c
@@ -56,7 +56,9 @@ static const char *get_shmdir(void)
  * @progname: argv[0]
  * @color:    non-zero for ANSI color
  */
-static void print_help(const char *progname, int color)
+static void print_help(
+    const char *progname,
+    int color)
 {
     milk_help_banner(progname, LSL_DESC, color);
     milk_help_section("Usage", color);
@@ -154,7 +156,9 @@ static void write_imsize(
     printf("  imsize written → %s\n", outfile);
 }
 
-int main(int argc, char *argv[])
+int main(
+    int argc,
+    char *argv[])
 {
     int action = milk_help_init(
         argc, argv, LSL_DESC, LSL_DESC_LONG);

--- a/src/coremods/COREMOD_memory/milk-stream-list.c
+++ b/src/coremods/COREMOD_memory/milk-stream-list.c
@@ -73,7 +73,8 @@ static void print_help(
     printf("  %s$ milk-stream-list%s %sdm.*%s\n\n",
            mh_color ? MH_CMD : "", mh_color ? MH_RST : "",
            mh_color ? MH_ARG : "", mh_color ? MH_RST : "");
-    const char *see_also[] = {
+    const char *see_also[] =
+    {
         "milk-stream-info:inspect stream metadata and data",
         "milk-stream-rm:remove shared memory streams",
         "milk-stream-create:create a new shared memory stream"
@@ -87,10 +88,12 @@ int main(
 {
     int action = milk_help_init(argc, argv,
                                 SL_DESC, SL_DESC_LONG);
-    if (action == MH_ACTION_H1 || action == MH_ACTION_H2)
+    if(action == MH_ACTION_H1 || action == MH_ACTION_H2)
+    {
         return 0;
+    }
     int mh_color = (action == MH_ACTION_HELP);
-    if (action == MH_ACTION_HELP || action == MH_ACTION_MONO)
+    if(action == MH_ACTION_HELP || action == MH_ACTION_MONO)
     {
         print_help(argv[0], mh_color);
         return 0;
@@ -99,22 +102,26 @@ int main(
     int show_all = 0;
     int opt;
 
-    static struct option long_options[] = {
+    static struct option long_options[] =
+    {
         {"all",     no_argument,       0, 'a'},
         {"help",    no_argument,       0, 'h'},
         {0, 0, 0, 0}
     };
 
-    while ((opt = getopt_long(argc, argv, "ah", long_options, NULL)) != -1) {
-        switch (opt) {
-            case 'a':
-                show_all = 1;
-                break;
-            case 'h': break; /* handled above */
-            default:
-                printf("\n\033[1;31mERROR\033[0m: Invalid option.\n\n");
-                print_help(argv[0], 1);
-                return 1;
+    while((opt = getopt_long(argc, argv, "ah", long_options, NULL)) != -1)
+    {
+        switch(opt)
+        {
+        case 'a':
+            show_all = 1;
+            break;
+        case 'h':
+            break; /* handled above */
+        default:
+            printf("\n\033[1;31mERROR\033[0m: Invalid option.\n\n");
+            print_help(argv[0], 1);
+            return 1;
         }
     }
 
@@ -122,10 +129,12 @@ int main(
     regex_t regex;
     int use_regex = 0;
 
-    if (optind < argc) {
+    if(optind < argc)
+    {
         pattern = argv[optind];
         int ret = regcomp(&regex, pattern, REG_EXTENDED | REG_NOSUB);
-        if (ret != 0) {
+        if(ret != 0)
+        {
             char error_msg[128];
             regerror(ret, &regex, error_msg, sizeof(error_msg));
             PRINT_ERROR("Error: Invalid regular expression. %s", error_msg);
@@ -135,11 +144,13 @@ int main(
     }
 
     const char *shmdir = getenv("MILK_SHM_DIR");
-    if (shmdir == NULL) {
-        shmdir = "/milk/shm"; 
+    if(shmdir == NULL)
+    {
+        shmdir = "/milk/shm";
         struct stat st;
-        if (stat(shmdir, &st) != 0) {
-             shmdir = "/dev/shm"; 
+        if(stat(shmdir, &st) != 0)
+        {
+            shmdir = "/dev/shm";
         }
     }
 
@@ -156,18 +167,23 @@ int main(
                "Type",
                "Size",
                "Cnt0");
-        if (show_all) {
+        if(show_all)
+        {
             printf(C_TITLE " %-40s" C_RST,
                    "Semaphores (up to 10)");
         }
         printf("\n");
 
         int total_width = 30 + 1 + 12 + 1 + 20 + 1 + 12;
-        if (show_all)
+        if(show_all)
+        {
             total_width += 1 + 40;
+        }
         printf(C_DIM);
-        for (int i = 0; i < total_width; i++)
+        for(int i = 0; i < total_width; i++)
+        {
             putchar('-');
+        }
         printf(C_RST "\n");
 
         while(((dir = readdir(d)) != NULL))
@@ -180,14 +196,15 @@ int main(
                 strncpy(sname, dir->d_name, sizeof(sname));
                 sname[strlen(dir->d_name) - 7] = '\0'; // Remove .im.shm
 
-                if (use_regex && regexec(&regex, sname, 0, NULL, 0) != 0) {
+                if(use_regex && regexec(&regex, sname, 0, NULL, 0) != 0)
+                {
                     continue; // Skip if it doesn't match the regex
                 }
 
                 // Check if it's a symlink
                 char fullname[STRINGMAXLEN_FULLFILENAME];
                 snprintf(fullname, sizeof(fullname), "%s/%s", shmdir, dir->d_name);
-                
+
                 struct stat buf;
                 if(lstat(fullname, &buf) == 0)
                 {
@@ -195,27 +212,33 @@ int main(
                     {
                         char linktarget[STRINGMAXLEN_FULLFILENAME];
                         ssize_t len = readlink(fullname,
-                            linktarget,
-                            sizeof(linktarget)-1);
-                        if (len != -1) {
+                                               linktarget,
+                                               sizeof(linktarget) - 1);
+                        if(len != -1)
+                        {
                             linktarget[len] = '\0';
-                            
+
                             struct stat target_stat;
                             int target_exists = (stat(fullname, &target_stat) == 0);
-                            
+
                             printf(C_LINK "%-30s" C_RST
                                    " " C_DIM "%-12s" C_RST
                                    " -> ",
                                    sname, "LINK");
-                            if (!target_exists) {
+                            if(!target_exists)
+                            {
                                 printf(C_ERR "%s"
                                        C_RST "\n",
                                        linktarget);
-                            } else {
+                            }
+                            else
+                            {
                                 printf("%s\n",
                                        linktarget);
                             }
-                        } else {
+                        }
+                        else
+                        {
                             printf(C_LINK "%-30s"
                                    C_RST " "
                                    C_ERR "%-12s"
@@ -228,17 +251,27 @@ int main(
                     {
                         // Try to open image to get details
                         IMAGE image = {0};
-                        
+
                         errno_t ret = ImageStreamIO_read_sharedmem_image_toIMAGE(
-                            sname,
-                            &image);
-                        
-                        if (ret == IMAGESTREAMIO_SUCCESS) {
+                                          sname,
+                                          &image);
+
+                        if(ret == IMAGESTREAMIO_SUCCESS)
+                        {
                             const char *typestr = ImageStreamIO_typename(image.md->datatype);
                             char size_str[32];
-                            if (image.md->naxis == 1) snprintf(size_str, 32, "%u", image.md->size[0]);
-                            else if (image.md->naxis == 2) snprintf(size_str, 32, "%u x %u", image.md->size[0], image.md->size[1]);
-                            else snprintf(size_str, 32, "%u x %u x %u", image.md->size[0], image.md->size[1], image.md->size[2]);
+                            if(image.md->naxis == 1)
+                            {
+                                snprintf(size_str, 32, "%u", image.md->size[0]);
+                            }
+                            else if(image.md->naxis == 2)
+                            {
+                                snprintf(size_str, 32, "%u x %u", image.md->size[0], image.md->size[1]);
+                            }
+                            else
+                            {
+                                snprintf(size_str, 32, "%u x %u x %u", image.md->size[0], image.md->size[1], image.md->size[2]);
+                            }
 
                             printf(C_NAME "%-30s" C_RST
                                    " " C_TYPE "%-12s" C_RST
@@ -248,21 +281,27 @@ int main(
                                    typestr ? typestr : "???",
                                    size_str,
                                    (unsigned long)image.md->cnt0);
-                            
-                            if (show_all) {
+
+                            if(show_all)
+                            {
                                 char sem_str[256] = "";
                                 int nbsem = image.md->sem;
-                                if (nbsem > 10)
+                                if(nbsem > 10)
+                                {
                                     nbsem = 10;
-                                for (int i = 0; i < nbsem; i++) {
+                                }
+                                for(int i = 0; i < nbsem; i++)
+                                {
                                     long sval =
                                         ImageStreamIO_semvalue(
                                             &image, i);
                                     char valbuf[16];
                                     snprintf(valbuf, 16,
                                              "%ld", sval);
-                                    if (i > 0)
+                                    if(i > 0)
+                                    {
                                         strcat(sem_str, ":");
+                                    }
                                     strcat(sem_str, valbuf);
                                 }
                                 printf(" " C_SEM "%-40s"
@@ -271,7 +310,9 @@ int main(
                             printf("\n");
 
                             ImageStreamIO_closeIm(&image);
-                        } else {
+                        }
+                        else
+                        {
                             printf(C_NAME "%-30s" C_RST
                                    " " C_ERR "%-12s"
                                    C_RST "\n",
@@ -291,7 +332,8 @@ int main(
         return 1;
     }
 
-    if (use_regex) {
+    if(use_regex)
+    {
         regfree(&regex);
     }
 

--- a/src/coremods/COREMOD_memory/milk-stream-list.c
+++ b/src/coremods/COREMOD_memory/milk-stream-list.c
@@ -38,7 +38,9 @@
     "and write counter. Use -a for full details including semaphores.\n" \
     "An optional regex pattern filters which streams are listed."
 
-static void print_help(const char *progname, int mh_color)
+static void print_help(
+    const char *progname,
+    int mh_color)
 {
     milk_help_banner(progname, SL_DESC, mh_color);
     milk_help_section("Usage", mh_color);
@@ -79,7 +81,9 @@ static void print_help(const char *progname, int mh_color)
     milk_help_see_also(see_also, 3, mh_color);
 }
 
-int main(int argc, char *argv[])
+int main(
+    int argc,
+    char *argv[])
 {
     int action = milk_help_init(argc, argv,
                                 SL_DESC, SL_DESC_LONG);

--- a/src/coremods/COREMOD_memory/milk-stream-rm.c
+++ b/src/coremods/COREMOD_memory/milk-stream-rm.c
@@ -24,7 +24,9 @@
     "  -r         Regex match: list matches then confirm.\n" \
     "  (no args)  Interactive: list all streams, select to remove."
 
-static void print_help(const char *progname, int mh_color)
+static void print_help(
+    const char *progname,
+    int mh_color)
 {
     milk_help_banner(progname, SR_DESC, mh_color);
     milk_help_section("Usage", mh_color);
@@ -275,7 +277,9 @@ static int read_confirmation(void)
  * Handles terminal mode setup and strips
  * trailing whitespace.  Returns 1 on success.
  */
-static int read_line(char *buf, int size)
+static int read_line(
+    char *buf,
+    int size)
 {
     struct termios old_term;
     int is_tty = isatty(STDIN_FILENO);
@@ -317,7 +321,9 @@ static int read_line(char *buf, int size)
     return 1;
 }
 
-int main(int argc, char *argv[])
+int main(
+    int argc,
+    char *argv[])
 {
     int action = milk_help_init(argc, argv,
                                 SR_DESC, SR_DESC_LONG);

--- a/src/coremods/COREMOD_memory/milk-stream-rm.c
+++ b/src/coremods/COREMOD_memory/milk-stream-rm.c
@@ -70,7 +70,8 @@ static void print_help(
            mh_color ? MH_CMD : "", mh_color ? MH_RST : "",
            mh_color ? MH_OPT : "", mh_color ? MH_RST : "",
            mh_color ? MH_ARG : "", mh_color ? MH_RST : "");
-    const char *see_also[] = {
+    const char *see_also[] =
+    {
         "milk-stream-list:list active shared memory streams",
         "milk-stream-info:inspect stream metadata and data"
     };
@@ -99,14 +100,16 @@ static int remove_single_stream(
     /* Check if symlink — just unlink */
     struct stat lbuf;
 
-    if (lstat(fullpath, &lbuf) == 0
-        && S_ISLNK(lbuf.st_mode))
+    if(lstat(fullpath, &lbuf) == 0
+            && S_ISLNK(lbuf.st_mode))
     {
-        if (verbose) {
+        if(verbose)
+        {
             printf("Removing symlink '%s'...\n",
                    sname);
         }
-        if (unlink(fullpath) != 0) {
+        if(unlink(fullpath) != 0)
+        {
             PRINT_ERROR("unlink: %s", strerror(errno));
             return 1;
         }
@@ -121,21 +124,23 @@ static int remove_single_stream(
         ImageStreamIO_read_sharedmem_image_toIMAGE(
             sname, &image);
 
-    if (ret != IMAGESTREAMIO_SUCCESS) {
+    if(ret != IMAGESTREAMIO_SUCCESS)
+    {
         fprintf(stderr,
                 "Error: cannot open stream"
                 " '%s'.\n", sname);
         return 1;
     }
 
-    if (verbose) {
+    if(verbose)
+    {
         printf("Removing stream '%s'...\n",
                sname);
     }
 
     /* Destroy semaphores */
-    for (int si = 0;
-         si < image.md->sem; si++)
+    for(int si = 0;
+            si < image.md->sem; si++)
     {
         sem_destroy(image.semptr[si]);
     }
@@ -144,7 +149,8 @@ static int remove_single_stream(
     ImageStreamIO_closeIm(&image);
 
     /* Unlink the SHM file */
-    if (unlink(fullpath) != 0) {
+    if(unlink(fullpath) != 0)
+    {
         PRINT_ERROR("unlink: %s", strerror(errno));
         return 1;
     }
@@ -169,7 +175,8 @@ static int scan_streams(
 {
     DIR *d = opendir(shmdir);
 
-    if (!d) {
+    if(!d)
+    {
         fprintf(stderr,
                 "Error opening directory %s\n",
                 shmdir);
@@ -182,17 +189,20 @@ static int scan_streams(
 
     struct dirent *dir;
 
-    while ((dir = readdir(d)) != NULL) {
+    while((dir = readdir(d)) != NULL)
+    {
         char *pch =
             strstr(dir->d_name, ".im.shm");
-        if (!pch) {
+        if(!pch)
+        {
             continue;
         }
         int suffix_pos =
             (int)(pch - dir->d_name);
         int name_len =
             (int)strlen(dir->d_name);
-        if (suffix_pos != name_len - 7) {
+        if(suffix_pos != name_len - 7)
+        {
             continue;
         }
 
@@ -202,7 +212,8 @@ static int scan_streams(
                  "%.*s", suffix_pos,
                  dir->d_name);
 
-        if (count >= capacity) {
+        if(count >= capacity)
+        {
             capacity *= 2;
             *names = realloc(*names,
                              capacity
@@ -229,7 +240,8 @@ static int read_confirmation(void)
     struct termios old_term;
     int is_tty = isatty(STDIN_FILENO);
 
-    if (is_tty) {
+    if(is_tty)
+    {
         tcgetattr(STDIN_FILENO, &old_term);
         struct termios t = old_term;
 
@@ -244,12 +256,14 @@ static int read_confirmation(void)
         (fgets(linebuf, sizeof(linebuf),
                stdin) != NULL);
 
-    if (is_tty) {
+    if(is_tty)
+    {
         tcsetattr(STDIN_FILENO,
                   TCSANOW, &old_term);
     }
 
-    if (!ok) {
+    if(!ok)
+    {
         return 0;
     }
 
@@ -257,9 +271,9 @@ static int read_confirmation(void)
     {
         char *p = linebuf + strlen(linebuf);
 
-        while (p > linebuf
-               && (*(p - 1) == '\n'
-                   || *(p - 1) == '\r'))
+        while(p > linebuf
+                && (*(p - 1) == '\n'
+                    || *(p - 1) == '\r'))
         {
             *(--p) = '\0';
         }
@@ -284,7 +298,8 @@ static int read_line(
     struct termios old_term;
     int is_tty = isatty(STDIN_FILENO);
 
-    if (is_tty) {
+    if(is_tty)
+    {
         tcgetattr(STDIN_FILENO, &old_term);
         struct termios t = old_term;
 
@@ -297,12 +312,14 @@ static int read_line(
     int ok =
         (fgets(buf, size, stdin) != NULL);
 
-    if (is_tty) {
+    if(is_tty)
+    {
         tcsetattr(STDIN_FILENO,
                   TCSANOW, &old_term);
     }
 
-    if (!ok) {
+    if(!ok)
+    {
         return 0;
     }
 
@@ -310,9 +327,9 @@ static int read_line(
     {
         char *p = buf + strlen(buf);
 
-        while (p > buf
-               && (*(p - 1) == '\n'
-                   || *(p - 1) == '\r'))
+        while(p > buf
+                && (*(p - 1) == '\n'
+                    || *(p - 1) == '\r'))
         {
             *(--p) = '\0';
         }
@@ -327,10 +344,12 @@ int main(
 {
     int action = milk_help_init(argc, argv,
                                 SR_DESC, SR_DESC_LONG);
-    if (action == MH_ACTION_H1 || action == MH_ACTION_H2)
+    if(action == MH_ACTION_H1 || action == MH_ACTION_H2)
+    {
         return 0;
+    }
     int mh_color = (action == MH_ACTION_HELP);
-    if (action == MH_ACTION_HELP || action == MH_ACTION_MONO)
+    if(action == MH_ACTION_HELP || action == MH_ACTION_MONO)
     {
         print_help(argv[0], mh_color);
         return 0;
@@ -341,7 +360,8 @@ int main(
     int force = 0;
     int opt;
 
-    static struct option long_options[] = {
+    static struct option long_options[] =
+    {
         {"verbose", no_argument, 0, 'v'},
         {"regex",   no_argument, 0, 'r'},
         {"force",   no_argument, 0, 'f'},
@@ -349,12 +369,13 @@ int main(
         {0, 0, 0, 0}
     };
 
-    while ((opt = getopt_long(argc, argv,
-                              "vrfh",
-                              long_options,
-                              NULL)) != -1)
+    while((opt = getopt_long(argc, argv,
+                             "vrfh",
+                             long_options,
+                             NULL)) != -1)
     {
-        switch (opt) {
+        switch(opt)
+        {
         case 'v':
             verbose = 1;
             break;
@@ -364,7 +385,8 @@ int main(
         case 'f':
             force = 1;
             break;
-        case 'h': break; /* handled above */
+        case 'h':
+            break; /* handled above */
         default:
             printf("\n\033[1;31mERROR\033[0m: Invalid option.\n\n");
             print_help(argv[0], 1);
@@ -374,18 +396,21 @@ int main(
 
     const char *pattern = NULL;
 
-    if (optind < argc) {
+    if(optind < argc)
+    {
         pattern = argv[optind];
     }
 
     /* Determine SHM directory */
     const char *shmdir = getenv("MILK_SHM_DIR");
 
-    if (shmdir == NULL) {
+    if(shmdir == NULL)
+    {
         shmdir = "/milk/shm";
         struct stat st;
 
-        if (stat(shmdir, &st) != 0) {
+        if(stat(shmdir, &st) != 0)
+        {
             shmdir = "/dev/shm";
         }
     }
@@ -393,9 +418,10 @@ int main(
     /* ------------------------------------------
      * Mode 1: Exact match (default with pattern)
      * ----------------------------------------*/
-    if (pattern != NULL && !use_regex) {
+    if(pattern != NULL && !use_regex)
+    {
         return remove_single_stream(
-            shmdir, pattern, verbose);
+                   shmdir, pattern, verbose);
     }
 
     /* ------------------------------------------
@@ -407,11 +433,13 @@ int main(
         scan_streams(shmdir, &all_names,
                      capacity);
 
-    if (total < 0) {
+    if(total < 0)
+    {
         return 1;
     }
 
-    if (total == 0) {
+    if(total == 0)
+    {
         printf("No streams found.\n");
         free(all_names);
         return 1;
@@ -420,16 +448,19 @@ int main(
     /* ------------------------------------------
      * Mode 2: Regex match (with -r flag)
      * ----------------------------------------*/
-    if (use_regex && pattern != NULL) {
+    if(use_regex && pattern != NULL)
+    {
         regex_t regex;
         int ret = regcomp(&regex, pattern,
                           REG_EXTENDED
                           | REG_NOSUB);
-        if (ret != 0) {
+        if(ret != 0)
+        {
             fprintf(stderr,
                     "Error: invalid regex"
                     " '%s'.\n", pattern);
-            for (int i = 0; i < total; i++) {
+            for(int i = 0; i < total; i++)
+            {
                 free(all_names[i]);
             }
             free(all_names);
@@ -442,28 +473,33 @@ int main(
         char **match_names =
             calloc(match_cap, sizeof(char *));
 
-        for (int i = 0; i < total; i++) {
-            if (regexec(&regex, all_names[i],
-                        0, NULL, 0) == 0)
+        for(int i = 0; i < total; i++)
+        {
+            if(regexec(&regex, all_names[i],
+                       0, NULL, 0) == 0)
             {
-                if (match_count >= match_cap) {
+                if(match_count >= match_cap)
+                {
                     match_cap *= 2;
                     match_names = realloc(
-                        match_names,
-                        match_cap
-                        * sizeof(char *));
+                                      match_names,
+                                      match_cap
+                                      * sizeof(char *));
                 }
                 match_names[match_count] =
                     all_names[i];
                 match_count++;
-            } else {
+            }
+            else
+            {
                 free(all_names[i]);
             }
         }
         free(all_names);
         regfree(&regex);
 
-        if (match_count == 0) {
+        if(match_count == 0)
+        {
             fprintf(stderr,
                     "No streams matching"
                     " '%s' found.\n",
@@ -476,19 +512,21 @@ int main(
         printf("\n  Streams matching '%s'"
                " (%d):\n\n",
                pattern, match_count);
-        for (int i = 0;
-             i < match_count; i++)
+        for(int i = 0;
+                i < match_count; i++)
         {
             printf("    %s\n", match_names[i]);
         }
         printf("\n");
 
         /* Confirm unless -f */
-        if (!force) {
-            if (!read_confirmation()) {
+        if(!force)
+        {
+            if(!read_confirmation())
+            {
                 printf("Cancelled.\n");
-                for (int i = 0;
-                     i < match_count; i++)
+                for(int i = 0;
+                        i < match_count; i++)
                 {
                     free(match_names[i]);
                 }
@@ -500,17 +538,18 @@ int main(
         /* Remove all matched streams */
         int errors = 0;
 
-        for (int i = 0;
-             i < match_count; i++)
+        for(int i = 0;
+                i < match_count; i++)
         {
             errors += remove_single_stream(
-                shmdir, match_names[i],
-                verbose);
+                          shmdir, match_names[i],
+                          verbose);
             free(match_names[i]);
         }
         free(match_names);
 
-        if (errors > 0) {
+        if(errors > 0)
+        {
             fprintf(stderr,
                     "%d stream(s) failed"
                     " to remove.\n",
@@ -524,7 +563,8 @@ int main(
      * Mode 3: Interactive selection (no pattern)
      * ----------------------------------------*/
     printf("\n  Streams:\n\n");
-    for (int i = 0; i < total; i++) {
+    for(int i = 0; i < total; i++)
+    {
         printf("  %3d  %s\n",
                i + 1, all_names[i]);
     }
@@ -536,11 +576,12 @@ int main(
 
     char linebuf[512];
 
-    if (!read_line(linebuf,
-                   sizeof(linebuf)))
+    if(!read_line(linebuf,
+                  sizeof(linebuf)))
     {
         printf("Cancelled.\n");
-        for (int i = 0; i < total; i++) {
+        for(int i = 0; i < total; i++)
+        {
             free(all_names[i]);
         }
         free(all_names);
@@ -552,10 +593,12 @@ int main(
         parse_multiselect(linebuf,
                           selected, total);
 
-    if (nsel <= 0) {
+    if(nsel <= 0)
+    {
         printf("Cancelled.\n");
         free(selected);
-        for (int i = 0; i < total; i++) {
+        for(int i = 0; i < total; i++)
+        {
             free(all_names[i]);
         }
         free(all_names);
@@ -564,21 +607,25 @@ int main(
 
     int errors = 0;
 
-    for (int i = 0; i < total; i++) {
-        if (selected[i]) {
+    for(int i = 0; i < total; i++)
+    {
+        if(selected[i])
+        {
             errors += remove_single_stream(
-                shmdir, all_names[i],
-                verbose);
+                          shmdir, all_names[i],
+                          verbose);
         }
     }
 
     free(selected);
-    for (int i = 0; i < total; i++) {
+    for(int i = 0; i < total; i++)
+    {
         free(all_names[i]);
     }
     free(all_names);
 
-    if (errors > 0) {
+    if(errors > 0)
+    {
         fprintf(stderr,
                 "%d stream(s) failed"
                 " to remove.\n", errors);

--- a/src/coremods/COREMOD_memory/milk-streamCTRL-cli.c
+++ b/src/coremods/COREMOD_memory/milk-streamCTRL-cli.c
@@ -273,7 +273,9 @@ static void print_stream(
     printf("\n");
 }
 
-static void print_help(const char *progname, int mh_color)
+static void print_help(
+    const char *progname,
+    int mh_color)
 {
     milk_help_banner(progname, "command-line interface for monitoring shared memory streams", mh_color);
     milk_help_section("Usage", mh_color);
@@ -316,7 +318,9 @@ static void print_help(const char *progname, int mh_color)
     milk_help_see_also(see_also, 3, mh_color);
 }
 
-int main(int argc, char *argv[])
+int main(
+    int argc,
+    char *argv[])
 {
     const char *progname = basename(argv[0]);
 

--- a/src/coremods/COREMOD_memory/read_shmim_size.c
+++ b/src/coremods/COREMOD_memory/read_shmim_size.c
@@ -26,12 +26,13 @@
  * 1.  FPS COMPONENT IDENTITY
  * ============================================================= */
 
-static FPS_APP_INFO FPS_app_info = {
+static FPS_APP_INFO FPS_app_info =
+{
     .fps_name    = "readshmimsize",
     .cmdkey      = "readshmimsize",
     .description = "read shared memory image size",
     .description_long =
-        "Read only the size metadata of a shared memory stream without mapping the full pixel buffer. Lightweight probe for stream dimensions."
+    "Read only the size metadata of a shared memory stream without mapping the full pixel buffer. Lightweight probe for stream dimensions."
 };
 
 
@@ -77,7 +78,7 @@ imageID read_sharedmem_image_size(
     int             SM_fd;
     struct stat     file_stat;
     char            SM_fname[
-        STRINGMAXLEN_FULLFILENAME];
+     STRINGMAXLEN_FULLFILENAME];
     IMAGE_METADATA *map;
 
     FILE           *fp;
@@ -103,12 +104,12 @@ imageID read_sharedmem_image_size(
             fstat(SM_fd, &file_stat);
 
             map = (IMAGE_METADATA *) mmap(
-                0,
-                sizeof(IMAGE_METADATA),
-                PROT_READ | PROT_WRITE,
-                MAP_SHARED,
-                SM_fd,
-                0);
+                      0,
+                      sizeof(IMAGE_METADATA),
+                      PROT_READ | PROT_WRITE,
+                      MAP_SHARED,
+                      SM_fd,
+                      0);
             if(map == MAP_FAILED)
             {
                 close(SM_fd);
@@ -119,7 +120,7 @@ imageID read_sharedmem_image_size(
             }
 
             fp = fopen(fname, "w");
-            for( int i = 0; i < map[0].naxis; i++)
+            for(int i = 0; i < map[0].naxis; i++)
             {
                 fprintf(fp, "%ld ",
                         (long) map[0].size[i]);
@@ -129,7 +130,7 @@ imageID read_sharedmem_image_size(
 
             if(munmap(map,
                       sizeof(IMAGE_METADATA))
-                == -1)
+                    == -1)
             {
                 printf("unmapping %s\n",
                        SM_fname);
@@ -144,8 +145,8 @@ imageID read_sharedmem_image_size(
     {
         fp = fopen(fname, "w");
         for(int i = 0;
-             i < img.im->md[0].naxis;
-             i++)
+                i < img.im->md[0].naxis;
+                i++)
         {
             fprintf(
                 fp, "%ld ",
@@ -191,9 +192,9 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
 static errno_t CLIfunction(void)
 {
     return safe_fps_generic_CLIfunction(
-        &FPS_app_info, farg, &CLIcmddata,
-        my_bindings, nb_bindings,
-        compute_function);
+               &FPS_app_info, farg, &CLIcmddata,
+               my_bindings, nb_bindings,
+               compute_function);
 }
 
 errno_t

--- a/src/coremods/COREMOD_memory/read_shmim_size.c
+++ b/src/coremods/COREMOD_memory/read_shmim_size.c
@@ -79,7 +79,7 @@ imageID read_sharedmem_image_size(
     char            SM_fname[
         STRINGMAXLEN_FULLFILENAME];
     IMAGE_METADATA *map;
-    int             i;
+
     FILE           *fp;
 
     IMGID img = imgid_make_from_name(name);
@@ -119,7 +119,7 @@ imageID read_sharedmem_image_size(
             }
 
             fp = fopen(fname, "w");
-            for(i = 0; i < map[0].naxis; i++)
+            for( int i = 0; i < map[0].naxis; i++)
             {
                 fprintf(fp, "%ld ",
                         (long) map[0].size[i]);
@@ -143,7 +143,7 @@ imageID read_sharedmem_image_size(
     else
     {
         fp = fopen(fname, "w");
-        for(i = 0;
+        for(int i = 0;
              i < img.im->md[0].naxis;
              i++)
         {

--- a/src/coremods/COREMOD_memory/saveall.c
+++ b/src/coremods/COREMOD_memory/saveall.c
@@ -224,13 +224,13 @@ errno_t COREMOD_MEMORY_SaveAll_snapshot(
 {
     long *IDarray;
     long *IDarraycp;
-    long  i;
+
     long  imcnt = 0;
     char  imnamecp[STRINGMAXLEN_IMGNAME];
     char  fnamecp[STRINGMAXLEN_FULLFILENAME];
     long  ID;
 
-    for(i = 0; i < dcnimg; i++)
+    for(long i = 0; i < dcnimg; i++)
         if(dcimg[i].used == 1)
         {
             imcnt++;
@@ -242,7 +242,7 @@ errno_t COREMOD_MEMORY_SaveAll_snapshot(
         (long *) malloc(sizeof(long) * imcnt);
 
     imcnt = 0;
-    for(i = 0; i < dcnimg; i++)
+    for(int i = 0; i < dcnimg; i++)
     {
         if(dcimg[i].used == 1)
         {
@@ -254,7 +254,7 @@ errno_t COREMOD_MEMORY_SaveAll_snapshot(
     EXECUTE_SYSTEM_COMMAND_NOCHECK(
         "mkdir -p %s", dirname);
 
-    for(i = 0; i < imcnt; i++)
+    for(int i = 0; i < imcnt; i++)
     {
         ID = IDarray[i];
         WRITE_IMAGENAME(imnamecp,
@@ -267,7 +267,7 @@ errno_t COREMOD_MEMORY_SaveAll_snapshot(
     list_image_ID();
 
 #ifdef USE_CFITSIO
-    for(i = 0; i < imcnt; i++)
+    for(int i = 0; i < imcnt; i++)
     {
         ID = IDarray[i];
         WRITE_IMAGENAME(imnamecp,
@@ -299,7 +299,7 @@ errno_t COREMOD_MEMORY_SaveAll_sequ(
 {
     long   *IDarray;
     long   *IDarrayout;
-    long    i;
+
     long    imcnt = 0;
     char    imnameout[200];
     char    fnameout[500];
@@ -311,7 +311,7 @@ errno_t COREMOD_MEMORY_SaveAll_sequ(
     char     *ptr1;
     uint32_t *imsizearray;
 
-    for(i = 0; i < dcnimg; i++)
+    for(long i = 0; i < dcnimg; i++)
         if(dcimg[i].used == 1)
         {
             imcnt++;
@@ -325,7 +325,7 @@ errno_t COREMOD_MEMORY_SaveAll_sequ(
             sizeof(imageID) * imcnt);
 
     imcnt = 0;
-    for(i = 0; i < dcnimg; i++)
+    for(int i = 0; i < dcnimg; i++)
         if(dcimg[i].used == 1)
         {
             IDarray[imcnt] = i;
@@ -360,7 +360,7 @@ errno_t COREMOD_MEMORY_SaveAll_sequ(
     printf("Creating arrays\n");
     fflush(stdout);
 
-    for(i = 0; i < imcnt; i++)
+    for(int i = 0; i < imcnt; i++)
     {
         snprintf(imnameout,
                  sizeof(imnameout),
@@ -400,7 +400,7 @@ errno_t COREMOD_MEMORY_SaveAll_sequ(
     {
         ImageStreamIO_semwait(
             dcimg + IDtrig, semtrig);
-        for(i = 0; i < imcnt; i++)
+        for(int i = 0; i < imcnt; i++)
         {
             ID   = IDarray[i];
             ptr0 = (char *)
@@ -420,7 +420,7 @@ errno_t COREMOD_MEMORY_SaveAll_sequ(
     list_image_ID();
 
 #ifdef USE_CFITSIO
-    for(i = 0; i < imcnt; i++)
+    for(int i = 0; i < imcnt; i++)
     {
         ID = IDarray[i];
         snprintf(imnameout,

--- a/src/coremods/COREMOD_memory/stream_TCP_receive.c
+++ b/src/coremods/COREMOD_memory/stream_TCP_receive.c
@@ -73,7 +73,7 @@ imageID COREMOD_MEMORY_image_NETWORKreceive(int                         port,
     int             semval __attribute__((unused));
     int             semnb __attribute__((unused));
     int             OKim;
-    int             axis;
+
 
     imgmd = (IMAGE_METADATA *) malloc(sizeof(IMAGE_METADATA));
 
@@ -279,7 +279,7 @@ imageID COREMOD_MEMORY_image_NETWORKreceive(int                         port,
         }
         if(OKim == 1)
         {
-            for(axis = 0; axis < imgmd->naxis; axis++)
+            for(int axis = 0; axis < imgmd->naxis; axis++)
                 if(imgmd->size[axis] != img_p->md->size[axis])
                 {
                     OKim = 0;

--- a/src/coremods/COREMOD_memory/stream_TCP_receive.c
+++ b/src/coremods/COREMOD_memory/stream_TCP_receive.c
@@ -96,7 +96,7 @@ imageID COREMOD_MEMORY_image_NETWORKreceive(int                         port,
 
         char msgstring[200];
         snprintf(msgstring, 200, "Waiting for input stream");
-        
+
         PROCESSINFO_AUX_SETUP(processinfo, pinfoname, "", msgstring);
     }
 
@@ -246,7 +246,7 @@ imageID COREMOD_MEMORY_image_NETWORKreceive(int                         port,
 
     {
         IMGID img = imgid_make_from_name(
-            imgmd->name);
+                        imgmd->name);
         resolveIMGID(
             &img, ERRMODE_NULL,
             dcimg, dcnimg);
@@ -314,7 +314,7 @@ imageID COREMOD_MEMORY_image_NETWORKreceive(int                         port,
             imgrcv.mdt->naxis =
                 imgmd->naxis;
             for(int a = 0;
-                a < imgmd->naxis; a++)
+                    a < imgmd->naxis; a++)
             {
                 imgrcv.mdt->size[a] =
                     imgmd->size[a];
@@ -443,9 +443,9 @@ imageID COREMOD_MEMORY_image_NETWORKreceive(int                         port,
         while(recv_bytes == framesizefull)
         {
             recv_bytes = recv(fds_client,
-                socket_flush_buff,
-                framesizefull,
-                MSG_DONTWAIT);
+                              socket_flush_buff,
+                              framesizefull,
+                              MSG_DONTWAIT);
             printf("TCP recv buffer flush. %ld stray bytes.\n", recv_bytes);
         }
         if(recv_bytes >
@@ -523,8 +523,8 @@ imageID COREMOD_MEMORY_image_NETWORKreceive(int                         port,
             {
                 // copy kw
                 __builtin_memcpy(img_p->kw,
-                       (IMAGE_KEYWORD *)(buff + framesize1),
-                       img_p->md->NBkw * sizeof(IMAGE_KEYWORD));
+                                 (IMAGE_KEYWORD *)(buff + framesize1),
+                                 img_p->md->NBkw * sizeof(IMAGE_KEYWORD));
             }
 
             frameincr = (long) frame_md_p->cnt0 - cnt0previous;
@@ -607,4 +607,3 @@ imageID COREMOD_MEMORY_image_NETWORKreceive(int                         port,
 
     return ID;
 }
-

--- a/src/coremods/COREMOD_memory/stream_UDP_receive.c
+++ b/src/coremods/COREMOD_memory/stream_UDP_receive.c
@@ -32,7 +32,7 @@
 static int TCPTRANSFERKW = 1;
 static int MULTIGRAM_MAGIC = 0x3E;
 static int DGRAM_CHUNK_SIZE = 62 *
-    1024;
+                              1024;
 
 /** continuously receives 2D image through TCP link
  * do_counter_sync = 1, force counter to be used for synchronization, ignore semaphores if they exist
@@ -99,7 +99,7 @@ imageID COREMOD_MEMORY_image_NETUDPreceive(
         //
         char pinfoname[STRINGMAXLEN_FILENAME];
         snprintf(pinfoname, STRINGMAXLEN_FILENAME, "ntw-receive-%d", port);
-        
+
         PROCESSINFO_AUX_SETUP(processinfo, pinfoname, "", "Waiting for input stream");
     }
 
@@ -130,20 +130,20 @@ imageID COREMOD_MEMORY_image_NETUDPreceive(
     sock_server.sin_addr.s_addr = htonl(INADDR_ANY);
 
     setsockopt(fds_server,
-        SOL_SOCKET,
-        SO_NO_CHECK,
-        (char *) & flag,
-        sizeof(flag));
+               SOL_SOCKET,
+               SO_NO_CHECK,
+               (char *) & flag,
+               sizeof(flag));
     setsockopt(fds_server,
-        SOL_SOCKET,
-        SO_REUSEADDR,
-        (char *) & flag,
-        sizeof(flag));
+               SOL_SOCKET,
+               SO_REUSEADDR,
+               (char *) & flag,
+               sizeof(flag));
     setsockopt(fds_server,
-        SOL_SOCKET,
-        SO_REUSEPORT,
-        (char *) & flag,
-        sizeof(flag));
+               SOL_SOCKET,
+               SO_REUSEPORT,
+               (char *) & flag,
+               sizeof(flag));
 
 #ifdef SO_ATTACH_REUSEPORT_CBPF
     setsockopt(fds_server, SOL_SOCKET, SO_ATTACH_REUSEPORT_CBPF, (char *) & flag,
@@ -225,7 +225,7 @@ imageID COREMOD_MEMORY_image_NETUDPreceive(
 
     {
         IMGID img = imgid_make_from_name(
-            imgmd[0].name);
+                        imgmd[0].name);
         resolveIMGID(
             &img, ERRMODE_NULL,
             dcimg, dcnimg);
@@ -235,7 +235,7 @@ imageID COREMOD_MEMORY_image_NETUDPreceive(
     {
         // is it in shared memory ?
         ID = read_sharedmem_image(
-            imgmd[0].name, dcimg, dcnimg);
+                 imgmd[0].name, dcimg, dcnimg);
     }
 
     list_image_ID();
@@ -291,7 +291,7 @@ imageID COREMOD_MEMORY_image_NETUDPreceive(
             imgrcv.mdt->naxis =
                 imgmd[0].naxis;
             for(int a = 0;
-                a < imgmd[0].naxis; a++)
+                    a < imgmd[0].naxis; a++)
             {
                 imgrcv.mdt->size[a] =
                     imgmd[0].size[a];
@@ -545,8 +545,8 @@ imageID COREMOD_MEMORY_image_NETUDPreceive(
                     break;
                 }
                 __builtin_memcpy(buff + k_dgram * DGRAM_CHUNK_SIZE,
-                    buff_udp + 2,
-                    this_dgram_bytes);
+                                 buff_udp + 2,
+                                 this_dgram_bytes);
             }
         }
         if(socketOpen == 1 && abort_frame == 0)
@@ -559,8 +559,8 @@ imageID COREMOD_MEMORY_image_NETUDPreceive(
             {
                 // copy kw
                 __builtin_memcpy(dcimg[ID].kw,
-                       (IMAGE_KEYWORD *)(ptr_buff_keywords),
-                       nbkw * sizeof(IMAGE_KEYWORD));
+                                 (IMAGE_KEYWORD *)(ptr_buff_keywords),
+                                 nbkw * sizeof(IMAGE_KEYWORD));
             }
 
             frameincr = (long) imgmd_remote[0].cnt0 - cnt0previous;
@@ -657,4 +657,3 @@ imageID COREMOD_MEMORY_image_NETUDPreceive(
 
     return ID;
 }
-

--- a/src/coremods/COREMOD_memory/stream_UDP_receive.c
+++ b/src/coremods/COREMOD_memory/stream_UDP_receive.c
@@ -84,7 +84,7 @@ imageID COREMOD_MEMORY_image_NETUDPreceive(
     int             semval;
     int             semnb;
     int             OKim;
-    int             axis;
+
 
     imgmd = (IMAGE_METADATA *) malloc(sizeof(IMAGE_METADATA));
 
@@ -253,7 +253,7 @@ imageID COREMOD_MEMORY_image_NETUDPreceive(
         }
         if(OKim == 1)
         {
-            for(axis = 0; axis < imgmd[0].naxis; axis++)
+            for(int axis = 0; axis < imgmd[0].naxis; axis++)
                 if(imgmd[0].size[axis] != dcimg[ID].md[0].size[axis])
                 {
                     OKim = 0;

--- a/src/coremods/COREMOD_memory/stream_pixmapdecode.c
+++ b/src/coremods/COREMOD_memory/stream_pixmapdecode.c
@@ -137,7 +137,7 @@ imageID COREMOD_MEMORY_PixMapDecode_U(
     imageID            IDout = -1;
     imageID            IDin;
     imageID            IDmap;
-    long               slice, sliceii;
+    long sliceii;
     long               oldslice = 0;
     long               NBslice;
     long              *nbpixslice;
@@ -147,13 +147,13 @@ imageID COREMOD_MEMORY_PixMapDecode_U(
     FILE              *fp;
     uint32_t          *sizearray;
     imageID            IDout_pixslice;
-    long               ii;
+
     unsigned long long cnt = 0;
     //    int RT_priority = 80; //any number from 0-99
 
     //    struct sched_param schedpar;
     struct timespec ts;
-    long            scnt;
+
     int             semval;
     //    long long iter;
     //    int r;
@@ -348,7 +348,7 @@ imageID COREMOD_MEMORY_PixMapDecode_U(
         return RETURN_FAILURE;
     }
 
-    for(slice = 0; slice < NBslice; slice++)
+    for(long slice = 0; slice < NBslice; slice++)
     {
         int fscanfcnt =
             fscanf(fp, "%ld %ld %ld\n", &tmpl0, &nbpixslice[slice], &tmpl1);
@@ -377,7 +377,7 @@ imageID COREMOD_MEMORY_PixMapDecode_U(
     }
     fclose(fp);
 
-    for(slice = 0; slice < NBslice; slice++)
+    for(long slice = 0; slice < NBslice; slice++)
     {
         printf("Slice %5ld   : %5ld pix\n", slice, nbpixslice[slice]);
     }
@@ -400,11 +400,11 @@ imageID COREMOD_MEMORY_PixMapDecode_U(
         imgid_mkimage(&imgpixsl);
         IDout_pixslice = imgpixsl.ID;
 
-        for(slice = 0; slice < NBslice; slice++)
+        for(long slice = 0; slice < NBslice; slice++)
         {
             sliceii = slice * dcimg[IDmap].md[0].size[0] *
                       dcimg[IDmap].md[0].size[1];
-            for(ii = 0; ii < nbpixslice[slice]; ii++)
+            for(long ii = 0; ii < nbpixslice[slice]; ii++)
             {
                 // ocam2kpixi files MUST now be in int32 - otherwise we'll overflow in 240x240
                 dcimg[IDout_pixslice]
@@ -467,7 +467,7 @@ imageID COREMOD_MEMORY_PixMapDecode_U(
             if(processinfo->loopcnt == 0)
             {
                 semval = ImageStreamIO_semvalue(dcimg + IDin, in_semwaitindex);
-                for(scnt = 0; scnt < semval; scnt++)
+                for(long scnt = 0; scnt < semval; scnt++)
                 {
                     ImageStreamIO_semtrywait(dcimg + IDin, in_semwaitindex);
                 }
@@ -480,7 +480,7 @@ imageID COREMOD_MEMORY_PixMapDecode_U(
         {
             if(semr == 0)
             {
-                slice = dcimg[IDin].md[0].cnt1;
+                long slice = dcimg[IDin].md[0].cnt1;
                 if(slice > oldslice + 1)
                 {
                     slice = oldslice + 1;
@@ -501,7 +501,7 @@ imageID COREMOD_MEMORY_PixMapDecode_U(
                     {
                         sliceii = slice * dcimg[IDmap].md[0].size[0] *
                                   dcimg[IDmap].md[0].size[1];
-                        for(ii = 0; ii < nbpixslice[slice]; ii++)
+                        for(long ii = 0; ii < nbpixslice[slice]; ii++)
                         {
                             dcimg[IDout].array.UI16
                             [dcimg[IDmap].array.UI32[sliceii + ii]] =
@@ -511,7 +511,7 @@ imageID COREMOD_MEMORY_PixMapDecode_U(
                 }
                 else // reverse == 1, full image assumed (at least given how ocam is scrambled)
                 {
-                    for(ii = 0; ii < nbpixout; ++ii)
+                    for(long ii = 0; ii < nbpixout; ++ii)
                     {
                         dcimg[IDout].array.UI16[ii] =
                             dcimg[IDin]

--- a/src/coremods/COREMOD_memory/stream_sem.c
+++ b/src/coremods/COREMOD_memory/stream_sem.c
@@ -421,8 +421,8 @@ imageID COREMOD_MEMORY_image_seminfo(
     printf("----------------------------------\n");
     printf(" sem    value   writePID   readPID\n");
     printf("----------------------------------\n");
-    int s;
-    for(s = 0; s < dcimg[ID].md[0].sem; s++)
+
+    for(int s = 0; s < dcimg[ID].md[0].sem; s++)
     {
         int semval;
 
@@ -644,7 +644,7 @@ errno_t COREMOD_MEMORY_image_set_semwait_OR_IDarray(
     imageID *IDarray,
     long    NB_ID)
 {
-    int t;
+
     //    int semval;
 
     //   printf("======== ENTER COREMOD_MEMORY_image_set_semwait_OR_IDarray [%ld] =======\n", NB_ID);
@@ -653,7 +653,7 @@ errno_t COREMOD_MEMORY_image_set_semwait_OR_IDarray(
     thrarray_semwait    = (pthread_t *) malloc(sizeof(pthread_t) * NB_ID);
     NB_thrarray_semwait = NB_ID;
 
-    for(t = 0; t < NB_ID; t++)
+    for(int t = 0; t < NB_ID; t++)
     {
         //      printf("thread %d create, ID = %ld\n", t, IDarray[t]);
         //      fflush(stdout);
@@ -663,7 +663,7 @@ errno_t COREMOD_MEMORY_image_set_semwait_OR_IDarray(
                        (void *) IDarray[t]);
     }
 
-    for(t = 0; t < NB_ID; t++)
+    for(int t = 0; t < NB_ID; t++)
     {
         //         printf("thread %d tid %u join waiting\n", t, (unsigned int) thrarray_semwait[t]);
         //fflush(stdout);
@@ -691,14 +691,14 @@ errno_t COREMOD_MEMORY_image_set_semwait_OR_IDarray(
 errno_t COREMOD_MEMORY_image_set_semflush_IDarray(
     imageID *IDarray, long NB_ID)
 {
-    long i, cnt;
+
     int  semval;
-    int  s;
+
 
     list_image_ID();
-    for(i = 0; i < NB_ID; i++)
+    for(long i = 0; i < NB_ID; i++)
     {
-        for(s = 0; s < dcimg[IDarray[i]].md[0].sem; s++)
+        for(int s = 0; s < dcimg[IDarray[i]].md[0].sem; s++)
         {
             semval = ImageStreamIO_semvalue(dcimg + IDarray[i], s);
             printf("sem %d/%d of %s [%ld] = %d\n",
@@ -708,7 +708,7 @@ errno_t COREMOD_MEMORY_image_set_semflush_IDarray(
                    IDarray[i],
                    semval);
             fflush(stdout);
-            for(cnt = 0; cnt < semval; cnt++)
+            for(long cnt = 0; cnt < semval; cnt++)
             {
                 ImageStreamIO_semtrywait(dcimg + IDarray[i], s);
             }

--- a/src/coremods/COREMOD_memory/stream_updateloop.c
+++ b/src/coremods/COREMOD_memory/stream_updateloop.c
@@ -324,7 +324,7 @@ CLIADDCMD_COREMOD_memory__stream_updateloop()
 errno_t COREMOD_MEMORY_image_streamburst(
     const char *IDin_name,
     const char *IDout_name,
-    long        periodus)
+    long       periodus)
 {
     imageID IDin;
     imageID IDout;
@@ -445,20 +445,21 @@ errno_t COREMOD_MEMORY_image_streamburst(
  */
 imageID
 COREMOD_MEMORY_image_streamupdateloop(
-    const char                 *IDinname,
-    const char                 *IDoutname,
+    const char                  *IDinname,
+    const char                  *IDoutname,
     long                        usperiod,
     long                        NBcubes,
     long                        period,
     long                        offsetus,
-    const char                 *IDsync_name,
+    const char                  *IDsync_name,
     int                         semtrig,
     __attribute__((unused)) int timingmode)
 {
     imageID           *IDin;
-    long               cubeindex;
+
     char               imname[200];
     long               IDsync;
+    long               cubeindex; // used outside loop
     unsigned long long cntsync;
     long               pcnt         = 0;
     long               offsetfr     = 0;
@@ -799,11 +800,11 @@ COREMOD_MEMORY_image_streamupdateloop(
 imageID COREMOD_MEMORY_image_streamupdateloop_semtrig(
     const char                  *IDinname,
     const char                  *IDoutname,
-    long                         period,
-    long                         offsetus,
+    long                        period,
+    long                        offsetus,
     const char                  *IDsync_name,
-    int                          semtrig,
-    __attribute__((unused)) int  timingmode)
+    int                         semtrig,
+    __attribute__((unused)) int timingmode)
 {
     imageID IDin;
     imageID IDout;

--- a/src/coremods/COREMOD_tools/fileutils.c
+++ b/src/coremods/COREMOD_tools/fileutils.c
@@ -31,13 +31,14 @@ errno_t write_float_file(
  * 1.  FPS COMPONENT IDENTITY
  * ============================================================= */
 
-static FPS_APP_INFO FPS_app_info = {
+static FPS_APP_INFO FPS_app_info =
+{
     .fps_name    = "writef2file",
     .cmdkey      = "writef2file",
     .description =
-        "write float to file",
+    "write float to file",
     .description_long =
-        "File system utility operations: count files matching a pattern, list directory contents, and check file existence."
+    "File system utility operations: count files matching a pattern, list directory contents, and check file existence."
 };
 
 
@@ -83,9 +84,9 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
 static errno_t CLIfunction(void)
 {
     return safe_fps_generic_CLIfunction(
-        &FPS_app_info, farg, &CLIcmddata,
-        my_bindings, nb_bindings,
-        compute_function);
+               &FPS_app_info, farg, &CLIcmddata,
+               my_bindings, nb_bindings,
+               compute_function);
 }
 
 errno_t CLIADDCMD_COREMOD_tools__fileutils()
@@ -94,7 +95,7 @@ errno_t CLIADDCMD_COREMOD_tools__fileutils()
         farg, my_bindings, nb_bindings);
 
     int cmdi = RegisterCLIcmd(
-        CLIcmddata, CLIfunction);
+                   CLIcmddata, CLIfunction);
     CLIcmddata.cmdsettings =
         &data.cmd[cmdi].cmdsettings;
 

--- a/src/coremods/COREMOD_tools/fileutils.c
+++ b/src/coremods/COREMOD_tools/fileutils.c
@@ -108,7 +108,9 @@ int file_exist(char *filename)
     return (stat(filename, &buffer) == 0);
 }
 
-int create_counter_file(const char *fname, unsigned long NBpts)
+int create_counter_file(
+    const char *fname,
+    unsigned long NBpts)
 {
     unsigned long i;
     FILE         *fp;
@@ -119,7 +121,7 @@ int create_counter_file(const char *fname, unsigned long NBpts)
         abort();
     }
 
-    for(i = 0; i < NBpts; i++)
+    for(unsigned i = 0; i < NBpts; i++)
     {
         fprintf(fp, "%ld %f\n", i, (double)((double) i / NBpts));
     }
@@ -129,7 +131,9 @@ int create_counter_file(const char *fname, unsigned long NBpts)
     return (0);
 }
 
-int read_config_parameter_exists(const char *config_file, const char *keyword)
+int read_config_parameter_exists(
+    const char *config_file,
+    const char *keyword)
 {
     FILE *fp;
     char  line[1000];
@@ -206,7 +210,9 @@ int read_config_parameter(const char *config_file,
     return (read);
 }
 
-float read_config_parameter_float(const char *config_file, const char *keyword)
+float read_config_parameter_float(
+    const char *config_file,
+    const char *keyword)
 {
     float value;
     char  content[SBUFFERSIZE];
@@ -219,7 +225,9 @@ float read_config_parameter_float(const char *config_file, const char *keyword)
     return (value);
 }
 
-long read_config_parameter_long(const char *config_file, const char *keyword)
+long read_config_parameter_long(
+    const char *config_file,
+    const char *keyword)
 {
     long value;
     char content[SBUFFERSIZE];
@@ -230,7 +238,9 @@ long read_config_parameter_long(const char *config_file, const char *keyword)
     return (value);
 }
 
-int read_config_parameter_int(const char *config_file, const char *keyword)
+int read_config_parameter_int(
+    const char *config_file,
+    const char *keyword)
 {
     int  value;
     char content[SBUFFERSIZE];
@@ -290,13 +300,16 @@ FILE *open_file_r(const char *filename)
     return (fp);
 }
 
-errno_t write_1D_array(double *array, long nbpoints, const char *filename)
+errno_t write_1D_array(
+    double *array,
+    long nbpoints,
+    const char *filename)
 {
     FILE *fp;
-    long  ii;
+
 
     fp = open_file_w(filename);
-    for(ii = 0; ii < nbpoints; ii++)
+    for(long ii = 0; ii < nbpoints; ii++)
     {
         fprintf(fp, "%ld\t%f\n", ii, array[ii]);
     }
@@ -305,14 +318,17 @@ errno_t write_1D_array(double *array, long nbpoints, const char *filename)
     return RETURN_SUCCESS;
 }
 
-errno_t read_1D_array(double *array, long nbpoints, const char *filename)
+errno_t read_1D_array(
+    double *array,
+    long nbpoints,
+    const char *filename)
 {
     FILE *fp;
-    long  ii;
+
     long  tmpl;
 
     fp = open_file_r(filename);
-    for(ii = 0; ii < nbpoints; ii++)
+    for(long ii = 0; ii < nbpoints; ii++)
     {
         if(fscanf(fp, "%ld\t%lf\n", &tmpl, &array[ii]) != 2)
         {
@@ -349,7 +365,9 @@ int read_int_file(const char *fname)
     return (value);
 }
 
-errno_t write_int_file(const char *fname, int value)
+errno_t write_int_file(
+    const char *fname,
+    int value)
 {
     FILE *fp;
 
@@ -365,7 +383,9 @@ errno_t write_int_file(const char *fname, int value)
     return RETURN_SUCCESS;
 }
 
-errno_t write_float_file(const char *fname, float value)
+errno_t write_float_file(
+    const char *fname,
+    float value)
 {
     FILE *fp;
     int   mode = 0; // default, create single file

--- a/src/coremods/COREMOD_tools/imdisplay3d.c
+++ b/src/coremods/COREMOD_tools/imdisplay3d.c
@@ -27,18 +27,19 @@ errno_t COREMOD_TOOLS_imgdisplay3D(
  * ============================================================= */
 
 static char p_imname[
-    FUNCTION_PARAMETER_STRMAXLEN]
+     FUNCTION_PARAMETER_STRMAXLEN]
     = "im1";
 static long long p_step = 5;
 
-static FPS_APP_INFO FPS_app_info = {
+static FPS_APP_INFO FPS_app_info =
+{
     .fps_name    = "dispim3d",
     .cmdkey      = "dispim3d",
     .description =
-        "display 2D image as 3D surface "
-        "using gnuplot",
+    "display 2D image as 3D surface "
+    "using gnuplot",
     .description_long =
-        "Display slices of a 3D image cube interactively. Provides a TUI-based viewer for browsing through cube frames."
+    "Display slices of a 3D image cube interactively. Provides a TUI-based viewer for browsing through cube frames."
 };
 
 #define FPS_PARAMS(X) \
@@ -51,7 +52,8 @@ static FPS_APP_INFO FPS_app_info = {
       FPFLAG_DEFAULT_INPUT, \
       "pixel step")
 
-static FPS_CLI_BINDING my_bindings[] = {
+static FPS_CLI_BINDING my_bindings[] =
+{
     FPS_PARAMS(FPS_X_BINDING)
 };
 
@@ -59,11 +61,13 @@ static const int __attribute__((unused)) nb_bindings =
     sizeof(my_bindings) /
     sizeof(FPS_CLI_BINDING);
 
-static CLICMDARGDEF farg[] = {
+static CLICMDARGDEF farg[] =
+{
     FPS_PARAMS(FPS_X_FARG)
 };
 
-static CLICMDDATA CLIcmddata = {
+static CLICMDDATA CLIcmddata =
+{
     "", "", CLICMD_FIELDS_DEFAULTS
 };
 
@@ -80,9 +84,9 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
 static errno_t CLIfunction(void)
 {
     return safe_fps_generic_CLIfunction(
-        &FPS_app_info, farg, &CLIcmddata,
-        my_bindings, nb_bindings,
-        compute_function);
+               &FPS_app_info, farg, &CLIcmddata,
+               my_bindings, nb_bindings,
+               compute_function);
 }
 
 errno_t
@@ -91,7 +95,7 @@ CLIADDCMD_COREMOD_tools__imdisplay3d()
     safe_fps_fill_farg_examples(
         farg, my_bindings, nb_bindings);
     int cmdi = RegisterCLIcmd(
-        CLIcmddata, CLIfunction);
+                   CLIcmddata, CLIfunction);
     CLIcmddata.cmdsettings =
         &data.cmd[cmdi].cmdsettings;
     return RETURN_SUCCESS;

--- a/src/coremods/COREMOD_tools/imdisplay3d.c
+++ b/src/coremods/COREMOD_tools/imdisplay3d.c
@@ -100,11 +100,13 @@ CLIADDCMD_COREMOD_tools__imdisplay3d()
 
 // displays 2D image in 3D using gnuplot
 //
-errno_t COREMOD_TOOLS_imgdisplay3D(const char *IDname, long step)
+errno_t COREMOD_TOOLS_imgdisplay3D(
+    const char *IDname,
+    long step)
 {
     imageID ID;
     long    xsize, ysize;
-    long    ii, jj;
+    long ii;
     char    cmd[512];
     FILE   *fp;
 
@@ -135,7 +137,7 @@ errno_t COREMOD_TOOLS_imgdisplay3D(const char *IDname, long step)
     fprintf(fpgnuplot, "splot \"-\" w d notitle\n");
     for(ii = 0; ii < xsize; ii += step)
     {
-        for(jj = 0; jj < xsize; jj += step)
+        for(long jj = 0; jj < xsize; jj += step)
         {
             fprintf(fpgnuplot,
                     "%ld %ld %f\n",

--- a/src/coremods/COREMOD_tools/linregress.c
+++ b/src/coremods/COREMOD_tools/linregress.c
@@ -32,7 +32,7 @@ errno_t lin_regress(double      *a,
     Syy = 0;
     Sxy = 0;
 
-    for(i = 0; i < nb_points; i++)
+    for(unsigned i = 0; i < nb_points; i++)
     {
         S += 1.0 / sig[i] / sig[i];
         Sx += x[i] / sig[i] / sig[i];

--- a/src/coremods/COREMOD_tools/mvprocCPUset.c
+++ b/src/coremods/COREMOD_tools/mvprocCPUset.c
@@ -39,7 +39,7 @@ int COREMOD_TOOLS_mvProcCPUsetExt(
 
 static long long p_pid = 0;
 static char p_name[
-    FUNCTION_PARAMETER_STRMAXLEN]
+     FUNCTION_PARAMETER_STRMAXLEN]
     = "realtime";
 static long long p_rtprio = 80;
 
@@ -48,13 +48,14 @@ static long long p_rtprio = 80;
  *  CMD 1: rtprio (1 arg)
  * ============================================================= */
 
-static FPS_APP_INFO FPS_app_info_rtp = {
+static FPS_APP_INFO FPS_app_info_rtp =
+{
     .fps_name    = "rtprio",
     .cmdkey      = "rtprio",
     .description =
-        "set SCHED_FIFO priority",
+    "set SCHED_FIFO priority",
     .description_long =
-        "Move processes to specific CPU sets for core pinning and isolation. Supports assigning PIDs to NUMA-aware CPU groups for real-time performance."
+    "Move processes to specific CPU sets for core pinning and isolation. Supports assigning PIDs to NUMA-aware CPU groups for real-time performance."
 };
 
 #define FPS_PARAMS_RTP(X) \
@@ -63,7 +64,8 @@ static FPS_APP_INFO FPS_app_info_rtp = {
       FPFLAG_DEFAULT_INPUT, \
       "RT priority")
 
-static CLICMDDATA CLIcmddata_rtp = {
+static CLICMDDATA CLIcmddata_rtp =
+{
     "", "", CLICMD_FIELDS_NOPARAM
 };
 FPS_CMDSETTINGS_INIT(rtp, CLIcmddata_rtp, FPS_app_info_rtp)
@@ -79,13 +81,14 @@ static errno_t __attribute__((unused)) compute_rtp()
  *  CMD 2: tsetpmove (1 arg)
  * ============================================================= */
 
-static FPS_APP_INFO FPS_app_info_tset = {
+static FPS_APP_INFO FPS_app_info_tset =
+{
     .fps_name    = "tsetpmove",
     .cmdkey      = "tsetpmove",
     .description =
-        "assign taskset to current process",
+    "assign taskset to current process",
     .description_long =
-        "Move processes to specific CPU sets for core pinning and isolation. Supports assigning PIDs to NUMA-aware CPU groups for real-time performance."
+    "Move processes to specific CPU sets for core pinning and isolation. Supports assigning PIDs to NUMA-aware CPU groups for real-time performance."
 };
 
 #define FPS_PARAMS_TSET(X) \
@@ -94,7 +97,8 @@ static FPS_APP_INFO FPS_app_info_tset = {
       FPFLAG_DEFAULT_INPUT, \
       "taskset spec list")
 
-static CLICMDDATA CLIcmddata_tset = {
+static CLICMDDATA CLIcmddata_tset =
+{
     "", "", CLICMD_FIELDS_NOPARAM
 };
 FPS_CMDSETTINGS_INIT(tset, CLIcmddata_tset, FPS_app_info_tset)
@@ -110,13 +114,14 @@ static errno_t __attribute__((unused)) compute_tset()
  *  CMD 3: tsetpmoveext (2 args)
  * ============================================================= */
 
-static FPS_APP_INFO FPS_app_info_tsete = {
+static FPS_APP_INFO FPS_app_info_tsete =
+{
     .fps_name    = "tsetpmoveext",
     .cmdkey      = "tsetpmoveext",
     .description =
-        "assign taskset for any process",
+    "assign taskset for any process",
     .description_long =
-        "Move processes to specific CPU sets for core pinning and isolation. Supports assigning PIDs to NUMA-aware CPU groups for real-time performance."
+    "Move processes to specific CPU sets for core pinning and isolation. Supports assigning PIDs to NUMA-aware CPU groups for real-time performance."
 };
 
 #define FPS_PARAMS_TSETE(X) \
@@ -129,7 +134,8 @@ static FPS_APP_INFO FPS_app_info_tsete = {
       FPFLAG_DEFAULT_INPUT, \
       "taskset spec list")
 
-static CLICMDDATA CLIcmddata_tsete = {
+static CLICMDDATA CLIcmddata_tsete =
+{
     "", "", CLICMD_FIELDS_NOPARAM
 };
 FPS_CMDSETTINGS_INIT(tsete, CLIcmddata_tsete, FPS_app_info_tsete)
@@ -146,16 +152,18 @@ static errno_t __attribute__((unused)) compute_tsete()
  *  CMD 4: csetpmove (1 arg)
  * ============================================================= */
 
-static FPS_APP_INFO FPS_app_info_cset = {
+static FPS_APP_INFO FPS_app_info_cset =
+{
     .fps_name    = "csetpmove",
     .cmdkey      = "csetpmove",
     .description =
-        "move current process to CPU set",
+    "move current process to CPU set",
     .description_long =
-        "Move processes to specific CPU sets for core pinning and isolation. Supports assigning PIDs to NUMA-aware CPU groups for real-time performance."
+    "Move processes to specific CPU sets for core pinning and isolation. Supports assigning PIDs to NUMA-aware CPU groups for real-time performance."
 };
 
-static CLICMDDATA CLIcmddata_cset = {
+static CLICMDDATA CLIcmddata_cset =
+{
     "", "", CLICMD_FIELDS_NOPARAM
 };
 FPS_CMDSETTINGS_INIT(cset, CLIcmddata_cset, FPS_app_info_cset)
@@ -171,14 +179,15 @@ static errno_t __attribute__((unused)) compute_cset()
  *  CMD 5: csetandprioext (3 args, primary)
  * ============================================================= */
 
-static FPS_APP_INFO FPS_app_info = {
+static FPS_APP_INFO FPS_app_info =
+{
     .fps_name    = "csetandprioext",
     .cmdkey      = "csetandprioext",
     .description =
-        "move PID to CPU set and assign "
-        "RT priority",
+    "move PID to CPU set and assign "
+    "RT priority",
     .description_long =
-        "Move processes to specific CPU sets for core pinning and isolation. Supports assigning PIDs to NUMA-aware CPU groups for real-time performance."
+    "Move processes to specific CPU sets for core pinning and isolation. Supports assigning PIDs to NUMA-aware CPU groups for real-time performance."
 };
 
 #define FPS_PARAMS(X) \
@@ -195,7 +204,8 @@ static FPS_APP_INFO FPS_app_info = {
       FPFLAG_DEFAULT_INPUT, \
       "RT priority (0=ignore)")
 
-static FPS_CLI_BINDING my_bindings[] = {
+static FPS_CLI_BINDING my_bindings[] =
+{
     FPS_PARAMS(FPS_X_BINDING)
 };
 
@@ -203,11 +213,13 @@ static const int __attribute__((unused)) nb_bindings =
     sizeof(my_bindings) /
     sizeof(FPS_CLI_BINDING);
 
-static CLICMDARGDEF farg[] = {
+static CLICMDARGDEF farg[] =
+{
     FPS_PARAMS(FPS_X_FARG)
 };
 
-static CLICMDDATA CLIcmddata = {
+static CLICMDDATA CLIcmddata =
+{
     "", "", CLICMD_FIELDS_DEFAULTS
 };
 
@@ -232,33 +244,39 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
 #if !defined(FPS_STANDALONE) && !defined(MILK_NO_CLI)
 
 /* bindings for single-param commands */
-static FPS_CLI_BINDING bindings_rtp[] = {
+static FPS_CLI_BINDING bindings_rtp[] =
+{
     FPS_PARAMS_RTP(FPS_X_BINDING)
 };
 static const int nb_bindings_rtp =
     sizeof(bindings_rtp) /
     sizeof(FPS_CLI_BINDING);
-static CLICMDARGDEF farg_rtp[] = {
+static CLICMDARGDEF farg_rtp[] =
+{
     FPS_PARAMS_RTP(FPS_X_FARG)
 };
 
-static FPS_CLI_BINDING bindings_tset[] = {
+static FPS_CLI_BINDING bindings_tset[] =
+{
     FPS_PARAMS_TSET(FPS_X_BINDING)
 };
 static const int nb_bindings_tset =
     sizeof(bindings_tset) /
     sizeof(FPS_CLI_BINDING);
-static CLICMDARGDEF farg_tset[] = {
+static CLICMDARGDEF farg_tset[] =
+{
     FPS_PARAMS_TSET(FPS_X_FARG)
 };
 
-static FPS_CLI_BINDING bindings_tsete[] = {
+static FPS_CLI_BINDING bindings_tsete[] =
+{
     FPS_PARAMS_TSETE(FPS_X_BINDING)
 };
 static const int nb_bindings_tsete =
     sizeof(bindings_tsete) /
     sizeof(FPS_CLI_BINDING);
-static CLICMDARGDEF farg_tsete[] = {
+static CLICMDARGDEF farg_tsete[] =
+{
     FPS_PARAMS_TSETE(FPS_X_FARG)
 };
 
@@ -267,46 +285,46 @@ static CLICMDARGDEF farg_tsete[] = {
 static errno_t CLIfunction_rtp(void)
 {
     return safe_fps_generic_CLIfunction(
-        &FPS_app_info_rtp,
-        farg_rtp, &CLIcmddata_rtp,
-        bindings_rtp, nb_bindings_rtp,
-        compute_rtp);
+               &FPS_app_info_rtp,
+               farg_rtp, &CLIcmddata_rtp,
+               bindings_rtp, nb_bindings_rtp,
+               compute_rtp);
 }
 
 static errno_t CLIfunction_tset(void)
 {
     return safe_fps_generic_CLIfunction(
-        &FPS_app_info_tset,
-        farg_tset, &CLIcmddata_tset,
-        bindings_tset, nb_bindings_tset,
-        compute_tset);
+               &FPS_app_info_tset,
+               farg_tset, &CLIcmddata_tset,
+               bindings_tset, nb_bindings_tset,
+               compute_tset);
 }
 
 static errno_t CLIfunction_tsete(void)
 {
     return safe_fps_generic_CLIfunction(
-        &FPS_app_info_tsete,
-        farg_tsete, &CLIcmddata_tsete,
-        bindings_tsete,
-        nb_bindings_tsete,
-        compute_tsete);
+               &FPS_app_info_tsete,
+               farg_tsete, &CLIcmddata_tsete,
+               bindings_tsete,
+               nb_bindings_tsete,
+               compute_tsete);
 }
 
 static errno_t CLIfunction_cset(void)
 {
     return safe_fps_generic_CLIfunction(
-        &FPS_app_info_cset,
-        farg_tset, &CLIcmddata_cset,
-        bindings_tset, nb_bindings_tset,
-        compute_cset);
+               &FPS_app_info_cset,
+               farg_tset, &CLIcmddata_cset,
+               bindings_tset, nb_bindings_tset,
+               compute_cset);
 }
 
 static errno_t CLIfunction(void)
 {
     return safe_fps_generic_CLIfunction(
-        &FPS_app_info, farg, &CLIcmddata,
-        my_bindings, nb_bindings,
-        compute_function);
+               &FPS_app_info, farg, &CLIcmddata,
+               my_bindings, nb_bindings,
+               compute_function);
 }
 
 errno_t
@@ -326,35 +344,35 @@ CLIADDCMD_COREMOD_tools__mvprocCPUset()
 
     {
         int cmdi = RegisterCLIcmd(
-            CLIcmddata_rtp,
-            CLIfunction_rtp);
+                       CLIcmddata_rtp,
+                       CLIfunction_rtp);
         CLIcmddata_rtp.cmdsettings =
             &data.cmd[cmdi].cmdsettings;
     }
     {
         int cmdi = RegisterCLIcmd(
-            CLIcmddata_tset,
-            CLIfunction_tset);
+                       CLIcmddata_tset,
+                       CLIfunction_tset);
         CLIcmddata_tset.cmdsettings =
             &data.cmd[cmdi].cmdsettings;
     }
     {
         int cmdi = RegisterCLIcmd(
-            CLIcmddata_tsete,
-            CLIfunction_tsete);
+                       CLIcmddata_tsete,
+                       CLIfunction_tsete);
         CLIcmddata_tsete.cmdsettings =
             &data.cmd[cmdi].cmdsettings;
     }
     {
         int cmdi = RegisterCLIcmd(
-            CLIcmddata_cset,
-            CLIfunction_cset);
+                       CLIcmddata_cset,
+                       CLIfunction_cset);
         CLIcmddata_cset.cmdsettings =
             &data.cmd[cmdi].cmdsettings;
     }
     {
         int cmdi = RegisterCLIcmd(
-            CLIcmddata, CLIfunction);
+                       CLIcmddata, CLIfunction);
         CLIcmddata.cmdsettings =
             &data.cmd[cmdi].cmdsettings;
     }

--- a/src/coremods/COREMOD_tools/mvprocCPUset.c
+++ b/src/coremods/COREMOD_tools/mvprocCPUset.c
@@ -406,7 +406,9 @@ int COREMOD_TOOLS_mvProcTset(const char *tsetspec)
     return COREMOD_TOOLS_mvProcTsetExt(getpid(), tsetspec);
 }
 
-int COREMOD_TOOLS_mvProcTsetExt(const int pid, const char *tsetspec)
+int COREMOD_TOOLS_mvProcTsetExt(
+    const int pid,
+    const char *tsetspec)
 {
     char command[200];
 

--- a/src/coremods/COREMOD_tools/stringutils.c
+++ b/src/coremods/COREMOD_tools/stringutils.c
@@ -9,11 +9,14 @@
 
 #include <string.h>
 
-int replace_char(char *content, char cin, char cout)
+int replace_char(
+    char *content,
+    char cin,
+    char cout)
 {
     unsigned long i;
 
-    for(i = 0; i < strlen(content); i++)
+    for(unsigned i = 0; i < strlen(content); i++)
         if(content[i] == cin)
         {
             content[i] = cout;

--- a/src/engine/libfps/fps_ID.c
+++ b/src/engine/libfps/fps_ID.c
@@ -51,7 +51,7 @@ long fps_ID(const char *name)
 /* next available ID number */
 long next_avail_fps_ID()
 {
-    long i;
+
     long ID = -1;
 
     if(fpsarray == NULL)
@@ -59,7 +59,7 @@ long next_avail_fps_ID()
         return -1;
     }
 
-    for(i = 0; i < NB_FPS_MAX; i++)
+    for(long i = 0; i < NB_FPS_MAX; i++)
     {
         if(fpsarray[i].SMfd < 0)
         {

--- a/src/engine/libfps/fps_PrintParameterInfo.c
+++ b/src/engine/libfps/fps_PrintParameterInfo.c
@@ -26,8 +26,8 @@ functionparameter_PrintParameterInfo(
     printf("------------- FUNCTION PARAMETER STRUCTURE\n");
     printf("FPS name       : %s\n", fpsentry->md->name);
     printf("   %s ", fpsentry->md->pname);
-    int i;
-    for(i = 0; i < fpsentry->md->NBnameindex; i++)
+
+    for (int i = 0; i < fpsentry->md->NBnameindex; i++)
     {
         printf(" [%s]", fpsentry->md->nameindexW[i]);
     }
@@ -39,13 +39,13 @@ functionparameter_PrintParameterInfo(
     }
     else
     {
-        int msgi;
+
 
         printf("%s [%ld] %d ERROR(s)\n",
                fpsentry->md->name,
                fpsentry->md->msgcnt,
                fpsentry->md->conferrcnt);
-        for(msgi = 0; msgi < fpsentry->md->msgcnt; msgi++)
+        for(int msgi = 0; msgi < fpsentry->md->msgcnt; msgi++)
         {
             printf("%s [%3d] %s\n",
                    fpsentry->md->name,

--- a/src/engine/libfps/fps_PrintParameterInfo.c
+++ b/src/engine/libfps/fps_PrintParameterInfo.c
@@ -27,7 +27,7 @@ functionparameter_PrintParameterInfo(
     printf("FPS name       : %s\n", fpsentry->md->name);
     printf("   %s ", fpsentry->md->pname);
 
-    for (int i = 0; i < fpsentry->md->NBnameindex; i++)
+    for(int i = 0; i < fpsentry->md->NBnameindex; i++)
     {
         printf(" [%s]", fpsentry->md->nameindexW[i]);
     }

--- a/src/engine/libfps/fps_connectExternalFPS.c
+++ b/src/engine/libfps/fps_connectExternalFPS.c
@@ -25,8 +25,8 @@ int functionparameter_ConnectExternalFPS(
 
     fps->parray[pindex].info.fps.FPSNBparamActive = 0;
     fps->parray[pindex].info.fps.FPSNBparamUsed   = 0;
-    int pindexext;
-    for(pindexext = 0; pindexext < fps->parray[pindex].info.fps.FPSNBparamMAX;
+
+    for(int pindexext = 0; pindexext < fps->parray[pindex].info.fps.FPSNBparamMAX;
             pindexext++)
     {
         if(FPSext->parray[pindexext].fpflag & FPFLAG_ACTIVE)

--- a/src/engine/libfps/fps_processinfo.c
+++ b/src/engine/libfps/fps_processinfo.c
@@ -24,7 +24,9 @@
  * Looks up the FPS by name, reads its run PID,
  * and sends the specified signal.
  */
-errno_t functionparameter_FPS_processinfo_signal(const char *fps_name, int signal_val)
+errno_t functionparameter_FPS_processinfo_signal(
+    const char *fps_name,
+    int signal_val)
 {
     char procdname[STRINGMAXLEN_DIR_NAME];
     processinfo_procdirname(procdname);

--- a/src/engine/libfps/fps_scan.c
+++ b/src/engine/libfps/fps_scan.c
@@ -392,7 +392,7 @@ errno_t functionparameter_scan_fps(
                                         int match = 1;
                                         // keywords at all levels need to match
 
-                                        for (int ll = 0; ll < level; ll++)
+                                        for(int ll = 0; ll < level; ll++)
                                         {
                                             if(strcmp(fps[fpsindex]
                                                       .parray[pindex0]
@@ -435,7 +435,7 @@ errno_t functionparameter_scan_fps(
                                         {
                                             int match = 1;
 
-                                            for (
+                                            for(
                                                 int ll = 0; ll < level - 1;
                                                 ll++) // keywords at all levels need to match
                                             {

--- a/src/engine/libfps/fps_scan.c
+++ b/src/engine/libfps/fps_scan.c
@@ -33,7 +33,7 @@ errno_t functionparameter_scan_fps(
     int pindex;
     int kwnindex;
     int NBkwn;
-    int ll;
+
 
 
     // FPS list file
@@ -110,8 +110,8 @@ errno_t functionparameter_scan_fps(
             }
         }
 
-        int fpsi;
-        for(fpsi = 0; fpsi < fpslistcnt; fpsi++)
+
+        for(int fpsi = 0; fpsi < fpslistcnt; fpsi++)
         {
             if(verbose > 0)
             {
@@ -366,8 +366,8 @@ errno_t functionparameter_scan_fps(
                 {
 
 
-                    long pindex0;
-                    for(pindex0 = 0; pindex0 < NBparamMAX; pindex0++)
+
+                    for(long pindex0 = 0; pindex0 < NBparamMAX; pindex0++)
                     {
                         if(fps[fpsindex].parray[pindex0].fpflag &
                                 FPFLAG_ACTIVE) // if entry is active
@@ -392,7 +392,7 @@ errno_t functionparameter_scan_fps(
                                         int match = 1;
                                         // keywords at all levels need to match
 
-                                        for(ll = 0; ll < level; ll++)
+                                        for (int ll = 0; ll < level; ll++)
                                         {
                                             if(strcmp(fps[fpsindex]
                                                       .parray[pindex0]
@@ -435,8 +435,8 @@ errno_t functionparameter_scan_fps(
                                         {
                                             int match = 1;
 
-                                            for(
-                                                ll = 0; ll < level - 1;
+                                            for (
+                                                int ll = 0; ll < level - 1;
                                                 ll++) // keywords at all levels need to match
                                             {
                                                 if(strcmp(fps[fpsindex]
@@ -485,7 +485,7 @@ errno_t functionparameter_scan_fps(
                                     }
                                     keywnode[kwnindex].keywordlevel = level;
 
-                                    for(ll = 0; ll < level; ll++)
+                                    for(int ll = 0; ll < level; ll++)
                                     {
                                         char tmpstring[200];
                                         strncpy(

--- a/src/engine/libfpsseq/fpsseq_script.c
+++ b/src/engine/libfpsseq/fpsseq_script.c
@@ -56,7 +56,9 @@ static void trim_whitespace(char *str)
  * replaces the token with its value. Undefined variables
  * expand to the empty string.
  */
-static void expand_vars(SCRIPT_CTX *ctx, char *line)
+static void expand_vars(
+    SCRIPT_CTX *ctx,
+    char *line)
 {
     char result[MAX_LINE_LEN] = {0};
     char *p = line;
@@ -127,7 +129,10 @@ static void expand_vars(SCRIPT_CTX *ctx, char *line)
  * Return: 0 on success, -1 on error (max depth, open failure,
  *         or script exceeding MAX_SCRIPT_LINES)
  */
-static int load_and_preprocess(SCRIPT_CTX *ctx, const char *filename, int depth)
+static int load_and_preprocess(
+    SCRIPT_CTX *ctx,
+    const char *filename,
+    int depth)
 {
     if(depth > 10)
     {

--- a/src/engine/libprocessinfo/procCTRL/milk-procCTRL-scan.c
+++ b/src/engine/libprocessinfo/procCTRL/milk-procCTRL-scan.c
@@ -141,7 +141,9 @@ void *create_scan_shm(const char *name, size_t size, int *fd)
  * Scans all processinfo SHM files and updates
  * the scanner shared memory with current data.
  */
-void rebuild_process_list(const char *procdname, PROCSCAN_SHM *scan_shm)
+void rebuild_process_list(
+    const char *procdname,
+    PROCSCAN_SHM *scan_shm)
 {
     printf("Rebuilding process list from %s...\n", procdname);
     for(long i = 0; i < PROCESSINFOLISTSIZE; i++)
@@ -228,7 +230,9 @@ void rebuild_process_list(const char *procdname, PROCSCAN_SHM *scan_shm)
     }
 }
 
-int main(int argc, char *argv[])
+int main(
+    int argc,
+    char *argv[])
 {
     /* One-line help — before daemon check and SHM init */
     for(int i = 1; i < argc; i++)

--- a/src/engine/libprocessinfo/procCTRL/milk-procCTRL.c
+++ b/src/engine/libprocessinfo/procCTRL/milk-procCTRL.c
@@ -22,7 +22,9 @@ errno_t processinfo_CTRLscreen();
 /**
  * @brief Print help message for milk-procCTRL.
  */
-static void print_help(const char *progname, int mh_color)
+static void print_help(
+    const char *progname,
+    int mh_color)
 {
     milk_help_banner(progname, "interactive TUI for monitoring and controlling milk processes",
                      mh_color);

--- a/src/engine/libprocessinfo/procCTRL/procCTRL_TUI_input.c
+++ b/src/engine/libprocessinfo/procCTRL/procCTRL_TUI_input.c
@@ -7,7 +7,10 @@
  * Dispatches key presses to navigation, mode
  * switching, or process control actions.
  */
-void procctrl_handle_keyboard_event(procctrl_context_t *ctx, int ch, int NBactive)
+void procctrl_handle_keyboard_event(
+    procctrl_context_t *ctx,
+    int ch,
+    int NBactive)
 {
     ctx->last_ch = ch;
     if(ctx->flog)

--- a/src/engine/libprocessinfo/procCTRL/procCTRL_TUI_render.c
+++ b/src/engine/libprocessinfo/procCTRL/procCTRL_TUI_render.c
@@ -340,7 +340,10 @@ static void procctrl_render_help(void)
  *
  * Shows PID, name, loop state, and control actions.
  */
-static void procctrl_render_row_ctrl(procctrl_context_t *ctx, int m, int pindex)
+static void procctrl_render_row_ctrl(
+    procctrl_context_t *ctx,
+    int m,
+    int pindex)
 {
     // 4: tstart
     if(ctx->procinfoproc->col_visible[m][4])
@@ -453,7 +456,10 @@ static void procctrl_render_row_ctrl(procctrl_context_t *ctx, int m, int pindex)
  *
  * Shows memory, CPU affinity, and thread count.
  */
-static void procctrl_render_row_resources(procctrl_context_t *ctx, int m, int pindex)
+static void procctrl_render_row_resources(
+    procctrl_context_t *ctx,
+    int m,
+    int pindex)
 {
     // 4: pname
     if(ctx->procinfoproc->col_visible[m][4])
@@ -528,7 +534,10 @@ static void procctrl_render_row_resources(procctrl_context_t *ctx, int m, int pi
  * Shows trigger stream, semaphore index, and
  * timeout settings.
  */
-static void procctrl_render_row_trigger(procctrl_context_t *ctx, int m, int pindex)
+static void procctrl_render_row_trigger(
+    procctrl_context_t *ctx,
+    int m,
+    int pindex)
 {
     // 4: pname
     if(ctx->procinfoproc->col_visible[m][4])
@@ -616,7 +625,10 @@ static void procctrl_render_row_trigger(procctrl_context_t *ctx, int m, int pind
  *
  * Shows loop rate, latency, and jitter metrics.
  */
-static void procctrl_render_row_timing(procctrl_context_t *ctx, int m, int pindex)
+static void procctrl_render_row_timing(
+    procctrl_context_t *ctx,
+    int m,
+    int pindex)
 {
     // 4: pname
     if(ctx->procinfoproc->col_visible[m][4])
@@ -697,7 +709,10 @@ static void procctrl_render_row_timing(procctrl_context_t *ctx, int m, int pinde
  * Shows executable path, start time, and
  * status message.
  */
-static void procctrl_render_row_procinfo(procctrl_context_t *ctx, int m, int pindex)
+static void procctrl_render_row_procinfo(
+    procctrl_context_t *ctx,
+    int m,
+    int pindex)
 {
     // 4: pname
     if(ctx->procinfoproc->col_visible[m][4])
@@ -787,7 +802,9 @@ static void procctrl_render_row_procinfo(procctrl_context_t *ctx, int m, int pin
  * Iterates visible processes and dispatches to
  * the mode-specific row renderer.
  */
-static void procctrl_render_process_list(procctrl_context_t *ctx, int NBactive)
+static void procctrl_render_process_list(
+    procctrl_context_t *ctx,
+    int NBactive)
 {
     int dispindexMax = wrow - 6;
 
@@ -1019,7 +1036,9 @@ static void procctrl_render_process_list(procctrl_context_t *ctx, int NBactive)
  * Composes header, tabs, column headers, process
  * list, and status bar into a single screen update.
  */
-void procctrl_render_frame(procctrl_context_t *ctx, int NBactive)
+void procctrl_render_frame(
+    procctrl_context_t *ctx,
+    int NBactive)
 {
     if(ctx->freeze == 0)
     {

--- a/src/engine/libprocessinfo/procCTRL/procCTRL_TUI_sort.c
+++ b/src/engine/libprocessinfo/procCTRL/procCTRL_TUI_sort.c
@@ -25,7 +25,9 @@ PROCESSINFOLIST *sort_ctx_pinfolist = NULL;
  *
  * Sort key depends on the current column selection.
  */
-int proc_comp(const void *a, const void *b)
+int proc_comp(
+    const void *a,
+    const void *b)
 {
     int idx1 = *(const int *)a;
     int idx2 = *(const int *)b;

--- a/src/engine/libprocessinfo/quicksort.c
+++ b/src/engine/libprocessinfo/quicksort.c
@@ -35,11 +35,11 @@ int bubble_sort(
     unsigned long count
 )
 {
-    unsigned long a, b;
+    unsigned long a;
     double        t;
 
-    for(a = 1; a < count; a++)
-        for(b = count - 1; b >= a; b--)
+    for(unsigned a = 1; a < count; a++)
+        for(unsigned b = count - 1; b >= a; b--)
             if(array[b - 1] > array[b])
             {
                 t            = array[b - 1];


### PR DESCRIPTION
Adds coding standards rules for limiting variable scope via `{ }` blocks with comments, and mandating that loop indices be declared within the `for` statement unless used afterward. Refactors the entirety of `src/engine`, `src/coremods`, and `src/cli` to comply with the new loop index scoping rule and to automatically align function parameters across the codebase.

## Changes

### .agents/rules
- Updated `code-style-guide.md` with new rules requiring scoping blocks with explanatory comments for long-lived variables, and mandating in-loop index declarations.

### src/engine, src/coremods & src/cli
- Massively refactored C loops across all components to localize loop indices to the `for` statement scope.
- Declared loop indices (e.g., `i`, `j`, `ii`, `k`) within `for (int i = 0; ...)` definitions.
- Elevated variables explicitly needed after loops to function scope with descriptive comments.
- Formatted function definitions and prototypes so that each parameter is on its own line and variable names are column-aligned.
- Resolved resulting compilation errors by correctly localizing cascading variables in deeply nested loops, passing full `make -j$(nproc)` compilation.

## Verification

- [x] Build passes (`/compile-test`) completely with zero compilation errors in the entire tree.

## Prompt Summary

The user requested additions to the coding standards to enforce code blocks (`{ }`) for reducing variable scope and requiring loop indices to be declared within the `for` statement. After adding the rules, a codebase-wide refactoring was performed on `src/engine` and `src/coremods` and `src/cli` to ensure full compliance with the new scoping constraints, resolving all subsequent build failures. The user also requested to run a python script to automatically align all function parameters.

## Authorship

- **Model**: Gemini 3.1 Pro
- **Reviewed and signed off by**: oguyon
