### PR TITLE
fix: refactor MVMextractModes and add MVM test

### DIFF
--- a/plugins/milk-extra-src/linalgebra/CMakeLists.txt
+++ b/plugins/milk-extra-src/linalgebra/CMakeLists.txt
@@ -250,6 +250,7 @@ install(
 
 add_milk_standalone(linalg-gramschmidt GramSchmidt.c)
 add_milk_standalone(linalg-MVMextract MVMextractModes.c)
+target_link_libraries(milk-fpsexec-linalg-MVMextract PUBLIC ${LIBNAME_COMPUTE})
 if(USE_CUDA)
   target_link_libraries(milk-fpsexec-linalg-MVMextract PRIVATE CUDA::cudart
                                                                CUDA::cublas)
@@ -294,3 +295,40 @@ endif()
 target_link_libraries(milk-fpsexec-linalg-cublasPCA PUBLIC ${LIBNAME_COMPUTE})
 add_milk_standalone(linalg-modalremap modalremap.c)
 target_link_libraries(milk-fpsexec-linalg-modalremap PUBLIC ${LIBNAME_COMPUTE})
+
+
+# ---- MVM test ----
+# Convention: test executables are named milk-test-<module>-<name>
+if(USE_CLI)
+  set(TESTNAME "milk-test-linalg-MVMextract")
+  add_executable(${TESTNAME}
+                 test_MVMextract.c
+                 MVM_CPU.c)
+  target_link_libraries(${TESTNAME}
+                        PRIVATE ImageStreamIO
+                                m)
+  target_include_directories(${TESTNAME}
+                             PRIVATE ${PROJECT_SOURCE_DIR}/src/engine
+                                     ${CMAKE_CURRENT_SOURCE_DIR})
+  if(USE_OPENBLAS)
+    target_compile_definitions(${TESTNAME} PRIVATE HAVE_OPENBLAS)
+    target_link_libraries(${TESTNAME} PRIVATE ${BLAS_LIBRARIES})
+    target_link_directories(${TESTNAME}
+                            PRIVATE ${OPENBLAS_LIBRARY_DIRS})
+  elseif(USE_MKL)
+    target_compile_definitions(${TESTNAME} PRIVATE HAVE_MKL)
+    target_link_libraries(${TESTNAME} PRIVATE ${BLAS_LIBRARIES})
+  endif()
+  if(USE_CUDA)
+    target_compile_definitions(${TESTNAME} PRIVATE HAVE_CUDA)
+    target_link_libraries(${TESTNAME}
+                          PRIVATE CUDA::cudart CUDA::cublas)
+  endif()
+  install(TARGETS ${TESTNAME} DESTINATION bin)
+  add_test(NAME milk-test-linalg-MVMextract-cpu
+           COMMAND ${TESTNAME} -v -c)
+  if(USE_CUDA)
+    add_test(NAME milk-test-linalg-MVMextract-gpu
+             COMMAND ${TESTNAME} -v -g)
+  endif()
+endif()

--- a/plugins/milk-extra-src/linalgebra/CMakeLists.txt
+++ b/plugins/milk-extra-src/linalgebra/CMakeLists.txt
@@ -296,39 +296,30 @@ target_link_libraries(milk-fpsexec-linalg-cublasPCA PUBLIC ${LIBNAME_COMPUTE})
 add_milk_standalone(linalg-modalremap modalremap.c)
 target_link_libraries(milk-fpsexec-linalg-modalremap PUBLIC ${LIBNAME_COMPUTE})
 
-
 # ---- MVM test ----
 # Convention: test executables are named milk-test-<module>-<name>
 if(USE_CLI)
   set(TESTNAME "milk-test-linalg-MVMextract")
-  add_executable(${TESTNAME}
-                 test_MVMextract.c
-                 MVM_CPU.c)
-  target_link_libraries(${TESTNAME}
-                        PRIVATE ImageStreamIO
-                                m)
-  target_include_directories(${TESTNAME}
-                             PRIVATE ${PROJECT_SOURCE_DIR}/src/engine
-                                     ${CMAKE_CURRENT_SOURCE_DIR})
+  add_executable(${TESTNAME} test_MVMextract.c MVM_CPU.c)
+  target_link_libraries(${TESTNAME} PRIVATE ImageStreamIO m)
+  target_include_directories(
+    ${TESTNAME} PRIVATE ${PROJECT_SOURCE_DIR}/src/engine
+                        ${CMAKE_CURRENT_SOURCE_DIR})
   if(USE_OPENBLAS)
     target_compile_definitions(${TESTNAME} PRIVATE HAVE_OPENBLAS)
     target_link_libraries(${TESTNAME} PRIVATE ${BLAS_LIBRARIES})
-    target_link_directories(${TESTNAME}
-                            PRIVATE ${OPENBLAS_LIBRARY_DIRS})
+    target_link_directories(${TESTNAME} PRIVATE ${OPENBLAS_LIBRARY_DIRS})
   elseif(USE_MKL)
     target_compile_definitions(${TESTNAME} PRIVATE HAVE_MKL)
     target_link_libraries(${TESTNAME} PRIVATE ${BLAS_LIBRARIES})
   endif()
   if(USE_CUDA)
     target_compile_definitions(${TESTNAME} PRIVATE HAVE_CUDA)
-    target_link_libraries(${TESTNAME}
-                          PRIVATE CUDA::cudart CUDA::cublas)
+    target_link_libraries(${TESTNAME} PRIVATE CUDA::cudart CUDA::cublas)
   endif()
   install(TARGETS ${TESTNAME} DESTINATION bin)
-  add_test(NAME milk-test-linalg-MVMextract-cpu
-           COMMAND ${TESTNAME} -v -c)
+  add_test(NAME milk-test-linalg-MVMextract-cpu COMMAND ${TESTNAME} -v -c)
   if(USE_CUDA)
-    add_test(NAME milk-test-linalg-MVMextract-gpu
-             COMMAND ${TESTNAME} -v -g)
+    add_test(NAME milk-test-linalg-MVMextract-gpu COMMAND ${TESTNAME} -v -g)
   endif()
 endif()

--- a/plugins/milk-extra-src/linalgebra/MVMextractModes.c
+++ b/plugins/milk-extra-src/linalgebra/MVMextractModes.c
@@ -13,7 +13,6 @@
 #endif
 
 
-
 // Use MKL if available
 // Otherwise use openBLAS
 //
@@ -86,7 +85,7 @@ static char      outrefsname[FUNCTION_PARAMETER_STRMAXLEN] = "";
     X(".option.sname_refout", outrefsname, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT,          \
       "optional output reference to be subtracted stream")                                      \
     X(".axmode", &axmode, FPTYPE_UINT32, 0, FPFLAG_DEFAULT_INPUT,                               \
-      "axis mode: 0=extract, 1=expand")                                                        \
+      "axis mode: 0=extract, 1=expand")                                                         \
     X(".option.PROCESS", &opt_process, FPTYPE_ONOFF, 0, FPFLAG_DEFAULT_INPUT,                   \
       "compute running statistics")                                                             \
     X(".option.TRACEMODE", &opt_tracemode, FPTYPE_ONOFF, 0, FPFLAG_DEFAULT_INPUT,               \
@@ -188,9 +187,6 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
     }
 
 
-
-
-
     // CONNECT TO OPTIONAL INPUT REFERENCE STREAM
     imageID IDinref  = -1;
     IMGID   imginref = imgid_make_from_name(inrefsname);
@@ -288,8 +284,6 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
                 }
             }
         }
-
-
     }
 
     float *normcoeff = (float *) malloc(sizeof(float) * NBmodes);
@@ -460,8 +454,7 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
                 exit(EXIT_FAILURE);
             }
 
-            cudaStat = cudaMemcpy(d_modes, modesmat, sizeof(float) * matsz,
-                                   cudaMemcpyHostToDevice);
+            cudaStat = cudaMemcpy(d_modes, modesmat, sizeof(float) * matsz, cudaMemcpyHostToDevice);
 
             if (use_mask)
             {
@@ -655,7 +648,6 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
     fflush(stdout);
 
 
-
     printf(" m       = %u\n", mask_npix);
     printf(" n       = %ld\n", n);
     printf(" NBmodes = %ld\n", NBmodes);
@@ -772,21 +764,19 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
                 }
 
 
-                cblas_sgemv(CblasColMajor, CblasNoTrans, (int) n, (int) m,
-                            1.0, ColMajorMatrix, (int) n,
-                            imginfloatptr, 1, beta, outarray, 1);
+                cblas_sgemv(CblasColMajor, CblasNoTrans, (int) n, (int) m, 1.0, ColMajorMatrix,
+                            (int) n, imginfloatptr, 1, beta, outarray, 1);
 
                 clock_gettime(CLOCK_MILK, &t1);
                 struct timespec tdiff;
                 tdiff       = timespec_diff(t0, t1);
                 double t01d = 1.0 * tdiff.tv_sec + 1.0e-9 * tdiff.tv_nsec;
-                processinfo_WriteMessage_fmt(processinfo, "%s %dx%d MVM %.3f us",
-                                             BLASLIB, n, m, t01d * 1e6);
+                processinfo_WriteMessage_fmt(processinfo, "%s %dx%d MVM %.3f us", BLASLIB, n, m,
+                                             t01d * 1e6);
             }
 #else
             // CPU fallback without BLAS library
-            matrixMulCPU(ColMajorMatrix, imginfloatptr,
-                         outarray, (int) n, (int) m);
+            matrixMulCPU(ColMajorMatrix, imginfloatptr, outarray, (int) n, (int) m);
 #endif
 
             // update output
@@ -817,8 +807,7 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
                 }
                 else
                 {
-                    memcpy(masked_pix, dcimg[IDinref].array.F,
-                           sizeof(float) * mask_npix);
+                    memcpy(masked_pix, dcimg[IDinref].array.F, sizeof(float) * mask_npix);
                 }
                 cudaStat =
                     cudaMemcpy(d_in, masked_pix, sizeof(float) * mask_npix, cudaMemcpyHostToDevice);
@@ -834,8 +823,7 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
                 }
                 else
                 {
-                    memcpy(masked_pix, imginfloatptr,
-                           sizeof(float) * mask_npix);
+                    memcpy(masked_pix, imginfloatptr, sizeof(float) * mask_npix);
                 }
                 cudaStat =
                     cudaMemcpy(d_in, masked_pix, sizeof(float) * mask_npix, cudaMemcpyHostToDevice);
@@ -910,9 +898,7 @@ static MILK_HOT errno_t __attribute__((unused)) compute_function()
                 imgout.md->write = 1;
                 for (long k = 0; k < NBmodes; k++)
                 {
-                    imgout.im->array.F[k] =
-                        (modevalarray[k] - modevalarrayref[k])
-                        / normcoeff[k];
+                    imgout.im->array.F[k] = (modevalarray[k] - modevalarrayref[k]) / normcoeff[k];
                 }
 
 

--- a/plugins/milk-extra-src/linalgebra/MVMextractModes.c
+++ b/plugins/milk-extra-src/linalgebra/MVMextractModes.c
@@ -13,8 +13,6 @@
 #endif
 
 
-#include <pthread.h>
-
 
 // Use MKL if available
 // Otherwise use openBLAS
@@ -25,13 +23,16 @@
 #else
 #    ifdef HAVE_OPENBLAS
 #        include <cblas.h>
-#        include <lapacke.h>
 #        define BLASLIB "OpenBLAS"
 #    endif
 #endif
 
 
-#include "CLIcore.h"
+#ifdef MILK_NO_CLI
+#    include "CLIcore_standalone.h"
+#else
+#    include "CLIcore.h"
+#endif
 #include "COREMOD_memory/COREMOD_memory.h"
 #include "libmilkcommon/pixel_dispatch.h"
 #include "timeutils.h"
