### PR TITLE
feat: add api-quick-reference and pseudocode-to-compute-unit agent skills

### DIFF
--- a/.agents/skills/api-quick-reference/SKILL.md
+++ b/.agents/skills/api-quick-reference/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: api-quick-reference
+description: Deep reference for milk APIs including IMGID, datatype dispatch, processinfo macros, magic context variables, FPS parameter types, and stream write protocols.
+---
+
+# milk API Quick Reference
+
+This skill provides a condensed "cheat sheet" of critical APIs used in milk compute units.
+
+## 1. IMGID API Reference
+`IMGID` is the structure used to represent shared memory image streams.
+Always use `mdt->` (metadata template) when configuring a new stream, never direct struct fields.
+
+```c
+IMGID img = imgid_make_from_name("mystream");
+
+// Configure metadata BEFORE create/connect
+img.mdt->naxis = 2;
+img.mdt->size[0] = 128;
+img.mdt->size[1] = 128;
+img.mdt->datatype = _DATATYPE_FLOAT;
+img.mdt->shared = 1;
+
+// To create a new stream:
+imcreateIMGID(&img);
+
+// OR to resolve (connect to) an existing stream:
+resolveIMGID(&img, ERRMODE_WARN, dcimg, dcnimg);
+
+// OR to connect with flags (creates if doesn't exist):
+imgid_connect(&img, IMGID_CONNECT_CHECK_CREATE);
+
+// Accessing pixel data (always via im->array):
+float *ptr = img.im->array.F;
+
+// Free the struct at the end
+imgid_free(&img);
+```
+
+## 2. Datatype Dispatch Table
+When a function supports multiple datatypes, use an `else if` chain matching `_DATATYPE_*` to the correct union member of `im->array`.
+
+| Type Constant | Union Member | C Type | Size Macro |
+|---|---|---|---|
+| `_DATATYPE_UINT8` | `.UI8` | `uint8_t` | `SIZEOF_DATATYPE_UINT8` |
+| `_DATATYPE_INT8` | `.I8` | `int8_t` | `SIZEOF_DATATYPE_INT8` |
+| `_DATATYPE_UINT16` | `.UI16` | `uint16_t` | `SIZEOF_DATATYPE_UINT16` |
+| `_DATATYPE_INT16` | `.I16` | `int16_t` | `SIZEOF_DATATYPE_INT16` |
+| `_DATATYPE_UINT32` | `.UI32` | `uint32_t` | `SIZEOF_DATATYPE_UINT32` |
+| `_DATATYPE_INT32` | `.I32` | `int32_t` | `SIZEOF_DATATYPE_INT32` |
+| `_DATATYPE_UINT64` | `.UI64` | `uint64_t` | `SIZEOF_DATATYPE_UINT64` |
+| `_DATATYPE_INT64` | `.I64` | `int64_t` | `SIZEOF_DATATYPE_INT64` |
+| `_DATATYPE_FLOAT` | `.F` | `float` | `SIZEOF_DATATYPE_FLOAT` |
+| `_DATATYPE_DOUBLE` | `.D` | `double` | `SIZEOF_DATATYPE_DOUBLE` |
+| `_DATATYPE_COMPLEX_FLOAT` | `.CF` | `complex float`| `SIZEOF_DATATYPE_COMPLEX_FLOAT` |
+| `_DATATYPE_COMPLEX_DOUBLE` | `.CD` | `complex double`| `SIZEOF_DATATYPE_COMPLEX_DOUBLE` |
+
+For untyped generic copies, use `.raw` with `__builtin_memcpy`.
+
+## 3. processinfo Macro Reference
+These macros wrap your compute loop to provide timing, semaphore triggering, and tmux status.
+
+- `INSERT_STD_PROCINFO_COMPUTEFUNC_INIT`: Initializes the `processinfo` structure based on CLI options. Must be called before the loop.
+- `INSERT_STD_PROCINFO_COMPUTEFUNC_LOOPSTART`: Begins the `while(processloopOK)` loop and handles semaphore waiting.
+- `INSERT_STD_PROCINFO_COMPUTEFUNC_START`: Convenience macro combining `INIT` and `LOOPSTART`.
+- `INSERT_STD_PROCINFO_COMPUTEFUNC_END`: Closes the loop and cleans up.
+
+A standard continuous-loop compute unit looks like:
+```c
+INSERT_STD_PROCINFO_COMPUTEFUNC_INIT
+
+// (Optional) custom setup here
+
+INSERT_STD_PROCINFO_COMPUTEFUNC_LOOPSTART
+{
+    // Do computation here...
+
+    // (Optional) If you wrote to outimg based on inimg's trigger:
+    processinfo_update_output_stream(processinfo, outimg.im, inimg.im);
+}
+INSERT_STD_PROCINFO_COMPUTEFUNC_END
+```
+
+## 4. Magic Context Variables
+These global variables are defined by the framework and are always available in compute functions.
+
+| Variable | Type | Defined By | Description |
+|---|---|---|---|
+| `dcfpsptr` | `FPS*` | `milkdata_macros.h` | Pointer to the current FPS instance. |
+| `dcfpsname` | `char[]` | `milkdata_macros.h` | Name of the current FPS instance. |
+| `dcimg` | `IMAGE*` | `milkdata_macros.h` | The global image array (used in `resolveIMGID`). |
+| `dcnimg` | `long` | `milkdata_macros.h` | Size of the `dcimg` array. |
+| `processinfo`| `PROCESSINFO*`| `fps_procinfo_macros.h` | Struct tracking process timing, loop limits, and triggers. Injected by `INSERT_STD_PROCINFO_COMPUTEFUNC_INIT`. |
+| `processloopOK`| `int` | `fps_procinfo_macros.h` | Loop condition variable. Injected by `INIT`, checked in `LOOPSTART`. |
+
+## 5. Stream Write Protocol
+When writing data to a shared memory stream (`IMAGE`), you must use the semaphore protocol so readers know when the data is ready.
+
+```c
+// 1. Acquire write lock (increments md->cnt0)
+SHMIM_WRITE_ACQUIRE(outimg.im->md);
+
+// 2. Modify data
+for(int i = 0; i < N; i++) outimg.im->array.F[i] = ...;
+
+// 3. Release write lock (increments md->cnt1)
+SHMIM_WRITE_RELEASE(outimg.im->md);
+
+// 4. Update timing and post semaphores
+// If inside a processinfo loop triggered by an input stream:
+processinfo_update_output_stream(processinfo, outimg.im, inimg.im);
+
+// Or if not using processinfo triggers (e.g. one-shot or generator):
+ImageStreamIO_UpdateIm(outimg.im);
+```
+
+## 6. FPS Parameter Quick-Reference
+Common `FPTYPE_*` mapped to C types:
+- `FPTYPE_INT32` / `FPTYPE_UINT32` → `int32_t` / `uint32_t`
+- `FPTYPE_INT64` / `FPTYPE_UINT64` → `int64_t` / `uint64_t`
+- `FPTYPE_FLOAT32` / `FPTYPE_FLOAT64` → `float` / `double`
+- `FPTYPE_ONOFF` → `int32_t` (0 = OFF, nonzero = ON)
+- `FPTYPE_STREAMNAME`, `FPTYPE_FILENAME`, `FPTYPE_STRING` → `char[]` buffer
+- `FPTYPE_TIMESPEC` → `struct timespec`
+- `FPTYPE_PID` → `pid_t`
+
+X-Macro Binding Column Order (Strict):
+`X(keyword, pointer, type, is_primary, flags, description)`

