### PR TITLE
fix: improve overview TUI parameter selection and exit button interaction

### DIFF
--- a/src/cli/overview/overview_data_scan.c
+++ b/src/cli/overview/overview_data_scan.c
@@ -471,8 +471,20 @@ static void fill_fps_from_struct(OV_FPS *f, ov_fps_cache_t *ce)
         char valstr[FUNCTION_PARAMETER_STRMAXLEN] = { 0 };
         switch (fp->type)
         {
+        case FPTYPE_UNDEF:
+            snprintf(valstr, sizeof(valstr), "[UNDEF]");
+            break;
+        case FPTYPE_INT32:
+            snprintf(valstr, sizeof(valstr), "%" PRIi32, fp->val.i32[0]);
+            break;
+        case FPTYPE_UINT32:
+            snprintf(valstr, sizeof(valstr), "%" PRIu32, fp->val.ui32[0]);
+            break;
         case FPTYPE_INT64:
             snprintf(valstr, sizeof(valstr), "%" PRIi64, fp->val.i64[0]);
+            break;
+        case FPTYPE_UINT64:
+            snprintf(valstr, sizeof(valstr), "%" PRIu64, fp->val.ui64[0]);
             break;
         case FPTYPE_FLOAT64:
             snprintf(valstr, sizeof(valstr), "%g", fp->val.f64[0]);
@@ -498,6 +510,9 @@ static void fill_fps_from_struct(OV_FPS *f, ov_fps_cache_t *ce)
         case FPTYPE_DIRNAME:
         case FPTYPE_FILENAME:
         case FPTYPE_EXECFILENAME:
+        case FPTYPE_FITSFILENAME:
+        case FPTYPE_PROCESS:
+        case FPTYPE_STRING_NOT_STREAM:
             strncpy(valstr, fp->val.string[0], sizeof(valstr) - 1);
             break;
         default:

--- a/src/cli/overview/overview_input.c
+++ b/src/cli/overview/overview_input.c
@@ -1040,6 +1040,16 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
             last_click_c  = mc;
         }
 
+        /* Check for status bar exit button clicks */
+        if (mr == lay->term_rows)
+        {
+            int col_start = lay->term_cols - 18;
+            if (mc >= col_start && mc < col_start + 10)
+            {
+                return 2; /* exit request */
+            }
+        }
+
         /* Check for header tab clicks */
         if (mr == lay->r_header.row && mc >= 1)
         {
@@ -1242,8 +1252,25 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
                 int body_row         = mr - lay->r_fps_params.row - 2;
                 if (body_row >= 0)
                 {
-                    int idx            = lay->fps_param_scroll + body_row;
-                    lay->fps_param_sel = idx;
+                    int fsel = lay->sel_fps;
+                    if (fsel >= 0 && fsel < m->nb_fps)
+                    {
+                        const OV_FPS   *fps = &m->fps[fsel];
+                        fps_tree_item_t items[1024];
+                        int nitems = ov_get_fps_tree_items(fps, lay->fps_param_path, items, 1024);
+                        if (nitems > 0)
+                        {
+                            int idx = lay->fps_param_scroll + body_row;
+                            if (idx >= nitems)
+                            {
+                                lay->fps_param_sel = nitems - 1;
+                            }
+                            else
+                            {
+                                lay->fps_param_sel = idx;
+                            }
+                        }
+                    }
                 }
             }
             else if (INSIDE(lay->r_fps, mr, mc))