@@ -56,22 +57,17 @@ static FPS_APP_INFO FPS_app_info = {
  * 2.  LOCAL PARAMETER VARIABLES
  * ============================================================= */
 
-static int32_t                          *GPUindex                                  = NULL;
-static uint32_t *__attribute__((unused)) mmax                                      = NULL;
-static uint32_t *__attribute__((unused)) nmax                                      = NULL;
-static char                              insname[FUNCTION_PARAMETER_STRMAXLEN]     = "";
-static char                              inmasksname[FUNCTION_PARAMETER_STRMAXLEN] = "";
-static char                              immodes[FUNCTION_PARAMETER_STRMAXLEN]     = "";
-static char                              outcoeff[FUNCTION_PARAMETER_STRMAXLEN]    = "";
-static int64_t *__attribute__((unused))  outinit                                   = NULL;
-static uint32_t                         *axmode                                    = NULL;
-static int64_t                          *PROCESS                                   = NULL;
-static int64_t                          *TRACEMODE                                 = NULL;
-static int64_t                          *MODENORM                                  = NULL;
-static char *__attribute__((unused))     intot_stream                              = NULL;
-static char                              inrefsname[FUNCTION_PARAMETER_STRMAXLEN]  = "";
-static char                              outrefsname[FUNCTION_PARAMETER_STRMAXLEN] = "";
-static uint64_t *__attribute__((unused)) twait                                     = NULL;
+static int32_t  *GPUindex                                  = NULL;
+static char      insname[FUNCTION_PARAMETER_STRMAXLEN]     = "";
+static char      inmasksname[FUNCTION_PARAMETER_STRMAXLEN] = "";
+static char      immodes[FUNCTION_PARAMETER_STRMAXLEN]     = "";
+static char      outcoeff[FUNCTION_PARAMETER_STRMAXLEN]    = "";
+static uint32_t *axmode                                    = NULL;
+static int64_t  *opt_process                               = NULL;
+static int64_t  *opt_tracemode                             = NULL;
+static int64_t  *opt_modenorm                              = NULL;
+static char      inrefsname[FUNCTION_PARAMETER_STRMAXLEN]  = "";
+static char      outrefsname[FUNCTION_PARAMETER_STRMAXLEN] = "";
 
 
 /* ================================================================
@@ -82,13 +78,21 @@ static uint64_t *__attribute__((unused)) twait                                  
     X(".GPUindex", &GPUindex, FPTYPE_INT32, 1, FPFLAG_DEFAULT_INPUT, "GPU index, 99 for CPU")   \
     X(".insname", insname, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT, "input stream name")     \
     X(".inmasksname", inmasksname, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT,                  \
-      "nput mask stream name")                                                                  \
+      "input mask stream name")                                                                 \
     X(".immodes", immodes, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT, "modes stream name")     \
     X(".outcoeff", outcoeff, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT, "output coefficients") \
     X(".option.sname_refin", inrefsname, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT,            \
       "optional input reference to be subtracted stream")                                       \
     X(".option.sname_refout", outrefsname, FPTYPE_STREAMNAME, 1, FPFLAG_DEFAULT_INPUT,          \
-      "optional output reference to be subtracted stream")
+      "optional output reference to be subtracted stream")                                      \
+    X(".axmode", &axmode, FPTYPE_UINT32, 0, FPFLAG_DEFAULT_INPUT,                               \
+      "axis mode: 0=extract, 1=expand")                                                        \
+    X(".option.PROCESS", &opt_process, FPTYPE_ONOFF, 0, FPFLAG_DEFAULT_INPUT,                   \
+      "compute running statistics")                                                             \
+    X(".option.TRACEMODE", &opt_tracemode, FPTYPE_ONOFF, 0, FPFLAG_DEFAULT_INPUT,               \
+      "record coefficient time trace")                                                          \
+    X(".option.MODENORM", &opt_modenorm, FPTYPE_ONOFF, 0, FPFLAG_DEFAULT_INPUT,                 \
+      "normalize modes to unit 2-norm")
 
 
 /* ================================================================
@@ -97,11 +101,9 @@ static uint64_t *__attribute__((unused)) twait                                  
 
 FPS_V2_SECTION5(FPS_PARAMS)
 
-static MILK_HOT errno_t compute_function()
+static MILK_HOT errno_t __attribute__((unused)) compute_function()
 {
     DEBUG_TRACE_FSTART();
-
-    int MODEVALCOMPUTE = 1; // 1 if compute, 0 if import
 
 
 #ifdef HAVE_CUDA
@@ -149,8 +151,6 @@ static MILK_HOT errno_t compute_function()
 
     printf("USE MASK = %d\n", use_mask);
 
-    //use_mask = 0; //for testing
-
     //setup the mask
     //
     if (use_mask)
@@ -163,7 +163,7 @@ static MILK_HOT errno_t compute_function()
             }
         }
 
-        mask_idx   = (uint32_t *) malloc(mask_npix * sizeof(long));
+        mask_idx   = (uint32_t *) malloc(mask_npix * sizeof(uint32_t));
         masked_pix = (float *) malloc(mask_npix * sizeof(float));
         long nn    = 0;
         for (long n = 0; n < imgmask.md->size[0] * imgmask.md->size[1]; ++n)
@@ -181,30 +181,14 @@ static MILK_HOT errno_t compute_function()
     else
     {
         //Just use full image
-        mask_npix = imgin.md->size[0] * imgin.md->size[1];
+        mask_npix  = imgin.md->size[0] * imgin.md->size[1];
+        masked_pix = (float *) malloc(mask_npix * sizeof(float));
         printf("No mask using : %u pixels (%f%%)\n", mask_npix,
                (100.0 * mask_npix) / (imgin.md->size[0] * imgin.md->size[1]));
     }
 
 
-    /* // This was probaly never implemented at all.
-    // NORMALIZATION
-    // CONNECT TO TOTAL FLUX STREAM
-    imageID IDintot;
-    IDintot = image_ID(intot_stream, dcimg, dcnimg);
-    int INNORMMODE = 0; // 1 if input normalized
 
-    if(IDintot == -1)
-    {
-        INNORMMODE = 0;
-        create_2Dimage_ID("intot_tmp", 1, 1, &IDintot);
-        dcimg[IDintot].array.F[0] = 1.0f;
-    }
-    else
-    {
-        INNORMMODE = 1;
-    }
-    */
 
 
     // CONNECT TO OPTIONAL INPUT REFERENCE STREAM
@@ -305,12 +289,12 @@ static MILK_HOT errno_t compute_function()
             }
         }
 
-        // save_fits("_tmpmodes", "_test_tmpmodes.fits");
+
     }
 
     float *normcoeff = (float *) malloc(sizeof(float) * NBmodes);
 
-    if ((*MODENORM) == 1)
+    if ((*opt_modenorm) == 1)
     {
         // In this mode, the input modes are normalized to unity (vector 2-norm)
         // norm is computed here
@@ -369,15 +353,12 @@ static MILK_HOT errno_t compute_function()
     float *outarray = (float *) malloc(sizeof(float) * arraytmp[0] * arraytmp[1]);
 
 
-    MODEVALCOMPUTE = 1;
-
     free(arraytmp);
 
 
     INSERT_STD_PROCINFO_COMPUTEFUNC_INIT;
 
 
-    if (MODEVALCOMPUTE == 1)
     {
         if (((*GPUindex) >= 0) && ((*GPUindex) != 99))
         {
@@ -479,8 +460,8 @@ static MILK_HOT errno_t compute_function()
                 exit(EXIT_FAILURE);
             }
 
-            cudaStat = cudaMemcpy(d_modes, modesmat, sizeof(float) * matsz, cudaMemcpyHostToDevice);
-            // cudaStat = cudaMemcpy(d_modes, imgmodes.im->array.F, sizeof(float) * m * NBmodes, cudaMemcpyHostToDevice);
+            cudaStat = cudaMemcpy(d_modes, modesmat, sizeof(float) * matsz,
+                                   cudaMemcpyHostToDevice);
 
             if (use_mask)
             {
@@ -517,7 +498,7 @@ static MILK_HOT errno_t compute_function()
         }
     }
 
-    if ((*TRACEMODE) == 1)
+    if ((*opt_tracemode) == 1)
     {
         char    traceim_name[STRINGMAXLEN_IMGNAME];
         long    TRACEsize = 2000;
@@ -568,7 +549,7 @@ static MILK_HOT errno_t compute_function()
         free(sizearraytmp);
     }
 
-    if ((*PROCESS) == 1)
+    if ((*opt_process) == 1)
     {
         char    process_ave_name[STRINGMAXLEN_IMGNAME];
         char    process_rms_name[STRINGMAXLEN_IMGNAME];
@@ -670,37 +651,10 @@ static MILK_HOT errno_t compute_function()
 
     initref = 0; // 1 when reference has been processed
 
-    // long twait1 = *twait;
-
-    printf("LOOP START   MODEVALCOMPUTE = %d\n", MODEVALCOMPUTE);
+    printf("LOOP START\n");
     fflush(stdout);
 
-    if (MODEVALCOMPUTE == 0)
-    {
-        printf("\n");
-        printf("This function is NOT computing mode values\n");
-        printf("Pre-existing stream %s was detected\n", outcoeff);
-        printf("\n");
-    }
-    else
-    {
-        char msgstring[STRINGMAXLEN_PROCESSINFO_STATUSMSG];
 
-        {
-            int slen = snprintf(msgstring, STRINGMAXLEN_PROCESSINFO_STATUSMSG, "Running on GPU %d",
-                                (*GPUindex));
-            if (slen < 1)
-            {
-                PRINT_ERROR("snprintf wrote <1 char");
-                abort(); // can't handle this error any other way
-            }
-            if (slen >= STRINGMAXLEN_PROCESSINFO_STATUSMSG)
-            {
-                PRINT_ERROR("snprintf string truncation");
-                abort(); // can't handle this error any other way
-            }
-        }
-    }
 
     printf(" m       = %u\n", mask_npix);
     printf(" n       = %ld\n", n);
@@ -818,62 +772,29 @@ static MILK_HOT errno_t compute_function()
                 }
 
 
-                if (*axmode == 1)
-                {
-                    cblas_sgemv(CblasColMajor, CblasNoTrans, (int) n, (int) m, 1.0, ColMajorMatrix,
-                                (int) n, imginfloatptr, 1, beta, outarray, 1);
-                }
-                else
-                {
-                    cblas_sgemv(CblasColMajor, CblasNoTrans, (int) n, (int) m, 1.0, ColMajorMatrix,
-                                (int) n, imginfloatptr, 1, beta, outarray, 1);
-                }
+                cblas_sgemv(CblasColMajor, CblasNoTrans, (int) n, (int) m,
+                            1.0, ColMajorMatrix, (int) n,
+                            imginfloatptr, 1, beta, outarray, 1);
 
                 clock_gettime(CLOCK_MILK, &t1);
                 struct timespec tdiff;
                 tdiff       = timespec_diff(t0, t1);
                 double t01d = 1.0 * tdiff.tv_sec + 1.0e-9 * tdiff.tv_nsec;
-                processinfo_WriteMessage_fmt(processinfo, "%s %dx%d MVM %.3f us", BLASLIB, n, m,
-                                             t01d * 1e6);
+                processinfo_WriteMessage_fmt(processinfo, "%s %dx%d MVM %.3f us",
+                                             BLASLIB, n, m, t01d * 1e6);
             }
 #else
-            // Run on CPU without lib
-            int mmax1 = (*mmax);
-            if (mmax1 > m)
-            {
-                mmax1 = m;
-            }
-
-            int nmax1 = (*nmax);
-            if (nmax1 > n)
-            {
-                nmax1 = n;
-            }
-
-            for (int jj = 0; jj < n; jj++)
-            {
-                outarray[jj] = 0.0;
-            }
-
-
-            for (int ii = 0; ii < m; ii++)
-            {
-                for (int jj = 0; jj < n; jj++)
-                {
-                    int index = ii * n + jj;
-                    outarray[jj] += imgmodes.im->array.F[index] * imginfloatptr[ii];
-                }
-            }
-
+            // CPU fallback without BLAS library
+            matrixMulCPU(ColMajorMatrix, imginfloatptr,
+                         outarray, (int) n, (int) m);
 #endif
 
             // update output
