### PR TITLE
docs: update code_assist, AGENTS.md, and tutorial with new AI tools

### DIFF
--- a/.agents/workflows/add-new-module.md
+++ b/.agents/workflows/add-new-module.md
@@ -16,6 +16,9 @@ Ask the user for:
 - **One-line description** of the module
 - Whether it is a **milk** or **cacao** module
 
+> **Note:** If creating a plugin, refer to the `plugin-creator` skill and the `/create-plugin` workflow for plugin-specific guidance on group folder selection.
+
+
 ## 2. Create Directory Structure
 
 Create the module directory with these files:

--- a/.agents/workflows/create-fpsexec.md
+++ b/.agents/workflows/create-fpsexec.md
@@ -18,7 +18,9 @@ See also: [Developer Tutorial](docs/developer/tutorial.md) ·
    - Whether this is a milk or cacao standalone
    - If cacao: whether it needs plugin libraries (fft/imagegen/imagefilter/imagebasic)
 
-2. Copy the template `~/src/milk/src/milk_module_example/examplefunc_fps_cli_poc.c` to the target directory with the given C filename.
+2. **Parameter Design**: Consult the `pseudocode-to-compute-unit` skill. Analyze the intended computation and explicitly map variables to `FPTYPE_*` parameters. Determine which inputs will trigger the computation and which are tunable scalars.
+
+3. Copy the template `~/src/milk/src/milk_module_example/examplefunc_fps_cli_poc.c` to the target directory with the given C filename.
 
 3. Update the newly created C file to replace the default placeholders with the user's specifics:
    - Locate the `FPS_APP_INFO` struct in section 1 and update:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,9 +159,10 @@ automatically.
 
 ```c
 IMGID img = imgid_make_from_name("mystream");
-img.naxis = 2;
-img.size[0] = 128;  img.size[1] = 128;
-img.shared = 1;
+img.mdt->naxis = 2;
+img.mdt->size[0] = 128;
+img.mdt->size[1] = 128;
+img.mdt->shared = 1;
 imgid_mkimage(&img);
 
 // Access pixel data:
@@ -252,18 +253,21 @@ when domain-specific tasks require extended capabilities.
 
 | Skill | When to use |
 |-------|-------------|
-| `feature-planner` | Structured planning and decomposition for new features |
+| `api-quick-reference` | API cheat sheet for IMGID, processinfo macros, stream variables, datatypes, and parameter sync |
 | `batch-kernel-doc` | Systematic Kernel-Doc documentation passes |
 | `cli-test-writer` | Writing CLI robustness test cases |
 | `cmake-patterns` | Module CMake setup, standalone builds, `_compute` variants |
 | `debug-cli-behavior` | Investigating CLI crashes, display bugs, missing errors |
 | `diagnose-build-failure` | Triaging CMake/GCC build errors |
+| `feature-planner` | Structured planning and decomposition for new features |
 | `fps-parameter-guide` | FPS parameter types, flags, X-macro patterns |
 | `imagestream-internals` | SHM stream layout, semaphore protocol, circular buffers |
 | `milk-script-writer` | Generate correct milk-cli scripts from natural language prompts |
 | `module-loading-internals` | Debugging module registration, empty commands |
 | `optimize-compute-function` | Systematic performance optimization methodology |
+| `plugin-creator` | Scaffolding a new plugin module with CMake and module registration |
 | `pr-preparation` | Packaging work into a pull request |
+| `pseudocode-to-compute-unit` | Translating algorithms to V2 compute units |
 | `refactor-c-source` | Splitting large C files into smaller modules |
 | `stream-modifier-guide` | IMGID parsing, `@S:`/`@L:`/`@F:` modifiers, slice syntax |
 
@@ -276,10 +280,13 @@ listed task types:
 
 | Command | When to use |
 |---------|-------------|
+| `/add-cli-command` | Adding a CLI command to a module |
+| `/add-function` | Adding a function to an existing module |
+| `/add-new-module` | Creating a new module (core or plugin) |
+| `/add-stream-processor` | Creating a stream processing loop |
 | `/compile-test` | After any C or CMake edit |
 | `/create-fpsexec` | Scaffolding a new standalone executable |
-| `/add-new-module` | Creating a new plugin module from scratch |
-| `/add-function` | Adding a function to an existing module |
+| `/create-plugin` | Scaffolding a new plugin module with full boilerplate |
 | `/add-stream-processor` | Creating a stream processing loop |
 | `/add-cli-command` | Adding a CLI command to a module |
 | `/fix-bug` | Investigating, fixing, and verifying a bug |

--- a/docs/code_assist.md
+++ b/docs/code_assist.md
@@ -78,6 +78,7 @@ contains a `SKILL.md` with detailed instructions.
 
 | Skill | Folder | What it provides |
 |-------|--------|------------------|
+| API quick reference | [`api-quick-reference`](https://github.com/milk-org/milk/blob/framework-dev/.agents/skills/api-quick-reference/SKILL.md) | API cheat sheet for IMGID, processinfo macros, stream variables, datatypes, and parameter sync. |
 | Feature planner | [`feature-planner`](https://github.com/milk-org/milk/blob/framework-dev/.agents/skills/feature-planner/SKILL.md) | Structured planning and architectural decomposition for new features. |
 | Batch Kernel-Doc | [`batch-kernel-doc`](https://github.com/milk-org/milk/blob/framework-dev/.agents/skills/batch-kernel-doc/SKILL.md) | Systematic function documentation with scanning, templates, and batch processing. |
 | CLI test writer | [`cli-test-writer`](https://github.com/milk-org/milk/blob/framework-dev/.agents/skills/cli-test-writer/SKILL.md) | Writing test cases for the CLI robustness suite with coverage analysis. |
@@ -89,7 +90,9 @@ contains a `SKILL.md` with detailed instructions.
 | Module loading internals | [`module-loading-internals`](https://github.com/milk-org/milk/blob/framework-dev/.agents/skills/module-loading-internals/SKILL.md) | `dlopen` sequence, `data.moduleindex` race, constructor timing. |
 | Milk script writer | [`milk-script-writer`](https://github.com/milk-org/milk/blob/framework-dev/.agents/skills/milk-script-writer/SKILL.md) | Generate correct milk-cli scripts from natural language prompts. |
 | Optimize compute function | [`optimize-compute-function`](https://github.com/milk-org/milk/blob/framework-dev/.agents/skills/optimize-compute-function/SKILL.md) | Systematic performance optimization methodology. |
+| Plugin creator | [`plugin-creator`](https://github.com/milk-org/milk/blob/framework-dev/.agents/skills/plugin-creator/SKILL.md) | Scaffolding a new plugin module with CMake and module registration. |
 | PR preparation | [`pr-preparation`](https://github.com/milk-org/milk/blob/framework-dev/.agents/skills/pr-preparation/SKILL.md) | End-to-end PR packaging with template body and AI authorship. |
+| Pseudocode to compute unit | [`pseudocode-to-compute-unit`](https://github.com/milk-org/milk/blob/framework-dev/.agents/skills/pseudocode-to-compute-unit/SKILL.md) | Translating algorithms to V2 compute units. |
 | Refactor C source | [`refactor-c-source`](https://github.com/milk-org/milk/blob/framework-dev/.agents/skills/refactor-c-source/SKILL.md) | Safe file splitting with dependency analysis and CMake updates. |
 | Stream modifier guide | [`stream-modifier-guide`](https://github.com/milk-org/milk/blob/framework-dev/.agents/skills/stream-modifier-guide/SKILL.md) | IMGID parsing pipeline, `@S:`/`@L:`/`@F:` modifiers, slice syntax. |
 
@@ -103,7 +106,8 @@ step-by-step checklists for common tasks.
 |---------|------|--------------|
 | `/compile-test` | [`compile-test.md`](https://github.com/milk-org/milk/blob/framework-dev/.agents/workflows/compile-test.md) | Incremental build, install, and test from `_build/`. |
 | `/create-fpsexec` | [`create-fpsexec.md`](https://github.com/milk-org/milk/blob/framework-dev/.agents/workflows/create-fpsexec.md) | Scaffold a new V2 fpsexec standalone executable. |
-| `/add-new-module` | [`add-new-module.md`](https://github.com/milk-org/milk/blob/framework-dev/.agents/workflows/add-new-module.md) | Scaffold a new plugin module (README, CMake, boilerplate). |
+| `/create-plugin` | [`create-plugin.md`](https://github.com/milk-org/milk/blob/framework-dev/.agents/workflows/create-plugin.md) | Scaffold a new plugin module with full boilerplate. |
+| `/add-new-module` | [`add-new-module.md`](https://github.com/milk-org/milk/blob/framework-dev/.agents/workflows/add-new-module.md) | Scaffold a new module (README, CMake, boilerplate). |
 | `/add-function` | [`add-function.md`](https://github.com/milk-org/milk/blob/framework-dev/.agents/workflows/add-function.md) | Add a function to an existing module (dispatches to sub-workflows). |
 | `/add-stream-processor` | [`add-stream-processor.md`](https://github.com/milk-org/milk/blob/framework-dev/.agents/workflows/add-stream-processor.md) | Scaffold a stream processing loop compute unit. |
 | `/add-cli-command` | [`add-cli-command.md`](https://github.com/milk-org/milk/blob/framework-dev/.agents/workflows/add-cli-command.md) | Add a CLI command to an existing module. |

--- a/docs/developer/tutorial.md
+++ b/docs/developer/tutorial.md
@@ -145,5 +145,14 @@ milk-fpsCTRL myfirstexec
 
 Congratulations! You've successfully written a milk module and an FPS compute block.
 
+## 5. Next Steps
+
+Now that you've written your first module, you can automate this process and learn more advanced patterns using our built-in tools:
+
+- Run the `/create-plugin` workflow to scaffold new plugins automatically.
+- Run the `/create-fpsexec` workflow to scaffold new compute units.
+- Consult the `api-quick-reference` skill for a cheat sheet on streams and FPS parameters.
+- Review the `pseudocode-to-compute-unit` skill to learn how to translate abstract algorithms into V2 templates.
+
 ---
 ← [Documentation Index](../index.md)


### PR DESCRIPTION
### Prompt Summary
The user requested updates to existing agent files to incorporate the newly created code generation and plugin creation tools.

### Description
- Updated `/create-fpsexec` workflow to consult the `pseudocode-to-compute-unit` skill for parameter mapping.
- Updated `/add-new-module` workflow to reference the `/create-plugin` workflow.
- Registered new skills and workflows in `AGENTS.md` and `docs/code_assist.md`.
- Expanded `docs/developer/tutorial.md` to point developers to these automation tools.

### Authorship
- **Model(s) used:** Opus 4.6 and Gemini 3.1 Pro
- **Reviewed and signed off by:** @oguyon