@@ -1799,9 +1826,16 @@ static int ov_input__handle_mouse(int key, OV_LAYOUT *lay, const OV_MODEL *m)
         {
             if (INSIDE(lay->r_fps_params, mr, mc))
             {
-                sel    = &lay->fps_param_sel;
-                scroll = &lay->fps_param_scroll;
-                count  = 1000;
+                sel      = &lay->fps_param_sel;
+                scroll   = &lay->fps_param_scroll;
+                count    = 0;
+                int fsel = lay->sel_fps;
+                if (fsel >= 0 && fsel < m->nb_fps)
+                {
+                    const OV_FPS   *fps = &m->fps[fsel];
+                    fps_tree_item_t items[1024];
+                    count = ov_get_fps_tree_items(fps, lay->fps_param_path, items, 1024);
+                }
                 page_h = lay->r_fps_params.height - 3;
             }
             else if (INSIDE(lay->r_fps, mr, mc))
@@ -3025,12 +3059,34 @@ static int ov_input__handle_navigation(int key, OV_LAYOUT *lay, const OV_MODEL *
             has_params)
         {
             lay->fps_param_focus = 1;
+            if (nitems > 0)
+            {
+                if (lay->fps_param_sel < 0)
+                {
+                    lay->fps_param_sel = 0;
+                }
+                else if (lay->fps_param_sel >= nitems)
+                {
+                    lay->fps_param_sel = nitems - 1;
+                }
+            }
             return 1;
         }
 
         /* All nav/edit keys when param panel is focused */
         if (lay->fps_param_focus == 1)
         {
+            if (nitems > 0)
+            {
+                if (lay->fps_param_sel < 0)
+                {
+                    lay->fps_param_sel = 0;
+                }
+                else if (lay->fps_param_sel >= nitems)
+                {
+                    lay->fps_param_sel = nitems - 1;
+                }
+            }
             /* ESC / LEFT from param panel → back to list or ascend dir */
             if (key == OV_KEY_LEFT || key == OV_KEY_ESC)
             {
@@ -3746,7 +3802,12 @@ static int ov_handle_key_internal(int key, OV_LAYOUT *lay, const OV_MODEL *m)
     {
         return 0;
     }
-    if (ov_input__handle_mouse(key, lay, m))
+    int mouse_res = ov_input__handle_mouse(key, lay, m);
+    if (mouse_res == 2)
+    {
+        return 1;
+    }
+    if (mouse_res)
     {
         return 0;
     }

--- a/src/cli/overview/overview_render.c
+++ b/src/cli/overview/overview_render.c
@@ -506,6 +506,26 @@ void ov_render_frame(OV_LAYOUT *lay, const OV_MODEL *m)
     ov_hittest(lay, m, ov_mouse_row, ov_mouse_col);
     ov_hittest_resolve_globals(lay, m);
 
+    /* Ensure there exists a valid selected parameter when in the PARAMS panel on F5 view */
+    if (lay->view == OV_VIEW_FPS && lay->sel_fps >= 0 && lay->sel_fps < m->nb_fps)
+    {
+        const OV_FPS   *fps = &m->fps[lay->sel_fps];
+        fps_tree_item_t items[1024];
+        int             nitems = ov_get_fps_tree_items(fps, lay->fps_param_path, items, 1024);
+
+        if (nitems > 0)
+        {
+            if (lay->fps_param_sel < 0)
+            {
+                lay->fps_param_sel = 0;
+            }
+            else if (lay->fps_param_sel >= nitems)
+            {
+                lay->fps_param_sel = nitems - 1;
+            }
+        }
+    }
+
     /* One-shot sort: only runs once when the user
      * presses S or s.  Order stays frozen until
      * the user explicitly presses S/s again. */

--- a/src/cli/overview/overview_render_fps_params.c
+++ b/src/cli/overview/overview_render_fps_params.c
@@ -266,6 +266,18 @@ void ov_render_fps_params_panel(OV_LAYOUT *lay, const OV_MODEL *m)
     fps_tree_item_t items[1024];
     int             nitems = ov_get_fps_tree_items(fps, lay->fps_param_path, items, 1024);
 
+    if (lay->fps_param_focus == 1 && nitems > 0)
+    {
+        if (lay->fps_param_sel < 0)
+        {
+            lay->fps_param_sel = 0;
+        }
+        else if (lay->fps_param_sel >= nitems)
+        {
+            lay->fps_param_sel = nitems - 1;
+        }
+    }
+
     render_param_breadcrumb(lay, fps, r);
 
     if (nitems <= 0)
@@ -479,6 +491,15 @@ void ov_render_fps_params_panel(OV_LAYOUT *lay, const OV_MODEL *m)
  */
 void ov_render_fps_param_info(const OV_LAYOUT *lay, const OV_MODEL *m)
 {
+    if (lay->fps_param_focus == 0)
+    {
+        /* Clear row 3 to prevent stale parameter info */
+        ov_buf_pos(3, 1);
+        ov_theme_bg(OV_BG_PANEL);
+        ov_buf_hline(' ', lay->term_cols);
+        return;
+    }
+
     /* Clear rows 2 and 3 */
     ov_buf_pos(2, 1);
     ov_theme_bg(OV_BG_PANEL);

--- a/src/cli/overview/overview_render_status.c
+++ b/src/cli/overview/overview_render_status.c
@@ -282,10 +282,22 @@ void ov_render_status(const OV_LAYOUT *lay, const OV_MODEL *m)
         ov_buf_hline(' ', pad);
     }
 
-    /* Render [x] exit with distinct color */
-    ov_buf_fg(200, 80, 80);
+    /* Render [x] exit with distinct color or hover highlight */
+    int col_start = r.width - n_exit - n2;
+    if (lay->mouse_hover && (ov_mouse_row == r.row) && (ov_mouse_col >= col_start) &&
+        (ov_mouse_col < col_start + n_exit))
+    {
+        ov_buf_bg(220, 40, 40);   /* vibrant red background */
+        ov_buf_fg(255, 255, 255); /* white text */
+    }
+    else
+    {
+        ov_buf_fg(200, 80, 80);
+        ov_theme_bg(OV_BG_HEADER);
+    }
     ov_buf_printf("%s", exit_label);
 
+    ov_theme_bg(OV_BG_HEADER);
     ov_theme_fg(OV_FG_TEXT);
     ov_buf_printf("%s ", tstr);
     ov_buf_reset_attr();


### PR DESCRIPTION
### Prompt Summary
The user requested fixes for the milk-CTRL overview TUI, specifically regarding mouse interaction with the exit button, stale parameter info display, and selection state handling in the FPS parameter panel.

### Description
- Added mouse hover highlight and click handler for the `[x]` exit button in the status bar.
- Fixed stale parameter information display by clearing the info row when the parameter panel loses focus.
- Added boundary checks for `fps_param_sel` to prevent out-of-bounds selection when navigating or clicking in the parameter panel.
- Added missing `FPTYPE_FITSFILENAME`, `FPTYPE_PROCESS`, and `FPTYPE_STRING_NOT_STREAM` to string rendering logic.

### Authorship
- **Model(s) used:** Opus 4.6 and Gemini 3.1 Pro
- **Reviewed and signed off by:** @oguyon
