### PR TITLE
refactor: replace hand-written FPS Section 5 boilerplate with FPS_V2_SECTION5 macro

### DIFF
--- a/plugins/milk-extra-src/fft/dofft.c
+++ b/plugins/milk-extra-src/fft/dofft.c
@@ -73,19 +73,10 @@ static FPS_APP_INFO FPS_app_info_1dfft = {
     X(".in_name", p_1dfft_in, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT, "input complex image") \
     X(".out_name", p_1dfft_out, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "output complex image")
 
-static CLICMDDATA  CLIcmddata_1dfft = { "", "", CLICMD_FIELDS_NOPARAM };
-static CMDSETTINGS cms_1dfft        = { 0 };
+static CLICMDDATA CLIcmddata_1dfft = { "", "", CLICMD_FIELDS_NOPARAM };
 
-static __attribute__((constructor)) void init_cms_1dfft(void)
-{
-    strncpy(CLIcmddata_1dfft.key, FPS_app_info_1dfft.cmdkey, sizeof(CLIcmddata_1dfft.key) - 1);
-    strncpy(CLIcmddata_1dfft.description, FPS_app_info_1dfft.description,
-            sizeof(CLIcmddata_1dfft.description) - 1);
-    if (CLIcmddata_1dfft.cmdsettings == NULL)
-    {
-        CLIcmddata_1dfft.cmdsettings = &cms_1dfft;
-    }
-}
+FPS_CMDSETTINGS_INIT(1dfft, CLIcmddata_1dfft, FPS_app_info_1dfft)
+
 
 static errno_t __attribute__((unused)) compute_1dfft()
 {
@@ -114,19 +105,10 @@ static FPS_APP_INFO FPS_app_info_1drfft = {
     X(".in_name", p_1drfft_in, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT, "input real image") \
     X(".out_name", p_1drfft_out, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "output complex image")
 
-static CLICMDDATA  CLIcmddata_1drfft = { "", "", CLICMD_FIELDS_NOPARAM };
-static CMDSETTINGS cms_1drfft        = { 0 };
+static CLICMDDATA CLIcmddata_1drfft = { "", "", CLICMD_FIELDS_NOPARAM };
 
-static __attribute__((constructor)) void init_cms_1drfft(void)
-{
-    strncpy(CLIcmddata_1drfft.key, FPS_app_info_1drfft.cmdkey, sizeof(CLIcmddata_1drfft.key) - 1);
-    strncpy(CLIcmddata_1drfft.description, FPS_app_info_1drfft.description,
-            sizeof(CLIcmddata_1drfft.description) - 1);
-    if (CLIcmddata_1drfft.cmdsettings == NULL)
-    {
-        CLIcmddata_1drfft.cmdsettings = &cms_1drfft;
-    }
-}
+FPS_CMDSETTINGS_INIT(1drfft, CLIcmddata_1drfft, FPS_app_info_1drfft)
+
 
 static errno_t __attribute__((unused)) compute_1drfft()
 {

--- a/plugins/milk-extra-src/fft/fftcorrelation.c
+++ b/plugins/milk-extra-src/fft/fftcorrelation.c
@@ -43,23 +43,7 @@ static FPS_APP_INFO FPS_app_info = {
     X(".in2", p_in2, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT, "input image 2") \
     X(".out", p_out, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "output correlation")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-static CLICMDDATA  CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS cms        = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/fft/ffttranslate.c
+++ b/plugins/milk-extra-src/fft/ffttranslate.c
@@ -45,23 +45,7 @@ static FPS_APP_INFO FPS_app_info = {
     X(".xtransl", &p_xtransl, FPTYPE_FLOAT64, 1, FPFLAG_DEFAULT_INPUT, "x translation") \
     X(".ytransl", &p_ytransl, FPTYPE_FLOAT64, 1, FPFLAG_DEFAULT_INPUT, "y translation")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-static CLICMDDATA  CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS cms        = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/fft/init_fftwplan.c
+++ b/plugins/milk-extra-src/fft/init_fftwplan.c
@@ -32,23 +32,7 @@ static FPS_APP_INFO FPS_app_info = {
 
 #define FPS_PARAMS(X)
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING){ NULL, NULL, 0, 0, 0, NULL } };
-static const int       nb_bindings   = 0;
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-static CLICMDDATA  CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS cms        = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/fft/permut.c
+++ b/plugins/milk-extra-src/fft/permut.c
@@ -69,23 +69,7 @@ static FPS_APP_INFO FPS_app_info = {
 
 #define FPS_PARAMS(X) X(".in_name", p_imname, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT, "image")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-static CLICMDDATA  CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS cms        = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/fft/testfftspeed.c
+++ b/plugins/milk-extra-src/fft/testfftspeed.c
@@ -33,23 +33,7 @@ static FPS_APP_INFO FPS_app_info = {
 
 #define FPS_PARAMS(X) X(".nmax", &p_nmax, FPTYPE_INT64, 1, FPFLAG_DEFAULT_INPUT, "max power of 2")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-static CLICMDDATA  CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS cms        = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/image_basic/im3Dto2D.c
+++ b/plugins/milk-extra-src/image_basic/im3Dto2D.c
@@ -27,21 +27,7 @@ static FPS_APP_INFO FPS_app_info = {
 
 #define FPS_PARAMS(X) X(".in_name", p_in, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT, "input image")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-static CLICMDARGDEF    farg[]        = { FPS_PARAMS(FPS_X_FARG) };
-static CLICMDDATA      CLIcmddata    = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS     cms           = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/image_basic/image_add.c
+++ b/plugins/milk-extra-src/image_basic/image_add.c
@@ -56,18 +56,8 @@ static CLICMDDATA      CLIcmddata_1    = {
     "",   "",   __FILE__, sizeof(farg_1) / sizeof(CLICMDARGDEF), farg_1, CLICMDFLAG_FPS,
     NULL, NULL, NULL
 };
-static CMDSETTINGS cms_1 = { 0 };
+FPS_CMDSETTINGS_INIT(1, CLIcmddata_1, FPS_app_info_1)
 
-static __attribute__((constructor)) void init_cms_1(void)
-{
-    strncpy(CLIcmddata_1.key, FPS_app_info_1.cmdkey, sizeof(CLIcmddata_1.key) - 1);
-    strncpy(CLIcmddata_1.description, FPS_app_info_1.description,
-            sizeof(CLIcmddata_1.description) - 1);
-    if (CLIcmddata_1.cmdsettings == NULL)
-    {
-        CLIcmddata_1.cmdsettings = &cms_1;
-    }
-}
 
 static MILK_HOT errno_t compute_function_1()
 {
@@ -113,18 +103,8 @@ static CLICMDDATA      CLIcmddata_2    = {
     "",   "",   __FILE__, sizeof(farg_2) / sizeof(CLICMDARGDEF), farg_2, CLICMDFLAG_FPS,
     NULL, NULL, NULL
 };
-static CMDSETTINGS cms_2 = { 0 };
+FPS_CMDSETTINGS_INIT(2, CLIcmddata_2, FPS_app_info_2)
 
-static __attribute__((constructor)) void init_cms_2(void)
-{
-    strncpy(CLIcmddata_2.key, FPS_app_info_2.cmdkey, sizeof(CLIcmddata_2.key) - 1);
-    strncpy(CLIcmddata_2.description, FPS_app_info_2.description,
-            sizeof(CLIcmddata_2.description) - 1);
-    if (CLIcmddata_2.cmdsettings == NULL)
-    {
-        CLIcmddata_2.cmdsettings = &cms_2;
-    }
-}
 
 static MILK_HOT errno_t compute_function_2()
 {

--- a/plugins/milk-extra-src/image_basic/imcontract.c
+++ b/plugins/milk-extra-src/image_basic/imcontract.c
@@ -45,18 +45,8 @@ static CLICMDDATA      CLIcmddata_1    = {
     "",   "",   __FILE__, sizeof(farg_1) / sizeof(CLICMDARGDEF), farg_1, CLICMDFLAG_FPS,
     NULL, NULL, NULL
 };
-static CMDSETTINGS cms_1 = { 0 };
+FPS_CMDSETTINGS_INIT(1, CLIcmddata_1, FPS_app_info_1)
 
-static __attribute__((constructor)) void init_cms_1(void)
-{
-    strncpy(CLIcmddata_1.key, FPS_app_info_1.cmdkey, sizeof(CLIcmddata_1.key) - 1);
-    strncpy(CLIcmddata_1.description, FPS_app_info_1.description,
-            sizeof(CLIcmddata_1.description) - 1);
-    if (CLIcmddata_1.cmdsettings == NULL)
-    {
-        CLIcmddata_1.cmdsettings = &cms_1;
-    }
-}
 
 static MILK_HOT errno_t compute_function_1()
 {
@@ -100,18 +90,8 @@ static CLICMDDATA      CLIcmddata_2    = {
     "",   "",   __FILE__, sizeof(farg_2) / sizeof(CLICMDARGDEF), farg_2, CLICMDFLAG_FPS,
     NULL, NULL, NULL
 };
-static CMDSETTINGS cms_2 = { 0 };
+FPS_CMDSETTINGS_INIT(2, CLIcmddata_2, FPS_app_info_2)
 
-static __attribute__((constructor)) void init_cms_2(void)
-{
-    strncpy(CLIcmddata_2.key, FPS_app_info_2.cmdkey, sizeof(CLIcmddata_2.key) - 1);
-    strncpy(CLIcmddata_2.description, FPS_app_info_2.description,
-            sizeof(CLIcmddata_2.description) - 1);
-    if (CLIcmddata_2.cmdsettings == NULL)
-    {
-        CLIcmddata_2.cmdsettings = &cms_2;
-    }
-}
 
 static MILK_HOT errno_t compute_function_2()
 {

--- a/plugins/milk-extra-src/image_basic/imexpand.c
+++ b/plugins/milk-extra-src/image_basic/imexpand.c
@@ -45,18 +45,8 @@ static CLICMDDATA      CLIcmddata_1    = {
     "",   "",   __FILE__, sizeof(farg_1) / sizeof(CLICMDARGDEF), farg_1, CLICMDFLAG_FPS,
     NULL, NULL, NULL
 };
-static CMDSETTINGS cms_1 = { 0 };
+FPS_CMDSETTINGS_INIT(1, CLIcmddata_1, FPS_app_info_1)
 
-static __attribute__((constructor)) void init_cms_1(void)
-{
-    strncpy(CLIcmddata_1.key, FPS_app_info_1.cmdkey, sizeof(CLIcmddata_1.key) - 1);
-    strncpy(CLIcmddata_1.description, FPS_app_info_1.description,
-            sizeof(CLIcmddata_1.description) - 1);
-    if (CLIcmddata_1.cmdsettings == NULL)
-    {
-        CLIcmddata_1.cmdsettings = &cms_1;
-    }
-}
 
 static MILK_HOT errno_t compute_function_1()
 {
@@ -100,18 +90,8 @@ static CLICMDDATA      CLIcmddata_2    = {
     "",   "",   __FILE__, sizeof(farg_2) / sizeof(CLICMDARGDEF), farg_2, CLICMDFLAG_FPS,
     NULL, NULL, NULL
 };
-static CMDSETTINGS cms_2 = { 0 };
+FPS_CMDSETTINGS_INIT(2, CLIcmddata_2, FPS_app_info_2)
 
-static __attribute__((constructor)) void init_cms_2(void)
-{
-    strncpy(CLIcmddata_2.key, FPS_app_info_2.cmdkey, sizeof(CLIcmddata_2.key) - 1);
-    strncpy(CLIcmddata_2.description, FPS_app_info_2.description,
-            sizeof(CLIcmddata_2.description) - 1);
-    if (CLIcmddata_2.cmdsettings == NULL)
-    {
-        CLIcmddata_2.cmdsettings = &cms_2;
-    }
-}
 
 static MILK_HOT errno_t compute_function_2()
 {

--- a/plugins/milk-extra-src/image_basic/imgetcircasym.c
+++ b/plugins/milk-extra-src/image_basic/imgetcircasym.c
@@ -40,21 +40,7 @@ static FPS_APP_INFO FPS_app_info = {
     X(".xcenter", &p_xcenter, FPTYPE_FLOAT64, 1, FPFLAG_DEFAULT_INPUT, "x center") \
     X(".ycenter", &p_ycenter, FPTYPE_FLOAT64, 1, FPFLAG_DEFAULT_INPUT, "y center")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-static CLICMDARGDEF    farg[]        = { FPS_PARAMS(FPS_X_FARG) };
-static CLICMDDATA      CLIcmddata    = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS     cms           = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/image_basic/imgetcircsym.c
+++ b/plugins/milk-extra-src/image_basic/imgetcircsym.c
@@ -38,21 +38,7 @@ static FPS_APP_INFO FPS_app_info = { .fps_name    = "imgetcircsym",
     X(".xcenter", &p_xcenter, FPTYPE_FLOAT64, 1, FPFLAG_DEFAULT_INPUT, "x center") \
     X(".ycenter", &p_ycenter, FPTYPE_FLOAT64, 1, FPFLAG_DEFAULT_INPUT, "y center")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-static CLICMDARGDEF    farg[]        = { FPS_PARAMS(FPS_X_FARG) };
-static CLICMDDATA      CLIcmddata    = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS     cms           = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/image_basic/imswapaxis2D.c
+++ b/plugins/milk-extra-src/image_basic/imswapaxis2D.c
@@ -29,21 +29,7 @@ static FPS_APP_INFO FPS_app_info = { .fps_name    = "imswapaxis2D",
     X(".in_name", p_in, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT, "input image") \
     X(".out_name", p_out, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "output image")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-static CLICMDARGDEF    farg[]        = { FPS_PARAMS(FPS_X_FARG) };
-static CLICMDDATA      CLIcmddata    = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS     cms           = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/image_basic/indexmap.c
+++ b/plugins/milk-extra-src/image_basic/indexmap.c
@@ -34,21 +34,7 @@ static FPS_APP_INFO FPS_app_info = {
     X(".in_values", p_val, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT, "values image")   \
     X(".out_name", p_out, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "output image")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-static CLICMDARGDEF    farg[]        = { FPS_PARAMS(FPS_X_FARG) };
-static CLICMDDATA      CLIcmddata    = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS     cms           = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/image_basic/loadfitsimgcube.c
+++ b/plugins/milk-extra-src/image_basic/loadfitsimgcube.c
@@ -30,21 +30,7 @@ static FPS_APP_INFO FPS_app_info = { .fps_name    = "loadfitsimgcube",
     X(".in_pattern", p_pat, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "string pattern") \
     X(".out_name", p_out, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "output cube")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-static CLICMDARGDEF    farg[]        = { FPS_PARAMS(FPS_X_FARG) };
-static CLICMDDATA      CLIcmddata    = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS     cms           = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/image_basic/streamfeed.c
+++ b/plugins/milk-extra-src/image_basic/streamfeed.c
@@ -36,12 +36,7 @@ static FPS_APP_INFO FPS_app_info = {
     X(".stream", p_stream, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT, "output stream") \
     X(".freq", &p_freq, FPTYPE_FLOAT64, 1, FPFLAG_DEFAULT_INPUT, "frequency [Hz]")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-static CLICMDARGDEF    farg[]        = { FPS_PARAMS(FPS_X_FARG) };
-static CLICMDDATA      CLIcmddata    = { "", "", CLICMD_FIELDS_DEFAULTS };
-FPS_CMDSETTINGS_INIT(streamfeed, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS)
 static MILK_HOT errno_t compute_function()
 {
     IMAGE_BASIC_streamfeed(p_in, p_stream, (float) p_freq);

--- a/plugins/milk-extra-src/image_basic/streamrecord.c
+++ b/plugins/milk-extra-src/image_basic/streamrecord.c
@@ -35,21 +35,7 @@ static FPS_APP_INFO FPS_app_info = { .fps_name    = "imgstreamrec",
     X(".nframes", &p_nframes, FPTYPE_INT64, 1, FPFLAG_DEFAULT_INPUT, "number of frames") \
     X(".out_name", p_out, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "output image")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-static CLICMDARGDEF    farg[]        = { FPS_PARAMS(FPS_X_FARG) };
-static CLICMDDATA      CLIcmddata    = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS     cms           = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/image_filter/fconvolve.c
+++ b/plugins/milk-extra-src/image_filter/fconvolve.c
@@ -38,24 +38,7 @@ static FPS_APP_INFO FPS_app_info = { .fps_name    = "fconv",
     X(".ke_name", fconv_ke, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT, "kernel image") \
     X(".out_name", fconv_out, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "output image")
 
-static FPS_CLI_BINDING FPS_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings    = sizeof(FPS_bindings) / sizeof(FPS_CLI_BINDING);
-static CLICMDARGDEF    farg[]         = { FPS_PARAMS(FPS_X_FARG) };
-static CLICMDDATA      CLIcmddata     = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS     cms            = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    CLIcmddata.nbarg         = sizeof(farg) / sizeof(CLICMDARGDEF);
-    CLIcmddata.funcfpscliarg = farg;
-    CLIcmddata.flags         = CLICMDFLAG_FPS;
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {
@@ -65,13 +48,13 @@ static MILK_HOT errno_t compute_function()
 
 static errno_t __attribute__((unused)) CLIfunction(void)
 {
-    return safe_fps_generic_CLIfunction(&FPS_app_info, farg, &CLIcmddata, FPS_bindings, nb_bindings,
+    return safe_fps_generic_CLIfunction(&FPS_app_info, farg, &CLIcmddata, my_bindings, nb_bindings,
                                         compute_function);
 }
 
 errno_t CLIADDCMD_image_filter__fconvolve()
 {
-    safe_fps_fill_farg_examples(farg, FPS_bindings, nb_bindings);
+    safe_fps_fill_farg_examples(farg, my_bindings, nb_bindings);
     INSERT_STD_CLIREGISTERFUNC
     return RETURN_SUCCESS;
 }

--- a/plugins/milk-extra-src/image_format/CR2toFITS.c
+++ b/plugins/milk-extra-src/image_format/CR2toFITS.c
@@ -35,23 +35,7 @@ static FPS_APP_INFO FPS_app_info = {
     X(".in_name", p_in, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "input CR2 file") \
     X(".out_name", p_out, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "output FITS file")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-static CLICMDDATA  CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS cms        = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/image_format/FITS_to_floatbin_lock.c
+++ b/plugins/milk-extra-src/image_format/FITS_to_floatbin_lock.c
@@ -32,23 +32,7 @@ static FPS_APP_INFO FPS_app_info = { .fps_name    = "writefloatlock",
     X(".in_name", p_in, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT, "input image") \
     X(".out_name", p_fname, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "output binary file")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-static CLICMDDATA  CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS cms        = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/image_format/FITS_to_ushortintbin_lock.c
+++ b/plugins/milk-extra-src/image_format/FITS_to_ushortintbin_lock.c
@@ -28,21 +28,7 @@ static FPS_APP_INFO FPS_app_info = { .fps_name    = "writeushortintlock",
     X(".in_name", p_in, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT, "input image") \
     X(".out_name", p_fname, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "output binary file")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-static CLICMDARGDEF    farg[]        = { FPS_PARAMS(FPS_X_FARG) };
-static CLICMDDATA      CLIcmddata    = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS     cms           = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/image_format/imtoASCII.c
+++ b/plugins/milk-extra-src/image_format/imtoASCII.c
@@ -25,21 +25,7 @@ static FPS_APP_INFO FPS_app_info = { .fps_name    = "im2ascii",
     X(".in_name", p_in, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT, "input image") \
     X(".out_name", p_out, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "output ASCII file")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-static CLICMDARGDEF    farg[]        = { FPS_PARAMS(FPS_X_FARG) };
-static CLICMDDATA      CLIcmddata    = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS     cms           = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/image_format/loadCR2toFITSRGB.c
+++ b/plugins/milk-extra-src/image_format/loadCR2toFITSRGB.c
@@ -39,21 +39,7 @@ static FPS_APP_INFO FPS_app_info = {
     X(".out_g", p_g, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "output green")            \
     X(".out_b", p_b, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "output blue")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-static CLICMDARGDEF    farg[]        = { FPS_PARAMS(FPS_X_FARG) };
-static CLICMDDATA      CLIcmddata    = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS     cms           = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/image_format/read_binary32f.c
+++ b/plugins/milk-extra-src/image_format/read_binary32f.c
@@ -32,21 +32,7 @@ static FPS_APP_INFO FPS_app_info = {
     X(".ysize", &p_ysize, FPTYPE_INT64, 1, FPFLAG_DEFAULT_INPUT, "y size")         \
     X(".out_name", p_out, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "output image")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-static CLICMDARGDEF    farg[]        = { FPS_PARAMS(FPS_X_FARG) };
-static CLICMDDATA      CLIcmddata    = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS     cms           = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/info/cubeMatchMatrix.c
+++ b/plugins/milk-extra-src/info/cubeMatchMatrix.c
@@ -29,21 +29,7 @@ static FPS_APP_INFO FPS_app_info = {
     X(".in_name", p_in, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT, "input image cube") \
     X(".out_name", p_out, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "output image")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-static CLICMDARGDEF    farg[]        = { FPS_PARAMS(FPS_X_FARG) };
-static CLICMDDATA      CLIcmddata    = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS     cms           = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/info/cubestats.c
+++ b/plugins/milk-extra-src/info/cubestats.c
@@ -29,21 +29,7 @@ static FPS_APP_INFO FPS_app_info = { .fps_name    = "cubestats",
     X(".in_mask", p_mask, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT, "mask image")     \
     X(".out_fname", p_out, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "output file")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-static CLICMDARGDEF    farg[]        = { FPS_PARAMS(FPS_X_FARG) };
-static CLICMDDATA      CLIcmddata    = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS     cms           = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/info/image_stats.c
+++ b/plugins/milk-extra-src/info/image_stats.c
@@ -37,18 +37,8 @@ static CLICMDDATA      CLIcmddata_1    = {
     "",   "",   __FILE__, sizeof(farg_1) / sizeof(CLICMDARGDEF), farg_1, CLICMDFLAG_FPS,
     NULL, NULL, NULL
 };
-static CMDSETTINGS cms_1 = { 0 };
+FPS_CMDSETTINGS_INIT(1, CLIcmddata_1, FPS_app_info_1)
 
-static __attribute__((constructor)) void init_cms_1(void)
-{
-    strncpy(CLIcmddata_1.key, FPS_app_info_1.cmdkey, sizeof(CLIcmddata_1.key) - 1);
-    strncpy(CLIcmddata_1.description, FPS_app_info_1.description,
-            sizeof(CLIcmddata_1.description) - 1);
-    if (CLIcmddata_1.cmdsettings == NULL)
-    {
-        CLIcmddata_1.cmdsettings = &cms_1;
-    }
-}
 
 static MILK_HOT errno_t compute_function_1()
 {
@@ -85,18 +75,8 @@ static CLICMDDATA      CLIcmddata_2    = {
     "",   "",   __FILE__, sizeof(farg_2) / sizeof(CLICMDARGDEF), farg_2, CLICMDFLAG_FPS,
     NULL, NULL, NULL
 };
-static CMDSETTINGS cms_2 = { 0 };
+FPS_CMDSETTINGS_INIT(2, CLIcmddata_2, FPS_app_info_2)
 
-static __attribute__((constructor)) void init_cms_2(void)
-{
-    strncpy(CLIcmddata_2.key, FPS_app_info_2.cmdkey, sizeof(CLIcmddata_2.key) - 1);
-    strncpy(CLIcmddata_2.description, FPS_app_info_2.description,
-            sizeof(CLIcmddata_2.description) - 1);
-    if (CLIcmddata_2.cmdsettings == NULL)
-    {
-        CLIcmddata_2.cmdsettings = &cms_2;
-    }
-}
 
 static MILK_HOT errno_t compute_function_2()
 {

--- a/plugins/milk-extra-src/info/improfile.c
+++ b/plugins/milk-extra-src/info/improfile.c
@@ -40,21 +40,7 @@ static FPS_APP_INFO FPS_app_info = { .fps_name    = "profile",
     X(".step", &p_step, FPTYPE_FLOAT64, 1, FPFLAG_DEFAULT_INPUT, "step size")      \
     X(".nbstep", &p_nbstep, FPTYPE_INT64, 1, FPFLAG_DEFAULT_INPUT, "number of steps")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-static const int       nb_bindings   = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-static CLICMDARGDEF    farg[]        = { FPS_PARAMS(FPS_X_FARG) };
-static CLICMDDATA      CLIcmddata    = { "", "", CLICMD_FIELDS_DEFAULTS };
-static CMDSETTINGS     cms           = { 0 };
-
-static __attribute__((constructor)) void init_cms(void)
-{
-    strncpy(CLIcmddata.key, FPS_app_info.cmdkey, sizeof(CLIcmddata.key) - 1);
-    strncpy(CLIcmddata.description, FPS_app_info.description, sizeof(CLIcmddata.description) - 1);
-    if (CLIcmddata.cmdsettings == NULL)
-    {
-        CLIcmddata.cmdsettings = &cms;
-    }
-}
+FPS_V2_SECTION5(FPS_PARAMS)
 
 static MILK_HOT errno_t compute_function()
 {

--- a/plugins/milk-extra-src/linARfilterPred/applyARpfilt.c
+++ b/plugins/milk-extra-src/linARfilterPred/applyARpfilt.c
@@ -38,20 +38,7 @@ static MILK_HOT errno_t fpsexec()
     return RETURN_SUCCESS;
 }
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-
-static const int nb_bindings = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-#ifdef FPS_STANDALONE
-CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-#else
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-#endif
-
-FPS_CMDSETTINGS_INIT(dft, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS)
 static MILK_HOT errno_t compute_function()
 {
     INSERT_STD_PROCINFO_COMPUTEFUNC_START

--- a/plugins/milk-extra-src/linARfilterPred/imrepshiftx.c
+++ b/plugins/milk-extra-src/linARfilterPred/imrepshiftx.c
@@ -35,20 +35,7 @@ static MILK_HOT errno_t fpsexec()
     return RETURN_SUCCESS;
 }
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-
-static const int nb_bindings = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-#ifdef FPS_STANDALONE
-CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-#else
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-#endif
-
-FPS_CMDSETTINGS_INIT(dft, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS)
 static MILK_HOT errno_t compute_function()
 {
     INSERT_STD_PROCINFO_COMPUTEFUNC_START

--- a/plugins/milk-extra-src/linARfilterPred/linARPFMupdate.c
+++ b/plugins/milk-extra-src/linARfilterPred/linARPFMupdate.c
@@ -35,20 +35,7 @@ static MILK_HOT errno_t fpsexec()
     return RETURN_SUCCESS;
 }
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-
-static const int nb_bindings = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-#ifdef FPS_STANDALONE
-CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-#else
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-#endif
-
-FPS_CMDSETTINGS_INIT(dft, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS)
 static MILK_HOT errno_t compute_function()
 {
     INSERT_STD_PROCINFO_COMPUTEFUNC_START

--- a/plugins/milk-extra-src/linARfilterPred/linARapplyRT.c
+++ b/plugins/milk-extra-src/linARfilterPred/linARapplyRT.c
@@ -56,20 +56,7 @@ static MILK_HOT errno_t fpsexec()
     return RETURN_SUCCESS;
 }
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-
-static const int nb_bindings = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-#ifdef FPS_STANDALONE
-CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-#else
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-#endif
-
-FPS_CMDSETTINGS_INIT(dft, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS)
 static MILK_HOT errno_t compute_function()
 {
     INSERT_STD_PROCINFO_COMPUTEFUNC_START

--- a/plugins/milk-extra-src/linARfilterPred/mkARpfilt.c
+++ b/plugins/milk-extra-src/linARfilterPred/mkARpfilt.c
@@ -49,20 +49,7 @@ static MILK_HOT errno_t fpsexec()
     return RETURN_SUCCESS;
 }
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-
-static const int nb_bindings = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-#ifdef FPS_STANDALONE
-CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-#else
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-#endif
-
-FPS_CMDSETTINGS_INIT(dft, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS)
 static MILK_HOT errno_t compute_function()
 {
     INSERT_STD_PROCINFO_COMPUTEFUNC_START

--- a/plugins/milk-extra-src/linARfilterPred/mscangain.c
+++ b/plugins/milk-extra-src/linARfilterPred/mscangain.c
@@ -35,20 +35,7 @@ static MILK_HOT errno_t fpsexec()
     return RETURN_SUCCESS;
 }
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-
-static const int nb_bindings = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-#ifdef FPS_STANDALONE
-CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-#else
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-#endif
-
-FPS_CMDSETTINGS_INIT(dft, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS)
 static MILK_HOT errno_t compute_function()
 {
     INSERT_STD_PROCINFO_COMPUTEFUNC_START

--- a/plugins/milk-extra-src/linARfilterPred/mselblock.c
+++ b/plugins/milk-extra-src/linARfilterPred/mselblock.c
@@ -37,20 +37,7 @@ static MILK_HOT errno_t fpsexec()
     return RETURN_SUCCESS;
 }
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-
-static const int nb_bindings = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-#ifdef FPS_STANDALONE
-CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-#else
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-#endif
-
-FPS_CMDSETTINGS_INIT(dft, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS)
 static MILK_HOT errno_t compute_function()
 {
     INSERT_STD_PROCINFO_COMPUTEFUNC_START

--- a/plugins/milk-extra-src/linARfilterPred/pfloadascii.c
+++ b/plugins/milk-extra-src/linARfilterPred/pfloadascii.c
@@ -40,20 +40,7 @@ static MILK_HOT errno_t fpsexec()
     return RETURN_SUCCESS;
 }
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-
-static const int nb_bindings = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-#ifdef FPS_STANDALONE
-CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-#else
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-#endif
-
-FPS_CMDSETTINGS_INIT(dft, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS)
 static MILK_HOT errno_t compute_function()
 {
     INSERT_STD_PROCINFO_COMPUTEFUNC_START

--- a/src/cli/streamCTRL/mmon_ui.c
+++ b/src/cli/streamCTRL/mmon_ui.c
@@ -76,17 +76,7 @@ static char p_ttyname[FUNCTION_PARAMETER_STRMAXLEN] = "/dev/pts/4";
 #define FPS_PARAMS(X) \
     X(".ttyname", p_ttyname, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "terminal tty name")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-
-static const int nb_bindings = sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-
-FPS_CMDSETTINGS_INIT(mmon, CLIcmddata, FPS_app_info)
-
-
+FPS_V2_SECTION5(FPS_PARAMS)
 static MILK_HOT errno_t compute_function()
 {
     DEBUG_TRACE_FSTART();

--- a/src/coremods/COREMOD_arith/image_setzero.c
+++ b/src/coremods/COREMOD_arith/image_setzero.c
@@ -71,27 +71,7 @@ static errno_t imsetzero_computation(IMAGE *inimg)
  * INSERT_STD_PROCINFO macros reference CLIcmddata.
  * ============================================================= */
 
-static FPS_CLI_BINDING my_bindings[] = { IMSETZERO_PARAMS(FPS_X_BINDING) };
-
-static const int __attribute__((unused)) nb_bindings =
-    sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { IMSETZERO_PARAMS(FPS_X_FARG) };
-
-#ifdef FPS_STANDALONE
-CLICMDDATA CLIcmddata = {
-#else
-static CLICMDDATA CLIcmddata = {
-#endif
-    "", "", CLICMD_FIELDS_DEFAULTS
-};
-
-/*
- * Copy key and description from FPS_app_info so
- * they are defined in one place only.
- * Also provide a valid cmdsettings object.
- */
-FPS_CMDSETTINGS_INIT(dft, CLIcmddata, FPS_app_info)
+FPS_V2_SECTION5(IMSETZERO_PARAMS)
 
 
 /* ================================================================

--- a/src/coremods/COREMOD_memory/image_copy.c
+++ b/src/coremods/COREMOD_memory/image_copy.c
@@ -117,17 +117,7 @@ static FPS_APP_INFO FPS_app_info = {
         "metadata. Can also rename an existing image in the process table."
 };
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS_2STR(FPS_X_BINDING) };
-
-static const int __attribute__((unused)) nb_bindings =
-    sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS_2STR(FPS_X_FARG) };
-
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-
-FPS_CMDSETTINGS_INIT(shm, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS_2STR)
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {
     DEBUG_TRACE_FSTART();

--- a/src/coremods/COREMOD_memory/image_keyword.c
+++ b/src/coremods/COREMOD_memory/image_keyword.c
@@ -89,17 +89,7 @@ static char      p_comment[FUNCTION_PARAMETER_STRMAXLEN] = "my_keyword_comment";
     X(".kwval", &p_kwval, FPTYPE_INT64, 1, FPFLAG_DEFAULT_INPUT, "keyword value")    \
     X(".comment", p_comment, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "comment")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-
-static const int __attribute__((unused)) nb_bindings =
-    sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-
-FPS_CMDSETTINGS_INIT(writkw, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS)
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {
     DEBUG_TRACE_FSTART();

--- a/src/coremods/COREMOD_memory/image_keyword_add.c
+++ b/src/coremods/COREMOD_memory/image_keyword_add.c
@@ -69,20 +69,7 @@ static MILK_HOT errno_t fpsexec()
 /* ================================================================
  * 5.  BINDINGS, FARG, AND CLI DATA
  * ============================================================= */
-static __attribute__((unused)) FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-
-static const int __attribute__((unused)) nb_bindings =
-    sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static __attribute__((unused)) CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-#ifdef FPS_STANDALONE
-CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-#else
-static __attribute__((unused)) CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-#endif
-
-FPS_CMDSETTINGS_INIT(dft, CLIcmddata, FPS_app_info)
+FPS_V2_SECTION5(FPS_PARAMS)
 
 /* ================================================================
  * 6.  COMPUTE WRAPPER (processinfo loop support)

--- a/src/coremods/COREMOD_memory/image_set_counters.c
+++ b/src/coremods/COREMOD_memory/image_set_counters.c
@@ -112,17 +112,7 @@ static FPS_APP_INFO FPS_app_info = {
                         "stream. Useful for synchronization and testing."
 };
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS_IMGINT(FPS_X_BINDING) };
-
-static const int __attribute__((unused)) nb_bindings =
-    sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS_IMGINT(FPS_X_FARG) };
-
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-
-FPS_CMDSETTINGS_INIT(cms2, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS_IMGINT)
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {
     DEBUG_TRACE_FSTART();

--- a/src/coremods/COREMOD_memory/saveall.c
+++ b/src/coremods/COREMOD_memory/saveall.c
@@ -90,17 +90,7 @@ static long long p_nbframes                               = 20;
     X(".semtrig", &p_semtrig, FPTYPE_INT64, 1, FPFLAG_DEFAULT_INPUT, "trigger semaphore")   \
     X(".nbframes", &p_nbframes, FPTYPE_INT64, 1, FPFLAG_DEFAULT_INPUT, "number of frames")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-
-static const int __attribute__((unused)) nb_bindings =
-    sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-
-FPS_CMDSETTINGS_INIT(seq, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS)
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {
     DEBUG_TRACE_FSTART();

--- a/src/coremods/COREMOD_memory/shmim_setowner.c
+++ b/src/coremods/COREMOD_memory/shmim_setowner.c
@@ -109,17 +109,7 @@ static FPS_APP_INFO FPS_app_info = {
                         "transferring ownership when a process is restarted."
 };
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS_1STREAM(FPS_X_BINDING) };
-
-static const int __attribute__((unused)) nb_bindings =
-    sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS_1STREAM(FPS_X_FARG) };
-
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-
-FPS_CMDSETTINGS_INIT(cms2, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS_1STREAM)
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {
     DEBUG_TRACE_FSTART();

--- a/src/coremods/COREMOD_memory/stream_TCP.c
+++ b/src/coremods/COREMOD_memory/stream_TCP.c
@@ -96,17 +96,7 @@ static FPS_APP_INFO FPS_app_info = {
     X(".mode", &p_mode, FPTYPE_INT64, 1, FPFLAG_DEFAULT_INPUT, "sync mode")          \
     X(".rtprio", &p_rtprio, FPTYPE_INT64, 1, FPFLAG_DEFAULT_INPUT, "RT priority")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-
-static const int __attribute__((unused)) nb_bindings =
-    sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-
-FPS_CMDSETTINGS_INIT(tx, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS)
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {
     DEBUG_TRACE_FSTART();

--- a/src/coremods/COREMOD_memory/stream_UDP.c
+++ b/src/coremods/COREMOD_memory/stream_UDP.c
@@ -72,17 +72,7 @@ static FPS_APP_INFO FPS_app_info = {
     X(".csync", &p_csync, FPTYPE_INT64, 1, FPFLAG_DEFAULT_INPUT, "counter sync")     \
     X(".rtprio", &p_rtprio, FPTYPE_INT64, 1, FPFLAG_DEFAULT_INPUT, "RT priority")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-
-static const int __attribute__((unused)) nb_bindings =
-    sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-
-FPS_CMDSETTINGS_INIT(tx, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS)
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {
     DEBUG_TRACE_FSTART();

--- a/src/coremods/COREMOD_memory/stream_sem.c
+++ b/src/coremods/COREMOD_memory/stream_sem.c
@@ -152,17 +152,7 @@ static long long p_dtus = 1000;
     FPS_PARAMS_IMSEM(X) \
     X(".dtus", &p_dtus, FPTYPE_INT64, 1, FPFLAG_DEFAULT_INPUT, "time interval [us]")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-
-static const int __attribute__((unused)) nb_bindings =
-    sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-
-FPS_CMDSETTINGS_INIT(cms3, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS)
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {
     DEBUG_TRACE_FSTART();

--- a/src/coremods/COREMOD_memory/stream_updateloop.c
+++ b/src/coremods/COREMOD_memory/stream_updateloop.c
@@ -119,17 +119,7 @@ static FPS_APP_INFO FPS_app_info = {
     X(".semtrig", &p_semtrig, FPTYPE_INT64, 1, FPFLAG_DEFAULT_INPUT, "sem trigger index")      \
     X(".timingmode", &p_timingmode, FPTYPE_INT64, 1, FPFLAG_DEFAULT_INPUT, "timing mode")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-
-static const int __attribute__((unused)) nb_bindings =
-    sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-
-FPS_CMDSETTINGS_INIT(main, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS)
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {
     DEBUG_TRACE_FSTART();

--- a/src/coremods/COREMOD_tools/imdisplay3d.c
+++ b/src/coremods/COREMOD_tools/imdisplay3d.c
@@ -39,17 +39,7 @@ static FPS_APP_INFO FPS_app_info = {
     X(".imname", p_imname, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT, "image name") \
     X(".step", &p_step, FPTYPE_INT64, 1, FPFLAG_DEFAULT_INPUT, "pixel step")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-
-static const int __attribute__((unused)) nb_bindings =
-    sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-
-FPS_CMDSETTINGS_INIT(main, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS)
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {
     COREMOD_TOOLS_imgdisplay3D(p_imname, p_step);

--- a/src/coremods/COREMOD_tools/mvprocCPUset.c
+++ b/src/coremods/COREMOD_tools/mvprocCPUset.c
@@ -132,17 +132,7 @@ static FPS_APP_INFO FPS_app_info = {
     X(".name", p_name, FPTYPE_STRING, 1, FPFLAG_DEFAULT_INPUT, "CPU set name") \
     X(".rtprio", &p_rtprio, FPTYPE_INT64, 1, FPFLAG_DEFAULT_INPUT, "RT priority (0=ignore)")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-
-static const int __attribute__((unused)) nb_bindings =
-    sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-
-FPS_CMDSETTINGS_INIT(main, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS)
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {
     DEBUG_TRACE_FSTART();

--- a/src/coremods/COREMOD_tools/statusstat.c
+++ b/src/coremods/COREMOD_tools/statusstat.c
@@ -43,17 +43,7 @@ static FPS_APP_INFO FPS_app_info = {
     X(".imname", p_imname, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT, "status image") \
     X(".nbstep", &p_nbstep, FPTYPE_INT64, 1, FPFLAG_DEFAULT_INPUT, "number of steps")
 
-static FPS_CLI_BINDING my_bindings[] = { FPS_PARAMS(FPS_X_BINDING) };
-
-static const int __attribute__((unused)) nb_bindings =
-    sizeof(my_bindings) / sizeof(FPS_CLI_BINDING);
-
-static CLICMDARGDEF farg[] = { FPS_PARAMS(FPS_X_FARG) };
-
-static CLICMDDATA CLIcmddata = { "", "", CLICMD_FIELDS_DEFAULTS };
-
-FPS_CMDSETTINGS_INIT(main, CLIcmddata, FPS_app_info)
-
+FPS_V2_SECTION5(FPS_PARAMS)
 static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {
     COREMOD_TOOLS_statusStat(p_imname, p_nbstep);


### PR DESCRIPTION
## Summary

Replace all hand-written FPS Section 5 boilerplate (bindings, farg, CLIcmddata,
and constructor/CMDSETTINGS_INIT code) with the `FPS_V2_SECTION5()` macro across
51 source files. This eliminates ~700 lines of copy-pasted code with no
functional change.

## Changes

### milk-extra-src/ — Tier C (init_cms constructor) → Tier A

22 single-command files converted from 15-line hand-written `init_cms()`
constructors to a single `FPS_V2_SECTION5(FPS_PARAMS)` call:

- `fft/` (5 files), `image_basic/` (7), `image_filter/` (1),
  `image_format/` (6), `info/` (3)

5 multi-command files had secondary commands converted from `init_cms_N()`
to `FPS_CMDSETTINGS_INIT()`:

- `dofft.c`, `image_add.c`, `imcontract.c`, `imexpand.c`, `image_stats.c`

### milk-extra-src/ — Tier B (FPS_CMDSETTINGS_INIT) → Tier A

9 files converted from hand-written arrays + `FPS_CMDSETTINGS_INIT` to
`FPS_V2_SECTION5(FPS_PARAMS)`:

- `linARfilterPred/` (8 files), `streamfeed.c`

### src/ — Tier B → Tier A

14 files in `src/` converted:

- 5 single-command files: `mmon_ui.c`, `image_setzero.c`,
  `image_keyword_add.c`, `imdisplay3d.c`, `statusstat.c`
- 11 multi-command files: primary command block converted to
  `FPS_V2_SECTION5()` — secondary commands kept as `FPS_CMDSETTINGS_INIT()`

Special case: `fconvolve.c` also fixed non-standard `FPS_bindings` name.

### Not changed (by design)

- `clearall.c`, `fps_list.c` — zero-arg commands with no bindings
- `image_crop.c`, `image_crop3D.c`, `savefits.c` — already Tier A
- `examplefunc*.c` (4 files) — kept explicit as teaching templates

## Verification

- [x] Build passes (`make -j`)
- [x] All 38 tests pass (`ctest --output-on-failure`)
- [x] Pre-commit hooks pass (clang-format, trailing whitespace)
- [x] No functional change — `FPS_V2_SECTION5` expands to identical code

## Prompt Summary

User requested an audit of code duplication across the milk codebase. This
identified ~700 lines of triplicated FPS Section 5 boilerplate spread across
three maturity tiers (A/B/C). User approved the mechanical migration of all
Tier B and Tier C files to the Tier A pattern (`FPS_V2_SECTION5`).

## Authorship

- **Model**: Opus 4.6
- **Reviewed and signed off by**: oguyon
