### PR TITLE
fix: ctrl connections mouse alignment and FPS parameter UI enhancements

### DIFF
--- a/src/cli/overview/overview_ctrl.c
+++ b/src/cli/overview/overview_ctrl.c
@@ -753,17 +753,17 @@ void ov_ctrl_inspect_item(ov_focus_t panel, const void *item)
     if (panel == OV_FOCUS_STREAMS)
     {
         const OV_STREAM *s = (const OV_STREAM *) item;
-        snprintf(cmd, sizeof(cmd), "milk-stream-info %s | less -R", s->name);
+        snprintf(cmd, sizeof(cmd), "milk-stream-info %s", s->name);
     }
     else if (panel == OV_FOCUS_PROCS)
     {
         const OV_PROC *p = (const OV_PROC *) item;
-        snprintf(cmd, sizeof(cmd), "milk-procinfo-info %s | less -R", p->name);
+        snprintf(cmd, sizeof(cmd), "milk-procinfo-info %s", p->name);
     }
     else if (panel == OV_FOCUS_FPS)
     {
         const OV_FPS *f = (const OV_FPS *) item;
-        snprintf(cmd, sizeof(cmd), "milk-fps-info %s | less -R", f->name);
+        snprintf(cmd, sizeof(cmd), "milk-fps-info %s", f->name);
     }
     else
     {
@@ -775,9 +775,21 @@ void ov_ctrl_inspect_item(ov_focus_t panel, const void *item)
     int rc_clear = system("clear");
     (void) rc_clear;
 
-    /* Spawn interactive diagnostic tool */
+    /* Show the diagnostic output */
     int rc_cmd = system(cmd);
     (void) rc_cmd;
+
+    /* Prompt the user to return */
+    printf("\n\033[1;36m"
+           "--- Press ENTER to return to dashboard ---"
+           "\033[0m\n");
+    fflush(stdout);
+
+    /* Wait for ENTER (or any key) */
+    {
+        char buf[4];
+        (void) read(STDIN_FILENO, buf, sizeof(buf));
+    }
 
     /* Resume TUI */
     ov_raw_mode_enter();

--- a/src/cli/overview/overview_data.h
+++ b/src/cli/overview/overview_data.h
@@ -218,6 +218,11 @@ typedef struct
     int      nb_disp_params;
     char     disp_param_name[OV_FPS_MAX_DISP_PARAMS][FUNCTION_PARAMETER_STRMAXLEN];
     char     disp_param_value[OV_FPS_MAX_DISP_PARAMS][FUNCTION_PARAMETER_STRMAXLEN];
+    char     disp_param_descr[OV_FPS_MAX_DISP_PARAMS][FUNCTION_PARAMETER_DESCR_STRMAXLEN];
+    char     disp_param_min[OV_FPS_MAX_DISP_PARAMS][FUNCTION_PARAMETER_STRMAXLEN];
+    char     disp_param_max[OV_FPS_MAX_DISP_PARAMS][FUNCTION_PARAMETER_STRMAXLEN];
+    uint8_t  disp_param_has_min[OV_FPS_MAX_DISP_PARAMS];
+    uint8_t  disp_param_has_max[OV_FPS_MAX_DISP_PARAMS];
     uint32_t disp_param_type[OV_FPS_MAX_DISP_PARAMS];
     uint64_t disp_param_flags[OV_FPS_MAX_DISP_PARAMS];
 

--- a/src/cli/overview/overview_data_scan.c
+++ b/src/cli/overview/overview_data_scan.c
@@ -480,6 +480,12 @@ static void fill_fps_from_struct(OV_FPS *f, ov_fps_cache_t *ce)
         case FPTYPE_PID:
             snprintf(valstr, sizeof(valstr), "%d", (int) fp->val.pid[0]);
             break;
+        case FPTYPE_TIMESPEC:
+        {
+            double secs = fp->val.ts[0].tv_sec + (fp->val.ts[0].tv_nsec / 1e9);
+            snprintf(valstr, sizeof(valstr), "%g s", secs);
+            break;
+        }
         case FPTYPE_ONOFF:
             snprintf(valstr, sizeof(valstr), "%s", fp->val.i64[0] ? "ON" : "OFF");
             break;
@@ -498,6 +504,88 @@ static void fill_fps_from_struct(OV_FPS *f, ov_fps_cache_t *ce)
         strncpy(f->disp_param_value[dp], valstr, FUNCTION_PARAMETER_STRMAXLEN - 1);
         f->disp_param_type[dp]  = fp->type;
         f->disp_param_flags[dp] = fp->fpflag;
+
+        /* Description */
+        strncpy(f->disp_param_descr[dp], fp->description, FUNCTION_PARAMETER_DESCR_STRMAXLEN - 1);
+        f->disp_param_descr[dp][FUNCTION_PARAMETER_DESCR_STRMAXLEN - 1] = '\0';
+
+        /* Min & Max limits */
+        f->disp_param_has_min[dp] = (fp->fpflag & FPFLAG_MINLIMIT) != 0;
+        f->disp_param_has_max[dp] = (fp->fpflag & FPFLAG_MAXLIMIT) != 0;
+
+        if (f->disp_param_has_min[dp])
+        {
+            char minstr[FUNCTION_PARAMETER_STRMAXLEN] = { 0 };
+            switch (fp->type)
+            {
+            case FPTYPE_INT64:
+                snprintf(minstr, sizeof(minstr), "%" PRIi64, fp->val.i64[1]);
+                break;
+            case FPTYPE_INT32:
+                snprintf(minstr, sizeof(minstr), "%" PRIi32, fp->val.i32[1]);
+                break;
+            case FPTYPE_UINT64:
+                snprintf(minstr, sizeof(minstr), "%" PRIu64, fp->val.ui64[1]);
+                break;
+            case FPTYPE_UINT32:
+                snprintf(minstr, sizeof(minstr), "%" PRIu32, fp->val.ui32[1]);
+                break;
+            case FPTYPE_FLOAT64:
+                snprintf(minstr, sizeof(minstr), "%g", fp->val.f64[1]);
+                break;
+            case FPTYPE_FLOAT32:
+                snprintf(minstr, sizeof(minstr), "%g", (double) fp->val.f32[1]);
+                break;
+            case FPTYPE_TIMESPEC:
+            {
+                double secs = fp->val.ts[1].tv_sec + (fp->val.ts[1].tv_nsec / 1e9);
+                snprintf(minstr, sizeof(minstr), "%g s", secs);
+                break;
+            }
+            default:
+                f->disp_param_has_min[dp] = 0;
+                break;
+            }
+            strncpy(f->disp_param_min[dp], minstr, FUNCTION_PARAMETER_STRMAXLEN - 1);
+            f->disp_param_min[dp][FUNCTION_PARAMETER_STRMAXLEN - 1] = '\0';
+        }
+
+        if (f->disp_param_has_max[dp])
+        {
+            char maxstr[FUNCTION_PARAMETER_STRMAXLEN] = { 0 };
+            switch (fp->type)
+            {
+            case FPTYPE_INT64:
+                snprintf(maxstr, sizeof(maxstr), "%" PRIi64, fp->val.i64[2]);
+                break;
+            case FPTYPE_INT32:
+                snprintf(maxstr, sizeof(maxstr), "%" PRIi32, fp->val.i32[2]);
+                break;
+            case FPTYPE_UINT64:
+                snprintf(maxstr, sizeof(maxstr), "%" PRIu64, fp->val.ui64[2]);
+                break;
+            case FPTYPE_UINT32:
+                snprintf(maxstr, sizeof(maxstr), "%" PRIu32, fp->val.ui32[2]);
+                break;
+            case FPTYPE_FLOAT64:
+                snprintf(maxstr, sizeof(maxstr), "%g", fp->val.f64[2]);
+                break;
+            case FPTYPE_FLOAT32:
+                snprintf(maxstr, sizeof(maxstr), "%g", (double) fp->val.f32[2]);
+                break;
+            case FPTYPE_TIMESPEC:
+            {
+                double secs = fp->val.ts[2].tv_sec + (fp->val.ts[2].tv_nsec / 1e9);
+                snprintf(maxstr, sizeof(maxstr), "%g s", secs);
+                break;
+            }
+            default:
+                f->disp_param_has_max[dp] = 0;
+                break;
+            }
+            strncpy(f->disp_param_max[dp], maxstr, FUNCTION_PARAMETER_STRMAXLEN - 1);
+            f->disp_param_max[dp][FUNCTION_PARAMETER_STRMAXLEN - 1] = '\0';
+        }
     }
     f->nb_disp_params = ce->dparam_nb;
 

--- a/src/cli/overview/overview_data_sort.c
+++ b/src/cli/overview/overview_data_sort.c
@@ -8,8 +8,11 @@
  *
  * Streams: 0=NAME 1=TYP 2=SIZE 3=Hz
  *          4=INODE 5=COUNT
- * Procs:   0=NAME 1=PID 2=STAT 3=Hz
- * FPS:     0=NAME 1=C(alive)
+ * Procs:   0=NAME 1=PID 2=STAT 3=Hz 4=MEM
+ *          5=ANCESTRY 6=PRIO 7=UPTIME
+ *          8=CPU% 9=LOOPCNT 10=DUTY
+ * FPS:     0=NAME 1=CPID 2=MEM 3=ANCESTRY
+ *          4=RPID 5=TMX 6=STR
  * ========================================================= */
 
 /**
@@ -323,8 +326,89 @@ static int sort_proc_by_ancestry(const void *a, const void *b)
     return sort_proc_by_name(a, b);
 }
 
+static int sort_proc_by_prio(const void *a, const void *b)
+{
+    int pa = ((const OV_PROC *) a)->rt_priority;
+    int pb = ((const OV_PROC *) b)->rt_priority;
+    if (pa < pb)
+    {
+        return -ov_sort_dir_mul;
+    }
+    if (pa > pb)
+    {
+        return ov_sort_dir_mul;
+    }
+    return 0;
+}
+
+static int sort_proc_by_uptime(const void *a, const void *b)
+{
+    int64_t ua = ((const OV_PROC *) a)->start_time_sec;
+    int64_t ub = ((const OV_PROC *) b)->start_time_sec;
+    if (ua < ub)
+    {
+        return -ov_sort_dir_mul;
+    }
+    if (ua > ub)
+    {
+        return ov_sort_dir_mul;
+    }
+    return 0;
+}
+
+static int sort_proc_by_cpu(const void *a, const void *b)
+{
+    float ca = ((const OV_PROC *) a)->cpu_used;
+    float cb = ((const OV_PROC *) b)->cpu_used;
+    if (ca < cb)
+    {
+        return -ov_sort_dir_mul;
+    }
+    if (ca > cb)
+    {
+        return ov_sort_dir_mul;
+    }
+    return 0;
+}
+
+static int sort_proc_by_loopcnt(const void *a, const void *b)
+{
+    int64_t la = ((const OV_PROC *) a)->loopcnt;
+    int64_t lb = ((const OV_PROC *) b)->loopcnt;
+    if (la < lb)
+    {
+        return -ov_sort_dir_mul;
+    }
+    if (la > lb)
+    {
+        return ov_sort_dir_mul;
+    }
+    return 0;
+}
+
+static int sort_proc_by_duty(const void *a, const void *b)
+{
+    const OV_PROC *pa = (const OV_PROC *) a;
+    const OV_PROC *pb = (const OV_PROC *) b;
+    double         da = (pa->dtmedian_iter_ns > 0)
+                            ? (double) pa->dtmedian_exec_ns / (double) pa->dtmedian_iter_ns
+                            : 0.0;
+    double         db = (pb->dtmedian_iter_ns > 0)
+                            ? (double) pb->dtmedian_exec_ns / (double) pb->dtmedian_iter_ns
+                            : 0.0;
+    if (da < db)
+    {
+        return -ov_sort_dir_mul;
+    }
+    if (da > db)
+    {
+        return ov_sort_dir_mul;
+    }
+    return 0;
+}
+
 /** Number of sortable proc columns. */