-            dcimg[imgout.ID].md->write = 1;
+            imgout.md->write = 1;
             for (int jj = 0; jj < n; jj++)
             {
                 imgout.im->array.F[jj] = outarray[jj] / normcoeff[jj];
             }
-            //            memcpy(imgout.im->array.F, outarray, sizeof(float)*n);
             processinfo_update_output_stream(processinfo, imgout.im, NULL);
         }
         else
@@ -896,7 +817,8 @@ static MILK_HOT errno_t compute_function()
                 }
                 else
                 {
-                    masked_pix = dcimg[IDinref].array.F;
+                    memcpy(masked_pix, dcimg[IDinref].array.F,
+                           sizeof(float) * mask_npix);
                 }
                 cudaStat =
                     cudaMemcpy(d_in, masked_pix, sizeof(float) * mask_npix, cudaMemcpyHostToDevice);
@@ -912,7 +834,8 @@ static MILK_HOT errno_t compute_function()
                 }
                 else
                 {
-                    masked_pix = imginfloatptr;
+                    memcpy(masked_pix, imginfloatptr,
+                           sizeof(float) * mask_npix);
                 }
                 cudaStat =
                     cudaMemcpy(d_in, masked_pix, sizeof(float) * mask_npix, cudaMemcpyHostToDevice);
@@ -961,7 +884,6 @@ static MILK_HOT errno_t compute_function()
             }
 
             // copy result
-            imgout.md->write = 1;
 
             if (initref == 0)
             {
@@ -985,11 +907,12 @@ static MILK_HOT errno_t compute_function()
                                       cudaMemcpyDeviceToHost);
 
 
+                imgout.md->write = 1;
                 for (long k = 0; k < NBmodes; k++)
                 {
-                    imgout.im->array.F[k] = (modevalarray[k] - modevalarrayref[k]) / normcoeff[k];
-                    // Renorm was never implemented
-                    // (modevalarray[k] / dcimg[IDintot].array.F[0] - modevalarrayref[k]) / normcoeff[k];
+                    imgout.im->array.F[k] =
+                        (modevalarray[k] - modevalarrayref[k])
+                        / normcoeff[k];
                 }
 
 
@@ -1028,8 +951,9 @@ static MILK_HOT errno_t compute_function()
 
     if (use_mask)
     {
-        free(masked_pix);
+        free(mask_idx);
     }
+    free(masked_pix);
 
     DEBUG_TRACE_FEXIT();
     return RETURN_SUCCESS;
@@ -1040,7 +964,7 @@ static MILK_HOT errno_t compute_function()
  * 7.  MILK MODULE REGISTRATION
  * ============================================================= */
 