--- a/.agents/skills/pseudocode-to-compute-unit/SKILL.md
+++ b/.agents/skills/pseudocode-to-compute-unit/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: pseudocode-to-compute-unit
+description: Step-by-step methodology for translating algorithm pseudocode into a working milk V2 compute unit.
+---
+
+# Translating Pseudocode to a milk Compute Unit
+
+Use this methodology to convert an abstract algorithm into a fully functional milk compute unit using the V2 FPS architecture.
+
+## Prerequisite: Quick Reference
+Before you begin, consult the `api-quick-reference` skill to review the `IMGID` API, datatype dispatch tables, and stream write protocols.
+
+## Step 1: Algorithm Analysis
+Analyze the pseudocode to identify:
+1. **Inputs:** Are they continuous image streams? Static files? Scalar parameters?
+2. **Outputs:** Does it produce a new stream? Does it modify a stream in place? Does it return a scalar value?
+3. **Tunables:** What numerical thresholds, gains, or switches does the algorithm need?
+4. **Execution Mode:**
+   - *Stream Processor:* Runs continuously, triggered by a new frame in an input stream.
+   - *One-shot:* Runs once when called, then exits.
+   - *Generator:* Runs continuously, self-timed (e.g. at a set delay), outputting data.
+
+## Step 2: Parameter Mapping
+Map each identified variable to an `FPTYPE_*` parameter.
+
+1. **Streams:** Map input/output stream names to `FPTYPE_STREAMNAME`. Give the input a flag like `FPFLAG_DEFAULT_TRIGGER_STREAM` if it drives the loop.
+2. **Tunables:** Map floats to `FPTYPE_FLOAT32` or `FLOAT64`, integers to `FPTYPE_INT32` or `INT64`.
+3. **Switches:** Map booleans to `FPTYPE_ONOFF`.
+
+Set up the `FPS_PARAMS` X-Macro block. Follow the strict column order:
+`X(keyword, &var, type, is_primary, flags, description)`
+
+## Step 3: Stream I/O Design
+Determine how streams will be connected in your `compute_function`:
+- **Input Stream:** Use `imgid_make_from_name()` + `resolveIMGID()`.
+- **Output Stream:**
+  - If it matches the input exactly: `imgid_copy(&in, &out)` + `imcreateIMGID(&out)`.
+  - If it differs: manually set `out.mdt->naxis`, `out.mdt->size[]`, `out.mdt->datatype`, `out.mdt->shared`, then `imcreateIMGID(&out)`.
+
+## Step 4: Code Structure Selection
+Based on the execution mode, choose the template:
+- **Stream Processor:** Look at `src/milk_module_example/examplefunc4_streamprocess.c`. You will need `INSERT_STD_PROCINFO_COMPUTEFUNC_INIT`, `LOOPSTART`, and `END`.
+- **One-shot / Custom:** Look at `src/milk_module_example/examplefunc_fps_cli_poc.c`.
+
+## Step 5: Datatype Handling
+If the algorithm must handle multiple datatypes (e.g., FLOAT and UINT16), use the standard milk dispatch pattern inside your inner compute block:
+
+```c
+uint32_t dt = inimg->mdt->datatype;
+if (dt == _DATATYPE_FLOAT)
+{
+    float * restrict in_ptr = inimg->im->array.F;
+    float * restrict out_ptr = outimg->im->array.F;
+    // ... compute ...
+}
+else if (dt == _DATATYPE_UINT16)
+{
+    uint16_t * restrict in_ptr = inimg->im->array.UI16;
+    // ... compute ...
+}
+```
+
+## Step 6: Memory and Performance
+- **No malloc in the loop:** Allocate any scratch buffers *before* `INSERT_STD_PROCINFO_COMPUTEFUNC_LOOPSTART`.
+- **Pointer Alignment:** Use `MILK_RESTRICT` and `MILK_ASSUME_ALIGNED(ptr)` in compute-heavy inner loops to help GCC vectorize.
+- **Write Protocol:** Use `SHMIM_WRITE_ACQUIRE(out.im->md)`, modify pixels, `SHMIM_WRITE_RELEASE(...)`, and `processinfo_update_output_stream()`.
+
+## Step 7: Scaffold and Finalize
+Copy the chosen template, replace `FPS_APP_INFO`, inject your `FPS_PARAMS`, and place your core logic inside the computation function. Make sure to define the CMake target with `add_milk_standalone()` or equivalent in the module's `CMakeLists.txt`.


### PR DESCRIPTION
### Prompt Summary
The user requested capabilities for AI agents to translate algorithm pseudocode into fully functional milk V2 compute units.

### Description
- Created `api-quick-reference` skill to provide agents with a condensed cheat sheet of `IMGID`, `processinfo` macros, FPS datatypes, and parameter mapping.
- Created `pseudocode-to-compute-unit` skill containing a step-by-step methodology for converting abstract logic into the V2 template execution model.

### Authorship
- **Model(s) used:** Opus 4.6 and Gemini 3.1 Pro
- **Reviewed and signed off by:** @oguyon