-#define OV_PROC_SORT_NCOL 5
+#define OV_PROC_SORT_NCOL 10
 
 void ov_sort_procs(OV_MODEL *model, int key, int dir)
 {
@@ -350,6 +434,21 @@ void ov_sort_procs(OV_MODEL *model, int key, int dir)
         break;
     case 5:
         cmp = sort_proc_by_ancestry;
+        break;
+    case 6:
+        cmp = sort_proc_by_prio;
+        break;
+    case 7:
+        cmp = sort_proc_by_uptime;
+        break;
+    case 8:
+        cmp = sort_proc_by_cpu;
+        break;
+    case 9:
+        cmp = sort_proc_by_loopcnt;
+        break;
+    case 10:
+        cmp = sort_proc_by_duty;
         break;
     default:
         cmp = sort_proc_by_name;
@@ -436,8 +535,38 @@ static int sort_fps_by_ancestry(const void *a, const void *b)
     return sort_fps_by_name(a, b);
 }
 
+static int sort_fps_by_tmux(const void *a, const void *b)
+{
+    int ta = ((const OV_FPS *) a)->tmux_flags;
+    int tb = ((const OV_FPS *) b)->tmux_flags;
+    if (ta < tb)
+    {
+        return -ov_sort_dir_mul;
+    }
+    if (ta > tb)
+    {
+        return ov_sort_dir_mul;
+    }
+    return 0;
+}
+
+static int sort_fps_by_nstreams(const void *a, const void *b)
+{
+    int sa = ((const OV_FPS *) a)->nb_stream_params;
+    int sb = ((const OV_FPS *) b)->nb_stream_params;
+    if (sa < sb)
+    {
+        return -ov_sort_dir_mul;
+    }
+    if (sa > sb)
+    {
+        return ov_sort_dir_mul;
+    }
+    return 0;
+}
+
 /** Number of sortable FPS columns. */
-#define OV_FPS_SORT_NCOL 4
+#define OV_FPS_SORT_NCOL 6
 
 void ov_sort_fps(OV_MODEL *model, int key, int dir)
 {
@@ -460,6 +589,12 @@ void ov_sort_fps(OV_MODEL *model, int key, int dir)
         break;
     case 4:
         cmp = sort_fps_by_rpid;
+        break;
+    case 5:
+        cmp = sort_fps_by_tmux;
+        break;
+    case 6:
+        cmp = sort_fps_by_nstreams;
         break;
     default:
         cmp = sort_fps_by_name;

--- a/src/cli/overview/overview_input.c
+++ b/src/cli/overview/overview_input.c
@@ -13,6 +13,17 @@
 #include "overview_ctrl.h"
 #include "overview_fps_edit.h"
 #include "stream_graph.h"
+#include "overview_data_internal.h"
+
+/* libfps headers after overview headers to
+ * avoid macro redefinition warnings */
+#undef STRINGMAXLEN_DIRNAME
+#undef STRINGMAXLEN_FULLFILENAME
+#undef STRINGMAXLEN_COMMAND
+#undef PRINT_ERROR
+#include "fps_types.h"
+#include "fps_WriteParameterToDisk.h"
+#include "fps_save2disk.h"
 
 static int get_graph_start_node(const OV_LAYOUT *lay, const OV_MODEL *m)
 {
@@ -242,11 +253,15 @@ static int ov_input__handle_filter_mode(int key, OV_LAYOUT *lay)
  * enable ctrl_mode and log the action.
  */
 /* Forward declarations for helpers defined below */
-static const OV_PROC *ov_input_get_sel_proc(const OV_LAYOUT *lay, const OV_MODEL *m);
+static const OV_STREAM *ov_input_get_sel_stream(const OV_LAYOUT *lay, const OV_MODEL *m);
+static const OV_PROC   *ov_input_get_sel_proc(const OV_LAYOUT *lay, const OV_MODEL *m);
 /**
  * @brief Get the currently selected FPS entry.
  */
 static const OV_FPS *ov_input_get_sel_fps(const OV_LAYOUT *lay, const OV_MODEL *m);
+
+static void ov_input_save_dir_history(OV_LAYOUT *lay, const char *fps_name, const char *path);
+static void ov_input_load_dir_history(OV_LAYOUT *lay, const char *fps_name, const char *path);
 
 /**
  * @brief Count visible items after filtering.
@@ -361,7 +376,8 @@ static void ov_input__streams_header_click(OV_LAYOUT *lay, int mc)
     }
 }
 
-static const char *proc_col_names[] = { "NAME", "PID", "STAT", "Hz", "MEM", "ANCESTRY" };
+static const char *proc_col_names[] = { "NAME", "PID",    "STAT", "Hz",      "MEM", "ANCESTRY",
+                                        "PRIO", "UPTIME", "CPU%", "LOOPCNT", "DUTY" };
 
 static void ov_input__procs_header_click(OV_LAYOUT *lay, int mc)
 {
@@ -373,27 +389,47 @@ static void ov_input__procs_header_click(OV_LAYOUT *lay, int mc)
     int col_idx = -1;
     if (c < 4)
     {
-        col_idx = 5;
+        col_idx = 5; /* ANCESTRY */
     }
     else if (c < 19)
     {
-        col_idx = 0;
+        col_idx = 0; /* NAME */
     }
     else if (c < 27)
     {
-        col_idx = 1;
+        col_idx = 1; /* PID */
     }
-    else if (c < 33)
+    else if (c < 32)
     {
-        col_idx = 2;
+        col_idx = 6; /* PRIO */
     }
-    else if (c < 40)
+    else if (c < 37)
     {
-        col_idx = 3;
+        col_idx = 2; /* STAT */
     }
-    else if (c >= 88 && c < 94)
+    else if (c < 44)
     {
-        col_idx = 4;
+        col_idx = 3; /* Hz */
+    }
+    else if (c < 51)
+    {
+        col_idx = 7; /* UPTIME */
+    }
+    else if (c >= 73 && c < 79)
+    {
+        col_idx = 10; /* DUTY */
+    }
+    else if (c >= 79 && c < 86)
+    {
+        col_idx = 8; /* CPU% */
+    }
+    else if (c >= 86 && c < 96)
+    {
+        col_idx = 9; /* LOOPCNT */
+    }
+    else if (c >= 96 && c < 102)
+    {
+        col_idx = 4; /* MEM */
     }
 
     if (col_idx >= 0)
@@ -414,7 +450,7 @@ static void ov_input__procs_header_click(OV_LAYOUT *lay, int mc)
     }
 }
 