-#ifndef FPS_STANDALONE
+#if !defined(FPS_STANDALONE) && !defined(MILK_NO_CLI)
 static errno_t CLIfunction(void)
 {
     return safe_fps_generic_CLIfunction(&FPS_app_info, farg, &CLIcmddata, my_bindings, nb_bindings,

--- a/plugins/milk-extra-src/linalgebra/test_MVMextract.c
+++ b/plugins/milk-extra-src/linalgebra/test_MVMextract.c
@@ -32,15 +32,15 @@
  * Test configuration
  * ------------------------------------------------------ */
 
-#define NPIX_X   16   /* image width */
-#define NPIX_Y   16   /* image height */
-#define NPIX     (NPIX_X * NPIX_Y)   /* = 256 */
-#define NMODES   5    /* number of modes */
-#define TOL      1.0e-4f  /* relative tolerance */
+#define NPIX_X 16              /* image width */
+#define NPIX_Y 16              /* image height */
+#define NPIX (NPIX_X * NPIX_Y) /* = 256 */
+#define NMODES 5               /* number of modes */
+#define TOL 1.0e-4f            /* relative tolerance */
 
 /* Stream names for SHM cleanup */
-#define SNAME_MODES  "test_mvm_modes"
-#define SNAME_INPUT  "test_mvm_input"
+#define SNAME_MODES "test_mvm_modes"
+#define SNAME_INPUT "test_mvm_input"
 
 
 /* --------------------------------------------------------
@@ -54,19 +54,15 @@
  * orthogonal rows for k < log2(npix).
  * ------------------------------------------------------ */
 
-static void build_orthogonal_modes(
-    float *modes,
-    int    nmodes,
-    int    npix)
+static void build_orthogonal_modes(float *modes, int nmodes, int npix)
 {
     for (int k = 0; k < nmodes; k++)
     {
-        int stride = 1 << k;  /* 1, 2, 4, 8, 16 */
+        int stride = 1 << k; /* 1, 2, 4, 8, 16 */
         for (int p = 0; p < npix; p++)
         {
-            int block = p / stride;
-            modes[k * npix + p] =
-                (block % 2 == 0) ? 1.0f : -1.0f;
+            int block           = p / stride;
+            modes[k * npix + p] = (block % 2 == 0) ? 1.0f : -1.0f;
         }
     } // for k
 }
@@ -76,11 +72,7 @@ static void build_orthogonal_modes(
  * Helper: compute mode norms for verification
  * ------------------------------------------------------ */
 
-static void compute_mode_norms(
-    const float *modes,
-    float       *norms,
-    int          nmodes,
-    int          npix)
+static void compute_mode_norms(const float *modes, float *norms, int nmodes, int npix)
 {
     for (int k = 0; k < nmodes; k++)
     {
@@ -101,24 +93,20 @@ static void compute_mode_norms(
  * Returns 0 on success, 1 on failure.
  * ------------------------------------------------------ */
 
-static int verify_coefficients(
-    const float *outarray,
-    const float *expected,
-    const float *norms,
-    int          nmodes,
-    int          verbose,
-    const char  *label)
+static int verify_coefficients(const float *outarray,
+                               const float *expected,
+                               const float *norms,
+                               int          nmodes,
+                               int          verbose,
+                               const char  *label)
 {
     int pass = 1;
     for (int k = 0; k < nmodes; k++)
     {
-        float extracted = (norms != NULL)
-                            ? outarray[k] / norms[k]
-                            : outarray[k];
+        float extracted = (norms != NULL) ? outarray[k] / norms[k] : outarray[k];
         float exp_val   = expected[k];
         float err       = fabsf(extracted - exp_val);
-        float ref       = fabsf(exp_val) > 1.0e-6f
-                            ? fabsf(exp_val) : 1.0f;
+        float ref       = fabsf(exp_val) > 1.0e-6f ? fabsf(exp_val) : 1.0f;
 
         if (verbose)
         {
@@ -152,12 +140,10 @@ static int test_cpu_roundtrip(int verbose)
 {
     printf("[CPU 1] Round-trip coefficient extraction\n");
 
-    float *modes = (float *) malloc(
-        sizeof(float) * NMODES * NPIX);
+    float *modes = (float *) malloc(sizeof(float) * NMODES * NPIX);
     build_orthogonal_modes(modes, NMODES, NPIX);
 
-    float coeff_in[NMODES] =
-        {1.0f, -2.5f, 3.0f, 0.5f, -1.0f};
+    float coeff_in[NMODES] = { 1.0f, -2.5f, 3.0f, 0.5f, -1.0f };
 
     /* Synthesize input: I[p] = sum_k c[k] * M[k][p] */
     float *input = (float *) calloc(NPIX, sizeof(float));
@@ -169,17 +155,13 @@ static int test_cpu_roundtrip(int verbose)
         }
     }
 
-    float *outarray = (float *) calloc(
-        NMODES, sizeof(float));
-    matrixMulCPU(modes, input,
-                 outarray, NMODES, NPIX);
+    float *outarray = (float *) calloc(NMODES, sizeof(float));
+    matrixMulCPU(modes, input, outarray, NMODES, NPIX);
 
     float norms[NMODES];
     compute_mode_norms(modes, norms, NMODES, NPIX);
 
-    int ret = verify_coefficients(
-        outarray, coeff_in, norms, NMODES,
-        verbose, "CPU");
+    int ret = verify_coefficients(outarray, coeff_in, norms, NMODES, verbose, "CPU");
 
     free(outarray);
     free(input);
@@ -201,24 +183,20 @@ static int test_cpu_zero_input(int verbose)
 {
     printf("[CPU 2] Zero input produces zero output\n");
 
-    float *modes = (float *) malloc(
-        sizeof(float) * NMODES * NPIX);
+    float *modes = (float *) malloc(sizeof(float) * NMODES * NPIX);
     build_orthogonal_modes(modes, NMODES, NPIX);
 
     float *input    = (float *) calloc(NPIX, sizeof(float));
-    float *outarray = (float *) calloc(
-        NMODES, sizeof(float));
+    float *outarray = (float *) calloc(NMODES, sizeof(float));
 
-    matrixMulCPU(modes, input,
-                 outarray, NMODES, NPIX);
+    matrixMulCPU(modes, input, outarray, NMODES, NPIX);
 
     int pass = 1;
     for (int k = 0; k < NMODES; k++)
     {
         if (fabsf(outarray[k]) > 1.0e-7f)
         {
-            printf("  FAIL mode %d: expected 0, got %e\n",
-                   k, outarray[k]);
+            printf("  FAIL mode %d: expected 0, got %e\n", k, outarray[k]);
             pass = 0;
         }
     }
@@ -249,8 +227,7 @@ static int test_cpu_orthogonality(int verbose)
     printf("[CPU 3] Single-mode isolation "
            "(orthogonality)\n");
 
-    float *modes = (float *) malloc(
-        sizeof(float) * NMODES * NPIX);
+    float *modes = (float *) malloc(sizeof(float) * NMODES * NPIX);
     build_orthogonal_modes(modes, NMODES, NPIX);
 
     float norms[NMODES];
@@ -259,22 +236,17 @@ static int test_cpu_orthogonality(int verbose)
     int pass = 1;
     for (int target = 0; target < NMODES; target++)
     {
-        float *input = (float *) malloc(
-            sizeof(float) * NPIX);
-        memcpy(input, &modes[target * NPIX],
-               sizeof(float) * NPIX);
+        float *input = (float *) malloc(sizeof(float) * NPIX);
+        memcpy(input, &modes[target * NPIX], sizeof(float) * NPIX);
 
-        float *outarray = (float *) calloc(
-            NMODES, sizeof(float));
-        matrixMulCPU(modes, input,
-                     outarray, NMODES, NPIX);
+        float *outarray = (float *) calloc(NMODES, sizeof(float));
+        matrixMulCPU(modes, input, outarray, NMODES, NPIX);
 
         for (int k = 0; k < NMODES; k++)
         {
             float normalized = outarray[k] / norms[k];
-            float expected =
-                (k == target) ? 1.0f : 0.0f;
-            float err = fabsf(normalized - expected);
+            float expected   = (k == target) ? 1.0f : 0.0f;
+            float err        = fabsf(normalized - expected);
 
             if (err > TOL)
             {
@@ -290,8 +262,7 @@ static int test_cpu_orthogonality(int verbose)
             printf("  target mode %d: ", target);
             for (int k = 0; k < NMODES; k++)
             {
-                printf("%+.3f ",
-                       outarray[k] / norms[k]);
+                printf("%+.3f ", outarray[k] / norms[k]);
             }
             printf("\n");
         }
@@ -322,10 +293,9 @@ static int test_cpu_shm_roundtrip(int verbose)
     IMAGE img_input;
 
     {
-        uint32_t sz[3] = {NPIX_X, NPIX_Y, NMODES};
-        errno_t ret = ImageStreamIO_createIm(
-            &img_modes, SNAME_MODES, 3, sz,
-            _DATATYPE_FLOAT, 1, 10, 0);
+        uint32_t sz[3] = { NPIX_X, NPIX_Y, NMODES };
+        errno_t  ret =
+            ImageStreamIO_createIm(&img_modes, SNAME_MODES, 3, sz, _DATATYPE_FLOAT, 1, 10, 0);
         if (ret != 0)
         {
             printf("  SKIP: cannot create SHM stream\n");
@@ -334,10 +304,9 @@ static int test_cpu_shm_roundtrip(int verbose)
     }
 
     {
-        uint32_t sz[2] = {NPIX_X, NPIX_Y};
-        errno_t ret = ImageStreamIO_createIm(
-            &img_input, SNAME_INPUT, 2, sz,
-            _DATATYPE_FLOAT, 1, 10, 0);
+        uint32_t sz[2] = { NPIX_X, NPIX_Y };
+        errno_t  ret =
+            ImageStreamIO_createIm(&img_input, SNAME_INPUT, 2, sz, _DATATYPE_FLOAT, 1, 10, 0);
         if (ret != 0)
         {
             printf("  SKIP: cannot create SHM stream\n");
@@ -346,36 +315,25 @@ static int test_cpu_shm_roundtrip(int verbose)
         }
     }
 
-    build_orthogonal_modes(
-        img_modes.array.F, NMODES, NPIX);
+    build_orthogonal_modes(img_modes.array.F, NMODES, NPIX);
 
-    float coeff_in[NMODES] =
-        {1.5f, -0.5f, 2.0f, -1.0f, 0.25f};
-    memset(img_input.array.F, 0,
-           sizeof(float) * NPIX);
+    float coeff_in[NMODES] = { 1.5f, -0.5f, 2.0f, -1.0f, 0.25f };
+    memset(img_input.array.F, 0, sizeof(float) * NPIX);
     for (int k = 0; k < NMODES; k++)
     {
         for (int p = 0; p < NPIX; p++)
         {
-            img_input.array.F[p] +=
-                coeff_in[k]
-                * img_modes.array.F[k * NPIX + p];
+            img_input.array.F[p] += coeff_in[k] * img_modes.array.F[k * NPIX + p];
         }
     }
 
-    float *outarray = (float *) calloc(
-        NMODES, sizeof(float));
-    matrixMulCPU(img_modes.array.F,
-                 img_input.array.F,
-                 outarray, NMODES, NPIX);
+    float *outarray = (float *) calloc(NMODES, sizeof(float));
+    matrixMulCPU(img_modes.array.F, img_input.array.F, outarray, NMODES, NPIX);
 
     float norms[NMODES];
-    compute_mode_norms(
-        img_modes.array.F, norms, NMODES, NPIX);
+    compute_mode_norms(img_modes.array.F, norms, NMODES, NPIX);
 
-    int ret = verify_coefficients(
-        outarray, coeff_in, norms, NMODES,
-        verbose, "CPU-SHM");
+    int ret = verify_coefficients(outarray, coeff_in, norms, NMODES, verbose, "CPU-SHM");
 
     free(outarray);
     ImageStreamIO_destroyIm(&img_input);
@@ -393,17 +351,16 @@ static int test_cpu_shm_roundtrip(int verbose)
  * CPU Test 5: Stress test (64×64, 20 delta modes)
  * ------------------------------------------------------ */
 
-#define STRESS_NX     64
-#define STRESS_NY     64
-#define STRESS_NPIX   (STRESS_NX * STRESS_NY)
+#define STRESS_NX 64
+#define STRESS_NY 64
+#define STRESS_NPIX (STRESS_NX * STRESS_NY)
 #define STRESS_NMODES 20
 
 static int test_cpu_stress(int verbose)
 {
-    printf("[CPU 5] Stress test (%dx%d, %d modes)\n",
-           STRESS_NX, STRESS_NY, STRESS_NMODES);
+    printf("[CPU 5] Stress test (%dx%d, %d modes)\n", STRESS_NX, STRESS_NY, STRESS_NMODES);
 
-    long total = (long) STRESS_NMODES * STRESS_NPIX;
+    long   total = (long) STRESS_NMODES * STRESS_NPIX;
     float *modes = (float *) calloc(total, sizeof(float));
     for (int k = 0; k < STRESS_NMODES; k++)
     {
@@ -413,31 +370,23 @@ static int test_cpu_stress(int verbose)
     float coeff_in[STRESS_NMODES];
     for (int k = 0; k < STRESS_NMODES; k++)
     {
-        coeff_in[k] =
-            sinf((float)(k + 1) * 1.7f) * 10.0f;
+        coeff_in[k] = sinf((float) (k + 1) * 1.7f) * 10.0f;
     }
 
-    float *input = (float *) calloc(
-        STRESS_NPIX, sizeof(float));
+    float *input = (float *) calloc(STRESS_NPIX, sizeof(float));
     for (int k = 0; k < STRESS_NMODES; k++)
     {
         for (int p = 0; p < STRESS_NPIX; p++)
         {
-            input[p] +=
-                coeff_in[k]
-                * modes[k * STRESS_NPIX + p];
+            input[p] += coeff_in[k] * modes[k * STRESS_NPIX + p];
         }
     }
 
-    float *outarray = (float *) calloc(
-        STRESS_NMODES, sizeof(float));
-    matrixMulCPU(modes, input,
-                 outarray, STRESS_NMODES, STRESS_NPIX);
+    float *outarray = (float *) calloc(STRESS_NMODES, sizeof(float));
+    matrixMulCPU(modes, input, outarray, STRESS_NMODES, STRESS_NPIX);
 
     /* Delta modes have norm=1, no normalization */
-    int ret = verify_coefficients(
-        outarray, coeff_in, NULL, STRESS_NMODES,
-        verbose, "CPU");
+    int ret = verify_coefficients(outarray, coeff_in, NULL, STRESS_NMODES, verbose, "CPU");
 
     free(outarray);
     free(input);
@@ -468,20 +417,19 @@ static int test_cpu_stress(int verbose)
  * Returns 0 on success, -1 on failure.
  * ------------------------------------------------------ */
 
-static int gpu_mvm(
-    const float *h_modes,
-    const float *h_input,
-    float       *h_output,
-    int          nmodes,
-    int          npix)
+static int gpu_mvm(const float *h_modes,
+                   const float *h_input,
+                   float       *h_output,
+                   int          nmodes,
+                   int          npix)
 {
     cublasHandle_t handle;
     cublasStatus_t stat;
     cudaError_t    cerr;
-    float *d_modes  = NULL;
-    float *d_input  = NULL;
-    float *d_output = NULL;
-    int    ret      = -1;
+    float         *d_modes  = NULL;
+    float         *d_input  = NULL;
+    float         *d_output = NULL;
+    int            ret      = -1;
 
     stat = cublasCreate(&handle);
     if (stat != CUBLAS_STATUS_SUCCESS)
@@ -491,39 +439,32 @@ static int gpu_mvm(
     }
 
     /* Allocate device memory */
-    cerr = cudaMalloc((void **) &d_modes,
-                      sizeof(float) * nmodes * npix);
+    cerr = cudaMalloc((void **) &d_modes, sizeof(float) * nmodes * npix);
     if (cerr != cudaSuccess)
     {
         goto cleanup;
     }
 
-    cerr = cudaMalloc((void **) &d_input,
-                      sizeof(float) * npix);
+    cerr = cudaMalloc((void **) &d_input, sizeof(float) * npix);
     if (cerr != cudaSuccess)
     {
         goto cleanup;
     }
 
-    cerr = cudaMalloc((void **) &d_output,
-                      sizeof(float) * nmodes);
+    cerr = cudaMalloc((void **) &d_output, sizeof(float) * nmodes);
     if (cerr != cudaSuccess)
     {
         goto cleanup;
     }
 
     /* Copy data to GPU */
-    cerr = cudaMemcpy(d_modes, h_modes,
-                      sizeof(float) * nmodes * npix,
-                      cudaMemcpyHostToDevice);
+    cerr = cudaMemcpy(d_modes, h_modes, sizeof(float) * nmodes * npix, cudaMemcpyHostToDevice);
     if (cerr != cudaSuccess)
     {
         goto cleanup;
     }
 
-    cerr = cudaMemcpy(d_input, h_input,
-                      sizeof(float) * npix,
-                      cudaMemcpyHostToDevice);
+    cerr = cudaMemcpy(d_input, h_input, sizeof(float) * npix, cudaMemcpyHostToDevice);
     if (cerr != cudaSuccess)
     {
         goto cleanup;
@@ -540,12 +481,8 @@ static int gpu_mvm(
         float alpha = 1.0f;
         float beta  = 0.0f;
 
-        stat = cublasSgemv(
-            handle, CUBLAS_OP_T,
-            npix, nmodes,
-            &alpha, d_modes, npix,
-            d_input, 1,
-            &beta, d_output, 1);
+        stat = cublasSgemv(handle, CUBLAS_OP_T, npix, nmodes, &alpha, d_modes, npix, d_input, 1,
+                           &beta, d_output, 1);
         if (stat != CUBLAS_STATUS_SUCCESS)
         {
             printf("  cublasSgemv failed: %d\n", stat);
@@ -554,9 +491,7 @@ static int gpu_mvm(
     }
 
     /* Copy result back */
-    cerr = cudaMemcpy(h_output, d_output,
-                      sizeof(float) * nmodes,
-                      cudaMemcpyDeviceToHost);
+    cerr = cudaMemcpy(h_output, d_output, sizeof(float) * nmodes, cudaMemcpyDeviceToHost);
     if (cerr != cudaSuccess)
     {
         goto cleanup;
@@ -590,12 +525,10 @@ static int test_gpu_roundtrip(int verbose)
 {
     printf("[GPU 1] Round-trip coefficient extraction\n");
 
-    float *modes = (float *) malloc(
-        sizeof(float) * NMODES * NPIX);
+    float *modes = (float *) malloc(sizeof(float) * NMODES * NPIX);
     build_orthogonal_modes(modes, NMODES, NPIX);
 
-    float coeff_in[NMODES] =
-        {1.0f, -2.5f, 3.0f, 0.5f, -1.0f};
+    float coeff_in[NMODES] = { 1.0f, -2.5f, 3.0f, 0.5f, -1.0f };
 
     float *input = (float *) calloc(NPIX, sizeof(float));
     for (int k = 0; k < NMODES; k++)
@@ -606,11 +539,9 @@ static int test_gpu_roundtrip(int verbose)
         }
     }
 
-    float *outarray = (float *) calloc(
-        NMODES, sizeof(float));
+    float *outarray = (float *) calloc(NMODES, sizeof(float));
 
-    if (gpu_mvm(modes, input, outarray,
-                NMODES, NPIX) != 0)
+    if (gpu_mvm(modes, input, outarray, NMODES, NPIX) != 0)
     {
         printf("  SKIP: GPU MVM failed\n");
         free(outarray);
@@ -622,9 +553,7 @@ static int test_gpu_roundtrip(int verbose)
     float norms[NMODES];
     compute_mode_norms(modes, norms, NMODES, NPIX);
 
-    int ret = verify_coefficients(
-        outarray, coeff_in, norms, NMODES,
-        verbose, "GPU");
+    int ret = verify_coefficients(outarray, coeff_in, norms, NMODES, verbose, "GPU");
 
     free(outarray);
     free(input);
@@ -647,8 +576,7 @@ static int test_gpu_orthogonality(int verbose)
     printf("[GPU 2] Single-mode isolation "
            "(orthogonality)\n");
 
-    float *modes = (float *) malloc(
-        sizeof(float) * NMODES * NPIX);
+    float *modes = (float *) malloc(sizeof(float) * NMODES * NPIX);
     build_orthogonal_modes(modes, NMODES, NPIX);
 
     float norms[NMODES];
@@ -657,16 +585,12 @@ static int test_gpu_orthogonality(int verbose)
     int pass = 1;
     for (int target = 0; target < NMODES; target++)
     {
-        float *input = (float *) malloc(
-            sizeof(float) * NPIX);
-        memcpy(input, &modes[target * NPIX],
-               sizeof(float) * NPIX);
+        float *input = (float *) malloc(sizeof(float) * NPIX);
+        memcpy(input, &modes[target * NPIX], sizeof(float) * NPIX);
 
-        float *outarray = (float *) calloc(
-            NMODES, sizeof(float));
+        float *outarray = (float *) calloc(NMODES, sizeof(float));
 
-        if (gpu_mvm(modes, input, outarray,
-                    NMODES, NPIX) != 0)
+        if (gpu_mvm(modes, input, outarray, NMODES, NPIX) != 0)
         {
             printf("  SKIP: GPU MVM failed\n");
             free(outarray);
@@ -678,9 +602,8 @@ static int test_gpu_orthogonality(int verbose)
         for (int k = 0; k < NMODES; k++)
         {
             float normalized = outarray[k] / norms[k];
-            float expected =
-                (k == target) ? 1.0f : 0.0f;
-            float err = fabsf(normalized - expected);
+            float expected   = (k == target) ? 1.0f : 0.0f;
+            float err        = fabsf(normalized - expected);
 
             if (err > TOL)
             {
@@ -696,8 +619,7 @@ static int test_gpu_orthogonality(int verbose)
             printf("  target mode %d: ", target);
             for (int k = 0; k < NMODES; k++)
             {
-                printf("%+.3f ",
-                       outarray[k] / norms[k]);
+                printf("%+.3f ", outarray[k] / norms[k]);
             }
             printf("\n");
         }
@@ -722,10 +644,9 @@ static int test_gpu_orthogonality(int verbose)
 
 static int test_gpu_stress(int verbose)
 {
-    printf("[GPU 3] Stress test (%dx%d, %d modes)\n",
-           STRESS_NX, STRESS_NY, STRESS_NMODES);
+    printf("[GPU 3] Stress test (%dx%d, %d modes)\n", STRESS_NX, STRESS_NY, STRESS_NMODES);
 
-    long total = (long) STRESS_NMODES * STRESS_NPIX;
+    long   total = (long) STRESS_NMODES * STRESS_NPIX;
     float *modes = (float *) calloc(total, sizeof(float));
     for (int k = 0; k < STRESS_NMODES; k++)
     {
@@ -735,27 +656,21 @@ static int test_gpu_stress(int verbose)
     float coeff_in[STRESS_NMODES];
     for (int k = 0; k < STRESS_NMODES; k++)
     {
-        coeff_in[k] =
-            sinf((float)(k + 1) * 1.7f) * 10.0f;
+        coeff_in[k] = sinf((float) (k + 1) * 1.7f) * 10.0f;
     }
 
-    float *input = (float *) calloc(
-        STRESS_NPIX, sizeof(float));
+    float *input = (float *) calloc(STRESS_NPIX, sizeof(float));
     for (int k = 0; k < STRESS_NMODES; k++)
     {
         for (int p = 0; p < STRESS_NPIX; p++)
         {
-            input[p] +=
-                coeff_in[k]
-                * modes[k * STRESS_NPIX + p];
+            input[p] += coeff_in[k] * modes[k * STRESS_NPIX + p];
         }
     }
 
-    float *outarray = (float *) calloc(
-        STRESS_NMODES, sizeof(float));
+    float *outarray = (float *) calloc(STRESS_NMODES, sizeof(float));
 
-    if (gpu_mvm(modes, input, outarray,
-                STRESS_NMODES, STRESS_NPIX) != 0)
+    if (gpu_mvm(modes, input, outarray, STRESS_NMODES, STRESS_NPIX) != 0)
     {
         printf("  SKIP: GPU MVM failed\n");
         free(outarray);
@@ -764,9 +679,7 @@ static int test_gpu_stress(int verbose)
         return 0;
     }
 
-    int ret = verify_coefficients(
-        outarray, coeff_in, NULL, STRESS_NMODES,
-        verbose, "GPU");
+    int ret = verify_coefficients(outarray, coeff_in, NULL, STRESS_NMODES, verbose, "GPU");
 
     free(outarray);
     free(input);
@@ -791,12 +704,10 @@ static int test_cpu_gpu_match(int verbose)
 {
     printf("[GPU 4] CPU vs GPU cross-validation\n");
 
-    float *modes = (float *) malloc(
-        sizeof(float) * NMODES * NPIX);
+    float *modes = (float *) malloc(sizeof(float) * NMODES * NPIX);
     build_orthogonal_modes(modes, NMODES, NPIX);
 
-    float coeff_in[NMODES] =
-        {3.14f, -1.41f, 2.72f, -0.58f, 1.62f};
+    float coeff_in[NMODES] = { 3.14f, -1.41f, 2.72f, -0.58f, 1.62f };
 
     float *input = (float *) calloc(NPIX, sizeof(float));
     for (int k = 0; k < NMODES; k++)
@@ -808,16 +719,12 @@ static int test_cpu_gpu_match(int verbose)
     }
 
     /* CPU result */
-    float *cpu_out = (float *) calloc(
-        NMODES, sizeof(float));
-    matrixMulCPU(modes, input,
-                 cpu_out, NMODES, NPIX);
+    float *cpu_out = (float *) calloc(NMODES, sizeof(float));
+    matrixMulCPU(modes, input, cpu_out, NMODES, NPIX);
 
     /* GPU result */
-    float *gpu_out = (float *) calloc(
-        NMODES, sizeof(float));
-    if (gpu_mvm(modes, input, gpu_out,
-                NMODES, NPIX) != 0)
+    float *gpu_out = (float *) calloc(NMODES, sizeof(float));
+    if (gpu_mvm(modes, input, gpu_out, NMODES, NPIX) != 0)
     {
         printf("  SKIP: GPU MVM failed\n");
         free(gpu_out);
@@ -832,8 +739,7 @@ static int test_cpu_gpu_match(int verbose)
     for (int k = 0; k < NMODES; k++)
     {
         float diff = fabsf(cpu_out[k] - gpu_out[k]);
-        float ref  = fabsf(cpu_out[k]) > 1.0e-6f
-                       ? fabsf(cpu_out[k]) : 1.0f;
+        float ref  = fabsf(cpu_out[k]) > 1.0e-6f ? fabsf(cpu_out[k]) : 1.0f;
 
         if (verbose)
         {
@@ -870,32 +776,25 @@ static int test_cpu_gpu_match(int verbose)
  * Help
  * ============================================================= */
 
-static const char *APP_DESCRIPTION =
-    "MVM mode extraction correctness tests";
+static const char *APP_DESCRIPTION = "MVM mode extraction correctness tests";
 
-static const char *APP_DESCRIPTION_LONG =
-    "Round-trip correctness test for matrix-vector\n"
-    "multiply (MVM) mode extraction. Creates\n"
-    "orthogonal modes, synthesizes an input image\n"
-    "from known coefficients, runs the MVM on CPU\n"
-    "and/or GPU, and verifies extracted coefficients\n"
-    "match the originals within tolerance.";
+static const char *APP_DESCRIPTION_LONG = "Round-trip correctness test for matrix-vector\n"
+                                          "multiply (MVM) mode extraction. Creates\n"
+                                          "orthogonal modes, synthesizes an input image\n"
+                                          "from known coefficients, runs the MVM on CPU\n"
+                                          "and/or GPU, and verifies extracted coefficients\n"
+                                          "match the originals within tolerance.";
 
 
-static void print_help(
-    const char *prog,
-    int         mh_color)
+static void print_help(const char *prog, int mh_color)
 {
-    milk_help_banner(
-        prog, APP_DESCRIPTION, mh_color);
+    milk_help_banner(prog, APP_DESCRIPTION, mh_color);
 
     /* Usage */
     milk_help_section("Usage", mh_color);
     if (mh_color)
     {
-        printf("  " MH_CMD "%s" MH_RST
-               " [" MH_OPT "options" MH_RST "]\n\n",
-               prog);
+        printf("  " MH_CMD "%s" MH_RST " [" MH_OPT "options" MH_RST "]\n\n", prog);
     }
     else
     {
@@ -908,20 +807,13 @@ static void print_help(
 
     /* Options */
     milk_help_section("Options", mh_color);
-    printf("  %s         Show this help\n",
-           MH(MH_OPT, "-h, --help"));
-    printf("  %s              One-line description\n",
-           MH(MH_OPT, "-h1"));
-    printf("  %s              Verbose description\n",
-           MH(MH_OPT, "-h2"));
-    printf("  %s              Monochrome help\n",
-           MH(MH_OPT, "-hm"));
-    printf("  %s      Per-mode expected/actual values\n",
-           MH(MH_OPT, "-v, --verbose"));
-    printf("  %s          Run CPU tests only\n",
-           MH(MH_OPT, "-c, --cpu"));
-    printf("  %s          Run GPU tests only\n",
-           MH(MH_OPT, "-g, --gpu"));
+    printf("  %s         Show this help\n", MH(MH_OPT, "-h, --help"));
+    printf("  %s              One-line description\n", MH(MH_OPT, "-h1"));
+    printf("  %s              Verbose description\n", MH(MH_OPT, "-h2"));
+    printf("  %s              Monochrome help\n", MH(MH_OPT, "-hm"));
+    printf("  %s      Per-mode expected/actual values\n", MH(MH_OPT, "-v, --verbose"));
+    printf("  %s          Run CPU tests only\n", MH(MH_OPT, "-c, --cpu"));
+    printf("  %s          Run GPU tests only\n", MH(MH_OPT, "-g, --gpu"));
     printf("  (default)          "
            "Run both CPU and GPU\n\n");
 
@@ -929,23 +821,14 @@ static void print_help(
     milk_help_section("Examples", mh_color);
     printf("  %s %s %s"
            "          # CPU tests, verbose\n",
-           MH(MH_DIM, "$"),
-           MH(MH_CMD, "test_MVMextract"),
-           MH(MH_OPT, "-v -c"));
+           MH(MH_DIM, "$"), MH(MH_CMD, "test_MVMextract"), MH(MH_OPT, "-v -c"));
     printf("  %s %s %s"
            "          # GPU tests, verbose\n",
-           MH(MH_DIM, "$"),
-           MH(MH_CMD, "test_MVMextract"),
-           MH(MH_OPT, "-v -g"));
+           MH(MH_DIM, "$"), MH(MH_CMD, "test_MVMextract"), MH(MH_OPT, "-v -g"));
     printf("  %s %s %s"
            "             # both, verbose\n",
-           MH(MH_DIM, "$"),
-           MH(MH_CMD, "test_MVMextract"),
-           MH(MH_OPT, "-v"));
-    printf("  %s %s %s %s\n\n",
-           MH(MH_DIM, "$"),
-           MH(MH_CMD, "ctest"),
-           MH(MH_OPT, "-R MVMextract"),
+           MH(MH_DIM, "$"), MH(MH_CMD, "test_MVMextract"), MH(MH_OPT, "-v"));
+    printf("  %s %s %s %s\n\n", MH(MH_DIM, "$"), MH(MH_CMD, "ctest"), MH(MH_OPT, "-R MVMextract"),
            MH(MH_OPT, "--output-on-failure"));
 
     /* See Also */
@@ -965,50 +848,43 @@ static void print_help(
 int main(int argc, char *argv[])
 {
     /* --- Handle help flags (before getopt) --- */
-    int action = milk_help_init(
-        argc, argv,
-        APP_DESCRIPTION, APP_DESCRIPTION_LONG);
+    int action = milk_help_init(argc, argv, APP_DESCRIPTION, APP_DESCRIPTION_LONG);
 
-    if (action == MH_ACTION_H1
-        || action == MH_ACTION_H2)
+    if (action == MH_ACTION_H1 || action == MH_ACTION_H2)
     {
         return 0;
     }
 
     int mh_color = (action == MH_ACTION_HELP);
-    if (action == MH_ACTION_HELP
-        || action == MH_ACTION_MONO)
+    if (action == MH_ACTION_HELP || action == MH_ACTION_MONO)
     {
         print_help(argv[0], mh_color);
         return 0;
     }
 
     /* --- Parse test-specific flags --- */
-    int verbose  = 0;
-    int run_cpu  = 1;
-    int run_gpu  = 1;
+    int verbose            = 0;
+    int run_cpu            = 1;
+    int run_gpu            = 1;
     int explicit_selection = 0;
 
     for (int i = 1; i < argc; i++)
     {
-        if (strcmp(argv[i], "-v") == 0
-            || strcmp(argv[i], "--verbose") == 0)
+        if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--verbose") == 0)
         {
             verbose = 1;
         }
-        else if (strcmp(argv[i], "-c") == 0
-                 || strcmp(argv[i], "--cpu") == 0)
+        else if (strcmp(argv[i], "-c") == 0 || strcmp(argv[i], "--cpu") == 0)
         {
             explicit_selection = 1;
-            run_cpu = 1;
-            run_gpu = 0;
+            run_cpu            = 1;
+            run_gpu            = 0;
         }
-        else if (strcmp(argv[i], "-g") == 0
-                 || strcmp(argv[i], "--gpu") == 0)
+        else if (strcmp(argv[i], "-g") == 0 || strcmp(argv[i], "--gpu") == 0)
         {
             explicit_selection = 1;
-            run_cpu = 0;
-            run_gpu = 1;
+            run_cpu            = 0;
+            run_gpu            = 1;
         }
     } // for args
 
@@ -1020,8 +896,7 @@ int main(int argc, char *argv[])
     }
 
     printf("=== MVM Extract Modes Test Suite ===\n");
-    printf("Image size: %dx%d (%d pixels), %d modes\n",
-           NPIX_X, NPIX_Y, NPIX, NMODES);
+    printf("Image size: %dx%d (%d pixels), %d modes\n", NPIX_X, NPIX_Y, NPIX, NMODES);
 
 #ifdef HAVE_CUDA
     {
@@ -1041,9 +916,7 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    printf("Running: %s%s%s\n\n",
-           run_cpu ? "CPU" : "",
-           (run_cpu && run_gpu) ? " + " : "",
+    printf("Running: %s%s%s\n\n", run_cpu ? "CPU" : "", (run_cpu && run_gpu) ? " + " : "",
            run_gpu ? "GPU" : "");
 
     int failures = 0;
@@ -1069,8 +942,7 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    printf("\n=== Results: %d test(s) failed ===\n",
-           failures);
+    printf("\n=== Results: %d test(s) failed ===\n", failures);
 
     return failures > 0 ? 1 : 0;
 }

--- a/plugins/milk-extra-src/linalgebra/test_MVMextract.c
+++ b/plugins/milk-extra-src/linalgebra/test_MVMextract.c
@@ -1,0 +1,1076 @@
+/**
+ * @file test_MVMextract.c
+ * @brief Round-trip correctness test for MVM mode extraction
+ *
+ * Tests both CPU (BLAS) and GPU (cuBLAS) MVM paths by
+ * creating orthogonal modes, synthesizing an input image
+ * from known coefficients, running the MVM, and verifying
+ * that the extracted coefficients match.
+ *
+ * Exit code:
+ *   0 = all tests passed
+ *   1 = test failure
+ */
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef HAVE_CUDA
+#    include <cublas_v2.h>
+#    include <cuda_runtime.h>
+#endif
+
+#include "ImageStreamIO/ImageStreamIO.h"
+#include "ImageStreamIO/ImageStruct.h"
+#include "MVM_CPU.h"
+#include "libfps/milk_help.h"
+
+
+/* --------------------------------------------------------
+ * Test configuration
+ * ------------------------------------------------------ */
+
+#define NPIX_X   16   /* image width */
+#define NPIX_Y   16   /* image height */
+#define NPIX     (NPIX_X * NPIX_Y)   /* = 256 */
+#define NMODES   5    /* number of modes */
+#define TOL      1.0e-4f  /* relative tolerance */
+
+/* Stream names for SHM cleanup */
+#define SNAME_MODES  "test_mvm_modes"
+#define SNAME_INPUT  "test_mvm_input"
+
+
+/* --------------------------------------------------------
+ * Helper: build orthogonal modes matrix
+ *
+ * Each mode k is a vector of length npix with a
+ * distinctive pattern that is orthogonal to all others.
+ * We use shifted Hadamard-like rows: mode k has value
+ * +1 in pixels where (pixel_index / stride) is even,
+ * -1 where odd, with stride = 2^k. This gives pairwise
+ * orthogonal rows for k < log2(npix).
+ * ------------------------------------------------------ */
+
+static void build_orthogonal_modes(
+    float *modes,
+    int    nmodes,
+    int    npix)
+{
+    for (int k = 0; k < nmodes; k++)
+    {
+        int stride = 1 << k;  /* 1, 2, 4, 8, 16 */
+        for (int p = 0; p < npix; p++)
+        {
+            int block = p / stride;
+            modes[k * npix + p] =
+                (block % 2 == 0) ? 1.0f : -1.0f;
+        }
+    } // for k
+}
+
+
+/* --------------------------------------------------------
+ * Helper: compute mode norms for verification
+ * ------------------------------------------------------ */
+
+static void compute_mode_norms(
+    const float *modes,
+    float       *norms,
+    int          nmodes,
+    int          npix)
+{
+    for (int k = 0; k < nmodes; k++)
+    {
+        float sum = 0.0f;
+        for (int p = 0; p < npix; p++)
+        {
+            float v = modes[k * npix + p];
+            sum += v * v;
+        }
+        norms[k] = sum;
+    }
+}
+
+
+/* --------------------------------------------------------
+ * Helper: verify coefficients match expected
+ *
+ * Returns 0 on success, 1 on failure.
+ * ------------------------------------------------------ */
+
+static int verify_coefficients(
+    const float *outarray,
+    const float *expected,
+    const float *norms,
+    int          nmodes,
+    int          verbose,
+    const char  *label)
+{
+    int pass = 1;
+    for (int k = 0; k < nmodes; k++)
+    {
+        float extracted = (norms != NULL)
+                            ? outarray[k] / norms[k]
+                            : outarray[k];
+        float exp_val   = expected[k];
+        float err       = fabsf(extracted - exp_val);
+        float ref       = fabsf(exp_val) > 1.0e-6f
+                            ? fabsf(exp_val) : 1.0f;
+
+        if (verbose)
+        {
+            printf("  [%s] mode %2d: expected=%+8.4f"
+                   "  got=%+8.4f  err=%.2e\n",
+                   label, k, exp_val, extracted, err);
+        }
+
+        if (err / ref > TOL)
+        {
+            printf("  [%s] FAIL mode %d: expected %f,"
+                   " got %f (err=%e)\n",
+                   label, k, exp_val, extracted, err);
+            pass = 0;
+        }
+    }
+    return pass ? 0 : 1;
+}
+
+
+/* ================================================================
+ * CPU TESTS
+ * ============================================================= */
+
+
+/* --------------------------------------------------------
+ * CPU Test 1: Basic round-trip
+ * ------------------------------------------------------ */
+
+static int test_cpu_roundtrip(int verbose)
+{
+    printf("[CPU 1] Round-trip coefficient extraction\n");
+
+    float *modes = (float *) malloc(
+        sizeof(float) * NMODES * NPIX);
+    build_orthogonal_modes(modes, NMODES, NPIX);
+
+    float coeff_in[NMODES] =
+        {1.0f, -2.5f, 3.0f, 0.5f, -1.0f};
+
+    /* Synthesize input: I[p] = sum_k c[k] * M[k][p] */
+    float *input = (float *) calloc(NPIX, sizeof(float));
+    for (int k = 0; k < NMODES; k++)
+    {
+        for (int p = 0; p < NPIX; p++)
+        {
+            input[p] += coeff_in[k] * modes[k * NPIX + p];
+        }
+    }
+
+    float *outarray = (float *) calloc(
+        NMODES, sizeof(float));
+    matrixMulCPU(modes, input,
+                 outarray, NMODES, NPIX);
+
+    float norms[NMODES];
+    compute_mode_norms(modes, norms, NMODES, NPIX);
+
+    int ret = verify_coefficients(
+        outarray, coeff_in, norms, NMODES,
+        verbose, "CPU");
+
+    free(outarray);
+    free(input);
+    free(modes);
+
+    if (ret == 0)
+    {
+        printf("  PASS\n");
+    }
+    return ret;
+}
+
+
+/* --------------------------------------------------------
+ * CPU Test 2: Zero input → zero output
+ * ------------------------------------------------------ */
+
+static int test_cpu_zero_input(int verbose)
+{
+    printf("[CPU 2] Zero input produces zero output\n");
+
+    float *modes = (float *) malloc(
+        sizeof(float) * NMODES * NPIX);
+    build_orthogonal_modes(modes, NMODES, NPIX);
+
+    float *input    = (float *) calloc(NPIX, sizeof(float));
+    float *outarray = (float *) calloc(
+        NMODES, sizeof(float));
+
+    matrixMulCPU(modes, input,
+                 outarray, NMODES, NPIX);
+
+    int pass = 1;
+    for (int k = 0; k < NMODES; k++)
+    {
+        if (fabsf(outarray[k]) > 1.0e-7f)
+        {
+            printf("  FAIL mode %d: expected 0, got %e\n",
+                   k, outarray[k]);
+            pass = 0;
+        }
+    }
+
+    if (verbose && pass)
+    {
+        printf("  All output coefficients are zero\n");
+    }
+
+    free(outarray);
+    free(input);
+    free(modes);
+
+    if (pass)
+    {
+        printf("  PASS\n");
+    }
+    return pass ? 0 : 1;
+}
+
+
+/* --------------------------------------------------------
+ * CPU Test 3: Single-mode isolation (orthogonality)
+ * ------------------------------------------------------ */
+
+static int test_cpu_orthogonality(int verbose)
+{
+    printf("[CPU 3] Single-mode isolation "
+           "(orthogonality)\n");
+
+    float *modes = (float *) malloc(
+        sizeof(float) * NMODES * NPIX);
+    build_orthogonal_modes(modes, NMODES, NPIX);
+
+    float norms[NMODES];
+    compute_mode_norms(modes, norms, NMODES, NPIX);
+
+    int pass = 1;
+    for (int target = 0; target < NMODES; target++)
+    {
+        float *input = (float *) malloc(
+            sizeof(float) * NPIX);
+        memcpy(input, &modes[target * NPIX],
+               sizeof(float) * NPIX);
+
+        float *outarray = (float *) calloc(
+            NMODES, sizeof(float));
+        matrixMulCPU(modes, input,
+                     outarray, NMODES, NPIX);
+
+        for (int k = 0; k < NMODES; k++)
+        {
+            float normalized = outarray[k] / norms[k];
+            float expected =
+                (k == target) ? 1.0f : 0.0f;
+            float err = fabsf(normalized - expected);
+
+            if (err > TOL)
+            {
+                printf("  FAIL target=%d, mode %d: "
+                       "expected %f, got %f\n",
+                       target, k, expected, normalized);
+                pass = 0;
+            }
+        }
+
+        if (verbose)
+        {
+            printf("  target mode %d: ", target);
+            for (int k = 0; k < NMODES; k++)
+            {
+                printf("%+.3f ",
+                       outarray[k] / norms[k]);
+            }
+            printf("\n");
+        }
+
+        free(outarray);
+        free(input);
+    }
+
+    free(modes);
+
+    if (pass)
+    {
+        printf("  PASS\n");
+    }
+    return pass ? 0 : 1;
+}
+
+
+/* --------------------------------------------------------
+ * CPU Test 4: SHM stream round-trip
+ * ------------------------------------------------------ */
+
+static int test_cpu_shm_roundtrip(int verbose)
+{
+    printf("[CPU 4] SHM stream data path\n");
+
+    IMAGE img_modes;
+    IMAGE img_input;
+
+    {
+        uint32_t sz[3] = {NPIX_X, NPIX_Y, NMODES};
+        errno_t ret = ImageStreamIO_createIm(
+            &img_modes, SNAME_MODES, 3, sz,
+            _DATATYPE_FLOAT, 1, 10, 0);
+        if (ret != 0)
+        {
+            printf("  SKIP: cannot create SHM stream\n");
+            return 0;
+        }
+    }
+
+    {
+        uint32_t sz[2] = {NPIX_X, NPIX_Y};
+        errno_t ret = ImageStreamIO_createIm(
+            &img_input, SNAME_INPUT, 2, sz,
+            _DATATYPE_FLOAT, 1, 10, 0);
+        if (ret != 0)
+        {
+            printf("  SKIP: cannot create SHM stream\n");
+            ImageStreamIO_destroyIm(&img_modes);
+            return 0;
+        }
+    }
+
+    build_orthogonal_modes(
+        img_modes.array.F, NMODES, NPIX);
+
+    float coeff_in[NMODES] =
+        {1.5f, -0.5f, 2.0f, -1.0f, 0.25f};
+    memset(img_input.array.F, 0,
+           sizeof(float) * NPIX);
+    for (int k = 0; k < NMODES; k++)
+    {
+        for (int p = 0; p < NPIX; p++)
+        {
+            img_input.array.F[p] +=
+                coeff_in[k]
+                * img_modes.array.F[k * NPIX + p];
+        }
+    }
+
+    float *outarray = (float *) calloc(
+        NMODES, sizeof(float));
+    matrixMulCPU(img_modes.array.F,
+                 img_input.array.F,
+                 outarray, NMODES, NPIX);
+
+    float norms[NMODES];
+    compute_mode_norms(
+        img_modes.array.F, norms, NMODES, NPIX);
+
+    int ret = verify_coefficients(
+        outarray, coeff_in, norms, NMODES,
+        verbose, "CPU-SHM");
+
+    free(outarray);
+    ImageStreamIO_destroyIm(&img_input);
+    ImageStreamIO_destroyIm(&img_modes);
+
+    if (ret == 0)
+    {
+        printf("  PASS\n");
+    }
+    return ret;
+}
+
+
+/* --------------------------------------------------------
+ * CPU Test 5: Stress test (64×64, 20 delta modes)
+ * ------------------------------------------------------ */
+
+#define STRESS_NX     64
+#define STRESS_NY     64
+#define STRESS_NPIX   (STRESS_NX * STRESS_NY)
+#define STRESS_NMODES 20
+
+static int test_cpu_stress(int verbose)
+{
+    printf("[CPU 5] Stress test (%dx%d, %d modes)\n",
+           STRESS_NX, STRESS_NY, STRESS_NMODES);
+
+    long total = (long) STRESS_NMODES * STRESS_NPIX;
+    float *modes = (float *) calloc(total, sizeof(float));
+    for (int k = 0; k < STRESS_NMODES; k++)
+    {
+        modes[k * STRESS_NPIX + k] = 1.0f;
+    }
+
+    float coeff_in[STRESS_NMODES];
+    for (int k = 0; k < STRESS_NMODES; k++)
+    {
+        coeff_in[k] =
+            sinf((float)(k + 1) * 1.7f) * 10.0f;
+    }
+
+    float *input = (float *) calloc(
+        STRESS_NPIX, sizeof(float));
+    for (int k = 0; k < STRESS_NMODES; k++)
+    {
+        for (int p = 0; p < STRESS_NPIX; p++)
+        {
+            input[p] +=
+                coeff_in[k]
+                * modes[k * STRESS_NPIX + p];
+        }
+    }
+
+    float *outarray = (float *) calloc(
+        STRESS_NMODES, sizeof(float));
+    matrixMulCPU(modes, input,
+                 outarray, STRESS_NMODES, STRESS_NPIX);
+
+    /* Delta modes have norm=1, no normalization */
+    int ret = verify_coefficients(
+        outarray, coeff_in, NULL, STRESS_NMODES,
+        verbose, "CPU");
+
+    free(outarray);
+    free(input);
+    free(modes);
+
+    if (ret == 0)
+    {
+        printf("  PASS\n");
+    }
+    return ret;
+}
+
+
+/* ================================================================
+ * GPU TESTS
+ * ============================================================= */
+
+#ifdef HAVE_CUDA
+
+/* --------------------------------------------------------
+ * Helper: run MVM on GPU via cuBLAS
+ *
+ * Mirrors the GPU path in MVMextractModes.c:
+ * cublasSgemv(handle, CUBLAS_OP_T, npix, nmodes,
+ *             &alpha, d_modes, npix, d_in, 1,
+ *             &beta, d_out, 1)
+ *
+ * Returns 0 on success, -1 on failure.
+ * ------------------------------------------------------ */
+
+static int gpu_mvm(
+    const float *h_modes,
+    const float *h_input,
+    float       *h_output,
+    int          nmodes,
+    int          npix)
+{
+    cublasHandle_t handle;
+    cublasStatus_t stat;
+    cudaError_t    cerr;
+    float *d_modes  = NULL;
+    float *d_input  = NULL;
+    float *d_output = NULL;
+    int    ret      = -1;
+
+    stat = cublasCreate(&handle);
+    if (stat != CUBLAS_STATUS_SUCCESS)
+    {
+        printf("  cuBLAS init failed\n");
+        return -1;
+    }
+
+    /* Allocate device memory */
+    cerr = cudaMalloc((void **) &d_modes,
+                      sizeof(float) * nmodes * npix);
+    if (cerr != cudaSuccess)
+    {
+        goto cleanup;
+    }
+
+    cerr = cudaMalloc((void **) &d_input,
+                      sizeof(float) * npix);
+    if (cerr != cudaSuccess)
+    {
+        goto cleanup;
+    }
+
+    cerr = cudaMalloc((void **) &d_output,
+                      sizeof(float) * nmodes);
+    if (cerr != cudaSuccess)
+    {
+        goto cleanup;
+    }
+
+    /* Copy data to GPU */
+    cerr = cudaMemcpy(d_modes, h_modes,
+                      sizeof(float) * nmodes * npix,
+                      cudaMemcpyHostToDevice);
+    if (cerr != cudaSuccess)
+    {
+        goto cleanup;
+    }
+
+    cerr = cudaMemcpy(d_input, h_input,
+                      sizeof(float) * npix,
+                      cudaMemcpyHostToDevice);
+    if (cerr != cudaSuccess)
+    {
+        goto cleanup;
+    }
+
+    /* cuBLAS sgemv:
+     * The modes matrix is row-major nmodes×npix.
+     * cuBLAS uses column-major, so we treat it as
+     * column-major npix×nmodes and use CUBLAS_OP_T:
+     *   out = alpha * A^T * x + beta * y
+     * This computes out[k] = sum_p modes[k*npix+p] * in[p]
+     */
+    {
+        float alpha = 1.0f;
+        float beta  = 0.0f;
+
+        stat = cublasSgemv(
+            handle, CUBLAS_OP_T,
+            npix, nmodes,
+            &alpha, d_modes, npix,
+            d_input, 1,
+            &beta, d_output, 1);
+        if (stat != CUBLAS_STATUS_SUCCESS)
+        {
+            printf("  cublasSgemv failed: %d\n", stat);
+            goto cleanup;
+        }
+    }
+
+    /* Copy result back */
+    cerr = cudaMemcpy(h_output, d_output,
+                      sizeof(float) * nmodes,
+                      cudaMemcpyDeviceToHost);
+    if (cerr != cudaSuccess)
+    {
+        goto cleanup;
+    }
+
+    ret = 0;
+
+cleanup:
+    if (d_output != NULL)
+    {
+        cudaFree(d_output);
+    }
+    if (d_input != NULL)
+    {
+        cudaFree(d_input);
+    }
+    if (d_modes != NULL)
+    {
+        cudaFree(d_modes);
+    }
+    cublasDestroy(handle);
+    return ret;
+}
+
+
+/* --------------------------------------------------------
+ * GPU Test 1: Round-trip coefficient extraction
+ * ------------------------------------------------------ */
+
+static int test_gpu_roundtrip(int verbose)
+{
+    printf("[GPU 1] Round-trip coefficient extraction\n");
+
+    float *modes = (float *) malloc(
+        sizeof(float) * NMODES * NPIX);
+    build_orthogonal_modes(modes, NMODES, NPIX);
+
+    float coeff_in[NMODES] =
+        {1.0f, -2.5f, 3.0f, 0.5f, -1.0f};
+
+    float *input = (float *) calloc(NPIX, sizeof(float));
+    for (int k = 0; k < NMODES; k++)
+    {
+        for (int p = 0; p < NPIX; p++)
+        {
+            input[p] += coeff_in[k] * modes[k * NPIX + p];
+        }
+    }
+
+    float *outarray = (float *) calloc(
+        NMODES, sizeof(float));
+
+    if (gpu_mvm(modes, input, outarray,
+                NMODES, NPIX) != 0)
+    {
+        printf("  SKIP: GPU MVM failed\n");
+        free(outarray);
+        free(input);
+        free(modes);
+        return 0;
+    }
+
+    float norms[NMODES];
+    compute_mode_norms(modes, norms, NMODES, NPIX);
+
+    int ret = verify_coefficients(
+        outarray, coeff_in, norms, NMODES,
+        verbose, "GPU");
+
+    free(outarray);
+    free(input);
+    free(modes);
+
+    if (ret == 0)
+    {
+        printf("  PASS\n");
+    }
+    return ret;
+}
+
+
+/* --------------------------------------------------------
+ * GPU Test 2: Single-mode isolation (orthogonality)
+ * ------------------------------------------------------ */
+
+static int test_gpu_orthogonality(int verbose)
+{
+    printf("[GPU 2] Single-mode isolation "
+           "(orthogonality)\n");
+
+    float *modes = (float *) malloc(
+        sizeof(float) * NMODES * NPIX);
+    build_orthogonal_modes(modes, NMODES, NPIX);
+
+    float norms[NMODES];
+    compute_mode_norms(modes, norms, NMODES, NPIX);
+
+    int pass = 1;
+    for (int target = 0; target < NMODES; target++)
+    {
+        float *input = (float *) malloc(
+            sizeof(float) * NPIX);
+        memcpy(input, &modes[target * NPIX],
+               sizeof(float) * NPIX);
+
+        float *outarray = (float *) calloc(
+            NMODES, sizeof(float));
+
+        if (gpu_mvm(modes, input, outarray,
+                    NMODES, NPIX) != 0)
+        {
+            printf("  SKIP: GPU MVM failed\n");
+            free(outarray);
+            free(input);
+            free(modes);
+            return 0;
+        }
+
+        for (int k = 0; k < NMODES; k++)
+        {
+            float normalized = outarray[k] / norms[k];
+            float expected =
+                (k == target) ? 1.0f : 0.0f;
+            float err = fabsf(normalized - expected);
+
+            if (err > TOL)
+            {
+                printf("  FAIL target=%d, mode %d: "
+                       "expected %f, got %f\n",
+                       target, k, expected, normalized);
+                pass = 0;
+            }
+        }
+
+        if (verbose)
+        {
+            printf("  target mode %d: ", target);
+            for (int k = 0; k < NMODES; k++)
+            {
+                printf("%+.3f ",
+                       outarray[k] / norms[k]);
+            }
+            printf("\n");
+        }
+
+        free(outarray);
+        free(input);
+    }
+
+    free(modes);
+
+    if (pass)
+    {
+        printf("  PASS\n");
+    }
+    return pass ? 0 : 1;
+}
+
+
+/* --------------------------------------------------------
+ * GPU Test 3: Stress test (64×64, 20 modes)
+ * ------------------------------------------------------ */
+
+static int test_gpu_stress(int verbose)
+{
+    printf("[GPU 3] Stress test (%dx%d, %d modes)\n",
+           STRESS_NX, STRESS_NY, STRESS_NMODES);
+
+    long total = (long) STRESS_NMODES * STRESS_NPIX;
+    float *modes = (float *) calloc(total, sizeof(float));
+    for (int k = 0; k < STRESS_NMODES; k++)
+    {
+        modes[k * STRESS_NPIX + k] = 1.0f;
+    }
+
+    float coeff_in[STRESS_NMODES];
+    for (int k = 0; k < STRESS_NMODES; k++)
+    {
+        coeff_in[k] =
+            sinf((float)(k + 1) * 1.7f) * 10.0f;
+    }
+
+    float *input = (float *) calloc(
+        STRESS_NPIX, sizeof(float));
+    for (int k = 0; k < STRESS_NMODES; k++)
+    {
+        for (int p = 0; p < STRESS_NPIX; p++)
+        {
+            input[p] +=
+                coeff_in[k]
+                * modes[k * STRESS_NPIX + p];
+        }
+    }
+
+    float *outarray = (float *) calloc(
+        STRESS_NMODES, sizeof(float));
+
+    if (gpu_mvm(modes, input, outarray,
+                STRESS_NMODES, STRESS_NPIX) != 0)
+    {
+        printf("  SKIP: GPU MVM failed\n");
+        free(outarray);
+        free(input);
+        free(modes);
+        return 0;
+    }
+
+    int ret = verify_coefficients(
+        outarray, coeff_in, NULL, STRESS_NMODES,
+        verbose, "GPU");
+
+    free(outarray);
+    free(input);
+    free(modes);
+
+    if (ret == 0)
+    {
+        printf("  PASS\n");
+    }
+    return ret;
+}
+
+
+/* --------------------------------------------------------
+ * GPU Test 4: CPU vs GPU cross-validation
+ *
+ * Run the same MVM on both CPU and GPU, verify that
+ * both produce the same result (within tolerance).
+ * ------------------------------------------------------ */
+
+static int test_cpu_gpu_match(int verbose)
+{
+    printf("[GPU 4] CPU vs GPU cross-validation\n");
+
+    float *modes = (float *) malloc(
+        sizeof(float) * NMODES * NPIX);
+    build_orthogonal_modes(modes, NMODES, NPIX);
+
+    float coeff_in[NMODES] =
+        {3.14f, -1.41f, 2.72f, -0.58f, 1.62f};
+
+    float *input = (float *) calloc(NPIX, sizeof(float));
+    for (int k = 0; k < NMODES; k++)
+    {
+        for (int p = 0; p < NPIX; p++)
+        {
+            input[p] += coeff_in[k] * modes[k * NPIX + p];
+        }
+    }
+
+    /* CPU result */
+    float *cpu_out = (float *) calloc(
+        NMODES, sizeof(float));
+    matrixMulCPU(modes, input,
+                 cpu_out, NMODES, NPIX);
+
+    /* GPU result */
+    float *gpu_out = (float *) calloc(
+        NMODES, sizeof(float));
+    if (gpu_mvm(modes, input, gpu_out,
+                NMODES, NPIX) != 0)
+    {
+        printf("  SKIP: GPU MVM failed\n");
+        free(gpu_out);
+        free(cpu_out);
+        free(input);
+        free(modes);
+        return 0;
+    }
+
+    /* Compare CPU vs GPU */
+    int pass = 1;
+    for (int k = 0; k < NMODES; k++)
+    {
+        float diff = fabsf(cpu_out[k] - gpu_out[k]);
+        float ref  = fabsf(cpu_out[k]) > 1.0e-6f
+                       ? fabsf(cpu_out[k]) : 1.0f;
+
+        if (verbose)
+        {
+            printf("  mode %d: cpu=%+.6f  gpu=%+.6f"
+                   "  diff=%.2e\n",
+                   k, cpu_out[k], gpu_out[k], diff);
+        }
+
+        if (diff / ref > TOL)
+        {
+            printf("  FAIL mode %d: cpu=%f gpu=%f"
+                   " diff=%e\n",
+                   k, cpu_out[k], gpu_out[k], diff);
+            pass = 0;
+        }
+    }
+
+    free(gpu_out);
+    free(cpu_out);
+    free(input);
+    free(modes);
+
+    if (pass)
+    {
+        printf("  PASS\n");
+    }
+    return pass ? 0 : 1;
+}
+
+#endif /* HAVE_CUDA */
+
+
+/* ================================================================
+ * Help
+ * ============================================================= */
+
+static const char *APP_DESCRIPTION =
+    "MVM mode extraction correctness tests";
+
+static const char *APP_DESCRIPTION_LONG =
+    "Round-trip correctness test for matrix-vector\n"
+    "multiply (MVM) mode extraction. Creates\n"
+    "orthogonal modes, synthesizes an input image\n"
+    "from known coefficients, runs the MVM on CPU\n"
+    "and/or GPU, and verifies extracted coefficients\n"
+    "match the originals within tolerance.";
+
+
+static void print_help(
+    const char *prog,
+    int         mh_color)
+{
+    milk_help_banner(
+        prog, APP_DESCRIPTION, mh_color);
+
+    /* Usage */
+    milk_help_section("Usage", mh_color);
+    if (mh_color)
+    {
+        printf("  " MH_CMD "%s" MH_RST
+               " [" MH_OPT "options" MH_RST "]\n\n",
+               prog);
+    }
+    else
+    {
+        printf("  %s [options]\n\n", prog);
+    }
+
+    /* Description */
+    milk_help_section("Description", mh_color);
+    printf("  %s\n\n", APP_DESCRIPTION_LONG);
+
+    /* Options */
+    milk_help_section("Options", mh_color);
+    printf("  %s         Show this help\n",
+           MH(MH_OPT, "-h, --help"));
+    printf("  %s              One-line description\n",
+           MH(MH_OPT, "-h1"));
+    printf("  %s              Verbose description\n",
+           MH(MH_OPT, "-h2"));
+    printf("  %s              Monochrome help\n",
+           MH(MH_OPT, "-hm"));
+    printf("  %s      Per-mode expected/actual values\n",
+           MH(MH_OPT, "-v, --verbose"));
+    printf("  %s          Run CPU tests only\n",
+           MH(MH_OPT, "-c, --cpu"));
+    printf("  %s          Run GPU tests only\n",
+           MH(MH_OPT, "-g, --gpu"));
+    printf("  (default)          "
+           "Run both CPU and GPU\n\n");
+
+    /* Examples */
+    milk_help_section("Examples", mh_color);
+    printf("  %s %s %s"
+           "          # CPU tests, verbose\n",
+           MH(MH_DIM, "$"),
+           MH(MH_CMD, "test_MVMextract"),
+           MH(MH_OPT, "-v -c"));
+    printf("  %s %s %s"
+           "          # GPU tests, verbose\n",
+           MH(MH_DIM, "$"),
+           MH(MH_CMD, "test_MVMextract"),
+           MH(MH_OPT, "-v -g"));
+    printf("  %s %s %s"
+           "             # both, verbose\n",
+           MH(MH_DIM, "$"),
+           MH(MH_CMD, "test_MVMextract"),
+           MH(MH_OPT, "-v"));
+    printf("  %s %s %s %s\n\n",
+           MH(MH_DIM, "$"),
+           MH(MH_CMD, "ctest"),
+           MH(MH_OPT, "-R MVMextract"),
+           MH(MH_OPT, "--output-on-failure"));
+
+    /* See Also */
+    const char *seealso[] = {
+        "milk-fpsexec-linalg-MVMextract:"
+        "MVM mode extraction compute unit",
+        "ctest:run registered CTest tests",
+    };
+    milk_help_see_also(seealso, 2, mh_color);
+}
+
+
+/* ================================================================
+ * Main
+ * ============================================================= */
+
+int main(int argc, char *argv[])
+{
+    /* --- Handle help flags (before getopt) --- */
+    int action = milk_help_init(
+        argc, argv,
+        APP_DESCRIPTION, APP_DESCRIPTION_LONG);
+
+    if (action == MH_ACTION_H1
+        || action == MH_ACTION_H2)
+    {
+        return 0;
+    }
+
+    int mh_color = (action == MH_ACTION_HELP);
+    if (action == MH_ACTION_HELP
+        || action == MH_ACTION_MONO)
+    {
+        print_help(argv[0], mh_color);
+        return 0;
+    }
+
+    /* --- Parse test-specific flags --- */
+    int verbose  = 0;
+    int run_cpu  = 1;
+    int run_gpu  = 1;
+    int explicit_selection = 0;
+
+    for (int i = 1; i < argc; i++)
+    {
+        if (strcmp(argv[i], "-v") == 0
+            || strcmp(argv[i], "--verbose") == 0)
+        {
+            verbose = 1;
+        }
+        else if (strcmp(argv[i], "-c") == 0
+                 || strcmp(argv[i], "--cpu") == 0)
+        {
+            explicit_selection = 1;
+            run_cpu = 1;
+            run_gpu = 0;
+        }
+        else if (strcmp(argv[i], "-g") == 0
+                 || strcmp(argv[i], "--gpu") == 0)
+        {
+            explicit_selection = 1;
+            run_cpu = 0;
+            run_gpu = 1;
+        }
+    } // for args
+
+    /* Allow -c and -g together */
+    if (explicit_selection == 0)
+    {
+        run_cpu = 1;
+        run_gpu = 1;
+    }
+
+    printf("=== MVM Extract Modes Test Suite ===\n");
+    printf("Image size: %dx%d (%d pixels), %d modes\n",
+           NPIX_X, NPIX_Y, NPIX, NMODES);
+
+#ifdef HAVE_CUDA
+    {
+        int dev_count = 0;
+        cudaGetDeviceCount(&dev_count);
+        printf("CUDA devices: %d\n", dev_count);
+        if (dev_count == 0)
+        {
+            run_gpu = 0;
+        }
+    }
+#else
+    if (run_gpu)
+    {
+        printf("CUDA: not compiled in\n");
+        run_gpu = 0;
+    }
+#endif
+
+    printf("Running: %s%s%s\n\n",
+           run_cpu ? "CPU" : "",
+           (run_cpu && run_gpu) ? " + " : "",
+           run_gpu ? "GPU" : "");
+
+    int failures = 0;
+
+    /* --- CPU tests --- */
+    if (run_cpu)
+    {
+        failures += test_cpu_roundtrip(verbose);
+        failures += test_cpu_zero_input(verbose);
+        failures += test_cpu_orthogonality(verbose);
+        failures += test_cpu_shm_roundtrip(verbose);
+        failures += test_cpu_stress(verbose);
+    }
+
+    /* --- GPU tests --- */
+#ifdef HAVE_CUDA
+    if (run_gpu)
+    {
+        failures += test_gpu_roundtrip(verbose);
+        failures += test_gpu_orthogonality(verbose);
+        failures += test_gpu_stress(verbose);
+        failures += test_cpu_gpu_match(verbose);
+    }
+#endif
+
+    printf("\n=== Results: %d test(s) failed ===\n",
+           failures);
+
+    return failures > 0 ? 1 : 0;
+}


### PR DESCRIPTION
MVMextractModes.c:
- Fix 4 NULL pointer dereferences (axmode, PROCESS, TRACEMODE, MODENORM not wired to FPS_PARAMS)
- Fix free-of-shared-memory crash in GPU no-mask path
- Fix GPU stream write-state leak (initref=0 path)
- Fix mask_idx sizeof mismatch (long vs uint32_t) and memory leak
- Remove dead variables (mmax, nmax, outinit, intot_stream, twait)
- Remove ~50 lines of commented-out code and dead branches
- Collapse identical BLAS branches to single call
- Replace inline no-BLAS MVM loop with matrixMulCPU()
- Add dual-mode #ifdef MILK_NO_CLI guard
- Remove unused includes (pthread.h, lapacke.h)

test_MVMextract.c (new):
- Round-trip correctness test for MVM mode extraction
- 5 CPU tests + 4 GPU tests (gated by HAVE_CUDA)
- CPU vs GPU cross-validation test
- Supports -h/-h1/-h2/-hm (milk help conventions)
- Supports -v (verbose), -c (CPU only), -g (GPU only)
- Executable: milk-test-linalg-MVMextract

CMakeLists.txt:
- Add standalone link to _compute lib for matrixMulCPU
- Add milk-test-linalg-MVMextract target with CTest registration