-static const char *fps_col_names[] = { "NAME", "CPID", "MEM", "ANCESTRY", "RPID" };
+static const char *fps_col_names[] = { "NAME", "CPID", "MEM", "ANCESTRY", "RPID", "TMX", "STR" };
 
 static void ov_input__fps_header_click(OV_LAYOUT *lay, int mc)
 {
@@ -426,23 +462,31 @@ static void ov_input__fps_header_click(OV_LAYOUT *lay, int mc)
     int col_idx = -1;
     if (c < 4)
     {
-        col_idx = 3;
+        col_idx = 3; /* ANCESTRY */
     }
     else if (c <= 23)
     {
-        col_idx = 0;
+        col_idx = 0; /* NAME */
     }
-    else if (c >= 26 && c <= 34)
+    else if (c >= 24 && c <= 27)
     {
-        col_idx = 1;
+        col_idx = 5; /* TMX */
     }
-    else if (c >= 34 && c <= 42)
+    else if (c >= 28 && c <= 35)
     {
-        col_idx = 4;
+        col_idx = 1; /* CPID */
     }
-    else if (c >= 46 && c <= 52)
+    else if (c >= 36 && c <= 43)
     {
-        col_idx = 2;
+        col_idx = 4; /* RPID */
+    }
+    else if (c >= 44 && c <= 47)
+    {
+        col_idx = 6; /* STR */
+    }
+    else if (c >= 48 && c <= 53)
+    {
+        col_idx = 2; /* MEM */
     }
 
     if (col_idx >= 0)
@@ -467,10 +511,41 @@ static void ov_input__exec_preview_btn(int btn_id, OV_LAYOUT *lay, const OV_MODE
 {
     OV_CMDLOG *log = &lay->cmdlog;
 
+    /* Inspect works without CONTROL mode */
+    if (btn_id == OV_BTN_INSPECT)
+    {
+        if (lay->focus == OV_FOCUS_STREAMS)
+        {
+            const OV_STREAM *s = ov_input_get_sel_stream(lay, m);
+            if (s)
+            {
+                ov_ctrl_inspect_item(OV_FOCUS_STREAMS, s);
+            }
+        }
+        else if (lay->focus == OV_FOCUS_PROCS)
+        {
+            const OV_PROC *p = ov_input_get_sel_proc(lay, m);
+            if (p)
+            {
+                ov_ctrl_inspect_item(OV_FOCUS_PROCS, p);
+            }
+        }
+        else if (lay->focus == OV_FOCUS_FPS)
+        {
+            const OV_FPS *f = ov_input_get_sel_fps(lay, m);
+            if (f)
+            {
+                ov_ctrl_inspect_item(OV_FOCUS_FPS, f);
+            }
+        }
+        return;
+    }
+
     if (!lay->ctrl_mode)
     {
         ov_cmdlog_push(&lay->cmdlog, OV_CMDLOG_WARN,
-                       "🚫 Action requires CONTROL mode (press c to toggle CTRL mode ON/OFF)");
+                       "\xf0\x9f\x9a\xab Action requires CONTROL mode"
+                       " (press c to toggle CTRL mode ON/OFF)");
         return;
     }
 
@@ -536,6 +611,15 @@ static void ov_input__exec_preview_btn(int btn_id, OV_LAYOUT *lay, const OV_MODE
         if (f)
         {
             ov_ctrl_fps_signal_pid(f, SIGTERM, log);
+        }
+        break;
+    }
+    case OV_BTN_STREAM_DEL:
+    {
+        const OV_STREAM *s = ov_input_get_sel_stream(lay, m);
+        if (s)
+        {
+            ov_ctrl_stream_delete(s, log);
         }
         break;
     }
@@ -652,7 +736,7 @@ void ov_hittest(OV_LAYOUT *lay, const OV_MODEL *m, int mr, int mc)
     else if (lay->view == OV_VIEW_GRAPH && INSIDE(lay->r_graph, mr, mc))
     {
         lay->hover_view = OV_FOCUS_GRAPH;
-        int body_row    = mr - lay->r_graph.row - 1;
+        int body_row    = mr - lay->r_graph.row - 2;
         if (body_row >= 0)
         {
             if (lay->graph_tab_mode == 0)
@@ -725,7 +809,7 @@ void ov_hittest(OV_LAYOUT *lay, const OV_MODEL *m, int mr, int mc)
         else if (INSIDE(lay->r_graph, mr, mc))
         {
             lay->hover_view = OV_FOCUS_GRAPH;
-            int body_row    = mr - lay->r_graph.row - 1;
+            int body_row    = mr - lay->r_graph.row - 2;
             if (body_row >= 0)
             {
                 if (lay->graph_tab_mode == 0)
@@ -835,11 +919,11 @@ void ov_hittest_resolve_globals(OV_LAYOUT *lay, const OV_MODEL *m)
                 {
                     const SG_TREE_NODE *rn       = &rnodes[lay->hover_idx];
                     int                 proc_idx = -1;
-                    if (rn->writer_name[0] != '\0')
+                    if (rn->reader_name[0] != '\0')
                     {
                         for (int i = 0; i < m->nb_procs; i++)
                         {
-                            if (strcmp(m->procs[i].name, rn->writer_name) == 0)
+                            if (strcmp(m->procs[i].name, rn->reader_name) == 0)
                             {
                                 proc_idx = i;
                                 break;
@@ -1178,11 +1262,8 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
                     {
                         if (lay->sel_fps != idx)
                         {
-                            lay->sel_fps           = idx;
-                            lay->sel_name_fps[0]   = '\0';
-                            lay->fps_param_path[0] = '\0';
-                            lay->fps_param_sel     = 0;
-                            lay->fps_param_scroll  = 0;
+                            lay->sel_fps         = idx;
+                            lay->sel_name_fps[0] = '\0';
                         }
                         if (is_dbl)
                         {
@@ -1253,7 +1334,7 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
             }
             else
             {
-                int body_row = mr - lay->r_graph.row - 1;
+                int body_row = mr - lay->r_graph.row - 2;
                 if (body_row >= 0)
                 {
                     if (lay->graph_tab_mode == 0)
@@ -1272,11 +1353,11 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
                                 const SG_TREE_NODE *rn = &rnodes[idx];
 
                                 int proc_idx = -1;
-                                if (rn->writer_name[0] != '\0')
+                                if (rn->reader_name[0] != '\0')
                                 {
                                     for (int i = 0; i < m->nb_procs; i++)
                                     {
-                                        if (strcmp(m->procs[i].name, rn->writer_name) == 0)
+                                        if (strcmp(m->procs[i].name, rn->reader_name) == 0)
                                         {
                                             proc_idx = i;
                                             break;
@@ -1416,7 +1497,7 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
                 }
                 else
                 {
-                    int body_row = mr - lay->r_graph.row - 1;
+                    int body_row = mr - lay->r_graph.row - 2;
                     if (body_row >= 0)
                     {
                         if (lay->graph_tab_mode == 0)
@@ -1435,11 +1516,11 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
                                     const SG_TREE_NODE *rn = &rnodes[idx];
 
                                     int proc_idx = -1;
-                                    if (rn->writer_name[0] != '\0')
+                                    if (rn->reader_name[0] != '\0')
                                     {
                                         for (int i = 0; i < m->nb_procs; i++)
                                         {
-                                            if (strcmp(m->procs[i].name, rn->writer_name) == 0)
+                                            if (strcmp(m->procs[i].name, rn->reader_name) == 0)
                                             {
                                                 proc_idx = i;
                                                 break;
@@ -2350,10 +2431,10 @@ static int ov_input__handle_sorting(int key, OV_LAYOUT *lay)
             lay->sort_key_stream = (lay->sort_key_stream + 1) % 8;
             break;
         case OV_FOCUS_PROCS:
-            lay->sort_key_proc = (lay->sort_key_proc + 1) % 6;
+            lay->sort_key_proc = (lay->sort_key_proc + 1) % 11;
             break;
         case OV_FOCUS_FPS:
-            lay->sort_key_fps = (lay->sort_key_fps + 1) % 5;
+            lay->sort_key_fps = (lay->sort_key_fps + 1) % 7;
             break;
         default:
             break;
@@ -2370,10 +2451,10 @@ static int ov_input__handle_sorting(int key, OV_LAYOUT *lay)
             lay->sort_key_stream = (lay->sort_key_stream + 7) % 8;
             break;
         case OV_FOCUS_PROCS:
-            lay->sort_key_proc = (lay->sort_key_proc + 5) % 6;
+            lay->sort_key_proc = (lay->sort_key_proc + 10) % 11;
             break;
         case OV_FOCUS_FPS:
-            lay->sort_key_fps = (lay->sort_key_fps + 4) % 5;
+            lay->sort_key_fps = (lay->sort_key_fps + 6) % 7;
             break;
         default:
             break;
@@ -2862,11 +2943,9 @@ static int ov_input__handle_ancestry_nav(int key, OV_LAYOUT *lay, const OV_MODEL
         }
         else if (lay->focus == OV_FOCUS_FPS && tn->type == OV_NODE_FPS)
         {
-            lay->sel_fps          = tn->index;
-            lay->sel_name_fps[0]  = '\0';
-            lay->fps_param_sel    = 0;
-            lay->fps_param_scroll = 0;
-            lay->fps_param_focus  = 0;
+            lay->sel_fps         = tn->index;
+            lay->sel_name_fps[0] = '\0';
+            lay->fps_param_focus = 0;
         }
     }
     return 1;
@@ -2904,9 +2983,7 @@ static int ov_input__handle_navigation(int key, OV_LAYOUT *lay, const OV_MODEL *
             (key == OV_KEY_RIGHT || key == OV_KEY_ENTER || key == '\r' || key == '\n') &&
             has_params)
         {
-            lay->fps_param_focus  = 1;
-            lay->fps_param_sel    = 0;
-            lay->fps_param_scroll = 0;
+            lay->fps_param_focus = 1;
             return 1;
         }
 
@@ -2922,18 +2999,45 @@ static int ov_input__handle_navigation(int key, OV_LAYOUT *lay, const OV_MODEL *
                 }
                 else
                 {
+                    ov_input_save_dir_history(lay, m->fps[fsel].name, lay->fps_param_path);
+
                     /* Ascend directory */
-                    char *last_dot = strrchr(lay->fps_param_path, '.');
+                    char  exited_dir[100] = { 0 };
+                    char *last_dot        = strrchr(lay->fps_param_path, '.');
                     if (last_dot)
                     {
+                        strncpy(exited_dir, last_dot + 1, sizeof(exited_dir) - 1);
                         *last_dot = '\0';
                     }
                     else
                     {
+                        strncpy(exited_dir, lay->fps_param_path, sizeof(exited_dir) - 1);
                         lay->fps_param_path[0] = '\0';
                     }
-                    lay->fps_param_sel    = 0;
-                    lay->fps_param_scroll = 0;
+
+                    ov_input_load_dir_history(lay, m->fps[fsel].name, lay->fps_param_path);
+
+                    int found_sel = -1;
+                    if (has_params)
+                    {
+                        fps_tree_item_t parent_items[1024];
+                        int             n_parent_items = ov_get_fps_tree_items(
+                            &m->fps[fsel], lay->fps_param_path, parent_items, 1024);
+
+                        for (int i = 0; i < n_parent_items; i++)
+                        {
+                            if (parent_items[i].is_dir &&
+                                strcmp(parent_items[i].name, exited_dir) == 0)
+                            {
+                                found_sel = i;
+                                break;
+                            }
+                        }
+                    }
+                    if (found_sel != -1)
+                    {
+                        lay->fps_param_sel = found_sel;
+                    }
                 }
                 return 1;
             }
@@ -2999,6 +3103,8 @@ static int ov_input__handle_navigation(int key, OV_LAYOUT *lay, const OV_MODEL *
                     fps_tree_item_t *item = &items[lay->fps_param_sel];
                     if (item->is_dir)
                     {
+                        ov_input_save_dir_history(lay, m->fps[fsel].name, lay->fps_param_path);
+
                         /* Descend directory */
                         if (lay->fps_param_path[0] == '\0')
                         {
@@ -3011,8 +3117,8 @@ static int ov_input__handle_navigation(int key, OV_LAYOUT *lay, const OV_MODEL *
                             snprintf(tmp, sizeof(tmp), "%s.%s", lay->fps_param_path, item->name);
                             strncpy(lay->fps_param_path, tmp, sizeof(lay->fps_param_path) - 1);
                         }
-                        lay->fps_param_sel    = 0;
-                        lay->fps_param_scroll = 0;
+
+                        ov_input_load_dir_history(lay, m->fps[fsel].name, lay->fps_param_path);
                     }
                     else if (key == OV_KEY_ENTER || key == '\r' || key == '\n')
                     {
@@ -3025,6 +3131,55 @@ static int ov_input__handle_navigation(int key, OV_LAYOUT *lay, const OV_MODEL *
                         else
                         {
                             ov_fps_inline_edit(lay, m->fps[fsel].name, item->param_idx);
+                        }
+                    }
+                }
+                return 1;
+            }
+            if (key == 'o')
+            {
+                if (lay->fps_param_sel >= 0 && lay->fps_param_sel < nitems)
+                {
+                    fps_tree_item_t *item = &items[lay->fps_param_sel];
+                    if (!item->is_dir)
+                    {
+                        int pi = item->param_idx;
+                        if (m->fps[fsel].disp_param_type[pi] == FPTYPE_ONOFF)
+                        {
+                            if (!lay->ctrl_mode)
+                            {
+                                ov_cmdlog_push(&lay->cmdlog, OV_CMDLOG_WARN,
+                                               "Toggle requires CONTROL mode (press c to toggle "
+                                               "CTRL mode ON/OFF)");
+                            }
+                            else
+                            {
+                                FPS *fps = ov_fcache_get_fps(m->fps[fsel].name);
+                                if (fps != NULL && fps->md != NULL)
+                                {
+                                    int pindex = ov_fcache_get_param_index(m->fps[fsel].name, pi);
+                                    if (pindex >= 0)
+                                    {
+                                        FPS_PARAM *fp      = &fps->parray[pindex];
+                                        int        current = (fp->fpflag & FPFLAG_ONOFF) ? 1 : 0;
+                                        int        newval  = current ? 0 : 1;
+                                        functionparameter_SetParamValue_ONOFF(fps, fp->keywordfull,
+                                                                              newval);
+
+                                        fps->md->signal |= FUNCTION_PARAMETER_STRUCT_SIGNAL_UPDATE;
+
+                                        if (fp->fpflag & FPFLAG_SAVEONCHANGE)
+                                        {
+                                            functionparameter_WriteParameterToDisk(
+                                                fps, pindex, "setval", "milk-CTRL_toggle");
+                                            functionparameter_SaveFPS2disk(fps);
+                                        }
+                                        ov_cmdlog_push(&lay->cmdlog, OV_CMDLOG_INFO,
+                                                       "Toggled parameter %s to %s",
+                                                       fp->keywordfull, newval ? "ON" : "OFF");
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -3330,9 +3485,7 @@ static int ov_input__handle_navigation(int key, OV_LAYOUT *lay, const OV_MODEL *
                     /* Reset param tree cursor when FPS selection moves */
                     if (lay->view == OV_VIEW_FPS)
                     {
-                        lay->fps_param_sel    = 0;
-                        lay->fps_param_scroll = 0;
-                        lay->fps_param_focus  = 0;
+                        lay->fps_param_focus = 0;
                     }
                 }
 
@@ -3409,7 +3562,7 @@ static int ov_input__handle_navigation(int key, OV_LAYOUT *lay, const OV_MODEL *
     return 0; /* Not a navigation key */
 }
 
-int ov_handle_key(int key, OV_LAYOUT *lay, const OV_MODEL *m)
+static int ov_handle_key_internal(int key, OV_LAYOUT *lay, const OV_MODEL *m)
 {
     if (key == OV_KEY_NONE)
     {
@@ -3668,4 +3821,204 @@ int ov_handle_key(int key, OV_LAYOUT *lay, const OV_MODEL *m)
         ov_cmdlog_push(&lay->cmdlog, OV_CMDLOG_WARN, "❔ Unmapped key code: %d", key);
     }
     return 0;
+}
+
+static void ov_input_save_dir_history(OV_LAYOUT *lay, const char *fps_name, const char *path)
+{
+    if (fps_name == NULL || fps_name[0] == '\0')
+    {
+        return;
+    }
+
+    int found_idx = -1;
+    for (int i = 0; i < lay->nb_fps_dir_history; i++)
+    {
+        if (strcmp(lay->fps_dir_history[i].fps_name, fps_name) == 0 &&
+            strcmp(lay->fps_dir_history[i].path, path) == 0)
+        {
+            found_idx = i;
+            break;
+        }
+    }
+
+    if (found_idx == -1)
+    {
+        if (lay->nb_fps_dir_history < 1000)
+        {
+            found_idx = lay->nb_fps_dir_history;
+            lay->nb_fps_dir_history++;
+            strncpy(lay->fps_dir_history[found_idx].fps_name, fps_name,
+                    sizeof(lay->fps_dir_history[found_idx].fps_name) - 1);
+            lay->fps_dir_history[found_idx]
+                .fps_name[sizeof(lay->fps_dir_history[found_idx].fps_name) - 1] = '\0';
+            strncpy(lay->fps_dir_history[found_idx].path, path,
+                    sizeof(lay->fps_dir_history[found_idx].path) - 1);
+            lay->fps_dir_history[found_idx].path[sizeof(lay->fps_dir_history[found_idx].path) - 1] =
+                '\0';
+        }
+        else
+        {
+            return;
+        }
+    }
+
+    lay->fps_dir_history[found_idx].sel    = lay->fps_param_sel;
+    lay->fps_dir_history[found_idx].scroll = lay->fps_param_scroll;
+}
+
+static void ov_input_load_dir_history(OV_LAYOUT *lay, const char *fps_name, const char *path)
+{
+    if (fps_name == NULL || fps_name[0] == '\0')
+    {
+        return;
+    }
+
+    int found_idx = -1;
+    for (int i = 0; i < lay->nb_fps_dir_history; i++)
+    {
+        if (strcmp(lay->fps_dir_history[i].fps_name, fps_name) == 0 &&
+            strcmp(lay->fps_dir_history[i].path, path) == 0)
+        {
+            found_idx = i;
+            break;
+        }
+    }
+
+    if (found_idx != -1)
+    {
+        lay->fps_param_sel    = lay->fps_dir_history[found_idx].sel;
+        lay->fps_param_scroll = lay->fps_dir_history[found_idx].scroll;
+    }
+    else
+    {
+        lay->fps_param_sel    = 0;
+        lay->fps_param_scroll = 0;
+    }
+}
+
+static void ov_input_save_fps_history(OV_LAYOUT *lay, const char *fps_name)
+{
+    if (fps_name == NULL || fps_name[0] == '\0')
+    {
+        return;
+    }
+
+    /* 1. Save the directory history for the current path */
+    ov_input_save_dir_history(lay, fps_name, lay->fps_param_path);
+
+    /* 2. Save the last path visited for this FPS */
+    int found_idx = -1;
+    for (int i = 0; i < lay->nb_fps_last_path; i++)
+    {
+        if (strcmp(lay->fps_last_path[i].fps_name, fps_name) == 0)
+        {
+            found_idx = i;
+            break;
+        }
+    }
+
+    if (found_idx == -1)
+    {
+        if (lay->nb_fps_last_path < 200)
+        {
+            found_idx = lay->nb_fps_last_path;
+            lay->nb_fps_last_path++;
+            strncpy(lay->fps_last_path[found_idx].fps_name, fps_name,
+                    sizeof(lay->fps_last_path[found_idx].fps_name) - 1);
+            lay->fps_last_path[found_idx]
+                .fps_name[sizeof(lay->fps_last_path[found_idx].fps_name) - 1] = '\0';
+        }
+        else
+        {
+            return;
+        }
+    }
+
+    strncpy(lay->fps_last_path[found_idx].path, lay->fps_param_path,
+            sizeof(lay->fps_last_path[found_idx].path) - 1);
+    lay->fps_last_path[found_idx].path[sizeof(lay->fps_last_path[found_idx].path) - 1] = '\0';
+}
+
+static void ov_input_load_fps_history(OV_LAYOUT *lay, const char *fps_name)
+{
+    if (fps_name == NULL || fps_name[0] == '\0')
+    {
+        return;
+    }
+
+    /* 1. Load the last path visited for this FPS */
+    int found_idx = -1;
+    for (int i = 0; i < lay->nb_fps_last_path; i++)
+    {
+        if (strcmp(lay->fps_last_path[i].fps_name, fps_name) == 0)
+        {
+            found_idx = i;
+            break;
+        }
+    }
+
+    if (found_idx != -1)
+    {
+        strncpy(lay->fps_param_path, lay->fps_last_path[found_idx].path,
+                sizeof(lay->fps_param_path) - 1);
+        lay->fps_param_path[sizeof(lay->fps_param_path) - 1] = '\0';
+    }
+    else
+    {
+        lay->fps_param_path[0] = '\0';
+    }
+
+    /* 2. Load the directory history for this path */
+    ov_input_load_dir_history(lay, fps_name, lay->fps_param_path);
+}
+
+int ov_handle_key(int key, OV_LAYOUT *lay, const OV_MODEL *m)
+{
+    if (key == OV_KEY_NONE)
+    {
+        return 0;
+    }
+
+    char          old_fps_name[80] = { 0 };
+    const OV_FPS *old_fps          = ov_input_get_sel_fps(lay, m);
+    if (old_fps != NULL)
+    {
+        strncpy(old_fps_name, old_fps->name, sizeof(old_fps_name) - 1);
+    }
+
+    int old_view = lay->view;
+
+    int ret = ov_handle_key_internal(key, lay, m);
+
+    if (lay->view == OV_VIEW_FPS)
+    {
+        char          new_fps_name[80] = { 0 };
+        const OV_FPS *new_fps          = ov_input_get_sel_fps(lay, m);
+        if (new_fps != NULL)
+        {
+            strncpy(new_fps_name, new_fps->name, sizeof(new_fps_name) - 1);
+        }
+
+        if (old_view != OV_VIEW_FPS || strcmp(old_fps_name, new_fps_name) != 0)
+        {
+            if (old_view == OV_VIEW_FPS && old_fps_name[0] != '\0')
+            {
+                ov_input_save_fps_history(lay, old_fps_name);
+            }
+            if (new_fps_name[0] != '\0')
+            {
+                ov_input_load_fps_history(lay, new_fps_name);
+                lay->fps_param_focus = 0;
+            }
+        }
+    }
+    else if (old_view == OV_VIEW_FPS)
+    {
+        if (old_fps_name[0] != '\0')
+        {
+            ov_input_save_fps_history(lay, old_fps_name);
+        }
+    }
+
+    return ret;
 }

--- a/src/cli/overview/overview_layout.c
+++ b/src/cli/overview/overview_layout.c
@@ -85,9 +85,19 @@ void ov_layout_compute(OV_LAYOUT *lay)
     {
         body_top = 2;
         body_h   = H - 2 - log_h;
-        if (body_h < 4)
+        if (lay->view == OV_VIEW_FPS)
         {
-            body_h = 4;
+            if (body_h < 6)
+            {
+                body_h = 6;
+            }
+        }
+        else
+        {
+            if (body_h < 4)
+            {
+                body_h = 4;
+            }
         }
         /* Full-screen for single-view modes */
         lay->r_streams = (OV_RECT) { body_top, 1, body_h, W };
@@ -107,8 +117,8 @@ void ov_layout_compute(OV_LAYOUT *lay)
             {
                 lw = W - 20;
             }
-            lay->r_fps_list   = (OV_RECT) { body_top, 1, body_h, lw };
-            lay->r_fps_params = (OV_RECT) { body_top, lw + 1, body_h, W - lw };
+            lay->r_fps_list   = (OV_RECT) { body_top + 2, 1, body_h - 2, lw };
+            lay->r_fps_params = (OV_RECT) { body_top + 2, lw + 1, body_h - 2, W - lw };
             /* Keep r_fps pointing to list for panel rendering */
             lay->r_fps = lay->r_fps_list;
         }

--- a/src/cli/overview/overview_layout.h
+++ b/src/cli/overview/overview_layout.h
@@ -45,6 +45,8 @@ typedef enum
 #define OV_BTN_FPS_CONF 5   /* toggle conf          */
 #define OV_BTN_FPS_RUN 6    /* toggle run           */
 #define OV_BTN_FPS_KILL 7   /* SIGTERM FPS pids     */
+#define OV_BTN_STREAM_DEL 8 /* delete stream SHM    */
+#define OV_BTN_INSPECT 9    /* inspect sel. item    */
 
 /* ---- Command Log ---- */
 #define OV_CMDLOG_MAX 32 /* ring buffer capacity */
@@ -172,6 +174,22 @@ typedef struct
     char fps_param_path[200]; /* Current tree path, e.g. "conf" or "conf.sub" */
     int  fps_param_sel;       /* selected row in param tree */
     int  fps_param_scroll;    /* scroll offset in param tree */
+    /* FPS parameter tree history */
+    struct
+    {
+        char fps_name[80];
+        char path[200];
+    } fps_last_path[200];
+    int nb_fps_last_path;
+
+    struct
+    {
+        char fps_name[80];
+        char path[200];
+        int  sel;
+        int  scroll;
+    } fps_dir_history[1000];
+    int nb_fps_dir_history;
     /* F5 view split rects */
     OV_RECT r_fps_list;   /* left: FPS list  */
     OV_RECT r_fps_params; /* right: param tree */
@@ -181,7 +199,7 @@ typedef struct
         int col;   /* 1-based start column (0 = unused) */
         int width; /* visible width in columns */
         int id;    /* action ID: OV_BTN_* */
-    } preview_btns[4];
+    } preview_btns[6];
     int nb_preview_btns;
     /* F5 view drag state */
     float fps_split_ratio;

--- a/src/cli/overview/overview_render.c
+++ b/src/cli/overview/overview_render.c
@@ -10,6 +10,7 @@
  */
 
 #include "overview_render_internal.h"
+#include "overview_render_fps_params.h"
 #include <math.h>
 
 
@@ -945,6 +946,7 @@ void ov_render_frame(OV_LAYOUT *lay, const OV_MODEL *m)
             ov_render_procs_panel(lay, m, &rel);
             break;
         case OV_VIEW_FPS:
+            ov_render_fps_param_info(lay, m);
             ov_render_fps_panel(lay, m, &rel);
             if (lay->sel_fps >= 0 && lay->sel_fps < m->nb_fps &&
                 m->fps[lay->sel_fps].nb_disp_params > 0)

--- a/src/cli/overview/overview_render_fps.c
+++ b/src/cli/overview/overview_render_fps.c
@@ -59,9 +59,9 @@ void ov_render_fps_panel(const OV_LAYOUT *lay, const OV_MODEL *m, const OV_RELAT
         char htext[256];
         int  sk = lay->sort_key_fps;
         int  sd = lay->sort_dir_fps;
-        char c_anc[8], c_name[24];
-        char c_c[8], c_r[8], c_mem[10];
-        char c_tmx[8], c_str[8];
+        char c_anc[32], c_name[32];
+        char c_c[32], c_r[32], c_mem[32];
+        char c_tmx[32], c_str[32];
         int  w_anc  = sort_col_label(c_anc, sizeof(c_anc), "A", 3, sk, sd, 3);
         int  w_name = sort_col_label(c_name, sizeof(c_name), "NAME", 0, sk, sd, 18);
         int  w_tmx  = sort_col_label(c_tmx, sizeof(c_tmx), "TMX", 5, sk, sd, 3);

--- a/src/cli/overview/overview_render_fps.c
+++ b/src/cli/overview/overview_render_fps.c
@@ -53,7 +53,7 @@ void ov_render_fps_panel(const OV_LAYOUT *lay, const OV_MODEL *m, const OV_RELAT
 
     ov_buf_pos(hrow, r.col + 1);
     ov_theme_bg(OV_BG_HEADER);
-    ov_buf_printf("    ");
+    ov_buf_printf(" ");
     ov_theme_fg(OV_FG_FPS_HDR);
     {
         char htext[256];
@@ -61,33 +61,36 @@ void ov_render_fps_panel(const OV_LAYOUT *lay, const OV_MODEL *m, const OV_RELAT
         int  sd = lay->sort_dir_fps;
         char c_anc[8], c_name[24];
         char c_c[8], c_r[8], c_mem[10];
+        char c_tmx[8], c_str[8];
         int  w_anc  = sort_col_label(c_anc, sizeof(c_anc), "A", 3, sk, sd, 3);
         int  w_name = sort_col_label(c_name, sizeof(c_name), "NAME", 0, sk, sd, 18);
+        int  w_tmx  = sort_col_label(c_tmx, sizeof(c_tmx), "TMX", 5, sk, sd, 3);
         int  w_c    = sort_col_label(c_c, sizeof(c_c), "CPID", 1, sk, sd, 7);
         int  w_r    = sort_col_label(c_r, sizeof(c_r), "RPID", 4, sk, sd, 7);
+        int  w_str  = sort_col_label(c_str, sizeof(c_str), "STR", 6, sk, sd, 3);
         int  w_mem  = sort_col_label(c_mem, sizeof(c_mem), "MEM", 2, sk, sd, 5);
         int  desc_w = (lay->view == OV_VIEW_FPS) ? 30 : 20;
         if (lay->compact_mode)
         {
-            snprintf(htext, sizeof(htext), "%-*s %-*s %3s %*s %*s %3s %*s", w_anc, c_anc, w_name,
-                     c_name, "TMX", w_c, c_c, w_r, c_r, "STR", w_mem, c_mem);
+            snprintf(htext, sizeof(htext), "%-*s %-*s %*s %*s %*s %*s %*s", w_anc, c_anc, w_name,
+                     c_name, w_tmx, c_tmx, w_c, c_c, w_r, c_r, w_str, c_str, w_mem, c_mem);
         }
         else
         {
             snprintf(htext, sizeof(htext),
-                     "%-*s %-*s %3s %*s %*s %3s %*s"
+                     "%-*s %-*s %*s %*s %*s %*s %*s"
                      " %-*s",
-                     w_anc, c_anc, w_name, c_name, "TMX", w_c, c_c, w_r, c_r, "STR", w_mem, c_mem,
-                     desc_w, "DESCRIPTION");
+                     w_anc, c_anc, w_name, c_name, w_tmx, c_tmx, w_c, c_c, w_r, c_r, w_str, c_str,
+                     w_mem, c_mem, desc_w, "DESCRIPTION");
         }
 
-        int vis_width = r.width - 4;
+        int vis_width = r.width - 1;
         if (vis_width < 0)
         {
             vis_width = 0;
         }
         int printed = ov_render_header_text(htext, hs, vis_width, OV_FG_FPS_HDR);
-        render_pad_spaces(4 + printed, r.width);
+        render_pad_spaces(1 + printed, r.width);
     }
 
     /* Separator between header and data rows */
@@ -180,7 +183,7 @@ void ov_render_fps_panel(const OV_LAYOUT *lay, const OV_MODEL *m, const OV_RELAT
             row_bg = zebra_bg(row_bg, i);
 
             int hs_rem  = hs;
-            int printed = 4;
+            int printed = 1;
             int avail   = r.width - 2;
 
             ov_buf_pos(row, r.col + 1);

--- a/src/cli/overview/overview_render_fps_params.c
+++ b/src/cli/overview/overview_render_fps_params.c
@@ -471,3 +471,149 @@ void ov_render_fps_params_panel(OV_LAYOUT *lay, const OV_MODEL *m)
 
     ov_buf_reset_attr();
 }
+
+/**
+ * ov_render_fps_param_info - draw FPS parameter metadata header on rows 2 and 3.
+ * @lay: layout state
+ * @m:   data model
+ */
+void ov_render_fps_param_info(const OV_LAYOUT *lay, const OV_MODEL *m)
+{
+    /* Clear rows 2 and 3 */
+    ov_buf_pos(2, 1);
+    ov_theme_bg(OV_BG_PANEL);
+    ov_buf_hline(' ', lay->term_cols);
+
+    ov_buf_pos(3, 1);
+    ov_theme_bg(OV_BG_PANEL);
+    ov_buf_hline(' ', lay->term_cols);
+
+    int fsel = lay->sel_fps;
+    if (fsel < 0 || fsel >= m->nb_fps)
+    {
+        return;
+    }
+
+    const OV_FPS *fps = &m->fps[fsel];
+
+    fps_tree_item_t items[1024];
+    int             nitems = ov_get_fps_tree_items(fps, lay->fps_param_path, items, 1024);
+
+    if (lay->fps_param_sel < 0 || lay->fps_param_sel >= nitems)
+    {
+        return;
+    }
+
+    const fps_tree_item_t *item = &items[lay->fps_param_sel];
+    if (item->is_dir)
+    {
+        /* Draw directory info */
+        ov_buf_pos(2, 2);
+        ov_theme_fg(OV_FG_WARN);
+        ov_buf_bold();
+        ov_buf_printf("DIR: ");
+        ov_theme_fg(OV_FG_TEXT);
+        ov_buf_printf("%s%s%s", lay->fps_param_path, lay->fps_param_path[0] ? "." : "", item->name);
+
+        ov_buf_pos(3, 2);
+        ov_theme_fg(OV_FG_DIM);
+        ov_buf_printf("Description: (Directory)");
+        ov_buf_reset_attr();
+        return;
+    }
+
+    int pi = item->param_idx;
+
+    /* Format full parameter path/name */
+    char full_name[256];
+    if (lay->fps_param_path[0] != '\0')
+    {
+        snprintf(full_name, sizeof(full_name), "%s.%s", lay->fps_param_path, item->name);
+    }
+    else
+    {
+        snprintf(full_name, sizeof(full_name), "%s", item->name);
+    }
+
+    /* Type badge */
+    const char *type_name = "UNKNOWN";
+    uint32_t    type      = fps->disp_param_type[pi];
+    if (type == FPTYPE_INT64 || type == FPTYPE_INT32)
+    {
+        type_name = "INT";
+    }
+    else if (type == FPTYPE_UINT64 || type == FPTYPE_UINT32)
+    {
+        type_name = "UINT";
+    }
+    else if (type == FPTYPE_FLOAT64 || type == FPTYPE_FLOAT32)
+    {
+        type_name = "FLOAT";
+    }
+    else if (type == FPTYPE_ONOFF)
+    {
+        type_name = "ON/OFF";
+    }
+    else if (type == FPTYPE_STREAMNAME)
+    {
+        type_name = "STREAM";
+    }
+    else if (FPTYPE_IS_STRING(type))
+    {
+        type_name = "STRING";
+    }
+    else if (type == FPTYPE_PID)
+    {
+        type_name = "PID";
+    }
+    else if (type == FPTYPE_TIMESPEC)
+    {
+        type_name = "TIMESPEC";
+    }
+
+    /* Display values and limits on Row 2 */
+    ov_buf_pos(2, 2);
+    ov_theme_fg(OV_FG_FPS);
+    ov_buf_bold();
+    ov_buf_printf("PARAM: ");
+    ov_theme_fg(OV_FG_TEXT);
+    ov_buf_printf("%s ", full_name);
+
+    ov_theme_fg(OV_FG_DIM);
+    ov_buf_printf("[%s]  ", type_name);
+
+    ov_theme_fg(OV_FG_FPS);
+    ov_buf_printf("Value: ");
+    ov_theme_fg(OV_FG_TEXT);
+    ov_buf_printf("%s  ", fps->disp_param_value[pi]);
+
+    if (fps->disp_param_has_min[pi])
+    {
+        ov_theme_fg(OV_FG_FPS);
+        ov_buf_printf("Min: ");
+        ov_theme_fg(OV_FG_TEXT);
+        ov_buf_printf("%s  ", fps->disp_param_min[pi]);
+    }
+    if (fps->disp_param_has_max[pi])
+    {
+        ov_theme_fg(OV_FG_FPS);
+        ov_buf_printf("Max: ");
+        ov_theme_fg(OV_FG_TEXT);
+        ov_buf_printf("%s  ", fps->disp_param_max[pi]);
+    }
+
+    /* Display description on Row 3 */
+    ov_buf_pos(3, 2);
+    ov_theme_fg(OV_FG_DIM);
+    ov_buf_printf("Description: ");
+    ov_theme_fg(OV_FG_TEXT);
+    ov_buf_printf("%s", fps->disp_param_descr[pi][0] ? fps->disp_param_descr[pi] : "(none)");
+
+    if (type == FPTYPE_ONOFF)
+    {
+        ov_theme_fg(OV_FG_WARN);
+        ov_buf_printf("  (Press 'o' to toggle. Control mode must be ON [press 'c'])");
+    }
+
+    ov_buf_reset_attr();
+}

--- a/src/cli/overview/overview_render_fps_params.h
+++ b/src/cli/overview/overview_render_fps_params.h
@@ -19,4 +19,11 @@
  */
 void ov_render_fps_params_panel(OV_LAYOUT *lay, const OV_MODEL *m);
 
+/**
+ * ov_render_fps_param_info - draw FPS parameter metadata header on rows 2 and 3.
+ * @lay: layout state
+ * @m:   data model
+ */
+void ov_render_fps_param_info(const OV_LAYOUT *lay, const OV_MODEL *m);
+
 #endif /* OVERVIEW_RENDER_FPS_PARAMS_H */

--- a/src/cli/overview/overview_render_graph.c
+++ b/src/cli/overview/overview_render_graph.c
@@ -150,13 +150,15 @@ void ov_render_preview_line(OV_LAYOUT *lay, const OV_MODEL *m)
 
     /* ---- Action buttons (right-aligned) ---- */
     {
-        /* Button definitions: label, bg color, id */
+        /* Button definitions: label, bg color, id,
+         * always_active (rendered even w/o ctrl_mode) */
         struct
         {
             const char *label;
             ov_rgb_t    bg;
             int         id;
-        } btns[5];
+            int         always_active;
+        } btns[6];
         int nb = 0;
 
         if (focus == OV_FOCUS_PROCS && psel >= 0 && psel < m->nb_procs)
@@ -165,33 +167,44 @@ void ov_render_preview_line(OV_LAYOUT *lay, const OV_MODEL *m)
             /* Pause / Resume */
             if (p->loopstat == 2)
             {
-                btns[nb].label = " [p] \xe2\x96\xb6 Resume ";
-                btns[nb].bg    = (ov_rgb_t) { 30, 120, 60 };
-                btns[nb].id    = OV_BTN_PROC_PAUSE;
+                btns[nb].label         = " [p] \xe2\x96\xb6 Resume ";
+                btns[nb].bg            = (ov_rgb_t) { 30, 120, 60 };
+                btns[nb].id            = OV_BTN_PROC_PAUSE;
+                btns[nb].always_active = 0;
                 nb++;
 
                 /* Step */
-                btns[nb].label = " [s] \xe2\x8f\xad Step ";
-                btns[nb].bg    = (ov_rgb_t) { 120, 100, 30 };
-                btns[nb].id    = OV_BTN_PROC_STEP;
+                btns[nb].label         = " [s] \xe2\x8f\xad Step ";
+                btns[nb].bg            = (ov_rgb_t) { 120, 100, 30 };
+                btns[nb].id            = OV_BTN_PROC_STEP;
+                btns[nb].always_active = 0;
                 nb++;
             }
             else
             {
-                btns[nb].label = " [p] \xe2\x8f\xb8 Pause ";
-                btns[nb].bg    = (ov_rgb_t) { 50, 90, 160 };
-                btns[nb].id    = OV_BTN_PROC_PAUSE;
+                btns[nb].label         = " [p] \xe2\x8f\xb8 Pause ";
+                btns[nb].bg            = (ov_rgb_t) { 50, 90, 160 };
+                btns[nb].id            = OV_BTN_PROC_PAUSE;
+                btns[nb].always_active = 0;
                 nb++;
             }
             /* Exit (clean stop) */
-            btns[nb].label = " [e] \xe2\x8f\xbb Exit ";
-            btns[nb].bg    = (ov_rgb_t) { 160, 120, 30 };
-            btns[nb].id    = OV_BTN_PROC_EXIT;
+            btns[nb].label         = " [e] \xe2\x8f\xbb Exit ";
+            btns[nb].bg            = (ov_rgb_t) { 160, 120, 30 };
+            btns[nb].id            = OV_BTN_PROC_EXIT;
+            btns[nb].always_active = 0;
             nb++;
             /* Kill (SIGTERM) */
-            btns[nb].label = " [k] \xe2\x98\xa0 Kill ";
-            btns[nb].bg    = (ov_rgb_t) { 180, 40, 40 };
-            btns[nb].id    = OV_BTN_PROC_KILL;
+            btns[nb].label         = " [k] \xe2\x98\xa0 Kill ";
+            btns[nb].bg            = (ov_rgb_t) { 180, 40, 40 };
+            btns[nb].id            = OV_BTN_PROC_KILL;
+            btns[nb].always_active = 0;
+            nb++;
+            /* Inspect */
+            btns[nb].label         = " [i] Inspect ";
+            btns[nb].bg            = (ov_rgb_t) { 50, 90, 160 };
+            btns[nb].id            = OV_BTN_INSPECT;
+            btns[nb].always_active = 1;
             nb++;
         }
         else if (focus == OV_FOCUS_FPS && fsel >= 0 && fsel < m->nb_fps)
@@ -201,16 +214,40 @@ void ov_render_preview_line(OV_LAYOUT *lay, const OV_MODEL *m)
             btns[nb].label = f->conf_alive ? " [s] \xe2\x96\xa0 Conf " : " [s] \xe2\x96\xb6 Conf ";
             btns[nb].bg = f->conf_alive ? (ov_rgb_t) { 160, 120, 30 } : (ov_rgb_t) { 30, 120, 60 };
             btns[nb].id = OV_BTN_FPS_CONF;
+            btns[nb].always_active = 0;
             nb++;
             /* Run toggle */
             btns[nb].label = f->run_alive ? " [r] \xe2\x96\xa0 Run " : " [r] \xe2\x96\xb6 Run ";
             btns[nb].bg = f->run_alive ? (ov_rgb_t) { 160, 120, 30 } : (ov_rgb_t) { 30, 120, 60 };
             btns[nb].id = OV_BTN_FPS_RUN;
+            btns[nb].always_active = 0;
             nb++;
             /* Kill */
-            btns[nb].label = " [k] \xe2\x98\xa0 Kill ";
-            btns[nb].bg    = (ov_rgb_t) { 180, 40, 40 };
-            btns[nb].id    = OV_BTN_FPS_KILL;
+            btns[nb].label         = " [k] \xe2\x98\xa0 Kill ";
+            btns[nb].bg            = (ov_rgb_t) { 180, 40, 40 };
+            btns[nb].id            = OV_BTN_FPS_KILL;
+            btns[nb].always_active = 0;
+            nb++;
+            /* Inspect */
+            btns[nb].label         = " [i] Inspect ";
+            btns[nb].bg            = (ov_rgb_t) { 50, 90, 160 };
+            btns[nb].id            = OV_BTN_INSPECT;
+            btns[nb].always_active = 1;
+            nb++;
+        }
+        else if (focus == OV_FOCUS_STREAMS && ssel >= 0 && ssel < m->nb_streams)
+        {
+            /* Delete stream */
+            btns[nb].label         = " [DEL] \xe2\x9c\x95 Delete ";
+            btns[nb].bg            = (ov_rgb_t) { 180, 40, 40 };
+            btns[nb].id            = OV_BTN_STREAM_DEL;
+            btns[nb].always_active = 0;
+            nb++;
+            /* Inspect */
+            btns[nb].label         = " [i] Inspect ";
+            btns[nb].bg            = (ov_rgb_t) { 50, 90, 160 };
+            btns[nb].id            = OV_BTN_INSPECT;
+            btns[nb].always_active = 1;
             nb++;
         }
 
@@ -218,7 +255,7 @@ void ov_render_preview_line(OV_LAYOUT *lay, const OV_MODEL *m)
         {
             /* Compute total width of all buttons
              * (1 space gap between each) */
-            int btn_widths[5];
+            int btn_widths[6];
             int total_w = 0;
             for (int bi = 0; bi < nb; bi++)
             {
@@ -254,7 +291,14 @@ void ov_render_preview_line(OV_LAYOUT *lay, const OV_MODEL *m)
             for (int bi = 0; bi < nb; bi++)
             {
                 ov_buf_pos(2, col);
-                if (!lay->ctrl_mode)
+                if (btns[bi].always_active)
+                {
+                    /* Always-active buttons (Inspect)
+                     * render in full color */
+                    ov_buf_bg(btns[bi].bg.r, btns[bi].bg.g, btns[bi].bg.b);
+                    ov_buf_fg(255, 255, 255);
+                }
+                else if (!lay->ctrl_mode)
                 {
                     ov_buf_bg(60, 60, 60);
                     ov_buf_fg(180, 180, 180);
@@ -269,7 +313,7 @@ void ov_render_preview_line(OV_LAYOUT *lay, const OV_MODEL *m)
                 ov_buf_reset_attr();
 
                 /* Record button position */
-                if (lay->nb_preview_btns < 4)
+                if (lay->nb_preview_btns < 6)
                 {
                     int idx                      = lay->nb_preview_btns;
                     lay->preview_btns[idx].col   = col;
@@ -397,11 +441,11 @@ void ov_render_graph_panel(const OV_LAYOUT *lay, const OV_MODEL *m)
         ov_buf_pos(row, r.col + 1);
 
         int      is_sel   = (ri == lay->sel_graph && lay->focus == OV_FOCUS_GRAPH);
-        ov_rgb_t row_bg   = OV_BG_PANEL;
+        int      is_hover = (lay->mouse_hover && lay->hover_view == OV_FOCUS_GRAPH &&
+                        lay->graph_tab_mode == 0 && ri == lay->hover_idx);
+        ov_rgb_t row_bg   = is_hover ? OV_BG_HOVER : OV_BG_PANEL;
         int      use_ul   = 0;
         ov_rgb_t ul_color = { 0, 0, 0 };
-
-        /* We no longer highlight the entire row on hover, only the specific element */
 
         if (is_sel)
         {
@@ -460,8 +504,8 @@ void ov_render_graph_panel(const OV_LAYOUT *lay, const OV_MODEL *m)
             ov_theme_bg(row_bg);
         }
 
-        /* Draw writer proc */
-        if (rn->writer_name[0] != '\0')
+        /* Draw reader proc */
+        if (rn->reader_name[0] != '\0')
         {
             GRAPH_FIELD(OV_FG_DIM, " [");
             if (rn->is_target_proc)
@@ -473,7 +517,7 @@ void ov_render_graph_panel(const OV_LAYOUT *lay, const OV_MODEL *m)
             int proc_idx = -1;
             for (int i = 0; i < m->nb_procs; i++)
             {
-                if (strcmp(m->procs[i].name, rn->writer_name) == 0)
+                if (strcmp(m->procs[i].name, rn->reader_name) == 0)
                 {
                     proc_idx = i;
                     break;
@@ -486,7 +530,7 @@ void ov_render_graph_panel(const OV_LAYOUT *lay, const OV_MODEL *m)
             {
                 ov_theme_bg(OV_BG_HOVER);
             }
-            GRAPH_FIELD(proc_color, "%s", rn->writer_name);
+            GRAPH_FIELD(proc_color, "%s", rn->reader_name);
             if (hl_proc)
             {
                 ov_theme_bg(row_bg);

--- a/src/cli/overview/overview_render_procs.c
+++ b/src/cli/overview/overview_render_procs.c
@@ -63,10 +63,10 @@ static void ov_procs__render_header(const OV_LAYOUT *lay, int hrow, int hs, OV_R
     {
         int  sk = lay->sort_key_proc;
         int  sd = lay->sort_dir_proc;
-        char c_anc[8], c_name[20], c_pid[12];
-        char c_prio[10], c_stat[10], c_hz[10];
-        char c_upt[10], c_duty[10], c_cpu[10];
-        char c_lpcnt[14], c_mem[10];
+        char c_anc[32], c_name[32], c_pid[32];
+        char c_prio[32], c_stat[32], c_hz[32];
+        char c_upt[32], c_duty[32], c_cpu[32];
+        char c_lpcnt[32], c_mem[32];
         int  w_anc   = sort_col_label(c_anc, sizeof(c_anc), "A", 5, sk, sd, 3);
         int  w_name  = sort_col_label(c_name, sizeof(c_name), "NAME", 0, sk, sd, 14);
         int  w_pid   = sort_col_label(c_pid, sizeof(c_pid), "PID", 1, sk, sd, 7);

--- a/src/cli/overview/overview_render_procs.c
+++ b/src/cli/overview/overview_render_procs.c
@@ -56,38 +56,44 @@ static void ov_procs__render_header(const OV_LAYOUT *lay, int hrow, int hs, OV_R
 {
     ov_buf_pos(hrow, r.col + 1);
     ov_theme_bg(OV_BG_HEADER);
-    ov_buf_printf("    ");
     ov_theme_fg(OV_FG_PROC_HDR);
 
-    char htext[256];
+    char htext[320];
     int  hlen;
     {
         int  sk = lay->sort_key_proc;
         int  sd = lay->sort_dir_proc;
         char c_anc[8], c_name[20], c_pid[12];
-        char c_stat[10], c_hz[10], c_mem[10];
-        int  w_anc  = sort_col_label(c_anc, sizeof(c_anc), "A", 5, sk, sd, 3);
-        int  w_name = sort_col_label(c_name, sizeof(c_name), "NAME", 0, sk, sd, 14);
-        int  w_pid  = sort_col_label(c_pid, sizeof(c_pid), "PID", 1, sk, sd, 7);
-        int  w_stat = sort_col_label(c_stat, sizeof(c_stat), "STAT", 2, sk, sd, 5);
-        int  w_hz   = sort_col_label(c_hz, sizeof(c_hz), "Hz", 3, sk, sd, 6);
-        int  w_mem  = sort_col_label(c_mem, sizeof(c_mem), "MEM", 4, sk, sd, 5);
-        hlen        = snprintf(htext, sizeof(htext),
-                               "%-*s %-*s %*s %4s %*s %*s"
-                                      " %6s"
-                                      " %3s %-10s %7s %5s"
-                                      "  CPU%%  %10s %*s %10s",
-                               w_anc, c_anc, w_name, c_name, w_pid, c_pid, "PRIO", w_stat, c_stat, w_hz,
-                               c_hz, "UPTIME", "TRG", "trig-strm", "exec", "DUTY", "LOOPCNT", w_mem, c_mem,
-                               "MISSED");
+        char c_prio[10], c_stat[10], c_hz[10];
+        char c_upt[10], c_duty[10], c_cpu[10];
+        char c_lpcnt[14], c_mem[10];
+        int  w_anc   = sort_col_label(c_anc, sizeof(c_anc), "A", 5, sk, sd, 3);
+        int  w_name  = sort_col_label(c_name, sizeof(c_name), "NAME", 0, sk, sd, 14);
+        int  w_pid   = sort_col_label(c_pid, sizeof(c_pid), "PID", 1, sk, sd, 7);
+        int  w_prio  = sort_col_label(c_prio, sizeof(c_prio), "PRIO", 6, sk, sd, 4);
+        int  w_stat  = sort_col_label(c_stat, sizeof(c_stat), "STAT", 2, sk, sd, 5);
+        int  w_hz    = sort_col_label(c_hz, sizeof(c_hz), "Hz", 3, sk, sd, 6);
+        int  w_upt   = sort_col_label(c_upt, sizeof(c_upt), "UPTIME", 7, sk, sd, 6);
+        int  w_duty  = sort_col_label(c_duty, sizeof(c_duty), "DUTY", 10, sk, sd, 5);
+        int  w_cpu   = sort_col_label(c_cpu, sizeof(c_cpu), "CPU%", 8, sk, sd, 6);
+        int  w_lpcnt = sort_col_label(c_lpcnt, sizeof(c_lpcnt), "LOOPCNT", 9, sk, sd, 10);
+        int  w_mem   = sort_col_label(c_mem, sizeof(c_mem), "MEM", 4, sk, sd, 5);
+        hlen         = snprintf(htext, sizeof(htext),
+                                "%-*s %-*s %*s %*s %*s %*s"
+                                        " %*s"
+                                        " %3s %-10s %7s %*s"
+                                        "  %*s  %*s %*s %10s",
+                                w_anc, c_anc, w_name, c_name, w_pid, c_pid, w_prio, c_prio, w_stat, c_stat,
+                                w_hz, c_hz, w_upt, c_upt, "TRG", "trig-strm", "exec", w_duty, c_duty, w_cpu,
+                                c_cpu, w_lpcnt, c_lpcnt, w_mem, c_mem, "MISSED");
     }
-    int vis_width = r.width - 4;
+    int vis_width = r.width;
     if (vis_width < 0)
     {
         vis_width = 0;
     }
     int printed = ov_render_header_text(htext, hs, vis_width, OV_FG_PROC_HDR);
-    render_pad_spaces(4 + printed, r.width);
+    render_pad_spaces(printed, r.width);
 
     /* Separator between header and data rows */
     render_separator(hrow + 1, r.col + 1, r.width - 2, OV_FG_PROC_HDR);

--- a/src/cli/overview/overview_render_status.c
+++ b/src/cli/overview/overview_render_status.c
@@ -27,13 +27,13 @@ void ov_render_status(const OV_LAYOUT *lay, const OV_MODEL *m)
         switch (lay->focus)
         {
         case OV_FOCUS_FPS:
-            ctrl_hint = "  r:run s:conf";
+            ctrl_hint = "  r:run s:conf k:kill";
             break;
         case OV_FOCUS_STREAMS:
-            ctrl_hint = "  d:delete";
+            ctrl_hint = "  DEL:delete";
             break;
         case OV_FOCUS_PROCS:
-            ctrl_hint = "  k:kill";
+            ctrl_hint = "  p:pause e:exit k:kill";
             break;
         default:
             ctrl_hint = "";
@@ -92,6 +92,21 @@ void ov_render_status(const OV_LAYOUT *lay, const OV_MODEL *m)
         case 5:
             sort_label = " [sort:ancestry]";
             break;
+        case 6:
+            sort_label = " [sort:PRIO]";
+            break;
+        case 7:
+            sort_label = " [sort:UPTIME]";
+            break;
+        case 8:
+            sort_label = " [sort:CPU%]";
+            break;
+        case 9:
+            sort_label = " [sort:LOOPCNT]";
+            break;
+        case 10:
+            sort_label = " [sort:DUTY]";
+            break;
         default:
             sort_label = " [sort:name]";
             break;
@@ -101,13 +116,22 @@ void ov_render_status(const OV_LAYOUT *lay, const OV_MODEL *m)
         switch (lay->sort_key_fps)
         {
         case 1:
-            sort_label = " [sort:alive]";
+            sort_label = " [sort:CPID]";
             break;
         case 2:
             sort_label = " [sort:MEM]";
             break;
         case 3:
             sort_label = " [sort:ancestry]";
+            break;
+        case 4:
+            sort_label = " [sort:RPID]";
+            break;
+        case 5:
+            sort_label = " [sort:TMX]";
+            break;
+        case 6:
+            sort_label = " [sort:STR]";
             break;
         default:
             sort_label = " [sort:name]";

--- a/src/cli/overview/overview_render_streams.c
+++ b/src/cli/overview/overview_render_streams.c
@@ -66,9 +66,9 @@ void ov_render_streams_panel(const OV_LAYOUT *lay, const OV_MODEL *m, const OV_R
     {
         int  sk = lay->sort_key_stream;
         int  sd = lay->sort_dir_stream;
-        char c_anc[8], c_name[20], c_typ[10];
-        char c_size[16];
-        char c_hz[10], c_mbps[12], c_ino[16], c_cnt[16];
+        char c_anc[32], c_name[32], c_typ[32];
+        char c_size[32];
+        char c_hz[32], c_mbps[32], c_ino[32], c_cnt[32];
         int  w_anc  = sort_col_label(c_anc, sizeof(c_anc), "A", 7, sk, sd, 3);
         int  w_name = sort_col_label(c_name, sizeof(c_name), "NAME", 0, sk, sd, 14);
         int  w_typ  = sort_col_label(c_typ, sizeof(c_typ), "TYP", 1, sk, sd, 4);

--- a/src/cli/overview/overview_render_streams.c
+++ b/src/cli/overview/overview_render_streams.c
@@ -58,7 +58,7 @@ void ov_render_streams_panel(const OV_LAYOUT *lay, const OV_MODEL *m, const OV_R
 
     ov_buf_pos(hrow, r.col + 1);
     ov_theme_bg(OV_BG_HEADER);
-    ov_buf_printf("    ");
+    ov_buf_printf(" ");
     ov_theme_fg(OV_FG_STREAM_HDR);
 
     char htext[300];
@@ -98,13 +98,13 @@ void ov_render_streams_panel(const OV_LAYOUT *lay, const OV_MODEL *m, const OV_R
     }
 
     {
-        int vis_width = r.width - 4;
+        int vis_width = r.width - 1;
         if (vis_width < 0)
         {
             vis_width = 0;
         }
         int printed = ov_render_header_text(htext, hs, vis_width, OV_FG_STREAM_HDR);
-        render_pad_spaces(4 + printed, r.width);
+        render_pad_spaces(1 + printed, r.width);
     }
 
     /* Separator between header and data rows */
@@ -281,7 +281,7 @@ void ov_render_streams_panel(const OV_LAYOUT *lay, const OV_MODEL *m, const OV_R
             row_bg = zebra_bg(row_bg, i);
 
             int hs_rem  = hs;
-            int printed = 4;
+            int printed = 1;
             int avail   = r.width - 2;
 
             ov_buf_pos(row, r.col + 1);

--- a/src/cli/overview/overview_theme.h
+++ b/src/cli/overview/overview_theme.h
@@ -41,7 +41,7 @@ typedef struct
 #define OV_BG_SELECTED (ov_rgb_t){ 50, 60, 90 }
 #define OV_BG_RELATED (ov_rgb_t){ 38, 50, 42 } /* soft green tint for related items */
 #define OV_BG_FROZEN (ov_rgb_t){ 40, 90, 140 } /* bright blue tint for frozen selection */
-#define OV_BG_HOVER (ov_rgb_t){ 38, 42, 55 }
+#define OV_BG_HOVER (ov_rgb_t){ 45, 52, 72 }
 #define OV_BG_PID_MATCH (ov_rgb_t){ 50, 180, 50 } /* green bg for PID match */
 #define OV_BG_STALE (ov_rgb_t){ 55, 45, 20 }      /* amber tint for stale procs */
 #define OV_BG_NEW_ITEM (ov_rgb_t){ 40, 60, 50 }   /* green flash for new items */

--- a/src/cli/overview/stream_graph.c
+++ b/src/cli/overview/stream_graph.c
@@ -726,6 +726,7 @@ int sg_compute_render_nodes(const OV_MODEL *m,
 }
 static void sg_dfs_tree(const OV_MODEL *m,
                         int             current_stream,
+                        int             reader_node_idx,
                         int             target_stream,
                         int             target_proc,
                         const uint64_t *S_words,
@@ -762,21 +763,17 @@ static void sg_dfs_tree(const OV_MODEL *m,
     strncpy(node->name, m->streams[current_stream].name, sizeof(node->name) - 1);
     node->name[sizeof(node->name) - 1] = '\0';
 
-    /* Find writer proc */
-    node->writer_name[0] = '\0';
+    /* Find reader proc */
+    node->reader_name[0] = '\0';
     node->is_target_proc = 0;
-    pid_t wpid           = m->streams[current_stream].write_pid;
-    if (wpid > 0)
+    if (reader_node_idx >= 0)
     {
-        int pidx = ov_find_proc_by_pid(m, wpid);
-        if (pidx >= 0)
+        const OV_NODE *rn = &m->nodes[reader_node_idx];
+        strncpy(node->reader_name, rn->name, sizeof(node->reader_name) - 1);
+        node->reader_name[sizeof(node->reader_name) - 1] = '\0';
+        if (rn->type == OV_NODE_PROC && rn->index == target_proc)
         {
-            strncpy(node->writer_name, m->procs[pidx].name, sizeof(node->writer_name) - 1);
-            node->writer_name[sizeof(node->writer_name) - 1] = '\0';
-            if (pidx == target_proc)
-            {
-                node->is_target_proc = 1;
-            }
+            node->is_target_proc = 1;
         }
     }
 
@@ -804,45 +801,101 @@ static void sg_dfs_tree(const OV_MODEL *m,
 
     path[path_len] = current_stream;
 
-    /* Find children in S */
-    int children[OV_MAX_STREAMS];
-    int nb_children = 0;
-
-    int n_node = m->streams[current_stream].node_idx;
-    if (n_node >= 0)
+    /* Find children nodes (stream, reader) */
+    struct
     {
+        int stream_idx;
+        int reader_node_idx;
+    } child_nodes[OV_MAX_NODES];
+    int nb_child_nodes = 0;
+
+    if (reader_node_idx >= 0)
+    {
+        /* Find streams written by the reader process/FPS */
+        int child_streams[OV_MAX_STREAMS];
+        int nb_child_streams = 0;
+
         for (int ei = 0; ei < m->nb_edges; ei++)
         {
-            const OV_EDGE *e1 = &m->edges[ei];
-            if (e1->src_node == n_node && sg_edge_matches_mode_from_stream(e1, mode))
+            const OV_EDGE *e = &m->edges[ei];
+            if (e->src_node == reader_node_idx &&
+                (e->type == OV_EDGE_PROC_WRITES_STREAM || e->type == OV_EDGE_FPS_OUTPUT_STREAM))
             {
-                int p_node = e1->tgt_node;
-                for (int ej = 0; ej < m->nb_edges; ej++)
+                int c_node = e->tgt_node;
+                if (c_node >= 0 && c_node < m->nb_nodes && m->nodes[c_node].type == OV_NODE_STREAM)
                 {
-                    const OV_EDGE *e2 = &m->edges[ej];
-                    if (e2->src_node == p_node)
+                    int c_stream = m->nodes[c_node].index;
+                    if (sg_bget(S_words, c_stream))
                     {
-                        int c_node = e2->tgt_node;
-                        if (c_node >= 0 && c_node < m->nb_nodes &&
-                            m->nodes[c_node].type == OV_NODE_STREAM)
+                        int duplicate = 0;
+                        for (int k = 0; k < nb_child_streams; k++)
                         {
-                            int c_stream = m->nodes[c_node].index;
-                            if (sg_bget(S_words, c_stream))
+                            if (child_streams[k] == c_stream)
                             {
-                                int duplicate = 0;
-                                for (int k = 0; k < nb_children; k++)
-                                {
-                                    if (children[k] == c_stream)
-                                    {
-                                        duplicate = 1;
-                                    }
-                                }
-                                if (!duplicate)
-                                {
-                                    children[nb_children++] = c_stream;
-                                }
+                                duplicate = 1;
+                                break;
                             }
                         }
+                        if (!duplicate)
+                        {
+                            child_streams[nb_child_streams++] = c_stream;
+                        }
+                    }
+                }
+            }
+        }
+
+        /* For each child stream, find its reader processes/FPS in S */
+        for (int i = 0; i < nb_child_streams; i++)
+        {
+            int c_stream = child_streams[i];
+            int n_node   = m->streams[c_stream].node_idx;
+            int readers[OV_MAX_PROCS];
+            int nb_readers = 0;
+
+            if (n_node >= 0)
+            {
+                for (int ei = 0; ei < m->nb_edges; ei++)
+                {
+                    const OV_EDGE *e1 = &m->edges[ei];
+                    if (e1->src_node == n_node && sg_edge_matches_mode_from_stream(e1, mode))
+                    {
+                        int r_node    = e1->tgt_node;
+                        int duplicate = 0;
+                        for (int k = 0; k < nb_readers; k++)
+                        {
+                            if (readers[k] == r_node)
+                            {
+                                duplicate = 1;
+                                break;
+                            }
+                        }
+                        if (!duplicate)
+                        {
+                            readers[nb_readers++] = r_node;
+                        }
+                    }
+                }
+            }
+
+            if (nb_readers == 0)
+            {
+                if (nb_child_nodes < OV_MAX_NODES)
+                {
+                    child_nodes[nb_child_nodes].stream_idx      = c_stream;
+                    child_nodes[nb_child_nodes].reader_node_idx = -1;
+                    nb_child_nodes++;
+                }
+            }
+            else
+            {
+                for (int r = 0; r < nb_readers; r++)
+                {
+                    if (nb_child_nodes < OV_MAX_NODES)
+                    {
+                        child_nodes[nb_child_nodes].stream_idx      = c_stream;
+                        child_nodes[nb_child_nodes].reader_node_idx = readers[r];
+                        nb_child_nodes++;
                     }
                 }
             }
@@ -861,11 +914,11 @@ static void sg_dfs_tree(const OV_MODEL *m,
                  is_last ? "    " : "\xe2\x94\x82   "); /* "    " and "│   " */
     }
 
-    for (int i = 0; i < nb_children; i++)
+    for (int i = 0; i < nb_child_nodes; i++)
     {
-        sg_dfs_tree(m, children[i], target_stream, target_proc, S_words, mode, child_prefix,
-                    (i == nb_children - 1), 0, depth + 1, path, path_len + 1, out_nodes,
-                    nb_out_nodes);
+        sg_dfs_tree(m, child_nodes[i].stream_idx, child_nodes[i].reader_node_idx, target_stream,
+                    target_proc, S_words, mode, child_prefix, (i == nb_child_nodes - 1), 0,
+                    depth + 1, path, path_len + 1, out_nodes, nb_out_nodes);
     }
 }
 
@@ -1004,10 +1057,74 @@ int sg_compute_render_tree(const OV_MODEL *m,
     }
 
     int path[OV_MAX_STREAMS];
+    /* For each root, find its reader processes/FPS and call sg_dfs_tree */
+    struct
+    {
+        int stream_idx;
+        int reader_node_idx;
+    } root_nodes[OV_MAX_STREAMS * 4];
+    int nb_root_nodes = 0;
+
     for (int i = 0; i < nb_roots; i++)
     {
-        sg_dfs_tree(m, roots[i], target_stream, target_proc, S_words, mode, "", (i == nb_roots - 1),
-                    1, 0, path, 0, out_nodes, &nb_out);
+        int r_stream = roots[i];
+        int n_node   = m->streams[r_stream].node_idx;
+        int readers[OV_MAX_PROCS];
+        int nb_readers = 0;
+
+        if (n_node >= 0)
+        {
+            for (int ei = 0; ei < m->nb_edges; ei++)
+            {
+                const OV_EDGE *e1 = &m->edges[ei];
+                if (e1->src_node == n_node && sg_edge_matches_mode_from_stream(e1, mode))
+                {
+                    int r_node    = e1->tgt_node;
+                    int duplicate = 0;
+                    for (int k = 0; k < nb_readers; k++)
+                    {
+                        if (readers[k] == r_node)
+                        {
+                            duplicate = 1;
+                            break;
+                        }
+                    }
+                    if (!duplicate)
+                    {
+                        readers[nb_readers++] = r_node;
+                    }
+                }
+            }
+        }
+
+        if (nb_readers == 0)
+        {
+            if (nb_root_nodes < OV_MAX_STREAMS * 4)
+            {
+                root_nodes[nb_root_nodes].stream_idx      = r_stream;
+                root_nodes[nb_root_nodes].reader_node_idx = -1;
+                nb_root_nodes++;
+            }
+        }
+        else
+        {
+            for (int r = 0; r < nb_readers; r++)
+            {
+                if (nb_root_nodes < OV_MAX_STREAMS * 4)
+                {
+                    root_nodes[nb_root_nodes].stream_idx      = r_stream;
+                    root_nodes[nb_root_nodes].reader_node_idx = readers[r];
+                    nb_root_nodes++;
+                }
+            }
+        }
+    }
+
+    for (int i = 0; i < nb_root_nodes; i++)
+    {
+        sg_dfs_tree(m, root_nodes[i].stream_idx, root_nodes[i].reader_node_idx, target_stream,
+                    target_proc, S_words, mode, "", (i == nb_root_nodes - 1), 1, 0, path, 0,
+                    out_nodes, &nb_out);
     }
 
     return nb_out;

--- a/src/cli/overview/stream_graph.h
+++ b/src/cli/overview/stream_graph.h
@@ -86,10 +86,10 @@ typedef struct
 {
     int  stream_idx;       /* Index in m->streams */
     int  is_target;        /* 1 if this is the target root stream */
-    int  is_target_proc;   /* 1 if the writer_name matches the target process */
+    int  is_target_proc;   /* 1 if the reader_name matches the target process */
     int  depth;            /* Graph depth */
     char name[64];         /* Stream name */
-    char writer_name[64];  /* Name of the process/fps writing this stream */
+    char reader_name[64];  /* Name of the process/fps reading this stream */
     char tree_prefix[128]; /* Prefix strings for rendering (e.g. "├── ") */
 } SG_TREE_NODE;
 


### PR DESCRIPTION
## Summary
Fixes `milk-CTRL` F5 tab connections tree mouse hitboxes, sorting, parameter display formatting, min/max limits, path persistence, and parameter ON/OFF toggling. 

## Changes

### `src/cli/overview`
- **Connections Tree:** Restructured stream processing connection display layout (`stream_graph.c`, `overview_render_streams.c`). Grouped outputs under readers, aligned reader/writer columns. Fixed mouse coordinate hit testing (`overview_input.c`) by correctly mapping tree vertical rendering offsets.
- **Sorting:** Enabled global sorting for PRIO, UPTIME, TMX, and STR columns (`overview_data_sort.c`).
- **FPS Parameter Rendering:** Rendered selected FPS parameter type, value, min, max, and description in the reserved UI rows 2 and 3 above the panels (`overview_render_fps_params.c`).
- **FPS Path Persistence:** Stored last-traveled path history internally per nested directory per FPS in `ov_layout_state` so directory descent/ascent consistently restores the exact previous selection parameter.
- **FPS Values Formatting:** Fixed `libfps` `min/max` limit index map (1->min, 2->max) instead of 2/3. Formatted `TIMESPEC` as floating-point seconds instead of internal nanosecond arrays (`overview_data_scan.c`).
- **FPS ONOFF toggling:** Mapped `'o'` key to toggle `ON/OFF` parameters when under focus. Replaced internal array flipping with `functionparameter_SetParamValue_ONOFF` API to correctly flip bitflags and value counts, ensuring downstream engine sync.
- **Highlight Bleed Fix:** Increased local char arrays for sorting headers from 8/10 to 32 bytes to prevent `snprintf` from truncating `\x02` ANSI reset sequences on short column names like `CPID` and `UPTIME`.

## Verification
- [x] Build passes (`/compile-test` -> `make -j$(nproc) milk-CTRL`)
- [x] Manual Verification (Verified interactively).

## Prompt Summary
User initially reported unaligned tree structures in `milk-CTRL` F5 panel, broken mouse clicking, and unaligned columns. Redesigned the tree grouped by readers, aligned columns, made columns sortable, displayed parameter descriptions and properties on rows 2/3, implemented directory-path navigation history persistence, and implemented the 'o' hotkey for toggling ON/OFF parameters. Finally, resolved highlight bleeding on sorted headers.

## Authorship
- **Model**: Antigravity AI
- **Reviewed and signed off by**: oguyon
